### PR TITLE
feat: stitch flow — press from prebuilt runtimes (Stage 3A-4)

### DIFF
--- a/lib/tebako/cli.rb
+++ b/lib/tebako/cli.rb
@@ -173,6 +173,17 @@ module Tebako
       #{" " * 65}# If this parameter is not set, the application will start in the current directory of the host file system.
     DESC
 
+    RUNTIME_DESCRIPTION = <<~DESC
+      Runtime provenance: 'prebuilt' resolves/downloads a prebuilt tebako runtime package and stitches the
+      #{" " * 65}# application image onto it (default for the 'bundle' mode); 'source' keeps the Stage-2 source build.
+      #{" " * 65}# Modes other than 'bundle' always build from source.
+    DESC
+
+    IMAGE_DESCRIPTION = <<~DESC
+      Additional image to stitch into the package, '<path>:<mount-point>'; repeatable, mount points
+      #{" " * 65}# must be distinct. Prebuilt runtime only.
+    DESC
+
     desc "press", "Press tebako image"
     method_option :cwd, type: :string, aliases: "-c", required: false, desc: CWD_DESCRIPTION
     method_option :"log-level", type: :string, aliases: "-l", required: false, enum: %w[error warn debug trace],
@@ -189,6 +200,10 @@ module Tebako
     method_option :mode, type: :string, aliases: "-m", required: false, enum: %w[bundle both runtime application],
                          desc: "Tebako press mode, 'bundle' by default"
     method_option :ref, type: :string, aliases: "-u", required: false, desc: REF_DESCRIPTION
+    method_option :runtime, type: :string, required: false, enum: %w[prebuilt source], desc: RUNTIME_DESCRIPTION
+    method_option :"build-runtime", type: :boolean, required: false,
+                                    desc: "Build the runtime from source (alias for '--runtime source')"
+    method_option :image, type: :array, required: false, desc: IMAGE_DESCRIPTION
 
     def press
       validate_press_options

--- a/lib/tebako/cli_helpers.rb
+++ b/lib/tebako/cli_helpers.rb
@@ -33,7 +33,9 @@ require "rbconfig"
 require_relative "codegen"
 require_relative "error"
 require_relative "options_manager"
+require_relative "runtime_manager"
 require_relative "scenario_manager"
+require_relative "stitcher"
 require_relative "packager_lite"
 
 # Tebako - an executable packager
@@ -85,8 +87,30 @@ module Tebako
       check_warnings(options_manager)
       puts options_manager.press_announce(scenario_manager.msys?)
 
+      if options_manager.prebuilt_runtime?
+        do_press_prebuilt(options_manager, scenario_manager)
+      else
+        do_press_source(options_manager, scenario_manager)
+      end
+    end
+
+    def do_press_source(options_manager, scenario_manager)
       do_press_runtime(options_manager, scenario_manager)
       do_press_application(options_manager, scenario_manager)
+    end
+
+    # Press onto a prebuilt runtime package: resolve (download/verify/cache)
+    # the runtime, deploy the application image, stitch, re-sign on macOS.
+    def do_press_prebuilt(options_manager, scenario_manager)
+      Tebako::Packager.check_prebuilt_env!(options_manager.stash_dir, options_manager.deps_bin_dir)
+      runtime_path = Tebako::RuntimeManager.resolve(options_manager.ruby_ver, options_manager.host_platform)
+      app_image = Tebako::Packager.build_app_image(options_manager, scenario_manager)
+
+      images = [{ path: app_image, mount_point: scenario_manager.fs_mount_point,
+                  format_id: Tebako::Stitcher::FORMAT_DWARFS }] + options_manager.images
+      package = "#{options_manager.package}#{scenario_manager.exe_suffix}"
+      Tebako::Stitcher.stitch(runtime_path, images: images, output: package)
+      puts "Created tebako #{options_manager.output_type_first} at \"#{package}\""
     end
 
     def do_press_application(options_manager, scenario_manager)

--- a/lib/tebako/error.rb
+++ b/lib/tebako/error.rb
@@ -53,6 +53,10 @@ module Tebako
     123 => "TEBAKO_OFFLINE is set and the requested tebako runtime package is not cached",
     124 => "Runtime package release carries no usable package index",
     125 => "Timed out waiting for the runtime package cache lock",
+    126 => "Invalid stitch specification",
+    127 => "Stitch input file is not accessible",
+    128 => "Prebuilt runtime press requires the packaging environment (run 'tebako setup' first)",
+    130 => "Option combination is not supported",
     201 => "Warning. Could not create cache version file"
   }.freeze
 

--- a/lib/tebako/options_manager.rb
+++ b/lib/tebako/options_manager.rb
@@ -33,6 +33,7 @@ require "rbconfig"
 require_relative "codegen"
 require_relative "error"
 require_relative "ruby_version"
+require_relative "stitcher"
 require_relative "version"
 
 # Tebako - an executable packager
@@ -157,6 +158,39 @@ module Tebako
 
     def mode
       @mode ||= @options["mode"].nil? ? "bundle" : @options["mode"]
