### PR TITLE
feat: runtime manager — resolve/download/verify/cache prebuilt runtimes (Stage 3A-3)

### DIFF
--- a/lib/tebako/cli.rb
+++ b/lib/tebako/cli.rb
@@ -38,6 +38,7 @@ require_relative "cache_manager"
 require_relative "cli_helpers"
 require_relative "error"
 require_relative "ruby_version"
+require_relative "runtime_manager"
 require_relative "scenario_manager"
 require_relative "version"
 
@@ -45,6 +46,78 @@ require_relative "version"
 # Implementation of tebako command-line interface
 module Tebako
   DEFAULT_TEBAFILE = ".tebako.yml"
+
+  # 'tebako cache' subcommands: machine-wide prebuilt runtime package cache
+  class CacheCli < Thor
+    package_name "tebako cache"
+
+    desc "list", "List cached tebako runtime packages with sizes and ages"
+    def list
+      entries = runtime_manager.entries
+      return puts empty_message if entries.empty?
+
+      entries.each { |entry| puts entry_line(entry) }
+      puts total_line(entries)
+    end
+
+    desc "prune", "Remove cached tebako runtime packages"
+    method_option :all, type: :boolean, default: false, desc: "Remove all cached runtime packages"
+    method_option :"older-than", type: :string,
+                                 desc: "Remove runtime packages installed more than N days ago (e.g. 30d)"
+    def prune
+      removed = do_prune
+      return if removed.nil?
+
+      removed.each { |name| puts "Removed #{name}" }
+      puts "#{removed.size} cached runtime package(s) removed"
+    end
+
+    no_commands do
+      def runtime_manager
+        Tebako::RuntimeManager.new
+      end
+
+      def empty_message
+        "Runtime package cache is empty (#{File.join(runtime_manager.cache_root, "runtimes")})"
+      end
+
+      def entry_line(entry)
+        format("%<name>-44s %<size>9s  %<age>s", name: entry[:name], size: human_size(entry[:size_bytes]),
+                                                 age: human_age(entry[:installed_at]))
+      end
+
+      def total_line(entries)
+        format("%<label>-44s %<size>9s", label: "Total (#{entries.size} package(s))",
+                                         size: human_size(entries.sum { |entry| entry[:size_bytes] }))
+      end
+    end
+
+    no_commands do
+      def do_prune
+        return runtime_manager.prune(all: true) if options[:all]
+
+        match = /\A(?<days>\d+)d?\z/.match(options[:"older-than"].to_s)
+        return runtime_manager.prune(older_than_days: match[:days].to_i) if match
+
+        puts "Nothing to do: pass --all or --older-than Nd"
+        nil
+      end
+
+      def human_size(bytes)
+        format("%.1f MB", bytes / (1024.0 * 1024))
+      end
+
+      def human_age(installed_at)
+        age = Time.now - installed_at
+        if age < 3600 then "#{(age / 60).floor}m ago"
+        elsif age < 86_400 then "#{(age / 3600).floor}h ago"
+        else
+          "#{(age / 86_400).floor}d ago"
+        end
+      end
+    end
+  end
+
   # Tebako packager front-end
   class Cli < Thor # rubocop:disable Metrics/ClassLength
     package_name "Tebako"
@@ -81,6 +154,9 @@ module Tebako
     def hash
       print Digest::SHA256.hexdigest [File.read(File.join(source, "CMakeLists.txt")), Tebako::VERSION].join
     end
+
+    desc "cache SUBCOMMAND", "Manage the machine-wide cache of prebuilt tebako runtime packages"
+    subcommand "cache", Tebako::CacheCli
 
     CWD_DESCRIPTION = <<~DESC
       Current working directory for packaged application. This directory shall be specified relative to root.

--- a/lib/tebako/error.rb
+++ b/lib/tebako/error.rb
@@ -47,6 +47,12 @@ module Tebako
     117 => "Failed to load Gemfile.lock",
     118 => "Bundler version in Gemfile.lock does satisfy minimal Tebako version requirememnts",
     119 => "Failed to find compatible bundler version",
+    120 => "No prebuilt tebako runtime package for the requested Ruby/platform combination",
+    121 => "SHA256 checksum mismatch for downloaded tebako runtime package",
+    122 => "Failed to download tebako runtime package",
+    123 => "TEBAKO_OFFLINE is set and the requested tebako runtime package is not cached",
+    124 => "Runtime package release carries no usable package index",
+    125 => "Timed out waiting for the runtime package cache lock",
     201 => "Warning. Could not create cache version file"
   }.freeze
 

