### PR TITLE
feat: trailer-aware tebako-main (append-mount path, Stage 3A-2)

### DIFF
--- a/include/tebako/tpkg.h
+++ b/include/tebako/tpkg.h
@@ -1,0 +1,575 @@
+/**
+ * @file tpkg.h
+ * @brief tebako package manifest (tpkg) — single-header C99 mini-lib
+ *
+ * Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ * This file is a part of the Tebako project (libtfs).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ============================================================================
+ * Manifest trailer v1 — wire layout (all integers little-endian):
+ *
+ *   [payload][slot 0 .. slot n-1 records][trailer header — fixed size, at EOF]
+ *
+ *   trailer header (TPKG_HEADER_SIZE = 166 bytes):
+ *     offset  size  field
+ *        0    10    magic "TEBAKOTFS\0" (10 bytes, NUL-terminated)
+ *       10     4    u32 version (TPKG_VERSION = 1)
+ *       14     4    u32 package_flags (bit 0: TPKG_FLAG_LEAN — bootstrap+images
+ *                    only, runtime resolved at run time)
+ *       18     4    u32 slot_count (1..TPKG_MAX_SLOTS)
+ *       22     8    u64 slot_table_offset (absolute file offset of slot 0 record)
+ *       30   128    char runtime_ref[128] (UTF-8, NUL-padded; empty = classic bundle)
+ *      158     4    u32 launcher_abi
+ *      162     4    u32 header_crc32 — tpkg_crc32() over header bytes [0, 162)
+ *
+ *   slot record (TPKG_SLOT_SIZE = 280 bytes):
+ *     offset  size  field
+ *        0     8    u64 offset (image start, absolute file offset)
+ *        8     8    u64 size   (image length in bytes)
+ *       16     4    u32 format_id (0=auto(magic), 1=dwarfs, 2=squashfs, 3=zip)
+ *       20     4    u32 flags
+ *       24   256    char mount_point[256] (UTF-8, NUL-padded)
+ *
+ * Reader algorithm: read the fixed-size header at EOF - TPKG_HEADER_SIZE,
+ * check the magic, verify header_crc32, then read slot_count slot records at
+ * slot_table_offset. The table (and therefore the payload) may sit at any —
+ * including odd — file offset.
+ *
+ * Absent vs. corrupt: a file whose last-166-byte window does not start with
+ * the 4-byte prefix "TEBA" is reported as TPKG_ERR_NO_TRAILER (a classic
+ * bundle without a manifest — not an error condition per se; callers fall
+ * back to offset auto-detection). A matching prefix with a mismatching full
+ * magic is TPKG_ERR_MAGIC (corrupt trailer); a magic-valid header with a bad
+ * crc is TPKG_ERR_CRC.
+ *
+ * Error handling: all tpkg_* functions (except tpkg_crc32, tpkg_errno and
+ * tpkg_strerror) return 0 on success and -1 on failure, with a TPKG_ERR_*
+ * code available from tpkg_errno(). The error state is a process-global
+ * (ISO C99 has no portable TLS); it is reset at the entry of every public
+ * function and is NOT thread-safe.
+ *
+ * Usage: in exactly one translation unit, #define TPKG_IMPLEMENTATION before
+ * #include <tebako/tpkg.h>; every other TU includes it plain. On POSIX the
+ * implementation section defines _POSIX_C_SOURCE 200809L if it is not
+ * defined yet, so include tpkg.h before any system header in that TU.
+ * No dependencies beyond libc.
+ * ============================================================================
+ */
+
+#ifndef TEBAKO_TPKG_H
+#define TEBAKO_TPKG_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- format constants ---------------------------------------------------- */
+
+#define TPKG_VERSION 1u
+#define TPKG_MAX_SLOTS 8u
+#define TPKG_HEADER_SIZE 166u
+#define TPKG_SLOT_SIZE 280u
+#define TPKG_MOUNT_POINT_LEN 256u
+#define TPKG_RUNTIME_REF_LEN 128u
+#define TPKG_MAGIC "TEBAKOTFS"
+#define TPKG_MAGIC_LEN 10u        /* including the terminating NUL */
+#define TPKG_MAGIC_PREFIX_LEN 4u  /* "TEBA": absent-vs-corrupt discriminator */
+
+/* package_flags */
+#define TPKG_FLAG_LEAN 0x1u
+
+/* format_id */
+#define TPKG_FORMAT_AUTO 0u
+#define TPKG_FORMAT_DWARFS 1u
+#define TPKG_FORMAT_SQUASHFS 2u
+#define TPKG_FORMAT_ZIP 3u
+
+/* ---- error codes (returned by tpkg_errno) -------------------------------- */
+
+enum {
+  TPKG_OK = 0,             /* success */
+  TPKG_ERR_NO_TRAILER = 1, /* no manifest trailer present (absent — not an error per se) */
+  TPKG_ERR_MAGIC = 2,      /* magic prefix present but full magic mismatch (corrupt) */
+  TPKG_ERR_CRC = 3,        /* header_crc32 mismatch (corrupt) */
+  TPKG_ERR_IO = 4,         /* underlying i/o failure */
+  TPKG_ERR_BOUNDS = 5,     /* slot table outside file bounds */
+  TPKG_ERR_SLOTS = 6,      /* slot_count == 0 or > TPKG_MAX_SLOTS */
+  TPKG_ERR_INVALID = 7,    /* structural validation failure */
+  TPKG_ERR_ARG = 8,        /* invalid argument (NULL, bad fd) */
+  TPKG_ERR_VERSION = 9     /* unsupported manifest version */
+};
+
+/* ---- manifest structures -------------------------------------------------- */
+
+typedef struct tpkg_slot {
+  uint64_t offset;
+  uint64_t size;
+  uint32_t format_id;
+  uint32_t flags;
+  char mount_point[TPKG_MOUNT_POINT_LEN];
+} tpkg_slot;
+
+typedef struct tpkg_manifest {
+  uint32_t version;
+  uint32_t package_flags;
+  uint32_t slot_count;
+  uint32_t launcher_abi;
+  char runtime_ref[TPKG_RUNTIME_REF_LEN];
+  tpkg_slot slots[TPKG_MAX_SLOTS];
+} tpkg_manifest;
+
+/* ---- API ------------------------------------------------------------------ */
+
+/* Read the manifest trailer of an open binary (seeks to EOF; the file offset
+ * is left unspecified). */
+int tpkg_read_fd(int fd, tpkg_manifest* out);
+
+/* Read the manifest trailer from an in-memory image of the binary. */
+int tpkg_read_mem(const void* data, size_t size, tpkg_manifest* out);
+
+/* Append the slot table + trailer header to an open binary (at current EOF).
+ * The manifest is validated first; a rejected manifest appends nothing. */
+int tpkg_write_fd(int fd, const tpkg_manifest* m);
+
+/* Magic-independent structural checks: version supported, slot_count in
+ * 1..TPKG_MAX_SLOTS, offset+size non-overflowing, format_id <= TPKG_FORMAT_ZIP,
+ * runtime_ref and mount_points NUL-terminated within their fixed fields. */
+int tpkg_validate(const tpkg_manifest* m);
+
+/* CRC-32 (zlib polynomial 0xEDB88320, init/xorout 0xFFFFFFFF) — exposed for
+ * header_crc32 computation and verification. Pure; does not touch tpkg_errno. */
+uint32_t tpkg_crc32(const void* data, size_t n);
+
+/* Code of the last failed (or succeeded) tpkg operation on this process. */
+int tpkg_errno(void);
+
+/* Static string for a TPKG_ERR_* code (never NULL). */
+const char* tpkg_strerror(int err);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TEBAKO_TPKG_H */
+
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~ implementation ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#if defined(TPKG_IMPLEMENTATION) && !defined(TPKG_IMPLEMENTATION_DONE)
+#define TPKG_IMPLEMENTATION_DONE
+
+#include <stdio.h> /* SEEK_SET / SEEK_END */
+#include <string.h>
+
+#if defined(_WIN32)
+#include <io.h>
+typedef __int64 tpkg__off_t;
+typedef int tpkg__ssize_t;
+typedef unsigned int tpkg__io_count_t;
+#define tpkg__lseek _lseeki64
+#define tpkg__read _read
+#define tpkg__write _write
+#else
+#if !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 200809L
+#endif
+#include <sys/types.h>
+#include <unistd.h>
+typedef off_t tpkg__off_t;
+typedef ssize_t tpkg__ssize_t;
+typedef size_t tpkg__io_count_t;
+#define tpkg__lseek lseek
+#define tpkg__read read
+#define tpkg__write write
+#endif
+
+/* header field offsets */
+enum {
+  TPKG__OFF_MAGIC = 0,
+  TPKG__OFF_VERSION = 10,
+  TPKG__OFF_PACKAGE_FLAGS = 14,
+  TPKG__OFF_SLOT_COUNT = 18,
+  TPKG__OFF_TABLE = 22,
+  TPKG__OFF_RUNTIME_REF = 30,
+  TPKG__OFF_LAUNCHER_ABI = 158,
+  TPKG__OFF_CRC32 = 162
+};
+
+/* slot record field offsets */
+enum {
+  TPKG__REC_OFFSET = 0,
+  TPKG__REC_SIZE = 8,
+  TPKG__REC_FORMAT = 16,
+  TPKG__REC_FLAGS = 20,
+  TPKG__REC_MOUNT = 24
+};
+
+/* wire sizes are fixed by the format; catch exotic padding at compile time */
+typedef char tpkg__assert_slot_size[(sizeof(tpkg_slot) == TPKG_SLOT_SIZE) ? 1 : -1];
+typedef char tpkg__assert_manifest_size[(sizeof(tpkg_manifest) ==
+                                         4 * sizeof(uint32_t) + TPKG_RUNTIME_REF_LEN +
+                                             TPKG_MAX_SLOTS * sizeof(tpkg_slot))
+                                            ? 1
+                                            : -1];
+
+/* ---- error state ---------------------------------------------------------- */
+
+static int tpkg__last_err = TPKG_OK;
+
+int tpkg_errno(void)
+{
+  return tpkg__last_err;
+}
+
+static int tpkg__fail(int code)
+{
+  tpkg__last_err = code;
+  return -1;
+}
+
+const char* tpkg_strerror(int err)
+{
+  switch (err) {
+    case TPKG_OK:
+      return "success";
+    case TPKG_ERR_NO_TRAILER:
+      return "no tpkg manifest trailer present";
+    case TPKG_ERR_MAGIC:
+      return "corrupt tpkg trailer magic";
+    case TPKG_ERR_CRC:
+      return "tpkg trailer header crc32 mismatch";
+    case TPKG_ERR_IO:
+      return "tpkg i/o error";
+    case TPKG_ERR_BOUNDS:
+      return "tpkg slot table out of file bounds";
+    case TPKG_ERR_SLOTS:
+      return "tpkg slot count out of range (1..TPKG_MAX_SLOTS)";
+    case TPKG_ERR_INVALID:
+      return "invalid tpkg manifest structure";
+    case TPKG_ERR_ARG:
+      return "invalid tpkg argument";
+    case TPKG_ERR_VERSION:
+      return "unsupported tpkg manifest version";
+    default:
+      return "unknown tpkg error";
+  }
+}
+
+/* ---- CRC-32 (zlib polynomial) -------------------------------------------- */
+
+uint32_t tpkg_crc32(const void* data, size_t n)
+{
+  const uint8_t* p = (const uint8_t*)data;
+  uint32_t crc = 0xFFFFFFFFu;
+  size_t i;
+  int k;
+  for (i = 0; i < n; i++) {
+    crc ^= p[i];
+    for (k = 0; k < 8; k++) {
+      crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
+    }
+  }
+  return crc ^ 0xFFFFFFFFu;
+}
+
+/* ---- little-endian codec -------------------------------------------------- */
+
+static void tpkg__put32(uint8_t* p, uint32_t v)
+{
+  p[0] = (uint8_t)(v & 0xFFu);
+  p[1] = (uint8_t)((v >> 8) & 0xFFu);
+  p[2] = (uint8_t)((v >> 16) & 0xFFu);
+  p[3] = (uint8_t)((v >> 24) & 0xFFu);
+}
+
+static void tpkg__put64(uint8_t* p, uint64_t v)
+{
+  int i;
+  for (i = 0; i < 8; i++) {
+    p[i] = (uint8_t)((v >> (8 * i)) & 0xFFu);
+  }
+}
+
+static uint32_t tpkg__get32(const uint8_t* p)
+{
+  return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint64_t tpkg__get64(const uint8_t* p)
+{
+  uint64_t v = 0;
+  int i;
+  for (i = 0; i < 8; i++) {
+    v |= (uint64_t)p[i] << (8 * i);
+  }
+  return v;
+}
+
+/* ---- helpers -------------------------------------------------------------- */
+
+static size_t tpkg__strnlen(const char* s, size_t max)
+{
+  const char* nul = (const char*)memchr(s, '\0', max);
+  return nul ? (size_t)(nul - s) : max;
+}
+
+/* copy a C string into a fixed-width field, zero-padding the remainder;
+ * callers must have validated NUL-termination within width */
+static void tpkg__put_str(uint8_t* p, const char* s, size_t width)
+{
+  size_t len = tpkg__strnlen(s, width);
+  memcpy(p, s, len);
+  memset(p + len, 0, width - len);
+}
+
+static int tpkg__read_full(int fd, void* buf, size_t n)
+{
+  uint8_t* p = (uint8_t*)buf;
+  while (n > 0) {
+    tpkg__ssize_t r = tpkg__read(fd, p, (tpkg__io_count_t)n);
+    if (r <= 0) {
+      return -1;
+    }
+    p += (size_t)r;
+    n -= (size_t)r;
+  }
+  return 0;
+}
+
+static int tpkg__write_full(int fd, const void* buf, size_t n)
+{
+  const uint8_t* p = (const uint8_t*)buf;
+  while (n > 0) {
+    tpkg__ssize_t r = tpkg__write(fd, p, (tpkg__io_count_t)n);
+    if (r <= 0) {
+      return -1;
+    }
+    p += (size_t)r;
+    n -= (size_t)r;
+  }
+  return 0;
+}
+
+/* ---- validation ------------------------------------------------------------ */
+
+int tpkg_validate(const tpkg_manifest* m)
+{
+  uint32_t i;
+  tpkg__last_err = TPKG_OK;
+  if (m == NULL) {
+    return tpkg__fail(TPKG_ERR_ARG);
+  }
+  if (m->version != TPKG_VERSION) {
+    return tpkg__fail(TPKG_ERR_VERSION);
+  }
+  if (m->slot_count == 0 || m->slot_count > TPKG_MAX_SLOTS) {
+    return tpkg__fail(TPKG_ERR_SLOTS);
+  }
+  if (tpkg__strnlen(m->runtime_ref, TPKG_RUNTIME_REF_LEN) == TPKG_RUNTIME_REF_LEN) {
+    return tpkg__fail(TPKG_ERR_INVALID);
+  }
+  for (i = 0; i < m->slot_count; i++) {
+    const tpkg_slot* s = &m->slots[i];
+    if (s->size > UINT64_MAX - s->offset) {
+      return tpkg__fail(TPKG_ERR_INVALID);
+    }
+    if (s->format_id > TPKG_FORMAT_ZIP) {
+      return tpkg__fail(TPKG_ERR_INVALID);
+    }
+    if (tpkg__strnlen(s->mount_point, TPKG_MOUNT_POINT_LEN) == TPKG_MOUNT_POINT_LEN) {
+      return tpkg__fail(TPKG_ERR_INVALID);
+    }
+  }
+  return 0;
+}
+
+/* ---- reader core ------------------------------------------------------------ */
+
+/* read exactly n bytes at absolute offset off (off+n guaranteed in bounds) */
+typedef int (*tpkg__readat_fn)(void* ctx, uint64_t off, void* buf, size_t n);
+
+static int tpkg__mem_readat(void* ctx, uint64_t off, void* buf, size_t n)
+{
+  memcpy(buf, (const uint8_t*)ctx + off, n);
+  return 0;
+}
+
+static int tpkg__fd_readat(void* ctx, uint64_t off, void* buf, size_t n)
+{
+  int fd = *(int*)ctx;
+  if (tpkg__lseek(fd, (tpkg__off_t)off, SEEK_SET) == (tpkg__off_t)-1) {
+    return -1;
+  }
+  return tpkg__read_full(fd, buf, n);
+}
+
+static int tpkg__read_core(tpkg__readat_fn readat, void* ctx, uint64_t size, tpkg_manifest* out)
+{
+  uint8_t hdr[TPKG_HEADER_SIZE];
+  uint8_t table[TPKG_MAX_SLOTS * TPKG_SLOT_SIZE];
+  uint64_t table_off;
+  uint64_t avail;
+  uint32_t version;
+  uint32_t slot_count;
+  uint32_t i;
+
+  if (size < TPKG_HEADER_SIZE) {
+    return tpkg__fail(TPKG_ERR_NO_TRAILER);
+  }
+  if (readat(ctx, size - TPKG_HEADER_SIZE, hdr, TPKG_HEADER_SIZE) != 0) {
+    return tpkg__fail(TPKG_ERR_IO);
+  }
+
+  /* absent vs corrupt: no "TEBA" prefix -> classic bundle, no trailer */
+  if (memcmp(hdr + TPKG__OFF_MAGIC, TPKG_MAGIC, TPKG_MAGIC_PREFIX_LEN) != 0) {
+    return tpkg__fail(TPKG_ERR_NO_TRAILER);
+  }
+  if (memcmp(hdr + TPKG__OFF_MAGIC, TPKG_MAGIC, TPKG_MAGIC_LEN) != 0) {
+    return tpkg__fail(TPKG_ERR_MAGIC);
+  }
+  if (tpkg_crc32(hdr, TPKG__OFF_CRC32) != tpkg__get32(hdr + TPKG__OFF_CRC32)) {
+    return tpkg__fail(TPKG_ERR_CRC);
+  }
+
+  version = tpkg__get32(hdr + TPKG__OFF_VERSION);
+  if (version != TPKG_VERSION) {
+    return tpkg__fail(TPKG_ERR_VERSION);
+  }
+  slot_count = tpkg__get32(hdr + TPKG__OFF_SLOT_COUNT);
+  if (slot_count == 0 || slot_count > TPKG_MAX_SLOTS) {
+    return tpkg__fail(TPKG_ERR_SLOTS);
+  }
+
+  table_off = tpkg__get64(hdr + TPKG__OFF_TABLE);
+  avail = size - TPKG_HEADER_SIZE; /* bytes preceding the header */
+  /* overflow-free: table must fit entirely before the header */
+  if (table_off > avail || (uint64_t)slot_count > (avail - table_off) / TPKG_SLOT_SIZE) {
+    return tpkg__fail(TPKG_ERR_BOUNDS);
+  }
+  if (readat(ctx, table_off, table, (size_t)slot_count * TPKG_SLOT_SIZE) != 0) {
+    return tpkg__fail(TPKG_ERR_IO);
+  }
+
+  memset(out, 0, sizeof *out);
+  out->version = version;
+  out->package_flags = tpkg__get32(hdr + TPKG__OFF_PACKAGE_FLAGS);
+  out->slot_count = slot_count;
+  out->launcher_abi = tpkg__get32(hdr + TPKG__OFF_LAUNCHER_ABI);
+  memcpy(out->runtime_ref, hdr + TPKG__OFF_RUNTIME_REF, TPKG_RUNTIME_REF_LEN);
+  for (i = 0; i < slot_count; i++) {
+    const uint8_t* rec = table + (size_t)i * TPKG_SLOT_SIZE;
+    tpkg_slot* s = &out->slots[i];
+    s->offset = tpkg__get64(rec + TPKG__REC_OFFSET);
+    s->size = tpkg__get64(rec + TPKG__REC_SIZE);
+    s->format_id = tpkg__get32(rec + TPKG__REC_FORMAT);
+    s->flags = tpkg__get32(rec + TPKG__REC_FLAGS);
+    memcpy(s->mount_point, rec + TPKG__REC_MOUNT, TPKG_MOUNT_POINT_LEN);
+  }
+
+  /* structural sanity of the parsed manifest (a valid crc does not imply
+   * well-formed fields when the trailer was not written by us) */
+  return tpkg_validate(out);
+}
+
+int tpkg_read_fd(int fd, tpkg_manifest* out)
+{
+  tpkg__off_t end;
+  tpkg__last_err = TPKG_OK;
+  if (fd < 0 || out == NULL) {
+    return tpkg__fail(TPKG_ERR_ARG);
+  }
+  end = tpkg__lseek(fd, 0, SEEK_END);
+  if (end == (tpkg__off_t)-1) {
+    return tpkg__fail(TPKG_ERR_IO);
+  }
+  return tpkg__read_core(tpkg__fd_readat, &fd, (uint64_t)end, out);
+}
+
+int tpkg_read_mem(const void* data, size_t size, tpkg_manifest* out)
+{
+  tpkg__last_err = TPKG_OK;
+  if (data == NULL || out == NULL) {
+    return tpkg__fail(TPKG_ERR_ARG);
+  }
+  return tpkg__read_core(tpkg__mem_readat, (void*)data, (uint64_t)size, out);
+}
+
+/* ---- writer ----------------------------------------------------------------- */
+
+int tpkg_write_fd(int fd, const tpkg_manifest* m)
+{
+  uint8_t buf[TPKG_MAX_SLOTS * TPKG_SLOT_SIZE + TPKG_HEADER_SIZE];
+  uint8_t* p = buf;
+  uint8_t* hdr;
+  tpkg__off_t end;
+  size_t total;
+  uint32_t i;
+
+  tpkg__last_err = TPKG_OK;
+  if (fd < 0 || m == NULL) {
+    return tpkg__fail(TPKG_ERR_ARG);
+  }
+  if (tpkg_validate(m) != 0) {
+    return -1; /* tpkg_errno set by tpkg_validate; nothing appended */
+  }
+
+  end = tpkg__lseek(fd, 0, SEEK_END);
+  if (end == (tpkg__off_t)-1) {
+    return tpkg__fail(TPKG_ERR_IO);
+  }
+
+  /* slot table */
+  for (i = 0; i < m->slot_count; i++) {
+    const tpkg_slot* s = &m->slots[i];
+    tpkg__put64(p + TPKG__REC_OFFSET, s->offset);
+    tpkg__put64(p + TPKG__REC_SIZE, s->size);
+    tpkg__put32(p + TPKG__REC_FORMAT, s->format_id);
+    tpkg__put32(p + TPKG__REC_FLAGS, s->flags);
+    tpkg__put_str(p + TPKG__REC_MOUNT, s->mount_point, TPKG_MOUNT_POINT_LEN);
+    p += TPKG_SLOT_SIZE;
+  }
+
+  /* trailer header */
+  hdr = p;
+  memcpy(hdr + TPKG__OFF_MAGIC, TPKG_MAGIC, TPKG_MAGIC_LEN);
+  tpkg__put32(hdr + TPKG__OFF_VERSION, m->version);
+  tpkg__put32(hdr + TPKG__OFF_PACKAGE_FLAGS, m->package_flags);
+  tpkg__put32(hdr + TPKG__OFF_SLOT_COUNT, m->slot_count);
+  tpkg__put64(hdr + TPKG__OFF_TABLE, (uint64_t)end);
+  tpkg__put_str(hdr + TPKG__OFF_RUNTIME_REF, m->runtime_ref, TPKG_RUNTIME_REF_LEN);
+  tpkg__put32(hdr + TPKG__OFF_LAUNCHER_ABI, m->launcher_abi);
+  tpkg__put32(hdr + TPKG__OFF_CRC32, tpkg_crc32(hdr, TPKG__OFF_CRC32));
+  p += TPKG_HEADER_SIZE;
+
+  total = (size_t)(p - buf);
+  if (tpkg__write_full(fd, buf, total) != 0) {
+    return tpkg__fail(TPKG_ERR_IO);
+  }
+  return 0;
+}
+
+#endif /* TPKG_IMPLEMENTATION */

--- a/src/tebako-main.cpp
+++ b/src/tebako-main.cpp
@@ -35,6 +35,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdint.h>
+#include <limits.h>
 
 #include <string>
 #include <cstdint>
@@ -45,6 +46,11 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <windows.h>
+#include <io.h>
+#endif
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
 #endif
 
 #include <tebako/tebako-config.h>
@@ -55,9 +61,156 @@
 #include <tebako/tebako-fs.h>
 #include <tebako/tebako-cmdline.h>
 
+/*
+ * tpkg manifest trailer reader (Stage 3A).
+ * Vendored copy of libtfs include/tebako/tpkg.h @ 37166d3 (PR #155) at
+ * include/tebako/tpkg.h in this repo -- keep in sync with upstream.
+ * TPKG_IMPLEMENTATION is defined in exactly this translation unit.
+ */
+#define TPKG_IMPLEMENTATION
+#include <tebako/tpkg.h>
+
 static int running_miniruby = 0;
 static tebako::cmdline_args* args = nullptr;
 static std::vector<char> package;
+/* Owns the self-executable bytes when a tpkg trailer mount replaces the
+   incbin image; process-lifetime like the incbin section itself. */
+static std::vector<char> self_image;
+
+namespace {
+
+/* Path of the running executable, UTF-8 (best effort; empty on failure) */
+std::string self_executable_path()
+{
+#if defined(_WIN32)
+  wchar_t wbuf[32768];
+  DWORD n = GetModuleFileNameW(nullptr, wbuf, static_cast<DWORD>(sizeof(wbuf) / sizeof(wbuf[0])));
+  if (n == 0 || n >= sizeof(wbuf) / sizeof(wbuf[0])) {
+    return std::string();
+  }
+  int len = WideCharToMultiByte(CP_UTF8, 0, wbuf, n, nullptr, 0, nullptr, nullptr);
+  if (len <= 0) {
+    return std::string();
+  }
+  std::string out(static_cast<size_t>(len), '\0');
+  WideCharToMultiByte(CP_UTF8, 0, wbuf, n, out.data(), len, nullptr, nullptr);
+  return out;
+#elif defined(__APPLE__)
+  uint32_t bufsize = 0;
+  _NSGetExecutablePath(nullptr, &bufsize);
+  std::vector<char> buf(bufsize);
+  if (_NSGetExecutablePath(buf.data(), &bufsize) != 0) {
+    return std::string();
+  }
+  char resolved[PATH_MAX];
+  if (realpath(buf.data(), resolved) != nullptr) {
+    return std::string(resolved);
+  }
+  return std::string(buf.data());
+#else
+  char buf[PATH_MAX];
+  ssize_t n = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+  if (n <= 0) {
+    return std::string();
+  }
+  buf[n] = '\0';
+  return std::string(buf);
+#endif
+}
+
+/* Open the running executable read-only; returns fd or -1 */
+int open_self_executable(const std::string& path)
+{
+#if defined(_WIN32)
+  int wlen = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, nullptr, 0);
+  if (wlen <= 0) {
+    return -1;
+  }
+  std::vector<wchar_t> wpath(static_cast<size_t>(wlen));
+  MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, wpath.data(), wlen);
+  return _wopen(wpath.data(), _O_RDONLY | _O_BINARY);
+#else
+  return open(path.c_str(), O_RDONLY);
+#endif
+}
+
+/*
+ * Probe the own executable for a tpkg manifest trailer.
+ *
+ * Returns 1 if a valid trailer was read into `manifest`, 0 if no trailer is
+ * present (classic incbin bundle -- caller falls back), and -1 if a corrupt
+ * trailer was detected (caller must fail startup; spec §6: never a partial
+ * mount). On return values other than 0 a message naming the binary is
+ * printed for the corrupt case.
+ */
+int read_self_manifest(tpkg_manifest* manifest)
+{
+  std::string self = self_executable_path();
+  if (self.empty()) {
+    return 0;  // cannot locate self -- treat as classic bundle
+  }
+
+  int fd = open_self_executable(self);
+  if (fd < 0) {
+    return 0;
+  }
+
+  int rc = tpkg_read_fd(fd, manifest);
+  if (rc == 0) {
+    // Validate slot geometry against the real file size; a CRC-valid
+    // manifest pointing outside the file is still corrupt for us.
+    off_t fsize = lseek(fd, 0, SEEK_END);
+    close(fd);
+    if (fsize < 0) {
+      return 0;
+    }
+    for (uint32_t i = 0; i < manifest->slot_count; ++i) {
+      const tpkg_slot& s = manifest->slots[i];
+      if (s.offset > static_cast<uint64_t>(fsize) || s.size > static_cast<uint64_t>(fsize) - s.offset) {
+        printf(
+            "Tebako: package manifest trailer in '%s' is corrupt (slot %u outside file bounds). "
+            "Re-stitch the package to repair the manifest.\n",
+            self.c_str(), i);
+        return -1;
+      }
+    }
+    return 1;
+  }
+
+  close(fd);
+  int err = tpkg_errno();
+  if (err == TPKG_ERR_NO_TRAILER) {
+    return 0;  // classic bundle, not an error
+  }
+
+  printf(
+      "Tebako: package manifest trailer in '%s' is corrupt (%s). "
+      "Re-stitch the package to repair the manifest.\n",
+      self.c_str(), tpkg_strerror(err));
+  return -1;
+}
+
+/* Read the whole file behind `fd` into self_image; 0 on success */
+int read_self_image(int fd)
+{
+  off_t fsize = lseek(fd, 0, SEEK_END);
+  if (fsize <= 0 || lseek(fd, 0, SEEK_SET) != 0) {
+    return -1;
+  }
+  self_image.resize(static_cast<size_t>(fsize));
+  size_t got = 0;
+  while (got < static_cast<size_t>(fsize)) {
+    ssize_t r = read(fd, self_image.data() + got, static_cast<size_t>(fsize) - got);
+    if (r <= 0) {
+      self_image.clear();
+      return -1;
+    }
+    got += static_cast<size_t>(r);
+  }
+  return 0;
+}
+
+}  // namespace
 
 static void tebako_clean(void)
 {
@@ -89,6 +242,15 @@ extern "C" int tebako_main(int* argc, char*** argv)
     }
     const void* data = &gfsData[0];
     size_t size = gfsSize;
