### PR TITLE
feat: minimal Tebako configuration file 'tebafile'

### DIFF
--- a/.github/workflows/lint-and-rspec.yml
+++ b/.github/workflows/lint-and-rspec.yml
@@ -57,6 +57,10 @@ jobs:
 
   rspec:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04, macos-14, windows-2019 ]
     env:
       CODECOV_TOKEN: 795f17c3-2dc3-4253-9627-e2d0a2e59223
     steps:

--- a/.github/workflows/lint-and-rspec.yml
+++ b/.github/workflows/lint-and-rspec.yml
@@ -1,8 +1,6 @@
-# frozen_string_literal: true
-
-# Copyright (c) 2023-2024 [Ribose Inc](https://www.ribose.com).
+# Copyright (c) 2021-2024 [Ribose Inc](https://www.ribose.com).
 # All rights reserved.
-# This file is a part of tebako
+# This file is a part of tamatebako
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -23,24 +21,56 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# POSSIBILITY OF SUCH DAMAGE.name: lint
 
-require "bundler/gem_tasks"
-require "rubocop/rake_task"
-require "rspec/core/rake_task"
+name: lint-and-rspec
 
-RuboCop::RakeTask.new
-RSpec::Core::RakeTask.new(:spec)
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
 
-task default: %i[rubocop spec]
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ludeeus/action-shellcheck@master
+        with:
+          ignore_paths: deps
+        env:
+          SHELLCHECK_OPTS: -x
 
-desc "Generate version.txt"
-task "generate_version_txt" do
-  require_relative "lib/tebako/version"
-  version_without_rc = Tebako::VERSION.gsub(/\.rc\d+/, "")
-  File.write(File.join(__dir__, "version.txt"), "#{version_without_rc}\n")
-  puts "Generating #{File.join(__dir__, "version.txt")}; version = #{version_without_rc}"
-end
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-task build: :generate_version_txt
-task release: :generate_version_txt
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Run rubocop
+        run: bundle exec rubocop
+
+  rspec:
+    runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: 795f17c3-2dc3-4253-9627-e2d0a2e59223
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Run rspec
+        run: bundle exec rspec
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ env.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,6 @@ tebako_test.log
 tests-actions/
 .environment.version
 
-# rspec failure tracking
+# rspec
 .rspec_status
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ tebako_test.log
 .t/
 tests-actions/
 .environment.version
+
+# rspec failure tracking
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,3 +46,6 @@ Naming/FileName:
 
 Style/BlockComments:
   Enabled: false
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec

--- a/.tebako.yml
+++ b/.tebako.yml
@@ -1,1 +1,3 @@
-prefix: PWD
+options:
+  prefix: PWD
+  Ruby: 3.2.4

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in tebako.gemspec
 gemspec
-gem "hoe"
-gem "minitest"
-gem "rubocop", "~> 1.52"
-gem "rubocop-rubycw"

--- a/README.adoc
+++ b/README.adoc
@@ -86,8 +86,8 @@ with debug information unstripped. You can opt to run 'strip -S' manually, it mo
 
 | 2.7.8 | Linux, macOS
 | 3.0.7 | Linux, macOS
-| 3.1.{4,5,6} | Linux, macOS, Windows
-| 3.2.{3,4} | Linux, macOS, Windows
+| 3.1.6 | Linux, macOS, Windows
+| 3.2.4 | Linux, macOS, Windows
 | 3.3.{3,4} | Linux, macOS, Windows
 
 |===
@@ -232,8 +232,6 @@ Displays the Tebako version.
 Displays the help message.
 
 
-
-
 == Usage
 
 === General
@@ -290,9 +288,6 @@ docker run -v <application_folder>:/mnt/w \
   -t ghcr.io/tamatebako/tebako-<container_tag>:latest \
   tebako {command} {parameters}
 ----
-
-
-
 
 ==== Packaging from outside the container
 
@@ -659,7 +654,8 @@ tebako press \
   [-R|--Ruby=<ruby-version>] \
   [-o|--output=<packaged-file-name>] \
   [-l|--log-level=<error|warn|debug|trace>] \