--- a/lib/tebako/runtime_manager.rb
+++ b/lib/tebako/runtime_manager.rb
@@ -1,0 +1,347 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of the Tebako project.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+require "digest"
+require "fileutils"
+require "json"
+require "net/http"
+require "uri"
+
+require_relative "error"
+require_relative "version"
+
+# Tebako - an executable packager
+module Tebako
+  # Resolution, download, verification and machine-wide caching of prebuilt
+  # tebako runtime packages published by tamatebako/tebako-runtime-ruby.
+  #
+  # Cache layout (rooted at $TEBAKO_HOME or ~/.tebako):
+  #   runtimes/ruby-<ruby-version>-<tebakoabi>-<platform>/
+  #     tebako-runtime-<tebakoabi>-<ruby-version>-<platform>[.exe]
+  #     sha256    -- digest the installed file was verified against
+  #     origin    -- URL the package was downloaded from
+  #
+  # Installs are serialized per entry with a flock'd lockfile; packages are
+  # downloaded to tmp/, SHA256-verified against the release index and moved
+  # into place with an atomic rename, so partial downloads never poison the
+  # cache.
+  class RuntimeManager # rubocop:disable Metrics/ClassLength
+    DEFAULT_MIRROR = "https://github.com/tamatebako/tebako-runtime-ruby/releases/download"
+    RUNTIMES_DIR = "runtimes"
+    TMP_DIR = "tmp"
+    LOCK_FILE = ".install.lock"
+    SHA256_FILE = "sha256"
+    ORIGIN_FILE = "origin"
+    RUNTIME_TYPE = "ruby"
+    LOCK_TIMEOUT = 300
+    DOWNLOAD_ATTEMPTS = 3
+    RETRY_DELAY = 1.0
+    REDIRECT_LIMIT = 5
+    INDEX_FILES = ["manifest.json", "SHA256SUMS.txt"].freeze
+
+    # The requested index asset is missing or unusable; try the next one
+    class IndexUnavailable < StandardError; end
+    # A download failed (after redirects/retries, at the HTTP layer)
+    class DownloadFailed < StandardError; end
+
+    class << self
+      def default_cache_root
+        tebako_home = ENV.fetch("TEBAKO_HOME", nil)
+        return tebako_home unless tebako_home.nil? || tebako_home.empty?
+
+        if Gem.win_platform?
+          File.join(ENV.fetch("LOCALAPPDATA", File.join(Dir.home, "AppData", "Local")), "tebako")
+        else
+          File.join(Dir.home, ".tebako")
+        end
+      end
+
+      def resolve(ruby_version, platform, tebako_version: Tebako::VERSION)
+        new.resolve(ruby_version, platform, tebako_version: tebako_version)
+      end
+    end
+
+    def initialize(cache_root: nil, mirror: nil, lock_timeout: LOCK_TIMEOUT, retry_delay: RETRY_DELAY)
+      @cache_root = cache_root || self.class.default_cache_root
+      @mirror = (mirror || ENV.fetch("TEBAKO_RUNTIME_MIRROR", nil) || DEFAULT_MIRROR).sub(%r{/+\z}, "")
+      @lock_timeout = lock_timeout
+      @retry_delay = retry_delay
+    end
+
+    attr_reader :cache_root
+
+    def resolve(ruby_version, platform, tebako_version: Tebako::VERSION)
+      dir = entry_dir(ruby_version, platform, tebako_version)
+      executable = File.join(dir, runtime_filename(ruby_version, platform, tebako_version))
+      return executable if File.file?(executable)
+
+      with_entry_lock(dir, runtime_ref(ruby_version, platform, tebako_version)) do
+        install(executable, ruby_version, platform, tebako_version) unless File.file?(executable)
+      end
+      executable
+    end
+
+    def entries
+      base = File.join(@cache_root, RUNTIMES_DIR)
+      return [] unless Dir.exist?(base)
+
+      Dir.children(base).sort.filter_map do |name|
+        path = File.join(base, name)
+        next unless File.directory?(path)
+
+        { name: name, path: path, size_bytes: dir_size(path), installed_at: File.mtime(path) }
+      end
+    end
+
+    def prune(all: false, older_than_days: nil)
+      raise ArgumentError, "prune requires :all or :older_than_days" unless all || older_than_days
+
+      cutoff = older_than_days && (Time.now - (older_than_days * 86_400))
+      entries.each_with_object([]) do |entry, removed|
+        next unless all || entry[:installed_at] < cutoff
+
+        FileUtils.rm_rf(entry[:path], secure: true)
+        removed << entry[:name]
+      end
+    end
+
+    private
+
+    def install(executable, ruby_version, platform, tebako_version)
+      ref = runtime_ref(ruby_version, platform, tebako_version)
+      offline_check(ref, tebako_version)
+      entry = find_entry(fetch_index(tebako_version), ruby_version, platform, tebako_version)
+      url = package_url(entry["filename"], tebako_version)
+      tmp = download(url, entry["filename"])
+      verify!(tmp, entry)
+      place(tmp, executable, entry, url)
+    end
+
+    def offline_check(ref, tebako_version)
+      return unless offline?
+
+      Tebako.packaging_error(123, "#{ref} is not cached and downloads are disabled " \
+                                  "(release index: #{index_urls(tebako_version).join(", ")}; " \
+                                  "TEBAKO_RUNTIME_MIRROR=#{@mirror})")
+    end
+
+    def find_entry(index, ruby_version, platform, tebako_version)
+      entry = index.find { |candidate| candidate["ruby_version"] == ruby_version && candidate["platform"] == platform }
+      return entry if entry
+
+      combos = index.map { |candidate| "#{candidate["ruby_version"]}/#{candidate["platform"]}" }
+      Tebako.packaging_error(120, "no package for ruby #{ruby_version} on #{platform} " \
+                                  "(tebako #{tebako_version}). Available: #{combos.join(", ")}. " \
+                                  "Use --build-runtime to build the runtime from source instead.")
+    end
+
+    def verify!(tmp, entry)
+      actual = Digest::SHA256.file(tmp).hexdigest
+      expected = entry["sha256"].to_s.downcase
+      return if actual == expected
+
+      FileUtils.rm_f(tmp)
+      Tebako.packaging_error(121, "#{entry["filename"]}: expected #{expected}, got #{actual}; download deleted")
+    end
+
+    def place(tmp, executable, entry, url)
+      FileUtils.chmod(0o755, tmp)
+      File.rename(tmp, executable)
+      dir = File.dirname(executable)
+      File.write(File.join(dir, SHA256_FILE), "#{entry["sha256"]}\n")
+      File.write(File.join(dir, ORIGIN_FILE), "#{url}\n")
+    end
+
+    def fetch_index(tebako_version)
+      tried = []
+      INDEX_FILES.each do |name|
+        return parse_index(name, fetch_text(index_url(name, tebako_version)), tebako_version)
+      rescue IndexUnavailable
+        tried << index_url(name, tebako_version)
+      rescue DownloadFailed => e
+        Tebako.packaging_error(122, e.message)
+      end
+      Tebako.packaging_error(124, "tebako-runtime-ruby release v#{tebako_version} provides no usable package " \
+                                  "index (tried: #{tried.join(", ")})")
+    end
+
+    def parse_index(name, body, tebako_version)
+      name == "manifest.json" ? parse_manifest(body, tebako_version) : parse_sha256sums(body, tebako_version)
+    end
+
+    def parse_manifest(body, tebako_version)
+      data = JSON.parse(body)
+      raise IndexUnavailable, "manifest.json is not an array" unless data.is_a?(Array)
+
+      data.select { |entry| entry["tebako_version"] == tebako_version && entry["sha256"] && entry["filename"] }
+    rescue JSON::ParserError
+      raise IndexUnavailable, "manifest.json is not valid JSON"
+    end
+
+    def parse_sha256sums(body, tebako_version)
+      pattern = /\Atebako-runtime-#{Regexp.escape(tebako_version)}-(\d+\.\d+\.\d+)-(.+?)(?:\.exe)?\z/
+      body.each_line.filter_map do |line|
+        sha256, file = line.strip.split(/\s+/, 2)
+        match = file && pattern.match(file.sub(/\A\*/, ""))
+        next unless match
+
+        { "tebako_version" => tebako_version, "ruby_version" => match[1], "platform" => match[2],
+          "filename" => file.sub(/\A\*/, ""), "sha256" => sha256.downcase, "size_bytes" => nil }
+      end
+    end
+
+    def download(url, filename)
+      FileUtils.mkdir_p(File.join(@cache_root, TMP_DIR))
+      tmp = File.join(@cache_root, TMP_DIR, "#{filename}.#{Process.pid}.part")
+      File.binwrite(tmp, with_retries(url) { read_url(url) })
+      tmp
+    rescue IndexUnavailable
+      FileUtils.rm_f(tmp)
+      Tebako.packaging_error(122, "#{url}: not found")
+    rescue DownloadFailed => e
+      FileUtils.rm_f(tmp)
+      Tebako.packaging_error(122, e.message)
+    end
+
+    def fetch_text(url)
+      with_retries(url) { read_url(url) }
+    end
+
+    def with_retries(url) # rubocop:disable Metrics/MethodLength
+      attempts = 0
+      begin
+        attempts += 1
+        yield
+      rescue IndexUnavailable
+        raise
+      rescue StandardError => e
+        raise DownloadFailed, retry_message(url, e) if attempts >= DOWNLOAD_ATTEMPTS
+
+        sleep @retry_delay
+        retry
+      end
+    end
+
+    def retry_message(url, error)
+      "failed to download #{url} after #{DOWNLOAD_ATTEMPTS} attempts: #{error.message}"
+    end
+
+    def read_url(url, redirects_left = REDIRECT_LIMIT)
+      uri = URI.parse(url)
+      return read_file_url(uri) if uri.scheme == "file"
+      raise DownloadFailed, "too many redirects fetching #{url}" if redirects_left.zero?
+
+      read_http_url(url, uri, redirects_left)
+    end
+
+    def read_file_url(uri)
+      File.binread(uri.path)
+    rescue Errno::ENOENT
+      raise IndexUnavailable, uri.path
+    end
+
+    def read_http_url(url, uri, redirects_left)
+      response = http_get(uri)
+      case response
+      when Net::HTTPSuccess then response.body
+      when Net::HTTPRedirection
+        read_url(URI.join(url, response["location"]).to_s, redirects_left - 1)
+      when Net::HTTPNotFound then raise IndexUnavailable, url
+      else raise DownloadFailed, "#{response.code} #{response.message} fetching #{url}"
+      end
+    end
+
+    def http_get(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = 15
+      http.read_timeout = 300
+      http.start { |session| session.get(uri.request_uri.empty? ? "/" : uri.request_uri) }
+    end
+
+    def with_entry_lock(dir, ref)
+      FileUtils.mkdir_p(dir)
+      File.open(File.join(dir, LOCK_FILE), File::RDWR | File::CREAT, 0o644) do |lock|
+        acquire_lock(lock, ref)
+        begin
+          yield
+        ensure
+          lock.flock(File::LOCK_UN)
+        end
+      end
+    end
+
+    def acquire_lock(lock, ref)
+      deadline = Time.now + @lock_timeout
+      until lock.flock(File::LOCK_EX | File::LOCK_NB)
+        if Time.now >= deadline
+          Tebako.packaging_error(125, "#{ref}: another process is installing this runtime " \
+                                      "(no lock after #{@lock_timeout}s; lockfile: #{lock.path})")
+        end
+        sleep 0.1
+      end
+    end
+
+    def offline?
+      %w[1 true yes].include?(ENV.fetch("TEBAKO_OFFLINE", "").downcase)
+    end
+
+    def entry_dir(ruby_version, platform, tebako_version)
+      File.join(@cache_root, RUNTIMES_DIR,
+                "#{RUNTIME_TYPE}-#{ruby_version}-#{tebako_version}-#{platform}")
+    end
+
+    def runtime_filename(ruby_version, platform, tebako_version)
+      suffix = platform.start_with?("windows") ? ".exe" : ""
+      "tebako-runtime-#{tebako_version}-#{ruby_version}-#{platform}#{suffix}"
+    end
+
+    def runtime_ref(ruby_version, platform, tebako_version)
+      "ruby@#{ruby_version} (tebako #{tebako_version}, #{platform})"
+    end
+
+    def release_url(tebako_version)
+      "#{@mirror}/v#{tebako_version.to_s.sub(/\Av/, "")}"
+    end
+
+    def index_url(name, tebako_version)
+      "#{release_url(tebako_version)}/#{name}"
+    end
+
+    def index_urls(tebako_version)
+      INDEX_FILES.map { |name| index_url(name, tebako_version) }
+    end
+
+    def package_url(filename, tebako_version)
+      "#{release_url(tebako_version)}/#{filename}"
+    end
+
+    def dir_size(path)
+      Dir.glob(File.join(path, "**", "*")).select { |file| File.file?(file) }.sum { |file| File.size(file) }
+    end
+  end
+end

--- a/spec/tebako/runtime_manager_spec.rb
+++ b/spec/tebako/runtime_manager_spec.rb
@@ -1,0 +1,433 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of the Tebako project.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+require "digest"
+require "fileutils"
+require "json"
+require "stringio"
+require "tmpdir"
+
+require "tebako/cli"
+require "tebako/runtime_manager"
+
+# rubocop:disable Metrics/BlockLength
+
+RSpec.describe Tebako::RuntimeManager do
+  let(:tebako_version) { "0.14.0" }
+  let(:ruby_version) { "3.3.7" }
+  let(:platform) { "macos-arm64" }
+  let(:filename) { "tebako-runtime-#{tebako_version}-#{ruby_version}-#{platform}" }
+  let(:package_body) { "fake tebako runtime binary\n" * 100 }
+  let(:package_sha256) { Digest::SHA256.hexdigest(package_body) }
+
+  let(:other_filename) { "tebako-runtime-#{tebako_version}-3.2.7-linux-gnu-x86_64" }
+  let(:other_body) { "other fake tebako runtime binary\n" }
+  let(:other_sha256) { Digest::SHA256.hexdigest(other_body) }
+
+  let(:win_filename) { "tebako-runtime-#{tebako_version}-#{ruby_version}-windows-x86_64.exe" }
+  let(:win_body) { "MZ fake windows tebako runtime\n" }
+  let(:win_sha256) { Digest::SHA256.hexdigest(win_body) }
+
+  let(:entry_name) { "ruby-#{ruby_version}-#{tebako_version}-#{platform}" }
+  let(:entry_dir) { File.join(@cache_root, "runtimes", entry_name) }
+  let(:executable) { File.join(entry_dir, filename) }
+
+  around do |example|
+    Dir.mktmpdir("tebako-runtime-manager-spec") do |dir|
+      @mirror = File.join(dir, "mirror")
+      @cache_root = File.join(dir, "tebako-home")
+      FileUtils.mkdir_p(release_dir)
+      example.run
+    end
+  end
+
+  def release_dir
+    File.join(@mirror, "v#{tebako_version}")
+  end
+
+  def manager(mirror_url: "file://#{@mirror}", **kwargs)
+    options = { cache_root: @cache_root, mirror: mirror_url, lock_timeout: 5, retry_delay: 0 }.merge(kwargs)
+    Tebako::RuntimeManager.new(**options)
+  end
+
+  def write_packages
+    File.binwrite(File.join(release_dir, filename), package_body)
+    File.binwrite(File.join(release_dir, other_filename), other_body)
+    File.binwrite(File.join(release_dir, win_filename), win_body)
+  end
+
+  def manifest_entries(sha256: package_sha256)
+    [
+      { "tebako_version" => tebako_version, "ruby_version" => ruby_version, "platform" => platform,
+        "filename" => filename, "sha256" => sha256, "size_bytes" => package_body.bytesize },
+      { "tebako_version" => tebako_version, "ruby_version" => "3.2.7", "platform" => "linux-gnu-x86_64",
+        "filename" => other_filename, "sha256" => other_sha256, "size_bytes" => other_body.bytesize },
+      { "tebako_version" => tebako_version, "ruby_version" => ruby_version, "platform" => "windows-x86_64",
+        "filename" => win_filename, "sha256" => win_sha256, "size_bytes" => win_body.bytesize }
+    ]
+  end
+
+  def write_manifest(sha256: package_sha256)
+    File.write(File.join(release_dir, "manifest.json"), JSON.pretty_generate(manifest_entries(sha256: sha256)))
+  end
+
+  def write_sha256sums(sha256: package_sha256)
+    lines = ["#{sha256}  #{filename}", "#{other_sha256}  #{other_filename}", "#{win_sha256}  #{win_filename}"]
+    File.write(File.join(release_dir, "SHA256SUMS.txt"), "#{lines.join("\n")}\n")
+  end
+
+  def with_env(vars)
+    saved = vars.keys.to_h { |key| [key, ENV.fetch(key, nil)] }
+    vars.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    yield
+  ensure
+    saved.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
+
+  describe "#resolve" do
+    context "with a manifest.json index" do
+      before do
+        write_packages
+        write_manifest
+      end
+
+      it "downloads, verifies and installs the runtime into the cache" do
+        path = manager.resolve(ruby_version, platform, tebako_version: tebako_version)
+
+        expect(path).to eq(executable)
+        expect(File.binread(path)).to eq(package_body)
+        expect(File.executable?(path)).to be(true)
+        expect(File.read(File.join(entry_dir, "sha256"))).to include(package_sha256)
+        expect(File.read(File.join(entry_dir, "origin"))).to include(filename)
+      end
+
+      it "returns the cached path without any download on the second resolve" do
+        first = manager.resolve(ruby_version, platform, tebako_version: tebako_version)
+        mtime = File.mtime(first)
+        FileUtils.rm_rf(@mirror)
+
+        second = manager.resolve(ruby_version, platform, tebako_version: tebako_version)
+
+        expect(second).to eq(first)
+        expect(File.mtime(second)).to eq(mtime)
+      end
+
+      it "prefers manifest.json over SHA256SUMS.txt" do
+        write_sha256sums(sha256: "0" * 64)
+        expect(manager.resolve(ruby_version, platform, tebako_version: tebako_version)).to eq(executable)
+      end
+    end
+
+    context "with only a SHA256SUMS.txt index (fallback)" do
+      before do
+        write_packages
+        write_sha256sums
+      end
+
+      it "resolves and verifies the runtime via the checksums file" do
+        path = manager.resolve(ruby_version, platform, tebako_version: tebako_version)
+
+        expect(path).to eq(executable)
+        expect(File.binread(path)).to eq(package_body)
+      end
+
+      it "resolves Windows .exe packages" do
+        path = manager.resolve(ruby_version, "windows-x86_64", tebako_version: tebako_version)
+
+        expect(path).to eq(File.join(@cache_root, "runtimes",
+                                     "ruby-#{ruby_version}-#{tebako_version}-windows-x86_64", win_filename))
+        expect(File.binread(path)).to eq(win_body)
+      end
+    end
+
+    context "when the requested ruby/platform combination is not published" do
+      before do
+        write_packages
+        write_manifest
+      end
+
+      it "fails listing available combinations and the --build-runtime hint" do
+        expect { manager.resolve("9.9.9", platform, tebako_version: tebako_version) }
+          .to raise_error(Tebako::Error) do |error|
+            expect(error.error_code).to eq(120)
+            expect(error.message).to include("3.3.7/macos-arm64", "3.2.7/linux-gnu-x86_64",
+                                             "3.3.7/windows-x86_64", "--build-runtime")
+          end
+      end
+    end
+
+    context "when the release carries neither manifest.json nor SHA256SUMS.txt" do
+      before { write_packages }
+
+      it "fails naming the release and the tried URLs" do
+        expect { manager.resolve(ruby_version, platform, tebako_version: tebako_version) }
+          .to raise_error(Tebako::Error) do |error|
+            expect(error.error_code).to eq(124)
+            expect(error.message).to include("v#{tebako_version}", "manifest.json", "SHA256SUMS.txt")
+          end
+      end
+    end
+
+    context "when the download fails SHA256 verification" do
+      before do
+        write_packages
+        write_manifest(sha256: "f" * 64)
+      end
+
+      it "deletes the download and never poisons the cache" do
+        expect { manager.resolve(ruby_version, platform, tebako_version: tebako_version) }
+          .to raise_error(Tebako::Error) { |error| expect(error.error_code).to eq(121) }
+
+        expect(File.exist?(executable)).to be(false)
+        tmp_glob = File.join(@cache_root, "tmp", "*")
+        expect(Dir.glob(tmp_glob)).to be_empty
+      end
+
+      it "recovers on a later resolve once the index is fixed" do
+        expect { manager.resolve(ruby_version, platform, tebako_version: tebako_version) }
+          .to raise_error(Tebako::Error)
+
+        write_manifest
+        expect(manager.resolve(ruby_version, platform, tebako_version: tebako_version)).to eq(executable)
+      end
+    end
+
+    context "when the network is unreachable" do
+      it "retries and then fails with a clear download error" do
+        unreachable = manager(mirror_url: "http://127.0.0.1:1")
+
+        expect { unreachable.resolve(ruby_version, platform, tebako_version: tebako_version) }
+          .to raise_error(Tebako::Error) do |error|
+            expect(error.error_code).to eq(122)
+            expect(error.message).to include("3 attempts")
+          end
+      end
+    end
+
+    context "when TEBAKO_OFFLINE=1" do
+      it "fails with a clear error naming the runtime reference when not cached" do
+        with_env("TEBAKO_OFFLINE" => "1") do
+          expect { manager.resolve(ruby_version, platform, tebako_version: tebako_version) }
+            .to raise_error(Tebako::Error) do |error|
+              expect(error.error_code).to eq(123)
+              expect(error.message).to include(ruby_version, platform, "TEBAKO_OFFLINE")
+            end
+        end
+      end
+
+      it "serves cache hits without any network access" do
+        write_packages
+        write_manifest
+        path = manager.resolve(ruby_version, platform, tebako_version: tebako_version)
+        FileUtils.rm_rf(@mirror)
+
+        with_env("TEBAKO_OFFLINE" => "1") do
+          expect(manager.resolve(ruby_version, platform, tebako_version: tebako_version)).to eq(path)
+        end
+      end
+    end
+
+    context "with concurrent installers" do
+      before do
+        write_packages
+        write_manifest
+      end
+
+      it "serializes installs so every resolver gets the same intact runtime" do
+        resolver = manager
+        results = Array.new(4) do
+          Thread.new { resolver.resolve(ruby_version, platform, tebako_version: tebako_version) }
+        end.map(&:value)
+
+        expect(results.uniq).to eq([executable])
+        expect(File.binread(executable)).to eq(package_body)
+      end
+
+      it "times out with a clear error when the entry lock is held by another process" do
+        FileUtils.mkdir_p(entry_dir)
+        lock_path = File.join(entry_dir, ".install.lock")
+        File.open(lock_path, File::RDWR | File::CREAT, 0o644) do |lock|
+          lock.flock(File::LOCK_EX)
+          expect { manager(lock_timeout: 0.3).resolve(ruby_version, platform, tebako_version: tebako_version) }
+            .to raise_error(Tebako::Error) do |error|
+              expect(error.error_code).to eq(125)
+              expect(error.message).to match(/lock/i)
+            end
+        end
+      end
+    end
+  end
+
+  describe ".resolve" do
+    it "resolves through TEBAKO_HOME and TEBAKO_RUNTIME_MIRROR" do
+      write_packages
+      write_manifest
+      with_env("TEBAKO_HOME" => @cache_root, "TEBAKO_RUNTIME_MIRROR" => "file://#{@mirror}") do
+        path = Tebako::RuntimeManager.resolve(ruby_version, platform, tebako_version: tebako_version)
+        expect(path).to eq(executable)
+        expect(File.binread(path)).to eq(package_body)
+      end
+    end
+  end
+
+  describe ".default_cache_root" do
+    it "honors TEBAKO_HOME" do
+      with_env("TEBAKO_HOME" => File.join(@cache_root, "custom")) do
+        expect(Tebako::RuntimeManager.default_cache_root).to eq(File.join(@cache_root, "custom"))
+      end
+    end
+
+    it "defaults to ~/.tebako" do
+      with_env("TEBAKO_HOME" => nil) do
+        expect(Tebako::RuntimeManager.default_cache_root).to eq(File.join(Dir.home, ".tebako"))
+      end
+    end
+  end
+
+  describe "#entries and #prune" do
+    def install_fake_entry(name, age_days)
+      dir = File.join(@cache_root, "runtimes", name)
+      FileUtils.mkdir_p(dir)
+      File.binwrite(File.join(dir, "tebako-runtime-fake"), "x" * 1024)
+      stamp = Time.now - (age_days * 86_400)
+      File.utime(stamp, stamp, dir)
+      dir
+    end
+
+    it "lists entries with sizes and ages" do
+      install_fake_entry(entry_name, 2)
+
+      entries = manager.entries
+
+      expect(entries.size).to eq(1)
+      expect(entries.first[:name]).to eq(entry_name)
+      expect(entries.first[:size_bytes]).to eq(1024)
+      expect(entries.first[:installed_at]).to be_within(5).of(Time.now - (2 * 86_400))
+    end
+
+    it "returns an empty list when the cache is empty" do
+      expect(manager.entries).to eq([])
+    end
+
+    it "prunes only entries older than the requested age" do
+      old_dir = install_fake_entry("ruby-3.1.6-0.13.4-linux-gnu-x86_64", 40)
+      new_dir = install_fake_entry(entry_name, 2)
+
+      removed = manager.prune(older_than_days: 30)
+
+      expect(removed).to eq(["ruby-3.1.6-0.13.4-linux-gnu-x86_64"])
+      expect(Dir.exist?(old_dir)).to be(false)
+      expect(Dir.exist?(new_dir)).to be(true)
+    end
+
+    it "prunes everything with :all" do
+      install_fake_entry("ruby-3.1.6-0.13.4-linux-gnu-x86_64", 40)
+      install_fake_entry(entry_name, 2)
+
+      removed = manager.prune(all: true)
+
+      expect(removed.size).to eq(2)
+      expect(Dir.children(File.join(@cache_root, "runtimes"))).to be_empty
+    end
+
+    it "refuses to prune without a selector" do
+      expect { manager.prune }.to raise_error(ArgumentError)
+    end
+  end
+end
+
+RSpec.describe "tebako cache subcommands" do
+  around do |example|
+    Dir.mktmpdir("tebako-cache-cli-spec") do |dir|
+      @cache_root = File.join(dir, "tebako-home")
+      saved = ENV.fetch("TEBAKO_HOME", nil)
+      ENV["TEBAKO_HOME"] = @cache_root
+      example.run
+      saved.nil? ? ENV.delete("TEBAKO_HOME") : ENV["TEBAKO_HOME"] = saved
+    end
+  end
+
+  def install_fake_entry(name, age_days)
+    dir = File.join(@cache_root, "runtimes", name)
+    FileUtils.mkdir_p(dir)
+    File.binwrite(File.join(dir, "tebako-runtime-fake"), "x" * (2 * 1024 * 1024))
+    stamp = Time.now - (age_days * 86_400)
+    File.utime(stamp, stamp, dir)
+    dir
+  end
+
+  def run_cli(*args)
+    stdout = $stdout
+    $stdout = StringIO.new
+    Tebako::Cli.start(args)
+    $stdout.string
+  ensure
+    $stdout = stdout
+  end
+
+  it "cache list shows entries with sizes and ages" do
+    install_fake_entry("ruby-3.3.7-0.14.0-macos-arm64", 3)
+
+    output = run_cli("cache", "list")
+
+    expect(output).to include("ruby-3.3.7-0.14.0-macos-arm64", "2.0 MB", "3d ago")
+  end
+
+  it "cache list reports an empty cache" do
+    expect(run_cli("cache", "list")).to match(/[Ee]mpty/)
+  end
+
+  it "cache prune --all removes every entry" do
+    install_fake_entry("ruby-3.3.7-0.14.0-macos-arm64", 3)
+    install_fake_entry("ruby-3.1.6-0.13.4-linux-gnu-x86_64", 40)
+
+    output = run_cli("cache", "prune", "--all")
+
+    expect(output).to include("Removed ruby-3.3.7-0.14.0-macos-arm64")
+    expect(Dir.children(File.join(@cache_root, "runtimes"))).to be_empty
+  end
+
+  it "cache prune --older-than removes only old entries" do
+    install_fake_entry("ruby-3.3.7-0.14.0-macos-arm64", 3)
+    install_fake_entry("ruby-3.1.6-0.13.4-linux-gnu-x86_64", 40)
+
+    run_cli("cache", "prune", "--older-than", "30d")
+
+    expect(Dir.children(File.join(@cache_root, "runtimes"))).to eq(["ruby-3.3.7-0.14.0-macos-arm64"])
+  end
+
+  it "cache prune without a selector removes nothing" do
+    install_fake_entry("ruby-3.3.7-0.14.0-macos-arm64", 3)
+
+    output = run_cli("cache", "prune")
+
+    expect(output).to match(/--all|--older-than/)
+    expect(Dir.children(File.join(@cache_root, "runtimes"))).to eq(["ruby-3.3.7-0.14.0-macos-arm64"])
+  end
+end
+
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## What

Stage 3A Task 3 ([plan](docs/superpowers/plans/2026-07-19-stage-3-stitch-and-three-part.md), spec §4.4/§6): `Tebako::RuntimeManager` — resolution, download, verification and machine-wide caching of prebuilt tebako runtime packages from [tamatebako/tebako-runtime-ruby](https://github.com/tamatebako/tebako-runtime-ruby/releases), plus `tebako cache list/prune` CLI subcommands. Consumes the hardened pipeline's `manifest.json` (tebako-runtime-ruby#7) with a `SHA256SUMS.txt` fallback parser.

## Contract

- `RuntimeManager.resolve(ruby_version, platform, tebako_version:) → String`: cache hit → path; else fetch index → find combo → download to `tmp/` → SHA256-verify against the release index → atomic rename into the cache.
- Cache root: `$TEBAKO_HOME` or `~/.tebako` (`%LOCALAPPDATA%\tebako` on Windows); layout `runtimes/ruby-<ruby>-<tebakoabi>-<platform>/` holding the executable + `sha256` + `origin` metadata.
- Concurrency: per-entry `flock` with timeout; partial downloads never poison the cache.
- Knobs: `TEBAKO_RUNTIME_MIRROR` (URL prefix override), `TEBAKO_OFFLINE=1` (cache-only).
- Errors (spec §6): missing ruby/platform combo → 120 with available combos + `--build-runtime` hint; sha mismatch → download deleted, 121; network failure → retried 3×, 122; offline miss → 123 naming runtime_ref + index URLs; release with no usable index → 124 naming release + tried URLs; lock timeout → 125.
- stdlib only (`net/http`, `fileutils`, `digest`, `json`) — no new gem deps.

## Verification

- `bundle exec rspec`: **492 examples, 0 failures** (465 existing + 27 new; fixtures served via `file://`, no real network in specs).
- `bundle exec rubocop`: no offenses.
- Live smoke (macOS arm64): resolved real `tebako-runtime-0.14.0-3.3.7-macos-arm64` from the v0.14.0 GitHub release via `manifest.json` (25,519,768 bytes, sha256 `1b51b2fc…1ea87` matches), Mach-O arm64, `--help` runs; second resolve is a cache hit (mtime unchanged, 0.0s); `TEBAKO_OFFLINE=1` serves the hit; SHA256SUMS fallback verified against the real v0.14.0 checksums via a `file://` mirror; real v0.13.4 binary resolved via fallback through a local mirror; `tebako cache list/prune` exercised end-to-end.

## Note on v0.13.4

The v0.13.4 release (pre-hardening) carries **no** `manifest.json` **and no** `SHA256SUMS.txt` — only bare binaries — so the manager correctly refuses it with error 124 (never downloads unverifiable binaries). Runtime packages from v0.14.0 onward are resolvable.

## Out of scope

Wiring resolution into `tebako press` (+`--build-runtime`) is Task 3A-4. No changes to libtfs/dwarfs-t.