+    end
+
+    # Runtime provenance: "prebuilt" (resolve/download a prebuilt runtime
+    # package and stitch the application image onto it) or "source" (the
+    # Stage-2 source build). Default is "prebuilt" for the bundle mode;
+    # other modes always build from source, and --build-runtime forces the
+    # source path everywhere (back-compat alias for '--runtime source').
+    def runtime_source
+      @runtime_source ||= checked_runtime_source(requested_runtime_source)
+    end
+
+    def prebuilt_runtime?
+      runtime_source == "prebuilt"
+    end
+
+    # Additional images for the stitched package, from repeatable
+    # '--image <path>:<mount-point>' (split on the last colon so Windows
+    # drive-letter paths survive)
+    def images
+      @images ||= Array(@options["image"]).map do |spec|
+        path, _sep, mount = spec.to_s.rpartition(":")
+        if path.empty? || mount.empty?
+          Tebako.packaging_error(130, "invalid --image specification '#{spec}' ('<path>:<mount-point>' expected)")
+        end
+
+        { path: path, mount_point: mount, format_id: Tebako::Stitcher::FORMAT_DWARFS }
+      end
+    end
+
+    # Platform id of the host, as used by tebako-runtime-ruby package names
+    # (e.g. "macos-arm64", "linux-gnu-x86_64")
+    def host_platform(ostype = RUBY_PLATFORM, arch = RbConfig::CONFIG["host_cpu"])
+      @host_platform ||= "#{host_os_id(ostype)}-#{host_arch_id(arch)}"
     end
 
     def output_folder
@@ -333,6 +367,43 @@ module Tebako
 
     def stash_dir_all
       @stash_dir_all ||= File.join(deps, "stash")
+    end
+
+    private
+
+    def requested_runtime_source
+      explicit = @options["runtime"]
+      return "source" if @options["build-runtime"]
+      return mode == "bundle" ? "prebuilt" : "source" if explicit.nil?
+
+      explicit
+    end
+
+    def checked_runtime_source(source)
+      if source == "prebuilt" && mode != "bundle"
+        Tebako.packaging_error(130, "--runtime prebuilt is supported in bundle mode only (mode: '#{mode}')")
+      end
+      source
+    end
+
+    def host_os_id(ostype)
+      case ostype
+      when /msys|mingw|cygwin/ then "windows"
+      when /darwin/ then "macos"
+      when /linux-musl/ then "linux-musl"
+      when /linux/ then "linux-gnu"
+      else
+        Tebako.packaging_error(112, ostype)
+      end
+    end
+
+    def host_arch_id(arch)
+      case arch
+      when /^(x86_64|amd64)$/ then "x86_64"
+      when /^(aarch64|arm64)$/ then "arm64"
+      else
+        Tebako.packaging_error(112, arch)
+      end
     end
   end
 end

--- a/lib/tebako/packager.rb
+++ b/lib/tebako/packager.rb
@@ -68,7 +68,7 @@ module Tebako
       win32/file.c
     ].freeze
 
-    class << self
+    class << self # rubocop:disable Metrics/ClassLength
       # Create implib
       def create_implib(src_dir, package_src_dir, app_name, ruby_ver)
         a_name = File.basename(app_name, ".*")
@@ -113,6 +113,45 @@ module Tebako
         puts "   ... creating packaging environment at #{src_dir}"
         PatchHelpers.recreate([src_dir, pre_dir, bin_dir])
         FileUtils.cp_r "#{stash_dir}/.", src_dir
+      end
+
+      # Check that the packaging environment the prebuilt-runtime press
+      # needs (pristine Ruby stash + mkdwarfs) is in place
+      def check_prebuilt_env!(stash_dir, deps_bin_dir)
+        missing = []
+        missing << "Ruby environment stash (#{stash_dir})" unless Dir.exist?(stash_dir)
+        missing << "mkdwarfs (#{deps_bin_dir})" if Dir.glob(File.join(deps_bin_dir, "mkdwarfs*")).empty?
+        return if missing.empty?
+
+        Tebako.packaging_error(128, missing.join(", "))
+      end
+
+      # Deploy the application and build its DwarFS image for stitching onto
+      # a prebuilt runtime. Same layout as the bundle-mode image, plus an
+      # entry dispatcher at /local/stub.rb (the runtime's compiled-in entry).
+      def build_app_image(options_manager, scenario_manager) # rubocop:disable Metrics/AbcSize
+        init(options_manager.stash_dir, options_manager.data_src_dir, options_manager.data_pre_dir,
+             options_manager.data_bin_dir)
+        deploy(options_manager.data_src_dir, options_manager.data_pre_dir, options_manager.rv,
+               options_manager.root, scenario_manager.fs_entrance, options_manager.cwd)
+        write_entry_dispatcher(options_manager.data_src_dir, scenario_manager, options_manager.cwd)
+        mkdwarfs(options_manager.deps_bin_dir, options_manager.data_bundle_file, options_manager.data_src_dir)
+        options_manager.data_bundle_file
+      end
+
+      # The prebuilt runtime packages are pressed in 'runtime' mode, so their
+      # compiled-in entry point is /local/stub.rb. A stitched package mounts
+      # the application image as the root filesystem; the dispatcher written
+      # here receives control from the runtime and loads the real entry point
+      # (replicating the bundle-mode working directory when --cwd was given).
+      def write_entry_dispatcher(data_src_dir, scenario_manager, cwd)
+        dispatcher = +""
+        dispatcher << "Dir.chdir(\"#{scenario_manager.fs_mount_point}/#{cwd}\")\n" unless cwd.nil?
+        dispatcher << "load \"#{scenario_manager.fs_mount_point}#{scenario_manager.fs_entry_point}\"\n"
+
+        local_dir = File.join(data_src_dir, "local")
+        FileUtils.mkdir_p(local_dir)
+        File.write(File.join(local_dir, "stub.rb"), dispatcher)
       end
 
       def mkdwarfs(deps_bin_dir, data_bin_file, data_src_dir, descriptor = nil)