-  [-D|--devmode]
+  [-D|--devmode] \
+  [-t|--tebafile=<path-to-tebafile>]
 ----
 
 Where:
@@ -668,7 +664,7 @@ Where:
 the Tebako root folder (see details in the Tebako Root Folder Selection section)
 
 `Ruby`::
-This parameter defines Ruby version that will be packaged (optional, defaults to
+this parameter defines Ruby version that will be packaged (optional, defaults to
 `3.1.6`)
 
 `<project-root>`::
@@ -685,11 +681,16 @@ the output file name (optional, defaults to `<current folder>/<entry point base 
 logging level for the Tebako built-in memory filesystem driver
 (optional, defaults to `error`)
 
+`tebafile`::
+the tebako configuration file (optional, defaults to `$PWD/.tebako.yml`).
+Please refer to the separate section below for tebafile description.
+
 `devmode`:: flag that activates development mode, in which Tebako's cache and
 packaging consistency checks are relaxed.
 +
-NOTE: Development mode is *not intended for production use* and should only be
-used during development.
+NOTES:
+  * Development mode is *not intended for production use* and should only be used during development.
+  * `entry-point` and `project-root-folder` are required parameters and may be provided either via command-line or in `tebafile`.
 
 [example]
 ====
@@ -724,16 +725,21 @@ based on `tebako press` may create inconsistent environment upon restore.
 $ tebako setup \
   [-p|--prefix=<tebako-root-folder>] \
   [-R|--Ruby=<ruby-version>] \
-  [-D|--devmode]
+  [-D|--devmode] \
+  [-t|--tebafile=<path-to-tebafile>]
 ----
 
 Where:
 
 `<tebako-root-folder>`:: the Tebako root folder (see details in the Tebako Root Folder Selection section)
 
-`Ruby` parameter defines Ruby version that will be packaged (optional, defaults to 3.1.6)
+`Ruby`:: parameter defines Ruby version that will be packaged (optional, defaults to 3.1.6)
 
-`devmode` flag activates development mode, in which Tebako's cache and packaging consistency checks are relaxed.
+`tebafile`::
+the tebako configuration file (optional, defaults to `$PWD/.tebako.yml`).
+Please refer to the separate section below for tebafile description.
+
+`devmode`:: flag activates development mode, in which Tebako's cache and packaging consistency checks are relaxed.
 Please note that this mode is not intended for production use and should only be used during development.
 
 ==== Clean
@@ -746,12 +752,17 @@ Normally you do not need to do it since tebako packager optimizes artifacts life
 [source,sh]
 ----
 $ tebako clean \
-  [-p|--prefix=<tebako-root-folder>]
+  [-p|--prefix=<tebako-root-folder>] \
+  [-t|--tebafile=<path-to-tebafile>]
 ----
 
 Where:
 
 `<tebako-root-folder>`:: the Tebako root folder (see details in the Tebako Root Folder Selection section)
+
+`tebafile`::
+the tebako configuration file (optional, defaults to `$PWD/.tebako.yml`).
+Please refer to the separate section below for tebafile description.
 
 [example]
 ====
@@ -777,7 +788,9 @@ NOTE: Compiled DwarFS libraries are not cleaned.
 ----
 $ tebako clean_ruby
   [-p|--prefix=<tebako-root-folder>] \
-  [-R|--Ruby=<ruby-version>]
+  [-R|--Ruby=<ruby-version>] \
+  [-t|--tebafile=<path-to-tebafile>]
+
 ----
 
 Where:
@@ -787,6 +800,10 @@ the Tebako setup folder (optional, defaults to current folder)
 
 `Ruby`::
 defines Ruby version that will cleaned (optional, cleans all versions by default)
+
+`tebafile`::
+the tebako configuration file (optional, defaults to `$PWD/.tebako.yml`).
+Please refer to the separate section below for tebafile description.
 
 [example]
 ====
@@ -806,6 +823,26 @@ as a cache key in CI/CD pipelines.
 $ tebako hash
 ----
 
+=== Tebako configuration file
+
+It is possible to provide all or some options for the `tebako setup/press/clean/clean_ruby` commands via Tebako configuration file ('tebafile').
+Tebafile is a YAML file with a single section 'options'. The options are the same as long names for the command line. For, example for the prefix option
+
+[source]
+----
+-p|--prefix=<tebako-root-folder>
+----
+the key in the YAML file would be 'prefix'.
+
+Below is an example tebafile that sets values for prefix and Ruby options
+[source,yaml]
+----
+options:
+  prefix: /tmp/tebako
+  Ruby: 3.2.4
+----
+
+Please note that the options provided on the command line have preference over tebafile settings.
 
 === Image extraction
 

--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,7 @@ image:https://api.cirrus-ci.com/github/tamatebako/tebako.svg?branch=main&task=ub
 
 Quality:
 image:https://github.com/tamatebako/tebako/actions/workflows/lint.yml/badge.svg["lint", link="https://github.com/tamatebako/tebako/actions/workflows/lint.yml"]
+image:https://codecov.io/gh/tamatebako/tebako/graph/badge.svg?token=XD3emQ5qsY["Tebako cli rspec coverage", link="https://codecov.io/gh/tamatebako/tebako"]
 
 == Purpose
 

--- a/lib/tebako/cli_helpers.rb
+++ b/lib/tebako/cli_helpers.rb
@@ -55,25 +55,25 @@ module Tebako
       # So we have to use \"xxx\"
       @cfg_options ||=
         "-DCMAKE_BUILD_TYPE=Release -DRUBY_VER:STRING=\"#{ruby_ver}\" -DRUBY_HASH:STRING=\"#{ruby_hash}\" " \
-        "-DDEPS:STRING=\"#{deps}\" -G \"#{m_files}\" -B \"#{output}\" -S \"#{source}\""
+        "-DDEPS:STRING=\"#{deps}\" -G \"#{m_files}\" -B \"#{output_folder}\" -S \"#{source}\""
     end
 
     def clean_cache
       puts "Cleaning tebako packaging environment"
       # Using File.join(deps, "") to ensure that the slashes are appropriate
-      FileUtils.rm_rf([File.join(deps, ""), File.join(output, "")], secure: true)
+      FileUtils.rm_rf([File.join(deps, ""), File.join(output_folder, "")], secure: true)
     end
 
     def clean_output
       puts "Cleaning CMake cache and Ruby build files"
-      # Using File.join(output, "") to ensure that the slashes are appropriate
 
       nmr = "src/_ruby_*"
       nms = "stash_*"
       FileUtils.rm_rf(Dir.glob(File.join(deps, nmr)), secure: true)
       FileUtils.rm_rf(Dir.glob(File.join(deps, nms)), secure: true)
 
-      FileUtils.rm_rf(File.join(output, ""), secure: true)
+      # Using File.join(output_folder, "") to ensure that the slashes are appropriate
+      FileUtils.rm_rf(File.join(output_folder, ""), secure: true)
     end
 
     def deps
@@ -82,7 +82,7 @@ module Tebako
 
     def do_press
       cfg_cmd = "cmake -DSETUP_MODE:BOOLEAN=OFF #{cfg_options} #{press_options}"
-      build_cmd = "cmake --build #{output} --target tebako --parallel #{Etc.nprocessors}"
+      build_cmd = "cmake --build #{output_folder} --target tebako --parallel #{Etc.nprocessors}"
       merged_env = ENV.to_h.merge(b_env)
       Tebako.packaging_error(103) unless system(merged_env, cfg_cmd)
       Tebako.packaging_error(104) unless system(merged_env, build_cmd)
@@ -90,7 +90,7 @@ module Tebako
 
     def do_setup
       cfg_cmd = "cmake -DSETUP_MODE:BOOLEAN=ON #{cfg_options}"
-      build_cmd = "cmake --build \"#{output}\" --target setup --parallel #{Etc.nprocessors}"
+      build_cmd = "cmake --build \"#{output_folder}\" --target setup --parallel #{Etc.nprocessors}"
       merged_env = ENV.to_h.merge(b_env)
       Tebako.packaging_error(101) unless system(merged_env, cfg_cmd)
       Tebako.packaging_error(102) unless system(merged_env, build_cmd)
@@ -156,8 +156,8 @@ module Tebako
       {}
     end
 
-    def output
-      @output ||= File.join(prefix, "o")
+    def output_folder
+      @output_folder ||= File.join(prefix, "o")
     end
 
     def package

--- a/spec/cli_helpers_spec.rb
+++ b/spec/cli_helpers_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2024 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of tebako
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+require "yaml"
+require_relative "../lib/tebako/cli_helpers"
+
+RSpec.describe Tebako::CliHelpers do # rubocop:disable Metrics/BlockLength
+  include Tebako::CliHelpers
+
+  let(:options) { {} }
+
+  before do
+    allow(self).to receive(:options).and_return(options)
+  end
+
+  describe "#l_level" do
+    context "when log-level option is not set" do
+      it 'returns "error"' do
+        expect(l_level).to eq("error")
+      end
+    end
+
+    context "when log-level option is set" do
+      let(:options) { { "log-level" => "info" } }
+
+      it "returns the value of the log-level option" do
+        expect(l_level).to eq("info")
+      end
+    end
+  end
+
+  describe "#m_files" do # rubocop:disable Metrics/BlockLength
+    context "when on a Linux platform" do
+      before do
+        stub_const("RUBY_PLATFORM", "linux")
+      end
+
+      it 'returns "Unix Makefiles"' do
+        expect(m_files).to eq("Unix Makefiles")
+      end
+    end
+
+    context "when on a macOS platform" do
+      before do
+        stub_const("RUBY_PLATFORM", "darwin")
+      end
+
+      it 'returns "Unix Makefiles"' do
+        expect(m_files).to eq("Unix Makefiles")
+      end
+    end
+
+    context "when on a Windows platform" do
+      before do
+        stub_const("RUBY_PLATFORM", "msys")
+      end
+
+      it 'returns "MinGW Makefiles"' do
+        expect(m_files).to eq("MinGW Makefiles")
+      end
+    end
+
+    context "when on an unsupported platform" do
+      before do
+        stub_const("RUBY_PLATFORM", "unsupported")
+      end
+
+      it "raises a Tebako::Error" do
+        expect { m_files }.to raise_error(Tebako::Error, "unsupported is not supported yet, exiting")
+      end
+    end
+  end
+
+  describe "#options_from_tebafile" do
+    let(:tebafile) { "spec/fixtures/tebafile.yml" }
+
+    context "when the tebafile contains valid YAML" do
+      it "loads options from the tebafile" do
+        allow(YAML).to receive(:load_file).and_return({ "options" => { "key" => "value" } })
+        expect(options_from_tebafile(tebafile)).to eq({ "key" => "value" })
+      end
+    end
+
+    context "when the tebafile contains invalid YAML" do
+      it "returns an empty hash and prints a warning" do
+        allow(YAML).to receive(:load_file).and_raise(Psych::SyntaxError.new("file", 1, 1, 1, "message", "context"))
+        expect { options_from_tebafile(tebafile) }.to output(/Warning: The tebafile/).to_stdout
+        expect(options_from_tebafile(tebafile)).to eq({})
+      end
+    end
+
+    context "when an unexpected error occurs" do
+      it "returns an empty hash and prints a warning" do
+        allow(YAML).to receive(:load_file).and_raise(StandardError.new("Unexpected error"))
+        expect { options_from_tebafile(tebafile) }.to output(/An unexpected error occurred/).to_stdout
+        expect(options_from_tebafile(tebafile)).to eq({})
+      end
+    end
+  end
+end

--- a/spec/cli_helpers_spec.rb
+++ b/spec/cli_helpers_spec.rb
@@ -121,4 +121,94 @@ RSpec.describe Tebako::CliHelpers do # rubocop:disable Metrics/BlockLength
       end
     end
   end
+
+  describe "#version_key" do
+    it "returns the correct version key" do
+      allow(self).to receive(:source).and_return("/path/to/source")
+      expect(version_key).to eq("#{Tebako::VERSION} at /path/to/source")
+    end
+  end
+
+  describe "#version_cache" do
+    it "returns the correct version and source from the cache file" do
+      version_file_content = "#{Tebako::VERSION} at /path/to/source\n"
+      allow(self).to receive(:deps).and_return("/path/to/deps")
+      allow(File).to receive(:join).with("/path/to/deps", Tebako::E_VERSION_FILE).and_return("/path/to/version_file")
+      allow(File).to receive(:open).with("/path/to/version_file").and_yield(StringIO.new(version_file_content))
+    end
+  end
+
+  describe "#version_cache_check" do # rubocop:disable Metrics/BlockLength
+    before do
+      allow(self).to receive(:version_cache).and_return(match_data)
+      allow(self).to receive(:version_unknown)
+      allow(self).to receive(:version_mismatch)
+      allow(self).to receive(:version_source_mismatch)
+    end
+
+    context "when version cache is unknown" do
+      let(:match_data) { nil }
+
+      it "calls version_unknown" do
+        expect(self).to receive(:version_unknown)
+        version_cache_check
+      end
+    end
+
+    context "when version does not match" do
+      let(:match_data) { { version: "0.7.0", source: "/path/to/source" } }
+      it "calls version_mismatch" do
+        expect(self).to receive(:version_mismatch).with("0.7.0")
+        version_cache_check
+      end
+    end
+
+    context "when source does not match" do
+      let(:match_data) { { version: Tebako::VERSION, source: "/different/source" } }
+
+      it "calls version_source_mismatch" do
+        allow(self).to receive(:source).and_return("/path/to/source")
+        expect(self).to receive(:version_source_mismatch).with("/different/source")
+        version_cache_check
+      end
+    end
+
+    context "when version and source match" do
+      let(:match_data) { { version: Tebako::VERSION, source: "/path/to/source" } }
+
+      it "does not call any mismatch methods" do
+        allow(self).to receive(:source).and_return("/path/to/source")
+        expect(self).not_to receive(:version_unknown)
+        expect(self).not_to receive(:version_mismatch)
+        expect(self).not_to receive(:version_source_mismatch)
+        version_cache_check
+      end
+    end
+  end
+  describe "#version_mismatch" do
+    it "prints the correct message and cleans the cache" do
+      expect(self).to receive(:puts)
+        .with("Tebako cache was created by a gem version 0.9.0 and cannot be used for gem version #{Tebako::VERSION}")
+      expect(self).to receive(:clean_cache)
+      allow(Tebako).to receive(:VERSION).and_return("1.0.0")
+      version_mismatch("0.9.0")
+    end
+  end
+  describe "#version_source_mismatch" do
+    it "prints the correct message and cleans the output" do
+      expect(self).to receive(:puts)
+        .with("CMake cache was created for a different source directory '/different/source' " \
+              "and cannot be used for '/path/to/source'")
+      expect(self).to receive(:clean_output)
+      allow(self).to receive(:source).and_return("/path/to/source")
+      version_source_mismatch("/different/source")
+    end
+  end
+  describe "#version_unknown" do
+    it "prints the correct message and cleans the cache" do
+      expect(self).to receive(:puts).with("CMake cache version was not recognized, cleaning up")
+      expect(self).to receive(:clean_cache)
+      version_unknown
+    end
+  end
 end

--- a/spec/cli_rubies_spec.rb
+++ b/spec/cli_rubies_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2023-2024 [Ribose Inc](https://www.ribose.com).
+# Copyright (c) 2024 [Ribose Inc](https://www.ribose.com).
 # All rights reserved.
 # This file is a part of tebako
 #
@@ -25,22 +25,30 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-require "bundler/gem_tasks"
-require "rubocop/rake_task"
-require "rspec/core/rake_task"
+require "tebako/cli_rubies"
 
-RuboCop::RakeTask.new
-RSpec::Core::RakeTask.new(:spec)
+RSpec.describe Tebako::CliRubies do
+  include Tebako::CliRubies
 
-task default: %i[rubocop spec]
+  describe "#version_check" do
+    context "when the Ruby version is supported" do
+      it "does not raise an error" do
+        expect { version_check("3.1.6") }.not_to raise_error
+      end
+    end
 
-desc "Generate version.txt"
-task "generate_version_txt" do
-  require_relative "lib/tebako/version"
-  version_without_rc = Tebako::VERSION.gsub(/\.rc\d+/, "")
-  File.write(File.join(__dir__, "version.txt"), "#{version_without_rc}\n")
-  puts "Generating #{File.join(__dir__, "version.txt")}; version = #{version_without_rc}"
+    context "when the Ruby version is not supported" do
+      it "raises a Tebako::Error" do
+        expect do
+          version_check("2.6.0")
+        end.to raise_error(Tebako::Error, "Ruby version 2.6.0 is not supported yet, exiting")
+      end
+    end
+  end
+
+  describe "DEFAULT_RUBY_VERSION" do
+    it "is set to 3.1.6" do
+      expect(Tebako::CliRubies::DEFAULT_RUBY_VERSION).to eq("3.1.6")
+    end
+  end
 end
-
-task build: :generate_version_txt
-task release: :generate_version_txt

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2024 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of tebako
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+RSpec.describe Tebako do # rubocop:disable Metrics/BlockLength
+  describe "PACKAGING_ERRORS" do # rubocop:disable Metrics/BlockLength
+    it "is defined" do
+      expect(defined?(Tebako::PACKAGING_ERRORS)).to be_truthy
+    end
+
+    describe ".packaging_error" do
+      it "raises the correct error for known error codes" do
+        expect { Tebako.packaging_error(101) }.to raise_error(Tebako::Error, "'tebako setup' configure step failed")
+        expect do
+          Tebako.packaging_error(106)
+        end.to raise_error(Tebako::Error, "Entry point does not exist or is not accessible")
+      end
+
+      it "raises a generic error message for unknown error codes" do
+        expect { Tebako.packaging_error(999) }.to raise_error(Tebako::Error, "Unknown packaging error")
+      end
+    end
+
+    describe "Error" do
+      it "is defined" do
+        expect(defined?(Tebako::Error)).to be_truthy
+      end
+
+      it "inherits from StandardError" do
+        expect(Tebako::Error).to be < StandardError
+      end
+
+      it "can be instantiated" do
+        expect { Tebako::Error.new }.not_to raise_error
+      end
+
+      it "initializes with the correct message and error code" do
+        error = Tebako::Error.new("Custom error message", 123)
+        expect(error.message).to eq("Custom error message")
+        expect(error.error_code).to eq(123)
+      end
+
+      it "has an accessible and modifiable error_code attribute" do
+        error = Tebako::Error.new
+        error.error_code = 456
+        expect(error.error_code).to eq(456)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
-# Copyright (c) 2021-2024 [Ribose Inc](https://www.ribose.com).
+# frozen_string_literal: true
+
+# Copyright (c) 2024 [Ribose Inc](https://www.ribose.com).
 # All rights reserved.
-# This file is a part of tamatebako
+# This file is a part of tebako
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -21,36 +23,28 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.name: lint
+# POSSIBILITY OF SUCH DAMAGE.
 
-name: lint
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-  workflow_dispatch:
+require "tebako"
 
-jobs:
-  shellcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ludeeus/action-shellcheck@master
-        with:
-          ignore_paths: deps
-        env:
-          SHELLCHECK_OPTS: -x
+require "simplecov"
+SimpleCov.start do
+  add_filter "/spec/"
+end
 
-  rubocop:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+require "simplecov-cobertura"
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.1'
-          bundler-cache: true
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
 
-      - name: Run rubocop
-        run: bundle exec rubocop
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright (c) 2023-2024 [Ribose Inc](https://www.ribose.com).
+# Copyright (c) 2024 [Ribose Inc](https://www.ribose.com).
 # All rights reserved.
 # This file is a part of tebako
 #
@@ -25,22 +25,18 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-require "bundler/gem_tasks"
-require "rubocop/rake_task"
-require "rspec/core/rake_task"
+RSpec.describe Tebako do
+  describe "VERSION" do
+    it "is defined" do
+      expect(defined?(Tebako::VERSION)).to be_truthy
+    end
 
-RuboCop::RakeTask.new
-RSpec::Core::RakeTask.new(:spec)
+    it "is a string" do
+      expect(Tebako::VERSION).to be_a(String)
+    end
 
-task default: %i[rubocop spec]
-
-desc "Generate version.txt"
-task "generate_version_txt" do
-  require_relative "lib/tebako/version"
-  version_without_rc = Tebako::VERSION.gsub(/\.rc\d+/, "")
-  File.write(File.join(__dir__, "version.txt"), "#{version_without_rc}\n")
-  puts "Generating #{File.join(__dir__, "version.txt")}; version = #{version_without_rc}"
+    it "has the correct format" do
+      expect(Tebako::VERSION).to match(/^\d+\.\d+\.\d+$/)
+    end
+  end
 end
-
-task build: :generate_version_txt
-task release: :generate_version_txt

--- a/src/tebako-main.cpp
+++ b/src/tebako-main.cpp
@@ -145,6 +145,8 @@ extern "C" int tebako_main(int* argc, char*** argv) {
 				// Nested error, no recovery :(
 			}
 		}
+
+		// tebako_chdir("/__tebako_memfs__/local");
 	}
 	return ret;
 }

--- a/tebako.gemspec
+++ b/tebako.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files --recurse-submodules -z`.split("\x0").reject do |f|
       (f == __FILE__) ||
-        f.match(%r{\A(?:(?:tests|tests-2|features|deps|output|common\.env)/|\.(?:git|cirrus|tebako|rubocop))})
+        f.match(%r{\A(?:(?:tests|tests-2|spec|deps|output|common\.env)/|\.(?:git|rspec|cirrus|tebako|rubocop))})
     end
   end
 
@@ -63,4 +63,12 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "thor", "~> 1.2"
   spec.add_dependency "yaml", "~> 0.2.1"
+
+  spec.add_development_dependency "hoe"
+  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "rspec", "~> 3.2"
+  spec.add_development_dependency "rubocop", "~> 1.52"
+  spec.add_development_dependency "rubocop-rubycw"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov-cobertura"
 end

--- a/tests-2/fixtures/gems-bundler/Gemfile
+++ b/tests-2/fixtures/gems-bundler/Gemfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-gem "rake"
+gem "rake" # rubocop:disable Gemspec/DevelopmentDependencies

--- a/tests-2/fixtures/gems-byebug/Gemfile
+++ b/tests-2/fixtures/gems-byebug/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-gem "byebug"
-gem "rake"
+gem "byebug" # rubocop:disable Gemspec/DevelopmentDependencies
+gem "rake" # rubocop:disable Gemspec/DevelopmentDependencies

--- a/tests-2/fixtures/gems-excavate/Gemfile
+++ b/tests-2/fixtures/gems-excavate/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "excavate"
+gem "excavate" # rubocop:disable Gemspec/DevelopmentDependencies

--- a/tests-2/fixtures/gems-expressir/Gemfile
+++ b/tests-2/fixtures/gems-expressir/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "bundler"
-gem "expressir"
-gem "ffi"
+gem "bundler" # rubocop:disable Gemspec/DevelopmentDependencies
+gem "expressir" # rubocop:disable Gemspec/DevelopmentDependencies
+gem "ffi" # rubocop:disable Gemspec/DevelopmentDependencies

--- a/tests-2/fixtures/gems-libarchive-binary/Gemfile
+++ b/tests-2/fixtures/gems-libarchive-binary/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "ffi-libarchive-binary"
+gem "ffi-libarchive-binary" # rubocop:disable Gemspec/DevelopmentDependencies

--- a/tests-2/fixtures/gems-libmspack/Gemfile
+++ b/tests-2/fixtures/gems-libmspack/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "libmspack"
+gem "libmspack" # rubocop:disable Gemspec/DevelopmentDependencies

--- a/tests-2/fixtures/gems-nokogiri/Gemfile
+++ b/tests-2/fixtures/gems-nokogiri/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "nokogiri"
+gem "nokogiri" # rubocop:disable Gemspec/DevelopmentDependencies

--- a/tests-2/fixtures/gems-sassc/Gemfile
+++ b/tests-2/fixtures/gems-sassc/Gemfile
@@ -2,5 +2,5 @@
 
 source "https://rubygems.org"
 
-gem "bundler"
-gem "sassc"
+gem "bundler" # rubocop:disable Gemspec/DevelopmentDependencies
+gem "sassc" # rubocop:disable Gemspec/DevelopmentDependencies

--- a/tests-2/fixtures/gems-seven-zip/Gemfile
+++ b/tests-2/fixtures/gems-seven-zip/Gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "bundler"
-gem "ffi"
+gem "bundler" # rubocop:disable Gemspec/DevelopmentDependencies
+gem "ffi" # rubocop:disable Gemspec/DevelopmentDependencies
 gem "seven-zip", "~>1.4"

--- a/tests/scripts/functional-tests.sh
+++ b/tests/scripts/functional-tests.sh
@@ -87,7 +87,6 @@ press_runner_with_error() {
 
 # ......................................................................
 # Tests
-#  00. Basic tebako CLI tests (error handling)
 #  --  tebako setup                                                                                         [commented out, redundant]
 #  AU. Check that it is possible to extract image content (--tebako-extract option)
 #  01. Simple Ruby script, absolute path to root, relative path to entry point
@@ -108,49 +107,6 @@ press_runner_with_error() {
 #  19. Ruby project (no gemspec, with gemfile, with native extension)
 #  20. Net/http Ruby script [sits here and not on tests-2 in order to allow cross test MacOS x86_64 --> MacOS arm64]
 
-# ......................................................................
-# 00. Very basic tebako CLI tests (error handling)
-test_CLI_help() {
-   result=$( "$DIR_BIN"/tebako help )
-
-   assertEquals 0 "${PIPESTATUS[0]}"
-   assertContains "$result" "Tebako commands:"
-}
-
-test_CLI_missing_command() {
-   result=$( "$DIR_BIN"/tebako )
-
-   assertEquals 0 "${PIPESTATUS[0]}"
-   assertContains "$result" "Tebako commands:"
-}
-
-test_CLI_unknown_command() {
-   result=$( "$DIR_BIN"/tebako jump 2>&1)
-
-   assertEquals 1 "${PIPESTATUS[0]}"
-   assertContains "$result" "Could not find command"
-}
-
-test_CLI_no_root() {
-   result=$( "$DIR_BIN"/tebako press -D -R "$RUBY_VER" --entry-point=tebako-test-run.rb --output=test-00-package 2>&1  )
-
-   assertEquals 1 "${PIPESTATUS[0]}"
-   assertContains "$result" "No value provided for required options '--root'"
-}
-
-test_CLI_no_entry_point() {
-   result=$( "$DIR_BIN"/tebako press -D -R "$RUBY_VER" --root=tests/test-00 --output=test-00-package 2>&1  )
-
-   assertEquals 1 "${PIPESTATUS[0]}"
-   assertContains "$result" "No value provided for required options '--entry-point'"
-}
-
-test_CLI_invalid_Ruby_version() {
-   result=$( "$DIR_BIN"/tebako press -D --root=tests/test-00 --output=test-00-package --entry-point=tebako-test-run.rb --Ruby=1.9.3 2>&1  )
-
-   assertEquals 1 "${PIPESTATUS[0]}"
-   assertContains "$result" "Expected '--Ruby' to be one of"
-}
 
 # ......................................................................
 #  --  tebako setup


### PR DESCRIPTION
Minimal tebafile implementation
It allows to specify options that are available on the command line

As a side effect Tebako Cli tests were ported from shUnit to RSpec