+    std::string root_image_offset = "auto";
+    /* Non-root tpkg slots: (recorded mount point, image offset, image size) */
+    struct extra_slot {
+      std::string mount_point;
+      uint64_t offset;
+      uint64_t size;
+    };
+    std::vector<extra_slot> extra_slots;
+    bool trailer_corrupt = false;
 
     try {
       args = new tebako::cmdline_args(*argc, (const char**)*argv);
@@ -106,14 +268,86 @@ extern "C" int tebako_main(int* argc, char*** argv)
         }
       }
 
-      fsret = mount_root_memfs(data, size, tebako::fs_log_level, nullptr, nullptr, nullptr, nullptr, "auto");
-      if (fsret == 0) {
-        args->process_mountpoints();
-        args->build_arguments(mount_point.c_str(), entry_point.c_str());
-        *argc = args->get_argc();
-        *argv = args->get_argv();
-        ret = 0;
-        atexit(tebako_clean);
+      if (data == &gfsData[0]) {
+        /*
+         * Incbin bundle startup: probe the own executable for a tpkg
+         * manifest trailer (Stage 3A, spec §4.3).
+         *  - trailer present: mount each slot at its recorded mount point via
+         *    the legacy memfs path with the slot's explicit offset
+         *  - no trailer: classic incbin mount below, unchanged
+         *  - corrupt trailer: clean startup error (spec §6), no mount at all
+         */
+        tpkg_manifest manifest;
+        int probe = read_self_manifest(&manifest);
+        if (probe < 0) {
+          trailer_corrupt = true;
+        }
+        else if (probe > 0) {
+          std::string self = self_executable_path();
+          int fd = open_self_executable(self);
+          if (fd >= 0 && read_self_image(fd) == 0) {
+            close(fd);
+            /* Root slot: the one recorded at the package mount point;
+               fall back to slot 0 (mounted at the compiled-in root). */
+            uint32_t root_slot = 0;
+            for (uint32_t i = 0; i < manifest.slot_count; ++i) {
+              if (mount_point == manifest.slots[i].mount_point) {
+                root_slot = i;
+                break;
+              }
+            }
+            /*
+             * Mount each slot through a memory window covering exactly the
+             * slot's image: the legacy memfs API takes an image offset but
+             * no image size, and DwarFS parses up to the end of the view --
+             * a whole-file view would let it run into the trailer. The
+             * slot's explicit file offset selects the window; the image
+             * sits at offset 0 within it.
+             */
+            data = self_image.data() + manifest.slots[root_slot].offset;
+            size = static_cast<size_t>(manifest.slots[root_slot].size);
+            root_image_offset = "0";
+            for (uint32_t i = 0; i < manifest.slot_count; ++i) {
+              if (i != root_slot) {
+                extra_slots.push_back(
+                    {std::string(manifest.slots[i].mount_point), manifest.slots[i].offset, manifest.slots[i].size});
+              }
+            }
+          }
+          else {
+            if (fd >= 0) {
+              close(fd);
+            }
+            printf("Tebako: failed to read package image from '%s': %s\n", self.c_str(), strerror(errno));
+            trailer_corrupt = true;
+          }
+        }
+      }
+
+      if (!trailer_corrupt) {
+        fsret = mount_root_memfs(data, size, tebako::fs_log_level, nullptr, nullptr, nullptr, nullptr,
+                                 root_image_offset.c_str());
+        if (fsret == 0) {
+          for (const auto& slot : extra_slots) {
+            // mount_memfs_at_root returns the memfs table index on success,
+            // -1 on failure
+            if (mount_memfs_at_root(self_image.data() + slot.offset, static_cast<unsigned int>(slot.size), "0",
+                                    slot.mount_point.c_str()) == -1) {
+              printf("Tebako: failed to mount package slot at '%s'\n", slot.mount_point.c_str());
+              unmount_root_memfs();  // spec §6: never a partial mount
+              fsret = -1;
+              break;
+            }
+          }
+        }
+        if (fsret == 0) {
+          args->process_mountpoints();
+          args->build_arguments(mount_point.c_str(), entry_point.c_str());
+          *argc = args->get_argc();
+          *argv = args->get_argv();
+          ret = 0;
+          atexit(tebako_clean);
+        }
       }
     }
     catch (std::exception e) {


### PR DESCRIPTION
**Merges after the thrift-free engine PR** (base branch: `feat/thrift-free-libtfs-engine`).

## Summary

tebako-main now probes the own executable for a **tpkg manifest trailer** at incbin startup (spec §4.3/§6) and, when one is present, mounts the recorded images instead of the incbin section:

- **Trailer present** — each slot is mounted at its recorded mount point via the legacy memfs path with the slot's explicit offset. The root slot is the one recorded at `fs_mount_point` (fallback: slot 0). Runtime surface stays the legacy mount API (`mount_root_memfs` / `mount_memfs_at_root`); the modern `tebako_fs_init_from_file_at` (libtfs PR #156) is for other consumers.
- **No trailer** — classic incbin mount, unchanged (back-compat).
- **Corrupt trailer** (bad magic / bad CRC / slots outside file bounds) — clean startup error naming the binary and suggesting re-stitch; **never a partial mount** (a failed extra-slot mount tears the root mount back down).

## Implementation notes

- `include/tebako/tpkg.h` is a **vendored, byte-identical** copy of libtfs `include/tebako/tpkg.h` @ 37166d3 (libtfs PR #155) — vendoring avoids build-order coupling; **keep in sync with upstream** (sha256 `11fa0c87…5d15`). No CMake changes needed (`tebako-main.cpp` already compiles with `-I include`).
- Self-executable path: `/proc/self/exe` (Linux), `_NSGetExecutablePath` + `realpath` (macOS), `GetModuleFileNameW` → UTF-8 → `_wopen` (Windows).
- Slots are mounted through **memory windows covering exactly the slot image** (`base + slot.offset`, `slot.size`, image offset `0`): the legacy memfs API takes an image offset but no image size, and DwarFS parses up to the end of the view — a whole-file view would run into the appended slot table + trailer (`truncated section header` error).
- `mount_memfs_at_root` returns the memfs table **index** on success and `-1` on failure (not `0`/`-1`) — handled accordingly.

## Verification (macOS arm64)

Press: `exe/tebako press -D -R 3.3.7 --root tests/test-00 --entry-point test.rb`. A tiny C stitcher (`tpkg.h` only) appended mkdwarfs images + manifest to the pressed binary:

| Case | Result |
|---|---|
| plain binary (no trailer) | `Hello!  This is test-00 talking from inside DwarFS`, exit 0 — incbin path unchanged |
| 1-slot trailer (image at offset 24246304, mount `/__tebako_memfs__`) | prints the **appended** image's marker entry file, exit 0 |
| `--tebako-extract` on stitched binary | extracts the appended image (marker `local/test.rb`) |
| corrupt CRC (1 byte in covered region) | `Tebako: package manifest trailer in '<binary>' is corrupt (tpkg trailer header crc32 mismatch). Re-stitch the package to repair the manifest.` — exit 255, no mount |
| corrupt magic (suffix byte) | same shape (`corrupt tpkg trailer magic`), exit 255 |

rspec: **465 examples, 0 failures**. libtfs ctest (PR #156 branch): **391/391 green**.

## Known limitation (pre-existing, not introduced here)

A 2+ slot package's **non-root slots** mount successfully but their content is unreadable due to a libtfs/dwarfs-t multi-memfs engine bug: the FlatBuffers metadata path (`common_metadata_operations.cpp`) double-subtracts `inode_offset` (`find(int)` subtracts before building the inode view; `opendir`/`readdir`/`getattr` subtract again), so any memfs with index ≥ 1 resolves out of bounds. The legacy multiply-chained-memfs test is not wired into the libtfs build, so nothing active covers it. Single-slot packages (Stage 3A-2) are unaffected; multi-slot mounting will start working once the engine is fixed (dwarfs-t change, out of scope here). Tracked in the SDD report `.superpowers/sdd/s3a-task-2-report.md`.