--- a/lib/tebako/stitcher.rb
+++ b/lib/tebako/stitcher.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of the Tebako project.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+require "fileutils"
+require "open3"
+require "rbconfig"
+require "zlib"
+
+require_relative "error"
+require_relative "version"
+
+# Tebako - an executable packager
+module Tebako
+  # Stitches tebako images onto a prebuilt runtime binary, producing a
+  # single-file package with a tpkg manifest trailer (spec §4.3).
+  #
+  # Wire layout (all integers little-endian), appended after the runtime:
+  #   [runtime bytes][pad to 8][image 0][pad to 8]...[image n-1]
+  #   [slot table: slot_count x 280 bytes][trailer header: 166 bytes at EOF]
+  #
+  # This is a pure-Ruby reimplementation of the tpkg.h writer (libtfs
+  # include/tebako/tpkg.h); the byte stream is identical to tpkg_write_fd()
+  # for the same manifest. CRC32 is the zlib polynomial (0xEDB88320,
+  # init/xorout 0xFFFFFFFF) — exactly what Zlib.crc32 computes.
+  #
+  # Codesigning: appending bytes invalidates any embedded code signature.
+  # On macOS a signed runtime (ad-hoc included, detected via `codesign -dv`)
+  # is re-signed ad-hoc after stitching (codesign --remove-signature, then
+  # codesign --sign - --force). Note that codesign(1) refuses to re-sign thin
+  # Mach-O binaries carrying trailing payload ("main executable failed strict
+  # validation"), so the re-sign is best-effort: on failure a warning is
+  # printed and the package is kept — the ad-hoc linker signature is
+  # invalidated by construction, but the binary still executes on macOS
+  # (verified on macOS 14/arm64). Re-signing with a real identity remains a
+  # user post-press step. An unsigned runtime is left alone.
+  # On Windows signing is a no-op — re-applying an Authenticode signature
+  # (signtool) is left to the user as a post-press step.
+  class Stitcher # rubocop:disable Metrics/ClassLength
+    MAGIC = "TEBAKOTFS\0".b # 10 bytes, NUL-terminated
+    VERSION = 1
+    MAX_SLOTS = 8
+    HEADER_SIZE = 166
+    SLOT_SIZE = 280
+    MOUNT_POINT_LEN = 256
+    RUNTIME_REF_LEN = 128
+    ALIGNMENT = 8
+
+    FLAG_LEAN = 0x1
+
+    FORMAT_AUTO = 0
+    FORMAT_DWARFS = 1
+    FORMAT_SQUASHFS = 2
+    FORMAT_ZIP = 3
+    FORMAT_IDS = (FORMAT_AUTO..FORMAT_ZIP).freeze
+
+    # Header field offsets
+    OFF_PACKAGE_FLAGS = 14
+    OFF_SLOT_COUNT = 18
+    OFF_TABLE = 22
+    OFF_RUNTIME_REF = 30
+    OFF_CRC32 = 162
+
+    class << self
+      # Stitch +images+ (Array of {path:, mount_point:, format_id:}) onto a
+      # copy of the runtime at +runtime_path+, writing +output+.
+      # lean: true marks the package LEAN and records runtime_ref
+      # ("ruby@<ruby_version>;tebako=<tebako_version>"); classic packages
+      # carry an empty runtime_ref.
+      def stitch(runtime_path, images:, output:, lean: false, ruby_version: nil, # rubocop:disable Metrics/ParameterLists
+                 tebako_version: Tebako::VERSION, launcher_abi: 0)
+        images = normalize_images(images)
+        validate_inputs!(runtime_path, images, lean, ruby_version)
+
+        FileUtils.mkdir_p(File.dirname(output))
+        FileUtils.cp(runtime_path, output)
+        FileUtils.chmod(0o755, output)
+
+        append(images, output, package_flags(lean), runtime_ref(lean, ruby_version, tebako_version), launcher_abi)
+        resign_if_needed(output)
+        output
+      end
+
+      def macos?
+        RbConfig::CONFIG["host_os"] =~ /darwin/i ? true : false
+      end
+
+      # True when +path+ carries any code signature (ad-hoc included)
+      def signed?(path)
+        _out, _err, status = Open3.capture3("codesign", "-dv", path)
+        status.success?
+      rescue Errno::ENOENT
+        false
+      end
+
+      # Re-apply an ad-hoc signature after the binary was mutated; true on
+      # success. codesign(1) refuses to re-sign thin Mach-O binaries with
+      # trailing payload (strict validation) — callers treat failure as
+      # non-fatal (see the class comment).
+      def adhoc_resign(path)
+        system("codesign", "--remove-signature", path, out: File::NULL, err: File::NULL) &&
+          system("codesign", "--sign", "-", "--force", path, out: File::NULL, err: File::NULL)
+      end
+
+      private
+
+      def normalize_images(images)
+        images.map do |image|
+          { path: image[:path], mount_point: image[:mount_point].to_s,
+            format_id: image.fetch(:format_id, FORMAT_DWARFS) }
+        end
+      end
+
+      def validate_inputs!(runtime_path, images, lean, ruby_version)
+        Tebako.packaging_error(126, "at least one image is required") if images.empty?
+        if images.size > MAX_SLOTS
+          Tebako.packaging_error(126, "#{images.size} images given, at most #{MAX_SLOTS} are supported")
+        end
+        if lean && ruby_version.nil?
+          Tebako.packaging_error(126, "lean packages require ruby_version for the runtime_ref")
+        end
+        validate_files!(runtime_path, images)
+        validate_images!(images)
+      end
+
+      def validate_files!(runtime_path, images)
+        Tebako.packaging_error(127, "runtime not found: #{runtime_path}") unless File.file?(runtime_path)
+        images.each do |image|
+          Tebako.packaging_error(127, "image not found: #{image[:path]}") unless File.file?(image[:path])
+        end
+      end
+
+      def validate_images!(images)
+        seen = {}
+        images.each do |image|
+          validate_image!(image)
+          mount = image[:mount_point]
+          Tebako.packaging_error(126, "duplicate mount point '#{mount}'") if seen[mount]
+
+          seen[mount] = true
+        end
+      end
+
+      def validate_image!(image)
+        unless FORMAT_IDS.cover?(image[:format_id])
+          Tebako.packaging_error(126, "invalid format_id #{image[:format_id]} (0..3 expected)")
+        end
+        return unless image[:mount_point].bytesize >= MOUNT_POINT_LEN
+
+        Tebako.packaging_error(126,
+                               "mount point '#{image[:mount_point][0, 32]}...' exceeds #{MOUNT_POINT_LEN - 1} bytes")
+      end
+
+      def package_flags(lean)
+        lean ? FLAG_LEAN : 0
+      end
+
+      def runtime_ref(lean, ruby_version, tebako_version)
+        return "" unless lean
+
+        ref = "ruby@#{ruby_version};tebako=#{tebako_version}"
+        if ref.bytesize >= RUNTIME_REF_LEN
+          Tebako.packaging_error(126, "runtime_ref '#{ref}' exceeds #{RUNTIME_REF_LEN - 1} bytes")
+        end
+        ref
+      end
+
+      # Appends images at 8-byte-aligned offsets; returns slot descriptors
+      def append(images, output, package_flags, runtime_ref, launcher_abi)
+        File.open(output, "ab") do |io|
+          io.seek(0, IO::SEEK_END) # append mode starts at pos 0 until the first write
+          slots = append_images(io, images)
+          write_trailer(io, slots, package_flags, runtime_ref, launcher_abi)
+        end
+      end
+
+      def append_images(io, images)
+        images.map do |image|
+          pad(io)
+          offset = io.pos
+          File.open(image[:path], "rb") { |src| IO.copy_stream(src, io) }
+          { offset: offset, size: io.pos - offset, format_id: image[:format_id], flags: 0,
+            mount_point: image[:mount_point] }
+        end
+      end
+
+      def pad(io)
+        remainder = io.pos % ALIGNMENT
+        io.write("\0" * (ALIGNMENT - remainder)) unless remainder.zero?
+      end
+
+      def write_trailer(io, slots, package_flags, runtime_ref, launcher_abi)
+        slot_table_offset = io.pos
+        slots.each { |slot| io.write(pack_slot(slot)) }
+        io.write(pack_header(slots.size, slot_table_offset, package_flags, runtime_ref, launcher_abi))
+      end
+
+      def pack_slot(slot)
+        [slot[:offset], slot[:size]].pack("Q2") +
+          [slot[:format_id], slot[:flags]].pack("V2") +
+          fixed_string(slot[:mount_point], MOUNT_POINT_LEN)
+      end
+
+      def pack_header(slot_count, slot_table_offset, package_flags, runtime_ref, launcher_abi)
+        header = MAGIC.dup
+        header << [VERSION, package_flags, slot_count].pack("V3")
+        header << [slot_table_offset].pack("Q")
+        header << fixed_string(runtime_ref, RUNTIME_REF_LEN)
+        header << [launcher_abi].pack("V")
+        header << [Zlib.crc32(header)].pack("V") # header bytes [0, 162)
+        header
+      end
+
+      # NUL-padded fixed-width field; callers validate the length beforehand
+      def fixed_string(string, width)
+        string.b.ljust(width, "\0")
+      end
+
+      def resign_if_needed(output)
+        # Windows: no-op. Re-signing an Authenticode-signed runtime is a
+        # documented user post-press step (signtool sign ...).
+        return unless macos?
+        return unless signed?(output)
+        return if adhoc_resign(output)
+
+        warn "Warning: ad-hoc re-sign failed for #{output}; the package still executes on macOS, " \
+             "but its code signature is invalidated by the appended images. " \
+             "Re-sign it with your own identity if you need a valid signature."
+      end
+    end
+  end
+end

--- a/spec/cli_helpers_spec.rb
+++ b/spec/cli_helpers_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Tebako::CliHelpers do
     context "when mode is set to 'bundle'" do
       before do
         options["mode"] = "bundle"
+        options["runtime"] = "source"
       end
 
       let(:options_manager) { Tebako::OptionsManager.new(options) }
@@ -93,6 +94,7 @@ RSpec.describe Tebako::CliHelpers do
     context "when mode is set to 'runtime'" do
       before do
         options["mode"] = "bundle"
+        options["runtime"] = "source"
       end
 
       let(:options_manager) { Tebako::OptionsManager.new(options) }
@@ -118,6 +120,7 @@ RSpec.describe Tebako::CliHelpers do
     context "when package_within_root? is true" do
       before do
         options["mode"] = "bundle"
+        options["runtime"] = "source"
         options["output"] = "/tmp/path/to/root/output"
       end
 
@@ -133,6 +136,51 @@ RSpec.describe Tebako::CliHelpers do
 
         allow(self).to receive(:sleep).with(any_args).and_return(nil)
         expect { do_press(options_manager) }.to output(/WARNING/).to_stdout
+      end
+    end
+
+    context "when runtime is prebuilt (the bundle-mode default)" do
+      before do
+        options["mode"] = "bundle"
+      end
+
+      let(:options_manager) { Tebako::OptionsManager.new(options) }
+
+      it "resolves the runtime, builds the app image and stitches" do
+        expect(Tebako::Packager).to receive(:check_prebuilt_env!)
+        expect(Tebako::RuntimeManager).to receive(:resolve)
+          .with(options_manager.ruby_ver, options_manager.host_platform)
+          .and_return("/cached/runtime")
+        expect(Tebako::Packager).to receive(:build_app_image).and_return("/o/p/fs.bin")
+        expect(Tebako::Stitcher).to receive(:stitch) do |runtime, images:, output:|
+          expect(runtime).to eq("/cached/runtime")
+          expect(images.first[:path]).to eq("/o/p/fs.bin")
+          expect(images.first[:mount_point]).to eq("/__tebako_memfs__")
+          expect(output).to eq(options_manager.package)
+        end
+
+        do_press(options_manager)
+      end
+
+      it "appends --image entries after the application image" do
+        options["image"] = ["/data/extra.tfs:extra"]
+        allow(Tebako::Packager).to receive(:check_prebuilt_env!)
+        allow(Tebako::RuntimeManager).to receive(:resolve).and_return("/cached/runtime")
+        allow(Tebako::Packager).to receive(:build_app_image).and_return("/o/p/fs.bin")
+        expect(Tebako::Stitcher).to receive(:stitch) do |_runtime, images:, **_|
+          expect(images.size).to eq(2)
+          expect(images.last).to eq({ path: "/data/extra.tfs", mount_point: "extra",
+                                      format_id: Tebako::Stitcher::FORMAT_DWARFS })
+        end
+
+        do_press(options_manager)
+      end
+
+      it "fails with error 128 when the packaging environment is missing" do
+        allow(Tebako::Packager).to receive(:check_prebuilt_env!)
+          .and_raise(Tebako::Error.new("Prebuilt runtime press requires the packaging environment", 128))
+        expect(Tebako::RuntimeManager).not_to receive(:resolve)
+        expect { do_press(options_manager) }.to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(128) }
       end
     end
   end

--- a/spec/options_manager_spec.rb
+++ b/spec/options_manager_spec.rb
@@ -824,6 +824,120 @@ RSpec.describe Tebako::OptionsManager do
       expect(options_manager.output_type_second).to eq("application package")
     end
   end
+
+  describe "#runtime_source / #prebuilt_runtime?" do
+    context "when nothing is given and mode is 'bundle'" do
+      let(:options_manager) { Tebako::OptionsManager.new({}) }
+
+      it "defaults to 'prebuilt'" do
+        expect(options_manager.runtime_source).to eq("prebuilt")
+        expect(options_manager.prebuilt_runtime?).to be(true)
+      end
+    end
+
+    context "when nothing is given and mode is not 'bundle'" do
+      let(:options_manager) { Tebako::OptionsManager.new({ "mode" => "runtime" }) }
+
+      it "stays on the source build" do
+        expect(options_manager.runtime_source).to eq("source")
+        expect(options_manager.prebuilt_runtime?).to be(false)
+      end
+    end
+
+    context "when --runtime source is given" do
+      let(:options_manager) { Tebako::OptionsManager.new({ "runtime" => "source" }) }
+
+      it "selects the source build" do
+        expect(options_manager.runtime_source).to eq("source")
+      end
+    end
+
+    context "when --build-runtime is given" do
+      let(:options_manager) { Tebako::OptionsManager.new({ "build-runtime" => true }) }
+
+      it "forces the source build" do
+        expect(options_manager.runtime_source).to eq("source")
+      end
+    end
+
+    context "when --runtime prebuilt is given with a non-bundle mode" do
+      let(:options_manager) { Tebako::OptionsManager.new({ "runtime" => "prebuilt", "mode" => "runtime" }) }
+
+      it "fails with error 130" do
+        expect { options_manager.runtime_source }
+          .to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(130) }
+      end
+    end
+  end
+
+  describe "#images" do
+    context "when --image is not given" do
+      let(:options_manager) { Tebako::OptionsManager.new({}) }
+
+      it "returns an empty list" do
+        expect(options_manager.images).to eq([])
+      end
+    end
+
+    context "when --image is given once" do
+      let(:options_manager) { Tebako::OptionsManager.new({ "image" => ["/data/extra.tfs:extra"] }) }
+
+      it "parses path and mount point with the dwarfs format" do
+        expect(options_manager.images).to eq([{ path: "/data/extra.tfs", mount_point: "extra",
+                                                format_id: Tebako::Stitcher::FORMAT_DWARFS }])
+      end
+    end
+
+    context "when --image is repeated" do
+      let(:options_manager) { Tebako::OptionsManager.new({ "image" => ["a.tfs:/mnt/a", "b.tfs:/mnt/b"] }) }
+
+      it "parses every entry" do
+        expect(options_manager.images.map { |image| image[:mount_point] }).to eq(["/mnt/a", "/mnt/b"])
+      end
+    end
+
+    context "when the path contains a colon (Windows drive letter)" do
+      let(:options_manager) { Tebako::OptionsManager.new({ "image" => ["C:/data/extra.tfs:extra"] }) }
+
+      it "splits on the last colon" do
+        expect(options_manager.images.first[:path]).to eq("C:/data/extra.tfs")
+        expect(options_manager.images.first[:mount_point]).to eq("extra")
+      end
+    end
+
+    context "when the mount point is missing" do
+      let(:options_manager) { Tebako::OptionsManager.new({ "image" => ["a.tfs"] }) }
+
+      it "fails with error 130" do
+        expect { options_manager.images }.to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(130) }
+      end
+    end
+  end
+
+  describe "#host_platform" do
+    let(:options_manager) { Tebako::OptionsManager.new({}) }
+
+    it "maps darwin/arm64 to macos-arm64" do
+      expect(options_manager.host_platform("arm64-darwin23", "arm64")).to eq("macos-arm64")
+    end
+
+    it "maps linux/x86_64 to linux-gnu-x86_64" do
+      expect(options_manager.host_platform("x86_64-linux", "x86_64")).to eq("linux-gnu-x86_64")
+    end
+
+    it "maps linux-musl/aarch64 to linux-musl-arm64" do
+      expect(options_manager.host_platform("aarch64-linux-musl", "aarch64")).to eq("linux-musl-arm64")
+    end
+
+    it "maps msys to windows" do
+      expect(options_manager.host_platform("x64-mingw-ucrt", "x86_64")).to eq("windows-x86_64")
+    end
+
+    it "rejects an unsupported os with error 112" do
+      expect { options_manager.host_platform("sparc-solaris", "sparc") }
+        .to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(112) }
+    end
+  end
 end
 
 # rubocop:enable Metrics/BlockLength

--- a/spec/tebako/stitcher_spec.rb
+++ b/spec/tebako/stitcher_spec.rb
@@ -1,0 +1,279 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+# All rights reserved.
+# This file is a part of the Tebako project.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+require "fileutils"
+require "tmpdir"
+require "zlib"
+
+require "tebako/error"
+require "tebako/stitcher"
+
+# rubocop:disable Metrics/BlockLength
+
+RSpec.describe Tebako::Stitcher do
+  let(:header_size) { Tebako::Stitcher::HEADER_SIZE }
+  let(:slot_size) { Tebako::Stitcher::SLOT_SIZE }
+  let(:magic) { Tebako::Stitcher::MAGIC }
+
+  let(:runtime_body) { "fake tebako runtime binary\n" * 37 } # 1023 bytes, off-alignment on purpose
+  let(:image_one) { "DWARFS-IMAGE-ONE|" * 61 } # 854 bytes
+  let(:image_two) { "dw2|" * 100 } # 400 bytes
+
+  around do |example|
+    Dir.mktmpdir("tebako-stitcher-spec") do |dir|
+      @dir = dir
+      @runtime = File.join(dir, "runtime")
+      File.binwrite(@runtime, runtime_body)
+      @img1 = File.join(dir, "app.tfs")
+      File.binwrite(@img1, image_one)
+      @img2 = File.join(dir, "extra.tfs")
+      File.binwrite(@img2, image_two)
+      @output = File.join(dir, "out", "package")
+      example.run
+    end
+  end
+
+  def stitch(**kwargs)
+    Tebako::Stitcher.stitch(@runtime,
+                            images: [{ path: @img1, mount_point: "/__tebako_memfs__", format_id: 1 }],
+                            output: @output, **kwargs)
+  end
+
+  # Independent reader of the spec §4.3 wire format, used to verify the writer
+  def read_trailer(path)
+    data = File.binread(path)
+    header = data[-Tebako::Stitcher::HEADER_SIZE..]
+    slot_count = header[18, 4].unpack1("V")
+    table_offset = header[22, 8].unpack1("Q")
+    read_header_fields(header).merge(
+      slot_count: slot_count, slot_table_offset: table_offset,
+      slots: read_slots(data, table_offset, slot_count),
+      crc32: header[162, 4].unpack1("V"), crc_region: header[0, 162], total_size: data.size
+    )
+  end
+
+  def read_header_fields(header)
+    { magic: header[0, 10],
+      version: header[10, 4].unpack1("V"),
+      package_flags: header[14, 4].unpack1("V"),
+      runtime_ref: header[30, 128].split("\0", 2).first,
+      launcher_abi: header[158, 4].unpack1("V") }
+  end
+
+  def read_slots(data, table_offset, slot_count)
+    (0...slot_count).map do |i|
+      rec = data[table_offset + (i * Tebako::Stitcher::SLOT_SIZE), Tebako::Stitcher::SLOT_SIZE]
+      { offset: rec[0, 8].unpack1("Q"), size: rec[8, 8].unpack1("Q"),
+        format_id: rec[16, 4].unpack1("V"), flags: rec[20, 4].unpack1("V"),
+        mount_point: rec[24, 256].split("\0", 2).first }
+    end
+  end
+
+  describe ".stitch (classic, single image)" do
+    before { stitch }
+
+    it "copies the runtime verbatim at offset 0" do
+      expect(File.binread(@output, runtime_body.bytesize)).to eq(runtime_body)
+    end
+
+    it "creates the output directory and an executable output" do
+      expect(File.file?(@output)).to be true
+      expect(File.executable?(@output)).to be true
+    end
+
+    it "appends the image at the next 8-byte aligned offset" do
+      trailer = read_trailer(@output)
+      expected_offset = (runtime_body.bytesize + 7) & ~7
+      expect(trailer[:slots].first[:offset]).to eq(expected_offset)
+      expect(File.binread(@output, image_one.bytesize, expected_offset)).to eq(image_one)
+    end
+
+    it "zero-fills the alignment gap" do
+      gap = ((runtime_body.bytesize + 7) & ~7) - runtime_body.bytesize
+      expect(File.binread(@output, gap, runtime_body.bytesize)).to eq("\0" * gap)
+    end
+
+    it "writes the slot table immediately after the last image" do
+      trailer = read_trailer(@output)
+      slot = trailer[:slots].first
+      expect(trailer[:slot_table_offset]).to eq(slot[:offset] + slot[:size])
+    end
+
+    it "writes a spec §4.3 trailer header at EOF" do
+      trailer = read_trailer(@output)
+      expect(trailer[:magic]).to eq(magic)
+      expect(trailer[:version]).to eq(1)
+      expect(trailer[:package_flags]).to eq(0)
+      expect(trailer[:slot_count]).to eq(1)
+      expect(trailer[:runtime_ref]).to eq("")
+      expect(trailer[:launcher_abi]).to eq(0)
+      expect(trailer[:total_size]).to eq(trailer[:slot_table_offset] + slot_size + header_size)
+    end
+
+    it "stores a zlib-polynomial CRC32 of header bytes [0, 162)" do
+      trailer = read_trailer(@output)
+      expect(trailer[:crc32]).to eq(Zlib.crc32(trailer[:crc_region]))
+    end
+
+    it "records slot fields (size, format_id, flags, mount_point)" do
+      slot = read_trailer(@output)[:slots].first
+      expect(slot[:size]).to eq(image_one.bytesize)
+      expect(slot[:format_id]).to eq(1)
+      expect(slot[:flags]).to eq(0)
+      expect(slot[:mount_point]).to eq("/__tebako_memfs__")
+    end
+  end
+
+  describe ".stitch with two images" do
+    it "writes two slot records in order at aligned offsets" do
+      stitch(images: [{ path: @img1, mount_point: "/__tebako_memfs__", format_id: 1 },
+                      { path: @img2, mount_point: "extra", format_id: 0 }])
+      trailer = read_trailer(@output)
+      expect(trailer[:slot_count]).to eq(2)
+
+      first, second = trailer[:slots]
+      expect(first[:offset]).to eq((runtime_body.bytesize + 7) & ~7)
+      expect(second[:offset]).to eq(((first[:offset] + first[:size]) + 7) & ~7)
+      expect(second[:format_id]).to eq(0)
+      expect(second[:mount_point]).to eq("extra")
+      expect(File.binread(@output, image_two.bytesize, second[:offset])).to eq(image_two)
+      expect(trailer[:slot_table_offset]).to eq(second[:offset] + second[:size])
+    end
+  end
+
+  describe ".stitch with lean: true" do
+    it "sets the LEAN package flag and the runtime_ref" do
+      stitch(lean: true, ruby_version: "3.3.7")
+      trailer = read_trailer(@output)
+      expect(trailer[:package_flags] & 0x1).to eq(1)
+      expect(trailer[:runtime_ref]).to eq("ruby@3.3.7;tebako=#{Tebako::VERSION}")
+    end
+
+    it "honours an explicit tebako_version" do
+      stitch(lean: true, ruby_version: "3.2.7", tebako_version: "0.15.0")
+      expect(read_trailer(@output)[:runtime_ref]).to eq("ruby@3.2.7;tebako=0.15.0")
+    end
+
+    it "fails without a ruby_version" do
+      expect { stitch(lean: true) }.to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(126) }
+    end
+  end
+
+  describe "validation" do
+    it "rejects an empty image list" do
+      expect { stitch(images: []) }.to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(126) }
+    end
+
+    it "rejects more than 8 images" do
+      images = Array.new(9) { |i| { path: @img1, mount_point: "m#{i}", format_id: 1 } }
+      expect { stitch(images: images) }.to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(126) }
+    end
+
+    it "rejects duplicate mount points" do
+      images = [{ path: @img1, mount_point: "dup", format_id: 1 }, { path: @img2, mount_point: "dup", format_id: 1 }]
+      expect { stitch(images: images) }.to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(126) }
+    end
+
+    it "rejects a mount point of 256 bytes (255 is accepted)" do
+      expect { stitch(images: [{ path: @img1, mount_point: "m" * 255, format_id: 1 }]) }.not_to raise_error
+      expect { stitch(images: [{ path: @img1, mount_point: "m" * 256, format_id: 1 }]) }
+        .to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(126) }
+    end
+
+    it "rejects an out-of-range format_id" do
+      expect { stitch(images: [{ path: @img1, mount_point: "m", format_id: 4 }]) }
+        .to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(126) }
+    end
+
+    it "rejects a missing runtime" do
+      expect do
+        Tebako::Stitcher.stitch(File.join(@dir, "nope"),
+                                images: [{ path: @img1, mount_point: "m" }], output: @output)
+      end.to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(127) }
+    end
+
+    it "rejects a missing image and does not leave a partial output" do
+      expect { stitch(images: [{ path: File.join(@dir, "nope"), mount_point: "m" }]) }
+        .to raise_error(Tebako::Error) { |e| expect(e.error_code).to eq(127) }
+      expect(File.exist?(@output)).to be false
+    end
+  end
+
+  describe "format_id default" do
+    it "defaults to 1 (dwarfs) when omitted" do
+      stitch(images: [{ path: @img1, mount_point: "/__tebako_memfs__" }])
+      expect(read_trailer(@output)[:slots].first[:format_id]).to eq(1)
+    end
+  end
+
+  describe "macOS ad-hoc re-sign" do
+    it "is a no-op off macOS" do
+      allow(Tebako::Stitcher).to receive(:macos?).and_return(false)
+      expect(Tebako::Stitcher).not_to receive(:adhoc_resign)
+      stitch
+    end
+
+    it "re-signs when the runtime carries a signature" do
+      allow(Tebako::Stitcher).to receive(:macos?).and_return(true)
+      allow(Tebako::Stitcher).to receive(:signed?).and_return(true)
+      expect(Tebako::Stitcher).to receive(:adhoc_resign).with(@output)
+      stitch
+    end
+
+    it "does not touch an unsigned runtime" do
+      allow(Tebako::Stitcher).to receive(:macos?).and_return(true)
+      allow(Tebako::Stitcher).to receive(:signed?).and_return(false)
+      expect(Tebako::Stitcher).not_to receive(:adhoc_resign)
+      stitch
+    end
+
+    it "warns and keeps the package when the re-sign fails" do
+      allow(Tebako::Stitcher).to receive(:macos?).and_return(true)
+      allow(Tebako::Stitcher).to receive(:signed?).and_return(true)
+      allow(Tebako::Stitcher).to receive(:adhoc_resign).and_return(false)
+      expect { stitch }.to output(/ad-hoc re-sign failed/).to_stderr
+      expect(File.file?(@output)).to be true
+      expect(read_trailer(@output)[:magic]).to eq(magic)
+    end
+
+    if Tebako::Stitcher.macos? && system("which codesign > /dev/null 2>&1")
+      it "keeps a stitched signed binary valid (live codesign check)" do
+        signed_runtime = File.join(@dir, "signed-runtime")
+        FileUtils.cp("/bin/echo", signed_runtime)
+        FileUtils.chmod(0o755, signed_runtime)
+        skip "fixture binary is not signed" unless Tebako::Stitcher.signed?(signed_runtime)
+
+        Tebako::Stitcher.stitch(signed_runtime,
+                                images: [{ path: @img1, mount_point: "/__tebako_memfs__", format_id: 1 }],
+                                output: @output)
+        expect(system("codesign", "-v", @output)).to be(true)
+      end
+    end
+  end
+end
+
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## Summary

Stage 3A Task 4 (plan: `docs/superpowers/plans/2026-07-19-stage-3-stitch-and-three-part.md`): press tebako packages from prebuilt runtime binaries by stitching the application image onto them with a tpkg manifest trailer (spec §4.3).

- **`lib/tebako/stitcher.rb`** (new, stdlib only — `zlib`/`fileutils`/`open3`): `Stitcher.stitch(runtime_path, images:, output:, lean: false, ruby_version:, tebako_version:, launcher_abi:)` copies the runtime, appends each image at an 8-byte-aligned offset, and writes the slot table + 166-byte trailer header at EOF. Pure-Ruby reimplementation of the libtfs `tpkg.h` writer — **byte-identical to `tpkg_write_fd`** (evidence below). `lean: true` sets the LEAN package flag and records `runtime_ref` (`ruby@<ver>;tebako=<ver>`); classic packages carry an empty ref.
- **Press wiring**: `tebako press --runtime prebuilt` (**default for the bundle mode**) resolves the runtime via `RuntimeManager`, deploys the app, builds the DwarFS image with `mkdwarfs`, and stitches. `--runtime source` (alias `--build-runtime`, back-compat) keeps the Stage-2 source build; `both`/`runtime`/`application` modes always build from source and are unchanged. `--image <path>:<mount>` (repeatable, distinct mount points) stitches extra images.
- **Entry point**: prebuilt runtimes are pressed in `runtime` mode, so their compiled-in entry is `/local/stub.rb`. The stitched application image carries a tiny dispatcher at that path which loads the real entry point (replicating `--cwd` when given), so a stitched package runs the app on trailer-aware runtimes (PR #338).
- **Codesigning**: on macOS a signed runtime is re-signed ad-hoc after stitching (`codesign --remove-signature` + `codesign --sign - --force`). Note: codesign(1) **refuses to re-sign thin Mach-O binaries with trailing payload** ("main executable failed strict validation"), so failure degrades to a warning — the ad-hoc linker signature is invalidated by construction, but the package still executes (verified). Windows is a documented no-op (Authenticode re-sign via signtool is a user post-press step).

## Byte-compat evidence (vs libtfs `tpkg.h`)

- Same manifest written by C `tpkg_write_fd` and by the Ruby packer → `cmp` **byte-identical** (726 bytes: 2×280 slot records + 166 header).
- C `tpkg_read_fd` parses Ruby-stitched packages: correct version/flags/slots/refs, on both golden stitched binaries below and on a 2-slot package.

## Golden tests (macOS arm64, `tests/test-00`)

| press | runtime | run result |
|---|---|---|
| `--runtime source` | (source build) | `Hello!  This is test-00 talking from inside DwarFS`, exit 0 |
| `--runtime prebuilt` (default) | real `tebako-runtime-0.14.0-3.3.7-macos-arm64` (sha256-verified from the release) | stub banner, exit 0 — **the released runtime predates PR #338 and ignores the trailer** (no `TEBAKOTFS` in its strings); trailer parses validly |
| `--runtime prebuilt` (default) | trailer-aware runtime pressed locally from `feat/stage-3a-trailer` | **`Hello!  This is test-00 talking from inside DwarFS`, exit 0 — stdout and exit code identical to the source-built package** |

Image layout (`--tebako-extract` through each binary, same libtfs engine): **identical except the dispatcher `local/stub.rb`** (by design; Stage 3B's `--tebako-entry` ABI removes the need for it).

## Gates

- `bundle exec rspec`: **535 examples, 0 failures** (492 baseline + 43 new)
- `bundle exec rubocop`: **98 files, no offenses**
- Source-build path re-verified end-to-end with explicit `--runtime source` after wiring.

## Notes / follow-ups

- The prebuilt press deploys from the pristine stash, so it still requires `tebako setup` (clear error 128 otherwise); dropping that requirement needs a prebuilt sysroot artifact (future work).
- Multi-image runtime mounts hit the known pre-existing libtfs/dwarfs-t multi-memfs engine bug documented in the Stage 3A-2 report (PR #338); stitch-side 2-slot output is structurally verified.
- A fresh `tebako setup` currently needs the libtfs v0.12.5 release assets (pin in place; release pending at time of writing).
- Stacked on #339 (base `feat/stage-3a-runtime-manager`); merges after it, same stacking as #338/#339.
