### PR TITLE
Install-UX stack: remote registry + manifest unify + suites + publish (roadmap 33/40/34/41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,10 +268,28 @@ Rust-consumable surface for it.
   against the registry) and is synthesized from the registry's tier-3
   fields otherwise (loud note, `/<command>` path convention); shims link
   through tebako-shim's library API (no spawn). `uninstall` removes
-  shims + cache entry and journals the trust anchors. Remaining for 28:
-  `tebako publish`, the brew tap + install.sh channels, and dispatch-time
-  registry caching for the shim's registry-default chain link (which
-  still reads `file://` registries only).
+  shims + cache entry and journals the trust anchors.
+- **The install-UX stack (spec 04 §2, 03 §6, 16 §5; roadmap 33/40/34/41)**:
+  the shim's registry-default chain link resolves **every registry form**
+  at dispatch behind the per-ref cache
+  `~/.tebako/registries/<sha256-of-ref>.yaml` (24 h TTL, `tebako
+  update-registries`, `TEBAKO_OFFLINE` = cache-or-named-error; `tebako
+  add-registry` primes it, `tebako-shim doctor` reports freshness). The
+  dispatch mirror IS the unified `tpkg::PayloadManifest` (40) — per-entry
+  runtime requirements included, which makes **suites** (34) work end to
+  end: `tebako press --suite <suite.yaml>` (per-entry imaging + slots +
+  the type-2 package manifest with per-entry runtime_refs), the
+  bootstrap's argv0 entry selection (exact match, entries[0] fallback),
+  N shims per installed suite each on its own runtime (two commands of
+  one package run different runtime versions simultaneously), and
+  `tebako install` registers every suite shim. **`tebako publish`** (41):
+  accept per-triplet payloads → optional `--sign[=<keyid>]` (per-artifact
+  `<artifact>.asc`) → upload to the referenced GitHub release in-process
+  (no gh CLI; `--upload-mirror` for file:// rehearsal) →
+  `tpkg-registry.yaml` upsert (idempotent re-publish) → `--tap` formula
+  render from the vendored template → built-in clean-cache `tebako
+  install` proof. Remaining: the GitLab/Bitbucket write legs, the brew
+  tap repo + install.sh channels.
 
 ### SHIPPED (milestone 8)
 

--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -8,11 +8,12 @@
 //! 3. check the trailer's launcher_abi against TEBAKO_BOOTSTRAP_LAUNCHER_ABI;
 //! 4. parse runtime_ref "type@version;tebako=<abi>[;image][;sha256=<hex>]"
 //!    — when the package carries the L2 package manifest (extension block
-//!    type 2, spec 02 §5b / spec 03 §6), its entries[0].runtime_ref is
-//!    used instead of the trailer's 128-byte field (per-entry refs for
-//!    suites and multi-runtime packages; the trailer field stays for
-//!    v1-era loaders and block-less packages behave byte-identically).
-//!    Resolution only — the handoff argv is unchanged (ABI stays 1);
+//!    type 2, spec 02 §5b / spec 03 §6), argv0 selects the entry whose
+//!    runtime_ref is used (exact name match, entries[0] fallback —
+//!    per-entry refs for suites and multi-runtime packages; the trailer
+//!    field stays for v1-era loaders and block-less packages behave
+//!    byte-identically). Resolution only — the handoff argv shape is
+//!    unchanged (ABI stays 1);
 //! 5. resolve the language runtime — shared cache hit, else a fat-package
 //!    payload extraction (SHA256-verified against the ;sha256= parameter of
 //!    runtime_ref), else a download from the tebako-runtime-ruby releases
@@ -196,24 +197,69 @@ pub fn runtime_ref_wants_image(ref_: &str) -> bool {
     ref_.split(';').any(|segment| segment == "image")
 }
 
-/// Which runtime_ref this package resolves against (spec 02 §5b / spec 03
-/// §6): when the package carries the L2 package manifest (extension block
-/// type 2), its `entries[0].runtime_ref` wins — per-entry refs kill the
-/// trailer's 128-byte single-field limit (suites, multi-runtime
-/// packages). A block-less package reads the trailer field exactly as
-/// before (byte-identical behavior). Resolution only — the handoff argv
-/// is unchanged (launcher ABI stays 1).
-pub fn resolution_runtime_ref(m: &tpkg::Manifest) -> Result<String, BootError> {
+/// Which entry of the package manifest `argv0` selects (spec 07 §2.0:
+/// argv0 is the selector). The selector is argv0's file name (both
+/// separators honored on every platform, any `.exe` suffix stripped); an
+/// exact entry-name match wins, otherwise the package's primary entry
+/// (`entries[0]`) — the standalone-download case, where the binary's
+/// file name is arbitrary (version/platform suffixes), always runs the
+/// primary command.
+pub fn select_entry<'a>(pm: &'a tpkg::PackageManifest, argv0: &str) -> &'a tpkg::PackageEntry {
+    let name = argv0.rsplit(['/', '\\']).next().unwrap_or(argv0);
+    let name = name.strip_suffix(".exe").unwrap_or(name);
+    pm.entries
+        .iter()
+        .find(|e| e.name == name)
+        .unwrap_or(&pm.entries[0])
+}
+
+/// The package-manifest selection for this invocation: `None` when the
+/// package carries no type-2 block (v1 behavior, byte-identical), else
+/// the parsed manifest and the entry `argv0` selects. A corrupt block is
+/// a named error; an entry naming a slot the container does not carry is
+/// a named error (the package is internally inconsistent).
+pub fn package_selection(
+    m: &tpkg::Manifest,
+    argv0: &str,
+) -> Result<Option<(tpkg::PackageManifest, tpkg::PackageEntry)>, BootError> {
     match m.package_manifest() {
-        // from_yaml validates: entries is non-empty (N >= 1).
-        Ok(Some(pm)) => Ok(pm.entries[0].runtime_ref.clone()),
-        Ok(None) => Ok(m.runtime_ref_str().unwrap_or_default().to_string()),
+        Ok(Some(pm)) => {
+            let entry = select_entry(&pm, argv0).clone();
+            if entry.slot as usize >= m.slots.len() {
+                return fail(
+                    EX_TEBAKO_MANIFEST,
+                    format!(
+                        "package manifest entry \"{}\" names slot {} but the package carries {} slot(s) — the package is internally inconsistent, re-stitch it",
+                        entry.name,
+                        entry.slot,
+                        m.slots.len()
+                    ),
+                );
+            }
+            Ok(Some((pm, entry.clone())))
+        }
+        Ok(None) => Ok(None),
         Err(e) => fail(
             EX_TEBAKO_MANIFEST,
             format!(
                 "invalid package manifest (extension block type 2): {e} — re-stitch the package"
             ),
         ),
+    }
+}
+
+/// Which runtime_ref this package resolves against (spec 02 §5b / spec 03
+/// §6): when the package carries the L2 package manifest (extension block
+/// type 2), the SELECTED entry's `runtime_ref` wins — per-entry refs kill
+/// the trailer's 128-byte single-field limit (suites, multi-runtime
+/// packages); argv0 selects the entry (exact name match, `entries[0]`
+/// fallback — [`select_entry`]). A block-less package reads the trailer
+/// field exactly as before (byte-identical behavior). Resolution only —
+/// the handoff argv is unchanged in shape (launcher ABI stays 1).
+pub fn resolution_runtime_ref(m: &tpkg::Manifest, argv0: &str) -> Result<String, BootError> {
+    match package_selection(m, argv0)? {
+        Some((_, entry)) => Ok(entry.runtime_ref),
+        None => Ok(m.runtime_ref_str().unwrap_or_default().to_string()),
     }
 }
 
@@ -1623,17 +1669,31 @@ fn resolve_image(
 
 /// The launcher ABI v1 handoff argv — byte-identical on every platform:
 /// nargv[0] is the runtime, then one `--tebako-image <self>:<slot>:<mount>`
-/// pair per non-runtime slot, then `--tebako-entry <argv0> <user args...>`.
-fn handoff_argv(
+/// pair per mounted slot, then `--tebako-entry <entry> <user args...>`.
+///
+/// Suite mount rule (spec 03 §6): the SELECTED entry's slot mounts, slots
+/// referenced by OTHER package-manifest entries do not (suite member
+/// images are mutually exclusive — they share one mount point by
+/// construction), and slots no entry references (extra `--image` payloads)
+/// mount as always. Without a package manifest every non-runtime slot
+/// mounts and `--tebako-entry` is argv0 verbatim — the v1 behavior.
+/// Public for the integration tests; the flow uses it once per run.
+pub fn handoff_argv(
     runtime: &Path,
     self_path: &Path,
     m: &tpkg::Manifest,
+    selection: Option<&(tpkg::PackageManifest, tpkg::PackageEntry)>,
     argv: &[String],
 ) -> Vec<String> {
     let mut nargv: Vec<String> = vec![runtime.to_string_lossy().into_owned()];
     for (s, slot) in m.slots.iter().enumerate() {
         if slot.format_id == tpkg::TPKG_FORMAT_RUNTIME {
             continue; // runtime payload: installed into the cache, never mounted
+        }
+        if let Some((pm, selected)) = selection {
+            if s != selected.slot as usize && pm.entries.iter().any(|e| e.slot as usize == s) {
+                continue; // another suite member's image — not mounted
+            }
         }
         nargv.push("--tebako-image".to_string());
         nargv.push(format!(
@@ -1643,11 +1703,13 @@ fn handoff_argv(
         ));
     }
     nargv.push("--tebako-entry".to_string());
-    nargv.push(
-        argv.first()
+    nargv.push(match selection {
+        Some((_, entry)) => entry.entrypoint.clone(),
+        None => argv
+            .first()
             .cloned()
             .unwrap_or_else(|| self_path.to_string_lossy().into_owned()),
-    );
+    });
     nargv.extend(argv.iter().skip(1).cloned());
     nargv
 }
@@ -1659,11 +1721,12 @@ fn exec_runtime(
     image: Option<&Path>,
     self_path: &Path,
     m: &tpkg::Manifest,
+    selection: Option<&(tpkg::PackageManifest, tpkg::PackageEntry)>,
     argv: &[String],
 ) -> BootError {
     use std::os::unix::process::CommandExt;
 
-    let nargv = handoff_argv(runtime, self_path, m, argv);
+    let nargv = handoff_argv(runtime, self_path, m, selection, argv);
     let mut cmd = std::process::Command::new(runtime);
     cmd.args(&nargv[1..]);
     if let Some(image) = image {
@@ -1692,9 +1755,10 @@ fn exec_runtime(
     image: Option<&Path>,
     self_path: &Path,
     m: &tpkg::Manifest,
+    selection: Option<&(tpkg::PackageManifest, tpkg::PackageEntry)>,
     argv: &[String],
 ) -> BootError {
-    let nargv = handoff_argv(runtime, self_path, m, argv);
+    let nargv = handoff_argv(runtime, self_path, m, selection, argv);
     let err = platform::spawn_handoff(runtime, &nargv[1..], image);
     BootError::new(
         EX_TEBAKO_IO,
@@ -1758,7 +1822,16 @@ pub fn run(argv: &[String]) -> Result<std::convert::Infallible, BootError> {
         );
     }
 
-    let runtime_ref = resolution_runtime_ref(&m)?;
+    // argv0 entry selection (spec 03 §6 / spec 07 §2.0): the type-2
+    // package manifest's entries map command names to per-entry runtime
+    // refs; argv0 picks one (entries[0] fallback), v1 packages see no
+    // selection at all.
+    let argv0 = argv.first().map(String::as_str).unwrap_or("");
+    let selection = package_selection(&m, argv0)?;
+    let runtime_ref = match &selection {
+        Some((_, entry)) => entry.runtime_ref.clone(),
+        None => m.runtime_ref_str().unwrap_or_default().to_string(),
+    };
     if runtime_ref.is_empty() {
         return fail(
             EX_TEBAKO_RUNTIME_REF,
@@ -1774,6 +1847,7 @@ pub fn run(argv: &[String]) -> Result<std::convert::Infallible, BootError> {
         image.as_deref(),
         &self_path,
         &m,
+        selection.as_ref(),
         argv,
     ))
 }

--- a/crates/tebako-bootstrap/tests/ext_blocks.rs
+++ b/crates/tebako-bootstrap/tests/ext_blocks.rs
@@ -1,10 +1,11 @@
 //! Package-manifest resolution tests (spec 02 §5b / spec 03 §6): when the
-//! package carries the type-2 extension block, its entries[0].runtime_ref
-//! drives runtime resolution; block-less packages fall back to the v1
-//! trailer field byte-identically. Handoff argv is not involved here
+//! package carries the type-2 extension block, argv0 selects the entry
+//! whose runtime_ref drives runtime resolution (exact name match,
+//! entries[0] fallback); block-less packages fall back to the v1 trailer
+//! field byte-identically. Handoff argv shape is not involved here
 //! (resolution behavior only — ABI stays 1).
 
-use tebako_bootstrap::{resolution_runtime_ref, EX_TEBAKO_MANIFEST};
+use tebako_bootstrap::{resolution_runtime_ref, select_entry, EX_TEBAKO_MANIFEST};
 
 fn manifest_with_ref(trailer_ref: &str) -> tpkg::Manifest {
     let mut m = tpkg::Manifest::default();
@@ -46,13 +47,13 @@ fn package_manifest(entries: &[(&str, u32, &str, &str)]) -> tpkg::PackageManifes
 fn block_less_package_reads_the_v1_trailer_field() {
     let m = manifest_with_ref("ruby@3.4.2;tebako=0.15.9");
     assert_eq!(
-        resolution_runtime_ref(&m).unwrap(),
+        resolution_runtime_ref(&m, "metanorma").unwrap(),
         "ruby@3.4.2;tebako=0.15.9"
     );
     // …and an empty trailer field stays empty (the classic-bundle error
     // path in run() is unchanged).
     let m = manifest_with_ref("");
-    assert_eq!(resolution_runtime_ref(&m).unwrap(), "");
+    assert_eq!(resolution_runtime_ref(&m, "metanorma").unwrap(), "");
 }
 
 #[test]
@@ -66,7 +67,7 @@ fn type_2_block_wins_over_the_trailer_field() {
     )]))
     .unwrap();
     assert_eq!(
-        resolution_runtime_ref(&m).unwrap(),
+        resolution_runtime_ref(&m, "metanorma").unwrap(),
         "ruby@3.4.2;tebako=0.15.9"
     );
 }
@@ -82,25 +83,86 @@ fn type_2_block_supplies_the_ref_when_the_trailer_field_is_empty() {
     )]))
     .unwrap();
     assert_eq!(
-        resolution_runtime_ref(&m).unwrap(),
+        resolution_runtime_ref(&m, "metanorma").unwrap(),
         "ruby@3.4.2;tebako=0.15.9"
     );
 }
 
 #[test]
-fn suites_resolve_against_entries_0() {
+fn argv0_selects_the_suite_entry() {
     let mut m = manifest_with_ref("ruby@3.3.7;tebako=0.15.9");
+    m.slots
+        .push(tpkg::Slot::new(100, 100, tpkg::TPKG_FORMAT_ZIP, "/app"));
     m.set_package_manifest(&package_manifest(&[
         ("metanorma", 0, "metanorma", "ruby@3.4.2;tebako=0.15.9"),
         ("mn2pdf", 1, "mn2pdf", "ruby@3.3.7;tebako=0.15.9"),
     ]))
     .unwrap();
-    // entries[0] drives resolution; per-entry refs beyond it are the
-    // dispatcher's business (spec 07), not the v1 bootstrap's.
+
+    // argv0 is the selector (spec 07 §2.0): each entry resolves ITS OWN
+    // runtime_ref — two commands of one package, two runtimes.
     assert_eq!(
-        resolution_runtime_ref(&m).unwrap(),
+        resolution_runtime_ref(&m, "metanorma").unwrap(),
         "ruby@3.4.2;tebako=0.15.9"
     );
+    assert_eq!(
+        resolution_runtime_ref(&m, "mn2pdf").unwrap(),
+        "ruby@3.3.7;tebako=0.15.9"
+    );
+    // full paths select by file name; a windows .exe suffix is stripped
+    assert_eq!(
+        resolution_runtime_ref(&m, "/usr/local/bin/mn2pdf").unwrap(),
+        "ruby@3.3.7;tebako=0.15.9"
+    );
+    assert_eq!(
+        resolution_runtime_ref(&m, "C:\\bin\\mn2pdf.exe").unwrap(),
+        "ruby@3.3.7;tebako=0.15.9"
+    );
+}
+
+#[test]
+fn unknown_argv0_falls_back_to_entries_0() {
+    let mut m = manifest_with_ref("ruby@3.3.7;tebako=0.15.9");
+    m.slots
+        .push(tpkg::Slot::new(100, 100, tpkg::TPKG_FORMAT_ZIP, "/app"));
+    m.set_package_manifest(&package_manifest(&[
+        ("metanorma", 0, "metanorma", "ruby@3.4.2;tebako=0.15.9"),
+        ("mn2pdf", 1, "mn2pdf", "ruby@3.3.7;tebako=0.15.9"),
+    ]))
+    .unwrap();
+    // the standalone-download case: the file name is arbitrary
+    // (version/platform suffixes) — the primary command runs.
+    assert_eq!(
+        resolution_runtime_ref(&m, "metanorma-1.2.3-macos-arm64").unwrap(),
+        "ruby@3.4.2;tebako=0.15.9"
+    );
+    assert_eq!(
+        resolution_runtime_ref(&m, "anything-at-all").unwrap(),
+        "ruby@3.4.2;tebako=0.15.9"
+    );
+
+    // select_entry itself: exact match else entries[0]
+    let pm = package_manifest(&[
+        ("metanorma", 0, "metanorma", "ruby@3.4.2;tebako=0.15.9"),
+        ("mn2pdf", 1, "mn2pdf", "ruby@3.3.7;tebako=0.15.9"),
+    ]);
+    assert_eq!(select_entry(&pm, "mn2pdf").name, "mn2pdf");
+    assert_eq!(select_entry(&pm, "bogus").name, "metanorma");
+}
+
+#[test]
+fn an_entry_naming_a_missing_slot_is_a_named_error() {
+    let mut m = manifest_with_ref("ruby@3.4.2;tebako=0.15.9");
+    m.set_package_manifest(&package_manifest(&[(
+        "metanorma",
+        3, // the container carries only slot 0
+        "metanorma",
+        "ruby@3.4.2;tebako=0.15.9",
+    )]))
+    .unwrap();
+    let err = resolution_runtime_ref(&m, "metanorma").unwrap_err();
+    assert_eq!(err.code, EX_TEBAKO_MANIFEST);
+    assert!(err.message.contains("slot 3"), "{err:?}");
 }
 
 #[test]
@@ -115,7 +177,7 @@ fn per_entry_refs_may_exceed_the_128_byte_trailer_limit() {
         &long_ref,
     )]))
     .unwrap();
-    assert_eq!(resolution_runtime_ref(&m).unwrap(), long_ref);
+    assert_eq!(resolution_runtime_ref(&m, "metanorma").unwrap(), long_ref);
 }
 
 #[test]
@@ -123,7 +185,110 @@ fn corrupt_block_is_a_named_error() {
     let mut m = manifest_with_ref("ruby@3.4.2;tebako=0.15.9");
     m.ext_blocks
         .push(tpkg::ExtBlock::new(2, b"schema_version: 99\n".to_vec()).unwrap());
-    let err = resolution_runtime_ref(&m).unwrap_err();
+    let err = resolution_runtime_ref(&m, "metanorma").unwrap_err();
     assert_eq!(err.code, EX_TEBAKO_MANIFEST);
     assert!(err.message.contains("extension block type 2"), "{err:?}");
+}
+
+// ---------------------------------------------------------------------
+// the entry-aware handoff (suite mount rule)
+// ---------------------------------------------------------------------
+
+fn suite_manifest() -> tpkg::Manifest {
+    let mut m = manifest_with_ref("ruby@3.4.2;tebako=0.15.9");
+    m.slots
+        .push(tpkg::Slot::new(100, 100, tpkg::TPKG_FORMAT_ZIP, "/app"));
+    m
+}
+
+#[test]
+fn handoff_mounts_only_the_selected_entrys_slot() {
+    let m = suite_manifest();
+    let pm = package_manifest(&[
+        ("metanorma", 0, "metanorma", "ruby@3.4.2;tebako=0.15.9"),
+        ("mn2pdf", 1, "mn2pdf", "ruby@3.3.7;tebako=0.15.9"),
+    ]);
+    let self_path = std::path::Path::new("/pkg/suite");
+    let runtime = std::path::Path::new("/rt/ruby");
+
+    // selecting mn2pdf mounts slot 1 only, entry is mn2pdf's entrypoint
+    let selection =
+        tebako_bootstrap::package_selection(&m.with_package_manifest(&pm), "mn2pdf").unwrap();
+    let argv = tebako_bootstrap::handoff_argv(
+        runtime,
+        self_path,
+        &m.with_package_manifest(&pm),
+        selection.as_ref(),
+        &["mn2pdf".to_string(), "in.xml".to_string()],
+    );
+    assert_eq!(
+        argv,
+        vec![
+            runtime.to_string_lossy().into_owned(),
+            "--tebako-image".to_string(),
+            "/pkg/suite:1:/app".to_string(),
+            "--tebako-entry".to_string(),
+            "mn2pdf".to_string(),
+            "in.xml".to_string(),
+        ]
+    );
+
+    // selecting metanorma mounts slot 0 only
+    let selection =
+        tebako_bootstrap::package_selection(&m.with_package_manifest(&pm), "metanorma").unwrap();
+    let argv = tebako_bootstrap::handoff_argv(
+        runtime,
+        self_path,
+        &m.with_package_manifest(&pm),
+        selection.as_ref(),
+        &["metanorma".to_string()],
+    );
+    assert_eq!(
+        argv,
+        vec![
+            runtime.to_string_lossy().into_owned(),
+            "--tebako-image".to_string(),
+            "/pkg/suite:0:/app".to_string(),
+            "--tebako-entry".to_string(),
+            "metanorma".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn handoff_without_a_package_manifest_is_byte_identical_to_v1() {
+    let m = suite_manifest(); // no block
+    let argv = tebako_bootstrap::handoff_argv(
+        std::path::Path::new("/rt/ruby"),
+        std::path::Path::new("/pkg/app"),
+        &m,
+        None,
+        &["./app".to_string(), "go".to_string()],
+    );
+    assert_eq!(
+        argv,
+        vec![
+            "/rt/ruby".to_string(),
+            "--tebako-image".to_string(),
+            "/pkg/app:0:/app".to_string(),
+            "--tebako-image".to_string(),
+            "/pkg/app:1:/app".to_string(),
+            "--tebako-entry".to_string(),
+            "./app".to_string(),
+            "go".to_string(),
+        ]
+    );
+}
+
+/// Helper: a manifest carrying the package manifest block (clone-on-write
+/// for the tests).
+trait WithPackageManifest {
+    fn with_package_manifest(&self, pm: &tpkg::PackageManifest) -> tpkg::Manifest;
+}
+impl WithPackageManifest for tpkg::Manifest {
+    fn with_package_manifest(&self, pm: &tpkg::PackageManifest) -> tpkg::Manifest {
+        let mut m = self.clone();
+        m.set_package_manifest(pm).unwrap();
+        m
+    }
 }

--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -16,6 +16,8 @@ tebako-pkg = { version = "0.1.0", path = "../tebako-pkg" }
 tebako-http = { version = "0.1.0", path = "../tebako-http" }
 # Registry/payload resolution for `tebako add-registry | install` (spec 04).
 tebako-resolve = { version = "0.1.0", path = "../tebako-resolve" }
+# Release-API JSON for the publish upload leg (GitHub release documents).
+tebako-json = { version = "0.1.0", path = "../tebako-json" }
 # Config writes (registries:), the manifest mirror and the shim link/unlink
 # — called as a library, never spawned (spec 14 §3: no shell-outs).
 tebako-shim = { version = "0.1.0", path = "../tebako-shim" }

--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -26,6 +26,10 @@ tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
 # (item 30b layout seeding); install reads the embedded payload manifest
 # (spec 03 §1) through the same ABI.
 tfs = { version = "0.1.0", path = "../tfs" }
+# The suite file (--suite) is authored YAML (spec 00 invariant 6) — the
+# tpkg manifest convention (serde_yml), not serde_yaml.
+serde = { version = "1", features = ["derive"] }
+serde_yml = "0.0.12"
 # The in-process DwarFS writer (dwarfs-t-rs): the application and deploy
 # driver images are built without any mkdwarfs binary.
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }

--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -750,7 +750,7 @@ fn now_unix() -> u64 {
 /// Unix seconds → "YYYY-MM-DDTHH:MM:SSZ" (RFC 3339, UTC). The manifest's
 /// `created` is a string the model never interprets; no time crate rides
 /// along for one rendering.
-fn rfc3339_utc(secs: u64) -> String {
+pub(crate) fn rfc3339_utc(secs: u64) -> String {
     let days = secs / 86_400;
     let rem = secs % 86_400;
     let (hour, min, sec) = (rem / 3600, (rem % 3600) / 60, rem % 60);

--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -881,6 +881,14 @@ fn verify_signature<T: Transport>(
 /// The `.asc` of a signature pin: a full reference, or an asset name
 /// within the same release (the common case — the `.asc` rides the
 /// release next to the artifact it signs).
+///
+/// One detached signature covers exactly ONE artifact's bytes, so a
+/// release carrying N artifacts carries N ascs by convention:
+/// `<artifact>.asc`. When the install already selected an artifact
+/// (per-triplet registry entries, explicit `#artifact` forms), the asc
+/// follows the SELECTED artifact — `sig.asc` is read as the exact name
+/// only when no selection happened (universal payloads), which is also
+/// the shape the registry's spec example documents.
 fn signature_reference(sig: &SignaturePin, release: &Reference) -> Result<Reference, TebakoError> {
     if looks_like_reference(&sig.asc) {
         return Reference::parse(&sig.asc).map_err(|e| {
@@ -896,8 +904,11 @@ fn signature_reference(sig: &SignaturePin, release: &Reference) -> Result<Refere
             artifact, sha256, ..
         } => {
             // The payload's own pin must not leak onto the signature asset.
-            *artifact = Some(sig.asc.clone());
             *sha256 = None;
+            *artifact = Some(match artifact {
+                Some(selected) => format!("{selected}.asc"),
+                None => sig.asc.clone(),
+            });
             Ok(reference)
         }
         _ => Err(err(

--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -100,14 +100,79 @@ pub fn add_registry_with<T: Transport>(
     fetcher: &Fetcher<T>,
 ) -> Result<(AddRegistryOutcome, tebako_resolve::Registry), TebakoError> {
     let r = RegistryRef::parse(registry_ref).map_err(|e| err(EX_USAGE, e.to_string()))?;
-    let registry = fetcher.resolve_registry(&r).map_err(map_resolve)?;
+    let bytes = fetcher.fetch_registry(&r).map_err(map_resolve)?;
+    let text = String::from_utf8(bytes.clone()).map_err(|e| {
+        err(
+            EX_TEBAKO_MANIFEST,
+            format!("the registry file is not UTF-8: {e}"),
+        )
+    })?;
+    let registry = tebako_resolve::Registry::from_yaml(&text).map_err(|e| {
+        err(
+            EX_TEBAKO_MANIFEST,
+            format!("cannot parse the registry: {e}"),
+        )
+    })?;
     let outcome = config::add_registry(home, &r.as_canonical_string()).map_err(map_shim)?;
+    // Prime the dispatch-time registry cache with the bytes just fetched
+    // (roadmap 33): the shim's registry-default link then resolves this
+    // remote registry without a second fetch. A prime failure never fails
+    // the add — dispatch refreshes on demand; noted, not silent.
+    if r.is_remote() {
+        if let Err(e) = tebako_shim::regcache::prime(home, &r.as_canonical_string(), &bytes) {
+            eprintln!(
+                "tebako: note: could not prime the dispatch registry cache: {}",
+                e.message
+            );
+        }
+    }
     Ok((outcome, registry))
 }
 
 /// `tebako list-registries`: the registered refs, in config order.
 pub fn list_registries(home: &Path) -> Result<Vec<String>, TebakoError> {
     Ok(config::load_config(home).map_err(map_shim)?.registries)
+}
+
+/// What `tebako update-registries` did (roadmap 33): per-registry outcome
+/// of the force-renew of the dispatch-time cache.
+#[derive(Debug, Default)]
+pub struct UpdateRegistriesOutcome {
+    /// Remote registries fetched and (re-)published into the cache.
+    pub refreshed: Vec<String>,
+    /// `file://` registries (read directly at dispatch — nothing to cache).
+    pub local: Vec<String>,
+    /// `(ref, error)` pairs that failed to refresh.
+    pub failed: Vec<(String, String)>,
+}
+
+/// `tebako update-registries`: force-renew every registered registry's
+/// dispatch cache. Every ref is attempted; failures are collected, not
+/// fatal to the other refs (the CLI maps a non-empty `failed` to a
+/// non-zero exit).
+pub fn update_registries(home: &Path) -> Result<UpdateRegistriesOutcome, TebakoError> {
+    update_registries_with(home, &Fetcher::new())
+}
+
+/// The transport-injected half of [`update_registries`] (tests).
+pub fn update_registries_with<T: Transport>(
+    home: &Path,
+    fetcher: &Fetcher<T>,
+) -> Result<UpdateRegistriesOutcome, TebakoError> {
+    let cfg = config::load_config(home).map_err(map_shim)?;
+    let mut out = UpdateRegistriesOutcome::default();
+    for reg_ref in &cfg.registries {
+        match tebako_shim::regcache::refresh_with(home, reg_ref, fetcher) {
+            Ok(tebako_shim::regcache::RefreshOutcome::Refreshed) => {
+                out.refreshed.push(reg_ref.clone())
+            }
+            Ok(tebako_shim::regcache::RefreshOutcome::LocalSkipped) => {
+                out.local.push(reg_ref.clone())
+            }
+            Err(e) => out.failed.push((reg_ref.clone(), e.message)),
+        }
+    }
+    Ok(out)
 }
 
 // ---------------------------------------------------------------------

--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -138,6 +138,9 @@ pub struct InstallOutcome {
 struct InstallPlan {
     name: String,
     version: String,
+    /// The payload kind (the registry declares it; the ref form assumes
+    /// app — its mirror falls back to the entrypoint convention).
+    kind: tpkg::PayloadKind,
     reference: Reference,
     /// The registry per-triplet sha256 anchor (the cache's expected
     /// digest; the reference's own pin is verified at the fetch boundary).
@@ -197,6 +200,7 @@ fn plan_from_reference(target: &str) -> Result<InstallPlan, TebakoError> {
     Ok(InstallPlan {
         name,
         version,
+        kind: tpkg::PayloadKind::App,
         reference,
         expected_sha256: None,
         signature: None,
@@ -418,6 +422,7 @@ fn plan_from_registry_entry(
     Ok(InstallPlan {
         name: name.clone(),
         version: entry.version.clone(),
+        kind: payload.kind,
         reference,
         expected_sha256,
         signature: entry.signature.clone(),
@@ -486,7 +491,11 @@ fn finish_install<T: Transport>(
     mirror.save(&record.manifest_mirror).map_err(map_shim)?;
 
     // Register every shim the payload PROVIDES declares (spec 07 §1).
-    let commands: Vec<String> = mirror.entrypoints.iter().map(|e| e.name.clone()).collect();
+    let commands: Vec<String> = mirror
+        .entrypoints()
+        .iter()
+        .map(|e| e.name.clone())
+        .collect();
     let shims = if commands.is_empty() {
         Vec::new()
     } else {
@@ -517,12 +526,13 @@ fn finish_install<T: Transport>(
     })
 }
 
-/// The manifest mirror for the payload record. The embedded manifest is
-/// authoritative; the name form cross-checks it against the registry (the
-/// registry is the trust source — a mismatch means it lied). Without an
-/// embedded manifest the mirror is synthesized from the registry's
-/// tier-3 fields (ref form: the payload name) with the `/<command>`
-/// entry-path convention — LOUD, never silent.
+/// The manifest mirror for the payload record (spec 03 §4 tier 3 — the
+/// unified [`tpkg::PayloadManifest`], item 40). The embedded manifest is
+/// authoritative and mirrored as parsed; the name form cross-checks it
+/// against the registry (the registry is the trust source — a mismatch
+/// means it lied). Without an embedded manifest the mirror is synthesized
+/// from the registry's tier-3 fields (ref form: the payload name) with
+/// the `/<command>` entry-path convention — LOUD, never silent.
 fn build_mirror(
     entry: &tebako_resolve::CacheEntry,
     plan: &InstallPlan,
@@ -551,58 +561,146 @@ fn build_mirror(
             }
             notes.push(msg);
         }
-        let entrypoints = match &embedded.provides {
-            tpkg::Provides::App(app) => app
-                .entrypoints
-                .iter()
-                .map(|e| manifest::Entrypoint {
-                    name: e.name.clone(),
-                    path: e.path.clone(),
-                    args_default: e.args_default.clone(),
-                    runtime_requirement: Some(manifest::RuntimeRequirement {
-                        engine: e.runtime_requirement.engine.clone(),
-                        constraint: e.runtime_requirement.constraint.as_str().to_string(),
-                    }),
-                })
-                .collect(),
-            _ => Vec::new(),
-        };
-        return Ok(Manifest {
-            name: plan.name.clone(),
-            version: plan.version.clone(),
-            entrypoints,
-            requires: Vec::new(),
-        });
+        return Ok(Manifest::from_payload_manifest(embedded));
     }
-    let names = if plan.entrypoints.is_empty() {
-        vec![plan.name.clone()]
-    } else {
-        plan.entrypoints.clone()
-    };
     notes.push(
         "the image carries no embedded manifest (/__tpkg__/manifest.yaml); \
          the mirror is synthesized with the /<command> entry-path convention"
             .to_string(),
     );
-    Ok(Manifest {
-        name: plan.name.clone(),
-        version: plan.version.clone(),
-        entrypoints: names
-            .into_iter()
-            .map(|n| manifest::Entrypoint {
-                path: format!("/{n}"),
-                name: n,
-                args_default: Vec::new(),
-                runtime_requirement: plan.runtime_requirement.as_ref().map(
-                    |(engine, constraint)| manifest::RuntimeRequirement {
-                        engine: engine.clone(),
-                        constraint: constraint.clone(),
-                    },
-                ),
+    Ok(Manifest::from_payload_manifest(synthesize_manifest(
+        entry, plan,
+    )?))
+}
+
+/// The synthesized mirror (no embedded manifest): a minimal valid
+/// [`tpkg::PayloadManifest`] from the plan's tier-3 fields. `created` is
+/// the install time (the model never interprets it); `tree_hash` is a
+/// placeholder — the fixed-point rule (spec 03 §7) keeps real digests one
+/// tier out, and `blob_sha256` carries the payload's verified digest.
+fn synthesize_manifest(
+    entry: &tebako_resolve::CacheEntry,
+    plan: &InstallPlan,
+) -> Result<tpkg::PayloadManifest, TebakoError> {
+    let requirement = match &plan.runtime_requirement {
+        Some((engine, constraint)) => Some(tpkg::RuntimeRequirement {
+            engine: engine.clone(),
+            constraint: tpkg::Constraint::new(constraint).map_err(|e| {
+                err(
+                    EX_TEBAKO_MANIFEST,
+                    format!("the registry's runtime_requirement constraint is invalid: {e}"),
+                )
+            })?,
+        }),
+        None => None,
+    };
+    let provides = match plan.kind {
+        tpkg::PayloadKind::App => {
+            let names = if plan.entrypoints.is_empty() {
+                vec![plan.name.clone()]
+            } else {
+                plan.entrypoints.clone()
+            };
+            tpkg::Provides::App(tpkg::AppProvides {
+                entrypoints: names
+                    .into_iter()
+                    .map(|n| tpkg::Entrypoint {
+                        path: format!("/{n}"),
+                        name: n,
+                        args_default: Vec::new(),
+                        runtime_requirement: requirement.clone(),
+                    })
+                    .collect(),
+                platforms: tpkg::Platforms::Universal,
+                capabilities: tpkg::Capabilities {
+                    exec: true,
+                    read: true,
+                    runtime: None,
+                },
             })
-            .collect(),
+        }
+        // Non-app kinds declare no entrypoints (never a shim); the
+        // consumer declares the mount (MOUNT RULE), the suggested "/" is
+        // the bare-image convention (spec 07 §0).
+        tpkg::PayloadKind::Data => tpkg::Provides::Data(tpkg::DataProvides {
+            mount_semantics: tpkg::MountSemantics {
+                suggested: "/".to_string(),
+            },
+            consumers: Vec::new(),
+            capabilities: tpkg::Capabilities {
+                exec: false,
+                read: true,
+                runtime: None,
+            },
+        }),
+        other => {
+            return Err(err(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "cannot synthesize a manifest mirror for a {other:?} payload without an embedded manifest — press the payload with an embedded /__tpkg__/manifest.yaml"
+                ),
+            ))
+        }
+    };
+    Ok(tpkg::PayloadManifest {
+        identity: tpkg::Identity {
+            schema_version: tpkg::PAYLOAD_SCHEMA_VERSION,
+            kind: plan.kind,
+            name: plan.name.clone(),
+            version: plan.version.clone(),
+            producer: tpkg::Producer {
+                tool: "tebako-cli".to_string(),
+                tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            },
+            created: rfc3339_utc(now_unix()),
+            source: None,
+            sbom: None,
+            digest: tpkg::Digest {
+                tree_hash: format!("sha256:{}", "0".repeat(64)),
+                blob_sha256: entry.sha256.clone(),
+            },
+            signing: tpkg::Signing {
+                state: tpkg::SigningState::Unsigned,
+                keyid: None,
+                mechanism: None,
+            },
+            encryption: tpkg::Encryption {
+                state: tpkg::EncryptionState::None,
+                parts: Vec::new(),
+            },
+            annotations: Default::default(),
+        },
+        provides,
         requires: Vec::new(),
     })
+}
+
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Unix seconds → "YYYY-MM-DDTHH:MM:SSZ" (RFC 3339, UTC). The manifest's
+/// `created` is a string the model never interprets; no time crate rides
+/// along for one rendering.
+fn rfc3339_utc(secs: u64) -> String {
+    let days = secs / 86_400;
+    let rem = secs % 86_400;
+    let (hour, min, sec) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+    // civil-from-days (Howard Hinnant's algorithm, days-from-civil inverse).
+    let z = days + 719_468;
+    let era = z / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}T{hour:02}:{min:02}:{sec:02}Z")
 }
 
 /// The dispatcher binary the shims link to: the explicit override >
@@ -807,8 +905,8 @@ pub fn uninstall(home: &Path, name: &str) -> Result<UninstallOutcome, TebakoErro
     for v in &versions {
         let record = manifest::payload_record(home, name, v);
         if let Ok(m) = Manifest::load(&record.manifest_mirror) {
-            for e in m.entrypoints {
-                commands.insert(e.name);
+            for e in m.entrypoints() {
+                commands.insert(e.name.clone());
             }
         }
         if let Ok(text) = std::fs::read_to_string(&record.sha_marker) {

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -5,10 +5,14 @@
 //!                [--cwd <dir>] [-R <ruby>] [-m lean|fat]
 //!                [--image <path>:<mount>]... [--bootstrap <path>]
 //!                [--tebako-version <v>]
+//!   tebako press --suite <suite.yaml>   (one package, N commands —
+//!                per-entry imaging + slots + the type-2 package manifest,
+//!                spec 03 §6)
 //!   tebako cache list
 //!   tebako cache prune [--all] [--older-than Nd]
 //!   tebako add-registry <ref>
 //!   tebako list-registries
+//!   tebako update-registries
 //!   tebako install <ref | name[@version]>
 //!   tebako uninstall <name>
 //!
@@ -61,6 +65,7 @@ pub mod runner;
 pub mod scenario;
 pub mod sdk;
 pub mod strip;
+pub mod suite;
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -80,7 +85,7 @@ pub const DEFAULT_TEBAKO_VERSION: &str = "0.15.9";
 
 pub const VERSION_BANNER: &str = "Tebako executable packager version 0.15.9";
 
-const WARN: &str = "
+pub(crate) const WARN: &str = "
 ******************************************************************************************************************
 *                                                                                                                *
 *  WARNING: You are packaging in-place, i.e.: tebako package will be placed inside application root.             *
@@ -110,7 +115,7 @@ const WARN2: &str = "
 // ---------------------------------------------------------------------
 
 /// Where the package's bootstrap portion comes from.
-enum BootstrapSource {
+pub(crate) enum BootstrapSource {
     /// An explicit local binary (--bootstrap, $TEBAKO_BOOTSTRAP, or the
     /// Rust tebako-bootstrap sitting next to the tebako binary).
     Path(PathBuf),
@@ -119,6 +124,21 @@ enum BootstrapSource {
 }
 
 pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
+    // --suite: one package, N entries (spec 03 §6 — src/suite.rs).
+    if let Some(suite_path) = &opts.suite {
+        let yaml = fs::read_to_string(suite_path).map_err(|e| {
+            plain_error(format!(
+                "cannot read the suite file {}: {e}",
+                suite_path.display()
+            ))
+        })?;
+        let spec = suite::parse_suite(&yaml, suite_path)?;
+        let dir = suite_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        return suite::press_suite(opts, &spec, &dir);
+    }
     if opts.mode == PressMode::Runtime {
         return Err(packaging_error(133, None));
     }
@@ -206,16 +226,18 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
         None
     };
 
+    let mut runtime_ref = format!("ruby@{ruby_ver};tebako={}", opts.tebako_version);
+    if resolved.image.is_some() {
+        // item 30b: the runtime is image-era — the bootstrap resolves
+        // the .tfs alongside the interpreter at first run.
+        runtime_ref.push_str(";image");
+    }
+    if let Some(sha) = &payload_sha256 {
+        runtime_ref.push_str(&format!(";sha256={sha}"));
+    }
+
     let package = format!("{}{}", opts.package(), scenario.exe_suffix);
-    stitch(
-        &bootstrap_path,
-        &images,
-        &package,
-        &ruby_ver,
-        &opts.tebako_version,
-        payload_sha256.as_deref(),
-        resolved.image.is_some(),
-    )?;
+    stitch(&bootstrap_path, &images, &package, &runtime_ref, None)?;
     println!("Created tebako package at \"{package}\"");
     ensure_version_file(opts);
     Ok(PathBuf::from(package))
@@ -238,7 +260,7 @@ fn check_warnings(opts: &PressOptions) {
 
 /// Bootstrap lookup: --bootstrap > $TEBAKO_BOOTSTRAP > the Rust
 /// tebako-bootstrap next to the tebako binary > the C++ release download.
-fn decide_bootstrap(opts: &PressOptions) -> BootstrapSource {
+pub(crate) fn decide_bootstrap(opts: &PressOptions) -> BootstrapSource {
     if let Some(path) = &opts.bootstrap {
         return BootstrapSource::Path(path.clone());
     }
@@ -285,15 +307,16 @@ fn check_bootstrap_version() -> Result<(), TebakoError> {
 /// then assemble with tebako-pkg (dense image layout — tpkg slots carry
 /// absolute offsets, so the gem's 8-byte padding is not required), chmod,
 /// and re-sign ad-hoc on macOS when the binary was signed.
-/// `image_era`: the runtime_ref carries the `;image` flag (item 30b).
-fn stitch(
+/// `runtime_ref` is the trailer's 128-byte field as built by the caller
+/// (suites: entries[0]'s ref — the type-2 manifest carries the per-entry
+/// refs, spec 02 §5b / spec 03 §6). `package_manifest`, when present, is
+/// embedded as extension block type 2.
+pub(crate) fn stitch(
     bootstrap_path: &Path,
     images: &[(PathBuf, String, u32)],
     package: &str,
-    ruby_version: &str,
-    tebako_version: &str,
-    runtime_sha256: Option<&str>,
-    image_era: bool,
+    runtime_ref: &str,
+    package_manifest: Option<&tpkg::PackageManifest>,
 ) -> Result<(), TebakoError> {
     if images.is_empty() {
         return Err(packaging_error(126, Some("at least one image is required")));
@@ -343,34 +366,19 @@ fn stitch(
         if *format_id == tpkg::TPKG_FORMAT_RUNTIME {
             continue; // payload slots are never mounted
         }
+        // Suite members share one mount point by construction (the
+        // bootstrap's argv0 selection mounts only the selected entry's
+        // slot — spec 03 §6); without a package manifest a duplicate
+        // mount stays the error it always was.
+        if package_manifest.is_some() {
+            continue;
+        }
         if !seen.insert(mount) {
             return Err(packaging_error(
                 126,
                 Some(&format!("duplicate mount point '{mount}'")),
             ));
         }
-    }
-    if let Some(sha) = runtime_sha256 {
-        let valid = sha.len() == 64
-            && sha
-                .bytes()
-                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase());
-        if !valid {
-            return Err(packaging_error(
-                126,
-                Some("runtime_sha256 must be 64 lowercase hex characters"),
-            ));
-        }
-    }
-
-    let mut runtime_ref = format!("ruby@{ruby_version};tebako={tebako_version}");
-    if image_era {
-        // item 30b: the runtime is image-era — the bootstrap resolves
-        // the .tfs alongside the interpreter at first run.
-        runtime_ref.push_str(";image");
-    }
-    if let Some(sha) = runtime_sha256 {
-        runtime_ref.push_str(&format!(";sha256={sha}"));
     }
     if runtime_ref.len() >= tpkg::TPKG_RUNTIME_REF_LEN {
         return Err(packaging_error(
@@ -395,9 +403,10 @@ fn stitch(
         })
         .collect();
     let pkg_options = tebako_pkg::PackageOptions {
-        runtime_ref,
+        runtime_ref: runtime_ref.to_string(),
         package_flags: tpkg::TPKG_FLAG_LEAN,
         launcher_abi: LAUNCHER_ABI,
+        package_manifest: package_manifest.cloned(),
         ..Default::default()
     };
     tebako_pkg::bundle_exact(bootstrap_path, &pkg_images, output, &pkg_options)
@@ -459,7 +468,7 @@ fn resign_if_needed(output: &Path) {
 }
 
 /// CacheManager#ensure_version_file (best effort).
-fn ensure_version_file(opts: &PressOptions) {
+pub(crate) fn ensure_version_file(opts: &PressOptions) {
     let deps = opts.deps();
     let _ = fs::create_dir_all(&deps);
     let version_file = deps.join(".environment.version");
@@ -482,7 +491,7 @@ fn version_key(opts: &PressOptions) -> String {
 /// → "not recognized" + clean_cache; version mismatch → "created by a
 /// gem version" + clean_cache; source mismatch → "created for a
 /// different source directory" + clean_output.
-fn version_cache_check(opts: &PressOptions) {
+pub(crate) fn version_cache_check(opts: &PressOptions) {
     let version_file = opts.deps().join(".environment.version");
     let parsed = fs::read_to_string(&version_file).ok().and_then(|content| {
         let line = content.lines().next()?.to_string();

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -60,6 +60,7 @@ pub mod image_manifest;
 pub mod install;
 pub mod options;
 pub mod packager;
+pub mod publish;
 pub mod resolve;
 pub mod runner;
 pub mod scenario;

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -17,6 +17,7 @@ const USAGE: &str = "Usage:
   tebako cache prune [--all] [--older-than Nd]
   tebako add-registry <ref>            register a tpkg-registry.yaml (spec 04 §2)
   tebako list-registries               list the registered registries
+  tebako update-registries             refresh the dispatch-time registry cache
   tebako install <ref | name[@ver]>    install a payload + register its shims
   tebako uninstall <name>              remove a payload's shims and cache entry";
 
@@ -80,6 +81,7 @@ fn run(args: &[String]) -> Result<(), CliExit> {
         "cache" => run_cache(rest),
         "add-registry" => run_add_registry(rest),
         "list-registries" => run_list_registries(rest),
+        "update-registries" => run_update_registries(rest),
         "install" => run_install(rest),
         "uninstall" => run_uninstall(rest),
         "clean" | "setup" | "hash" => Err(CliExit::Usage(format!(
@@ -133,6 +135,42 @@ fn run_list_registries(args: &[String]) -> Result<(), CliExit> {
         for r in &registries {
             println!("{r}");
         }
+    }
+    Ok(())
+}
+
+fn run_update_registries(args: &[String]) -> Result<(), CliExit> {
+    if !args.is_empty() {
+        return Err(CliExit::Usage(
+            "usage: tebako update-registries".to_string(),
+        ));
+    }
+    let outcome = tebako_cli::install::update_registries(&tebako_home()?)?;
+    for r in &outcome.refreshed {
+        println!("refreshed {r}");
+    }
+    for r in &outcome.local {
+        println!("{r}: file:// registry — read directly at dispatch, nothing to cache");
+    }
+    for (r, e) in &outcome.failed {
+        eprintln!("tebako: {r}: {e}");
+    }
+    if outcome.refreshed.is_empty() && outcome.local.is_empty() && outcome.failed.is_empty() {
+        println!("no registries registered — tebako add-registry <ref> registers one");
+    }
+    if !outcome.failed.is_empty() {
+        return Err(CliExit::Error(tebako_cli::error::TebakoError::new(
+            format!(
+                "{} registr{} failed to refresh",
+                outcome.failed.len(),
+                if outcome.failed.len() == 1 {
+                    "y"
+                } else {
+                    "ies"
+                }
+            ),
+            69,
+        )));
     }
     Ok(())
 }

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -13,6 +13,8 @@ const USAGE: &str = "Usage:
                [-R <ruby>] [-m lean|fat] [-l error|warn|debug|trace]
                [--image <path>:<mount>]... [--bootstrap <path>]
                [--tebako-version <v>] [--prefer-local]
+  tebako press --suite <suite.yaml> [-o <output>] [-p <prefix>] [-R <ruby>]
+               one package, N commands (spec 03 §6: per-entry slots + type-2 manifest)
   tebako cache list [--json]
   tebako cache prune [--all] [--older-than Nd]
   tebako add-registry <ref>            register a tpkg-registry.yaml (spec 04 §2)
@@ -285,6 +287,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
     let mut tebako_version = tebako_cli::DEFAULT_TEBAKO_VERSION.to_string();
     let mut prefer_local = false;
     let mut devmode = false;
+    let mut suite: Option<PathBuf> = None;
 
     let mut i = 0;
     while i < args.len() {
@@ -318,6 +321,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
             "--bootstrap" => bootstrap = Some(PathBuf::from(take_value(&mut i)?)),
             "--tebako-version" => tebako_version = take_value(&mut i)?,
             "--prefer-local" => prefer_local = true,
+            "--suite" => suite = Some(PathBuf::from(take_value(&mut i)?)),
             "-D" | "--devmode" => devmode = true,
             "-t" | "--tebafile" => {
                 let _ = take_value(&mut i)?;
@@ -331,21 +335,32 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
         i += 1;
     }
 
-    // Thor's required-options check, message shape included.
-    let mut missing = String::new();
-    if root.is_none() {
-        missing += " '--root'";
-    }
-    if entrance.is_none() {
-        if !missing.is_empty() {
-            missing += ", ";
+    // Thor's required-options check, message shape included. A suite
+    // carries its own roots/entries, so -r/-e are neither required nor
+    // accepted with --suite.
+    if suite.is_some() {
+        if root.is_some() || entrance.is_some() {
+            return Err(CliExit::Usage(
+                "--root/--entry-point come from the suite file with --suite (do not pass them)"
+                    .to_string(),
+            ));
         }
-        missing += " '--entry-point'";
-    }
-    if !missing.is_empty() {
-        return Err(CliExit::Usage(format!(
-            "No value provided for required options {missing}"
-        )));
+    } else {
+        let mut missing = String::new();
+        if root.is_none() {
+            missing += " '--root'";
+        }
+        if entrance.is_none() {
+            if !missing.is_empty() {
+                missing += ", ";
+            }
+            missing += " '--entry-point'";
+        }
+        if !missing.is_empty() {
+            return Err(CliExit::Usage(format!(
+                "No value provided for required options {missing}"
+            )));
+        }
     }
 
     let fs_current = std::env::current_dir()
@@ -354,8 +369,8 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
         .replace('\\', "/");
 
     Ok(PressOptions {
-        root_arg: root.unwrap().replace('\\', "/"),
-        entrance: entrance.unwrap().replace('\\', "/"),
+        root_arg: root.unwrap_or_default().replace('\\', "/"),
+        entrance: entrance.unwrap_or_default().replace('\\', "/"),
         output,
         prefix: resolve_prefix(prefix.as_deref()),
         cwd: cwd.map(|c| c.replace('\\', "/")),
@@ -369,5 +384,6 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
         verbose: verbose_mode(),
         devmode,
         fs_current,
+        suite,
     })
 }

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -21,7 +21,12 @@ const USAGE: &str = "Usage:
   tebako list-registries               list the registered registries
   tebako update-registries             refresh the dispatch-time registry cache
   tebako install <ref | name[@ver]>    install a payload + register its shims
-  tebako uninstall <name>              remove a payload's shims and cache entry";
+  tebako uninstall <name>              remove a payload's shims and cache entry
+  tebako publish --name <app> [--version <v>] --release tfs:github:<owner>/<repo>[:<tag>]
+               (--payload <path> | --payload <triplet>=<path>)...
+               [--standalone <triplet>=<path>]... [--sign[=<keyid>]]
+               [--upload-mirror <dir>] [--tap <org/homebrew-tap> [--tap-dir <dir>]]
+               [--registry-out <path>] [--skip-verify]";
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -86,6 +91,7 @@ fn run(args: &[String]) -> Result<(), CliExit> {
         "update-registries" => run_update_registries(rest),
         "install" => run_install(rest),
         "uninstall" => run_uninstall(rest),
+        "publish" => run_publish(rest),
         "clean" | "setup" | "hash" => Err(CliExit::Usage(format!(
             "'tebako {subcommand}' is a later tebako-rs milestone"
         ))),
@@ -218,6 +224,149 @@ fn run_uninstall(args: &[String]) -> Result<(), CliExit> {
     println!("removed {} ({})", outcome.name, outcome.versions.join(", "));
     for shim in &outcome.shims_removed {
         println!("  unlinked {}", shim.display());
+    }
+    Ok(())
+}
+
+/// `<triplet>=<path>` when the left side is a platform triplet, else the
+/// universal `<path>` (a path carrying '=' keeps it — the left side must
+/// be a triplet for the bound form).
+fn parse_payload_arg(value: &str) -> Result<(Option<tpkg::Platform>, PathBuf), CliExit> {
+    if let Some((lhs, rhs)) = value.split_once('=') {
+        if let Some(platform) = tpkg::Platform::from_triplet(lhs) {
+            if rhs.is_empty() {
+                return Err(CliExit::Usage(format!(
+                    "invalid payload argument '{value}' (<triplet>=<path>)"
+                )));
+            }
+            return Ok((Some(platform), PathBuf::from(rhs)));
+        }
+    }
+    Ok((None, PathBuf::from(value)))
+}
+
+fn parse_publish(args: &[String]) -> Result<tebako_cli::publish::PublishOptions, CliExit> {
+    let mut name: Option<String> = None;
+    let mut version: Option<String> = None;
+    let mut release: Option<String> = None;
+    let mut payloads = Vec::new();
+    let mut standalones = Vec::new();
+    let mut sign: Option<Option<String>> = None;
+    let mut upload_mirror: Option<PathBuf> = None;
+    let mut tap: Option<String> = None;
+    let mut tap_dir: Option<PathBuf> = None;
+    let mut license: Option<String> = None;
+    let mut desc: Option<String> = None;
+    let mut homepage: Option<String> = None;
+    let mut registry_out: Option<String> = None;
+    let mut skip_verify = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        let (flag, inline_value) = match arg.split_once('=') {
+            Some((f, v)) if f.starts_with("--") => (f, Some(v.to_string())),
+            _ => (arg.as_str(), None),
+        };
+        let take_value = |i: &mut usize| -> Result<String, CliExit> {
+            if let Some(v) = inline_value.clone() {
+                return Ok(v);
+            }
+            *i += 1;
+            args.get(*i)
+                .cloned()
+                .ok_or_else(|| CliExit::Usage(format!("option '{flag}' requires a value")))
+        };
+        match flag {
+            "--name" => name = Some(take_value(&mut i)?),
+            "--version" => version = Some(take_value(&mut i)?),
+            "--release" => release = Some(take_value(&mut i)?),
+            "--payload" => {
+                let (triplet, path) = parse_payload_arg(&take_value(&mut i)?)?;
+                payloads.push(tebako_cli::publish::PayloadInput { triplet, path });
+            }
+            "--standalone" => {
+                let value = take_value(&mut i)?;
+                match parse_payload_arg(&value)? {
+                    (Some(triplet), path) => standalones.push((triplet, path)),
+                    (None, _) => {
+                        return Err(CliExit::Usage(format!(
+                            "--standalone expects <triplet>=<path>, got '{value}'"
+                        )))
+                    }
+                }
+            }
+            "--sign" => sign = Some(inline_value.clone()),
+            "--upload-mirror" => upload_mirror = Some(PathBuf::from(take_value(&mut i)?)),
+            "--tap" => tap = Some(take_value(&mut i)?),
+            "--tap-dir" => tap_dir = Some(PathBuf::from(take_value(&mut i)?)),
+            "--license" => license = Some(take_value(&mut i)?),
+            "--desc" => desc = Some(take_value(&mut i)?),
+            "--homepage" => homepage = Some(take_value(&mut i)?),
+            "--registry-out" => registry_out = Some(take_value(&mut i)?),
+            "--skip-verify" => skip_verify = true,
+            other => return Err(CliExit::Usage(format!("unknown publish option '{other}'"))),
+        }
+        i += 1;
+    }
+
+    let name = name.ok_or_else(|| CliExit::Usage("publish requires --name <app>".to_string()))?;
+    let release =
+        release.ok_or_else(|| CliExit::Usage("publish requires --release <ref>".to_string()))?;
+    if payloads.is_empty() {
+        return Err(CliExit::Usage(
+            "publish requires at least one --payload".to_string(),
+        ));
+    }
+    if tap_dir.is_some() && tap.is_none() {
+        return Err(CliExit::Usage("--tap-dir needs --tap".to_string()));
+    }
+
+    Ok(tebako_cli::publish::PublishOptions {
+        name,
+        version,
+        release,
+        payloads,
+        standalones,
+        sign,
+        upload_mirror,
+        tap,
+        tap_dir,
+        license,
+        desc,
+        homepage,
+        registry_out,
+        skip_verify,
+    })
+}
+
+fn run_publish(args: &[String]) -> Result<(), CliExit> {
+    let opts = parse_publish(args)?;
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let outcome = tebako_cli::publish::publish(&opts, &tebako_home()?, &cwd)?;
+    for note in &outcome.notes {
+        eprintln!("tebako: note: {note}");
+    }
+    println!(
+        "published {} {} to tfs:github release tag {}",
+        outcome.name, outcome.version, outcome.tag
+    );
+    for (artifact, sha) in &outcome.artifacts {
+        println!("  {artifact}  sha256:{sha}");
+    }
+    if let Some(signer) = &outcome.signer {
+        println!("  signed (keyid {signer}): {} .asc", outcome.ascs.len());
+    }
+    if let Some(path) = &outcome.registry_path {
+        println!("  registry {}", path.display());
+    }
+    if let Some(path) = &outcome.formula_path {
+        println!("  tap formula {}", path.display());
+    } else if let Some(formula) = &outcome.formula {
+        println!("{formula}");
+    }
+    if let Some(verified) = &outcome.verified {
+        println!("  {verified}");
     }
     Ok(())
 }

--- a/crates/tebako-cli/src/options.rs
+++ b/crates/tebako-cli/src/options.rs
@@ -37,7 +37,7 @@ impl PressMode {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PressOptions {
     /// Root folder as given on the command line, made absolute
     /// (gem keeps the trailing slash for absolute roots).
@@ -68,6 +68,11 @@ pub struct PressOptions {
     pub devmode: bool,
     /// Press-time current directory.
     pub fs_current: String,
+    /// --suite <suite.yaml>: one package, N entries (spec 03 §6) —
+    /// per-entry imaging + slots + the type-2 package manifest. Roots and
+    /// entry points come from the suite file; -r/-e are not accepted with
+    /// it.
+    pub suite: Option<PathBuf>,
 }
 
 impl PressOptions {

--- a/crates/tebako-cli/src/packager.rs
+++ b/crates/tebako-cli/src/packager.rs
@@ -780,6 +780,7 @@ mod tests {
             verbose: false,
             devmode: false,
             fs_current: "/tmp".to_string(),
+            suite: None,
         }
     }
 

--- a/crates/tebako-cli/src/publish.rs
+++ b/crates/tebako-cli/src/publish.rs
@@ -1,0 +1,1274 @@
+//! `tebako publish` (spec 16 §5 developer side, roadmap 41): the release
+//! helper for persona C. One flow, all in-process (no gh CLI, no
+//! shell-outs — spec 14 §3):
+//!
+//! 1. **accept per-triplet payloads** (`--payload <triplet>=<path>` for
+//!    native-extension apps, one `--payload <path>` for universal) —
+//!    produced by prior `tebako press` runs (one per triplet, the CI
+//!    matrix); each must carry an embedded manifest (spec 03 §1 — the
+//!    registry's entrypoints/runtime mirror comes from it).
+//! 2. **optional sign** (`--sign[=<keyid>]`) via tebako-signer: a
+//!    detached OpenPGP signature per artifact, uploaded as
+//!    `<artifact>.asc` (the convention the installer verifies); the
+//!    registry entry pins `{keyid, asc}`.
+//! 3. **upload** to the referenced GitHub release (`--release
+//!    tfs:github:<owner>/<repo>[:<tag>]`) via tebako-http + the releases
+//!    API — or into a `file://` mirror directory (`--upload-mirror`,
+//!    the air-gapped rehearsal + test leg; same layout:
+//!    `<mirror>/<tag>/<artifact>`). Uploads replace same-named assets —
+//!    re-publish is idempotent.
+//! 4. **registry**: generate/update `tpkg-registry.yaml` (upsert the
+//!    payload's version entry; a re-published version replaces its entry,
+//!    a new payload's default starts at its first version).
+//! 5. **optional tap** (`--tap <org/homebrew-tap>`): render the vendored
+//!    app-formula template (provenance:
+//!    tamatebako/homebrew-tap/templates/app-formula.rb.template) from the
+//!    published standalones' digests.
+//! 6. **built-in verify**: a clean-temp-cache `tebako install` proof —
+//!    fresh TEBAKO_HOME, the just-written registry, the mirror (or live
+//!    release) as the source; the shims and the trust anchors must land.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use tebako_resolve::registry::SignaturePin;
+use tebako_resolve::{
+    Fetcher, Registry, RegistryPayload, RegistryPlatforms, RegistryRuntimeRequirement,
+    RegistryVersion, ReleaseRef, Transport,
+};
+use tpkg::Platform;
+
+use crate::error::TebakoError;
+use crate::image_manifest;
+
+const EX_USAGE: i32 = 64;
+const EX_TEBAKO_MANIFEST: i32 = 65;
+const EX_TEBAKO_UNAVAILABLE: i32 = 69;
+const EX_TEBAKO_SIGNATURE: i32 = 71;
+const EX_TEBAKO_IO: i32 = 74;
+
+fn err(code: i32, message: impl Into<String>) -> TebakoError {
+    TebakoError::new(message, code)
+}
+
+// ---------------------------------------------------------------------
+// options
+// ---------------------------------------------------------------------
+
+/// One `--payload` argument: a triplet-bound payload (per-triplet apps)
+/// or the universal one (`triplet: None`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PayloadInput {
+    pub triplet: Option<Platform>,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct PublishOptions {
+    /// The app name (payload + shim names).
+    pub name: String,
+    /// The version; derived from the payload file names when omitted.
+    pub version: Option<String>,
+    /// `tfs:github:<owner>/<repo>[:<tag>]` — the release the artifacts
+    /// land in (tag defaults to the version). This is ALSO the ref the
+    /// registry entry records, mirror mode or not.
+    pub release: String,
+    pub payloads: Vec<PayloadInput>,
+    /// Standalone binaries (`<triplet>=<path>`) — the tap formula's
+    /// artifacts; uploaded alongside the payloads.
+    pub standalones: Vec<(Platform, PathBuf)>,
+    /// `None` = unsigned; `Some(None)` = the press-local key;
+    /// `Some(Some(keyid))` = that key from ~/.tebako/keys.
+    pub sign: Option<Option<String>>,
+    /// file:// rehearsal: upload into `<mirror>/<tag>/` instead of the
+    /// live API (the registry still records the --release ref).
+    pub upload_mirror: Option<PathBuf>,
+    /// Render the tap formula for `<org/homebrew-tap>`.
+    pub tap: Option<String>,
+    /// Where the formula is written (`<dir>/Formula/<name>.rb`); stdout
+    /// when unset.
+    pub tap_dir: Option<PathBuf>,
+    pub license: Option<String>,
+    pub desc: Option<String>,
+    pub homepage: Option<String>,
+    /// The registry file to generate/update (default
+    /// `./tpkg-registry.yaml`; `-` prints to stdout).
+    pub registry_out: Option<String>,
+    pub skip_verify: bool,
+}
+
+/// What a publish produced.
+#[derive(Debug)]
+pub struct PublishOutcome {
+    pub name: String,
+    pub version: String,
+    pub tag: String,
+    /// `(artifact name, sha256)` of every uploaded artifact.
+    pub artifacts: Vec<(String, String)>,
+    /// Uploaded `.asc` names (when signed).
+    pub ascs: Vec<String>,
+    /// The signer keyid (when signed).
+    pub signer: Option<String>,
+    pub registry_path: Option<PathBuf>,
+    /// The rendered formula text (when --tap).
+    pub formula: Option<String>,
+    pub formula_path: Option<PathBuf>,
+    /// The built-in verify's summary line (unless --skip-verify).
+    pub verified: Option<String>,
+    pub notes: Vec<String>,
+}
+
+// ---------------------------------------------------------------------
+// the release reference + artifact naming
+// ---------------------------------------------------------------------
+
+/// `tfs:github:<owner>/<repo>[:<tag>]` → (owner, repo, tag?). The publish
+/// write leg is GitHub-only (the service adapters' read legs cover the
+/// rest; their write legs are a later milestone).
+fn parse_release_ref(release: &str) -> Result<(String, String, Option<String>), TebakoError> {
+    for (prefix, service) in [("tfs:gitlab:", "gitlab"), ("tfs:bb:", "bitbucket")] {
+        if release.starts_with(prefix) {
+            return Err(err(
+                EX_USAGE,
+                format!(
+                    "publish upload is implemented for GitHub releases (and file:// mirrors) — the {service} write leg is a later milestone"
+                ),
+            ));
+        }
+    }
+    let Some(rest) = release.strip_prefix("tfs:github:") else {
+        return Err(err(
+            EX_USAGE,
+            format!("invalid --release '{release}' — expected tfs:github:<owner>/<repo>[:<tag>]"),
+        ));
+    };
+    let (owner, repo_tag) = rest.rsplit_once('/').ok_or_else(|| {
+        err(
+            EX_USAGE,
+            format!("invalid --release '{release}' — expected tfs:github:<owner>/<repo>[:<tag>]"),
+        )
+    })?;
+    let (repo, tag) = match repo_tag.split_once(':') {
+        Some((r, t)) => (r.to_string(), Some(t.to_string())),
+        None => (repo_tag.to_string(), None),
+    };
+    for (what, value) in [("owner", &owner.to_string()), ("repo", &repo)] {
+        if value.is_empty()
+            || value
+                .chars()
+                .any(|c| matches!(c, '?' | '#' | '@' | ' ' | '\t'))
+        {
+            return Err(err(
+                EX_USAGE,
+                format!("invalid --release '{release}' — bad {what} '{value}'"),
+            ));
+        }
+    }
+    if let Some(t) = &tag {
+        if t.is_empty() || t.contains(['?', '#', ' ']) {
+            return Err(err(
+                EX_USAGE,
+                format!("invalid --release '{release}' — bad tag '{t}'"),
+            ));
+        }
+    }
+    Ok((owner.to_string(), repo, tag))
+}
+
+/// The version from a payload file name: `<name>-<version>.tfs` or
+/// `<name>-<version>-<release_asset_name>.tfs`.
+fn version_from_artifact(name: &str, file: &Path) -> Option<String> {
+    let base = file.file_name()?.to_string_lossy().into_owned();
+    let base = base.strip_suffix(".tfs")?;
+    let base = Platform::ALL
+        .iter()
+        .find_map(|p| base.strip_suffix(&format!("-{}", p.release_asset_name())))
+        .unwrap_or(base);
+    base.strip_prefix(&format!("{name}-")).map(str::to_string)
+}
+
+/// The payload's upload name (the locked release-asset convention).
+fn payload_artifact_name(name: &str, version: &str, triplet: Option<Platform>) -> String {
+    match triplet {
+        Some(p) => format!("{name}-{version}-{}.tfs", p.release_asset_name()),
+        None => format!("{name}-{version}.tfs"),
+    }
+}
+
+/// A standalone binary's upload name (no `.tfs` — the tap formula's urls).
+fn standalone_artifact_name(name: &str, version: &str, triplet: Platform) -> String {
+    format!("{name}-{version}-{}", triplet.release_asset_name())
+}
+
+// ---------------------------------------------------------------------
+// the upload stores
+// ---------------------------------------------------------------------
+
+/// The upload half of a release: idempotent asset placement (replace on
+/// re-publish).
+trait ReleaseStore {
+    fn ensure_release(&self, owner: &str, repo: &str, tag: &str) -> Result<(), TebakoError>;
+    fn upload_asset(
+        &self,
+        owner: &str,
+        repo: &str,
+        tag: &str,
+        name: &str,
+        bytes: &[u8],
+    ) -> Result<(), TebakoError>;
+}
+
+/// The `file://` mirror store: `<root>/<tag>/<artifact>` (the rehearsal +
+/// test leg; the registry still records the GitHub release ref).
+struct MirrorStore {
+    root: PathBuf,
+}
+
+impl ReleaseStore for MirrorStore {
+    fn ensure_release(&self, _owner: &str, _repo: &str, tag: &str) -> Result<(), TebakoError> {
+        let dir = self.root.join(tag);
+        std::fs::create_dir_all(&dir).map_err(|e| {
+            err(
+                EX_TEBAKO_IO,
+                format!("cannot create the release mirror {}: {e}", dir.display()),
+            )
+        })
+    }
+
+    fn upload_asset(
+        &self,
+        _owner: &str,
+        _repo: &str,
+        tag: &str,
+        name: &str,
+        bytes: &[u8],
+    ) -> Result<(), TebakoError> {
+        let dir = self.root.join(tag);
+        let tmp = dir.join(format!(".{name}.{}.part", std::process::id()));
+        let dst = dir.join(name);
+        std::fs::write(&tmp, bytes)
+            .map_err(|e| err(EX_TEBAKO_IO, format!("cannot write {}: {e}", tmp.display())))?;
+        // replace on re-publish — idempotent by construction
+        std::fs::rename(&tmp, &dst).map_err(|e| {
+            err(
+                EX_TEBAKO_IO,
+                format!("cannot install {}: {e}", dst.display()),
+            )
+        })
+    }
+}
+
+/// The GitHub releases store (live API via tebako-http; token from
+/// `TEBAKO_GITHUB_TOKEN` or `GITHUB_TOKEN`). Never constructed in tests.
+struct GithubStore {
+    token: String,
+}
+
+impl GithubStore {
+    fn release_api_url(owner: &str, repo: &str, tag: &str) -> String {
+        format!("https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag}")
+    }
+
+    fn create_release_url(owner: &str, repo: &str) -> String {
+        format!("https://api.github.com/repos/{owner}/{repo}/releases")
+    }
+
+    fn create_release_body(tag: &str) -> String {
+        format!(
+            "{{\"tag_name\":\"{}\",\"name\":\"{}\"}}",
+            tebako_json::escape(tag),
+            tebako_json::escape(tag)
+        )
+    }
+
+    /// The asset upload URL from a release's `upload_url` template.
+    fn upload_url(upload_url_template: &str, name: &str) -> String {
+        let base = upload_url_template
+            .split('{')
+            .next()
+            .unwrap_or(upload_url_template);
+        format!("{base}?name={}", tebako_json::escape(name))
+    }
+
+    fn delete_asset_url(owner: &str, repo: &str, asset_id: u64) -> String {
+        format!("https://api.github.com/repos/{owner}/{repo}/releases/assets/{asset_id}")
+    }
+
+    /// The release document `{id, upload_url, assets: [{name, id}]}`,
+    /// or None on 404.
+    fn get_release(
+        &self,
+        owner: &str,
+        repo: &str,
+        tag: &str,
+    ) -> Result<Option<ReleaseDoc>, TebakoError> {
+        let url = Self::release_api_url(owner, repo, tag);
+        let text = match tebako_http::get_text(&url) {
+            Ok(t) => t,
+            Err(tebako_http::FetchError::IndexUnavailable(_)) => return Ok(None),
+            Err(e) => {
+                return Err(err(
+                    EX_TEBAKO_UNAVAILABLE,
+                    format!("cannot read the GitHub release {owner}/{repo}:{tag}: {e}"),
+                ))
+            }
+        };
+        match ReleaseDoc::parse(&text) {
+            Some(doc) => Ok(Some(doc)),
+            None => Err(err(
+                EX_TEBAKO_UNAVAILABLE,
+                format!("unexpected GitHub release document from {url}"),
+            )),
+        }
+    }
+}
+
+/// The bits of a GitHub release document publish needs.
+struct ReleaseDoc {
+    upload_url: String,
+    /// `(asset name, asset id)` for replacement on re-publish.
+    assets: Vec<(String, u64)>,
+}
+
+impl ReleaseDoc {
+    fn parse(text: &str) -> Option<ReleaseDoc> {
+        let doc = tebako_json::parse(text).ok()?;
+        let upload_url = doc.find("upload_url")?.as_string()?;
+        let mut assets = Vec::new();
+        if let Some(tebako_json::Value::Array(items)) = doc.find("assets") {
+            for a in items {
+                let name = a.find("name")?.as_string()?;
+                let id = a.find("id")?.as_u64()?;
+                assets.push((name, id));
+            }
+        }
+        Some(ReleaseDoc { upload_url, assets })
+    }
+}
+
+impl ReleaseStore for GithubStore {
+    fn ensure_release(&self, owner: &str, repo: &str, tag: &str) -> Result<(), TebakoError> {
+        if self.get_release(owner, repo, tag)?.is_some() {
+            return Ok(());
+        }
+        tebako_http::post(
+            &Self::create_release_url(owner, repo),
+            Self::create_release_body(tag).as_bytes(),
+            "application/json",
+            Some(&self.token),
+        )
+        .map_err(|e| {
+            err(
+                EX_TEBAKO_UNAVAILABLE,
+                format!("cannot create the GitHub release {owner}/{repo}:{tag}: {e}"),
+            )
+        })?;
+        Ok(())
+    }
+
+    fn upload_asset(
+        &self,
+        owner: &str,
+        repo: &str,
+        tag: &str,
+        name: &str,
+        bytes: &[u8],
+    ) -> Result<(), TebakoError> {
+        let release = self.get_release(owner, repo, tag)?.ok_or_else(|| {
+            err(
+                EX_TEBAKO_UNAVAILABLE,
+                format!("the GitHub release {owner}/{repo}:{tag} vanished mid-publish"),
+            )
+        })?;
+        // replace on re-publish: delete a same-named asset first
+        if let Some((_, id)) = release.assets.iter().find(|(n, _)| n == name) {
+            tebako_http::delete(&Self::delete_asset_url(owner, repo, *id), Some(&self.token))
+                .map_err(|e| {
+                    err(
+                        EX_TEBAKO_UNAVAILABLE,
+                        format!("cannot replace the release asset {name}: {e}"),
+                    )
+                })?;
+        }
+        tebako_http::post(
+            &Self::upload_url(&release.upload_url, name),
+            bytes,
+            "application/octet-stream",
+            Some(&self.token),
+        )
+        .map_err(|e| {
+            err(
+                EX_TEBAKO_UNAVAILABLE,
+                format!("cannot upload the release asset {name}: {e}"),
+            )
+        })?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// the mirror transport (verify against a file:// release mirror)
+// ---------------------------------------------------------------------
+
+/// A transport answering the release's API shape from a mirror directory
+/// — the verify leg resolves the REAL registry (service ref, per-triplet
+/// selection, sha pins) with zero network.
+struct MirrorTransport {
+    api_url: String,
+    dir: PathBuf,
+}
+
+impl MirrorTransport {
+    fn for_release(owner: &str, repo: &str, tag: &str, mirror: &Path) -> MirrorTransport {
+        MirrorTransport {
+            api_url: GithubStore::release_api_url(owner, repo, tag),
+            dir: mirror.join(tag),
+        }
+    }
+}
+
+impl Transport for MirrorTransport {
+    fn get(&self, url: &str) -> Result<Vec<u8>, tebako_http::FetchError> {
+        if url == self.api_url {
+            let mut assets = String::from("[");
+            let mut first = true;
+            let entries = std::fs::read_dir(&self.dir).map_err(|e| {
+                tebako_http::FetchError::IndexUnavailable(format!("{}: {e}", self.dir.display()))
+            })?;
+            let mut names: Vec<String> = entries
+                .flatten()
+                .filter(|e| e.path().is_file())
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .filter(|n| !n.starts_with('.'))
+                .collect();
+            names.sort();
+            for name in names {
+                if !first {
+                    assets.push(',');
+                }
+                first = false;
+                assets.push_str(&format!(
+                    "{{\"name\":\"{}\",\"browser_download_url\":\"file://{}/{}\"}}",
+                    tebako_json::escape(&name),
+                    self.dir.display(),
+                    tebako_json::escape(&name)
+                ));
+            }
+            assets.push(']');
+            return Ok(format!("{{\"assets\":{assets}}}").into_bytes());
+        }
+        if url.starts_with("file://") {
+            return tebako_http::get(url);
+        }
+        Err(tebako_http::FetchError::IndexUnavailable(url.to_string()))
+    }
+}
+
+// ---------------------------------------------------------------------
+// the tap formula
+// ---------------------------------------------------------------------
+
+const TAP_TEMPLATE: &str = include_str!("../templates/app-formula.rb.template");
+
+/// The platforms the vendored template carries sha slots for.
+const TAP_PLATFORMS: [Platform; 4] = [
+    Platform::Aarch64Macos,
+    Platform::X86_64Macos,
+    Platform::Aarch64LinuxGnu,
+    Platform::X86_64LinuxGnu,
+];
+
+fn camelize(name: &str) -> String {
+    name.split(['-', '_'])
+        .filter(|p| !p.is_empty())
+        .map(|p| {
+            let mut chars = p.chars();
+            match chars.next() {
+                Some(c) => c.to_ascii_uppercase().to_string() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect()
+}
+
+/// Render the vendored app-formula template (provenance:
+/// tamatebako/homebrew-tap/templates/app-formula.rb.template, kept
+/// verbatim). Every template sha slot needs a standalone — a missing one
+/// is a named error, never a placeholder digest.
+fn render_formula(
+    opts: &PublishOptions,
+    owner: &str,
+    repo: &str,
+    version: &str,
+    standalones: &[(Platform, String)],
+) -> Result<String, TebakoError> {
+    let mut shas: BTreeMap<Platform, String> = BTreeMap::new();
+    for (p, sha) in standalones {
+        shas.insert(*p, sha.clone());
+    }
+    let missing: Vec<&str> = TAP_PLATFORMS
+        .iter()
+        .filter(|p| !shas.contains_key(p))
+        .map(|p| p.release_asset_name())
+        .collect();
+    if !missing.is_empty() {
+        return Err(err(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "--tap needs a standalone for every template platform — missing: {} (--standalone <triplet>=<path>)",
+                missing.join(", ")
+            ),
+        ));
+    }
+    let out = TAP_TEMPLATE
+        .replace("@@CAMELAPP@@", &camelize(&opts.name))
+        .replace(
+            "@@APP_DESC@@",
+            &opts
+                .desc
+                .clone()
+                .unwrap_or_else(|| format!("{} (tebako-packaged)", opts.name)),
+        )
+        .replace(
+            "@@APP_HOMEPAGE@@",
+            &opts
+                .homepage
+                .clone()
+                .unwrap_or_else(|| format!("https://github.com/{owner}/{repo}")),
+        )
+        .replace("@@APP_VERSION@@", version)
+        .replace(
+            "@@APP_LICENSE_SPDX@@",
+            &opts
+                .license
+                .clone()
+                .unwrap_or_else(|| "UNLICENSED".to_string()),
+        )
+        .replace(
+            "@@RELEASE_BASE_URL@@",
+            &format!("https://github.com/{owner}/{repo}/releases/download"),
+        )
+        .replace("@@APP@@", &opts.name)
+        .replace("@@SHA256_MACOS_ARM64@@", &shas[&Platform::Aarch64Macos])
+        .replace("@@SHA256_MACOS_X86_64@@", &shas[&Platform::X86_64Macos])
+        .replace(
+            "@@SHA256_LINUX_GNU_ARM64@@",
+            &shas[&Platform::Aarch64LinuxGnu],
+        )
+        .replace(
+            "@@SHA256_LINUX_GNU_X86_64@@",
+            &shas[&Platform::X86_64LinuxGnu],
+        );
+    if out
+        .lines()
+        .any(|line| !line.trim_start().starts_with('#') && line.contains("@@"))
+    {
+        return Err(err(
+            EX_TEBAKO_MANIFEST,
+            "the tap template carries an @@PLACEHOLDER@@ this build does not fill — the vendored template drifted",
+        ));
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------
+// publish
+// ---------------------------------------------------------------------
+
+fn resolve_signing_key(
+    home: &Path,
+    sign: &Option<Option<String>>,
+) -> Result<Option<tebako_signer::PressKey>, TebakoError> {
+    match sign {
+        None => Ok(None),
+        Some(None) => tebako_signer::press_local_key(home)
+            .map(Some)
+            .map_err(|e| err(EX_TEBAKO_SIGNATURE, format!("the press-local key: {e}"))),
+        Some(Some(keyid)) => match tebako_signer::secret_key_by_keyid(home, keyid)
+            .map_err(|e| err(EX_TEBAKO_SIGNATURE, format!("cannot read the key store: {e}")))?
+        {
+            Some(key) => Ok(Some(key)),
+            None => Err(err(
+                EX_TEBAKO_SIGNATURE,
+                format!(
+                    "no secret key with keyid {keyid} under {}/keys — generate one, or use bare --sign for the press-local key",
+                    home.display()
+                ),
+            )),
+        },
+    }
+}
+
+/// The production publish (`shim_binary: None` resolves the dispatcher
+/// like install does).
+pub fn publish(
+    opts: &PublishOptions,
+    home: &Path,
+    cwd: &Path,
+) -> Result<PublishOutcome, TebakoError> {
+    publish_full(opts, home, cwd, None)
+}
+
+/// The full publish flow; `shim_binary` overrides the dispatcher binary
+/// the verify install links (tests).
+pub fn publish_full(
+    opts: &PublishOptions,
+    home: &Path,
+    cwd: &Path,
+    shim_binary: Option<&Path>,
+) -> Result<PublishOutcome, TebakoError> {
+    let mut notes = Vec::new();
+
+    // ---- 1. inputs --------------------------------------------------
+    let (owner, repo, ref_tag) = parse_release_ref(&opts.release)?;
+    if opts.payloads.is_empty() {
+        return Err(err(
+            EX_USAGE,
+            "publish needs at least one --payload (<triplet>=<path>, or <path> for universal)",
+        ));
+    }
+    let universal = opts.payloads[0].triplet.is_none();
+    if universal && opts.payloads.len() > 1 {
+        return Err(err(
+            EX_USAGE,
+            "a universal payload is one artifact — do not mix it with per-triplet payloads",
+        ));
+    }
+    if !universal && opts.payloads.iter().any(|p| p.triplet.is_none()) {
+        return Err(err(
+            EX_USAGE,
+            "do not mix per-triplet and universal payloads in one publish",
+        ));
+    }
+    {
+        let mut triplets: Vec<Platform> = opts.payloads.iter().filter_map(|p| p.triplet).collect();
+        triplets.sort();
+        if triplets.windows(2).any(|w| w[0] == w[1]) {
+            return Err(err(EX_USAGE, "duplicate payload triplet"));
+        }
+        if let Some(p) = triplets.iter().find(|p| p.is_reserved()) {
+            return Err(err(
+                EX_USAGE,
+                format!("the reserved triplet {p} is not publishable in v1"),
+            ));
+        }
+    }
+
+    let version = match &opts.version {
+        Some(v) => v.clone(),
+        None => {
+            let mut versions = opts
+                .payloads
+                .iter()
+                .map(|p| version_from_artifact(&opts.name, &p.path))
+                .collect::<Vec<_>>();
+            versions.dedup();
+            match versions.as_slice() {
+                [Some(v)] => v.clone(),
+                _ => {
+                    return Err(err(
+                        EX_USAGE,
+                        format!(
+                            "cannot derive the version from the payload file names — pass --version (expected {name}-<version>[-<platform>].tfs)",
+                            name = opts.name
+                        ),
+                    ))
+                }
+            }
+        }
+    };
+    let tag = ref_tag.unwrap_or_else(|| version.clone());
+
+    // ---- 2. payloads: bytes, digests, the embedded manifest ----------
+    let mut artifacts: Vec<(String, String, Vec<u8>)> = Vec::new(); // (upload name, sha, bytes)
+    for input in &opts.payloads {
+        if !input.path.is_file() {
+            return Err(err(
+                EX_USAGE,
+                format!("payload not found: {}", input.path.display()),
+            ));
+        }
+        let bytes = std::fs::read(&input.path).map_err(|e| {
+            err(
+                EX_TEBAKO_IO,
+                format!("cannot read {}: {e}", input.path.display()),
+            )
+        })?;
+        let name = payload_artifact_name(&opts.name, &version, input.triplet);
+        let sha = tebako_resolve::sha256_hex(&bytes);
+        artifacts.push((name, sha, bytes));
+    }
+    let manifest_text = image_manifest::read_embedded_manifest(&opts.payloads[0].path)?
+        .ok_or_else(|| {
+            err(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "{} carries no embedded manifest (/__tpkg__/manifest.yaml) — the registry's entrypoint mirror comes from it; press/mkimage embeds one",
+                    opts.payloads[0].path.display()
+                ),
+            )
+        })?;
+    let embedded = tpkg::PayloadManifest::from_yaml(&manifest_text).map_err(|e| {
+        err(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "the embedded manifest of {} does not parse: {e}",
+                opts.payloads[0].path.display()
+            ),
+        )
+    })?;
+    if embedded.identity.name != opts.name || embedded.identity.version != version {
+        return Err(err(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "the embedded manifest declares {} {} but publish names {} {}",
+                embedded.identity.name, embedded.identity.version, opts.name, version
+            ),
+        ));
+    }
+    let tpkg::Provides::App(app) = &embedded.provides else {
+        return Err(err(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "publish ships apps — {} is a {:?} payload",
+                opts.payloads[0].path.display(),
+                embedded.identity.kind
+            ),
+        ));
+    };
+    let entrypoints: Vec<String> = app.entrypoints.iter().map(|e| e.name.clone()).collect();
+    let runtime_requirement = app
+        .entrypoints
+        .first()
+        .and_then(|e| e.runtime_requirement.as_ref())
+        .map(|r| RegistryRuntimeRequirement {
+            engine: r.engine.clone(),
+            constraint: r.constraint.as_str().to_string(),
+        });
+    for input in opts.payloads.iter().skip(1) {
+        // every triplet's manifest must agree (the registry mirrors ONE set)
+        if let Some(text) = image_manifest::read_embedded_manifest(&input.path)? {
+            let other = tpkg::PayloadManifest::from_yaml(&text).map_err(|e| {
+                err(
+                    EX_TEBAKO_MANIFEST,
+                    format!(
+                        "the embedded manifest of {} does not parse: {e}",
+                        input.path.display()
+                    ),
+                )
+            })?;
+            let other_eps: Vec<String> = match &other.provides {
+                tpkg::Provides::App(a) => a.entrypoints.iter().map(|e| e.name.clone()).collect(),
+                _ => Vec::new(),
+            };
+            if other_eps != entrypoints {
+                return Err(err(
+                    EX_TEBAKO_MANIFEST,
+                    format!(
+                        "{} declares different entrypoints than the first payload — per-triplet variants of one app must agree",
+                        input.path.display()
+                    ),
+                ));
+            }
+        }
+    }
+
+    // ---- 3. standalones ---------------------------------------------
+    let mut standalone_uploads: Vec<(String, String, Vec<u8>)> = Vec::new();
+    for (triplet, path) in &opts.standalones {
+        if triplet.is_reserved() {
+            return Err(err(
+                EX_USAGE,
+                format!("the reserved triplet {triplet} is not publishable in v1"),
+            ));
+        }
+        let bytes = std::fs::read(path)
+            .map_err(|e| err(EX_TEBAKO_IO, format!("cannot read {}: {e}", path.display())))?;
+        let name = standalone_artifact_name(&opts.name, &version, *triplet);
+        let sha = tebako_resolve::sha256_hex(&bytes);
+        standalone_uploads.push((name, sha, bytes));
+    }
+
+    // ---- 4. sign ------------------------------------------------------
+    let key = resolve_signing_key(home, &opts.sign)?;
+    let mut ascs: Vec<(String, Vec<u8>)> = Vec::new();
+    if let Some(key) = &key {
+        for (name, _, bytes) in artifacts.iter().chain(standalone_uploads.iter()) {
+            let asc = tebako_signer::sign_detached(bytes, &key.secret_key, &key.fingerprint)
+                .map_err(|e| err(EX_TEBAKO_SIGNATURE, format!("cannot sign {name}: {e}")))?;
+            ascs.push((format!("{name}.asc"), asc));
+        }
+    }
+
+    // ---- 5. upload ----------------------------------------------------
+    let store: Box<dyn ReleaseStore> = match &opts.upload_mirror {
+        Some(mirror) => Box::new(MirrorStore {
+            root: mirror.clone(),
+        }),
+        None => {
+            let token = std::env::var("TEBAKO_GITHUB_TOKEN")
+                .ok()
+                .filter(|t| !t.is_empty())
+                .or_else(|| std::env::var("GITHUB_TOKEN").ok().filter(|t| !t.is_empty()))
+                .ok_or_else(|| {
+                    err(
+                        EX_USAGE,
+                        "uploading to the live GitHub API needs TEBAKO_GITHUB_TOKEN (or GITHUB_TOKEN); --upload-mirror <dir> rehearses file://-only",
+                    )
+                })?;
+            Box::new(GithubStore { token })
+        }
+    };
+    store.ensure_release(&owner, &repo, &tag)?;
+    for (name, _, bytes) in artifacts.iter().chain(standalone_uploads.iter()) {
+        store.upload_asset(&owner, &repo, &tag, name, bytes)?;
+    }
+    for (name, asc) in &ascs {
+        store.upload_asset(&owner, &repo, &tag, name, asc)?;
+    }
+
+    // ---- 6. the registry ----------------------------------------------
+    let release_ref = format!("tfs:github:{owner}/{repo}:{tag}");
+    let platforms = if universal {
+        RegistryPlatforms::Universal
+    } else {
+        RegistryPlatforms::PerTriplet(
+            opts.payloads
+                .iter()
+                .enumerate()
+                .map(|(i, p)| {
+                    (
+                        p.triplet.expect("per-triplet checked"),
+                        tebako_resolve::registry::PlatformArtifact {
+                            artifact: artifacts[i].0.clone(),
+                            sha256: artifacts[i].1.clone(),
+                        },
+                    )
+                })
+                .collect(),
+        )
+    };
+    let signature = key.as_ref().map(|key| SignaturePin {
+        keyid: key.keyid_hex(),
+        // universal: the exact asc; per-triplet: the convention asc of the
+        // first artifact (the installer derives <selected-artifact>.asc).
+        asc: format!("{}.asc", artifacts[0].0),
+    });
+    let version_entry = RegistryVersion {
+        version: version.clone(),
+        platforms,
+        release: ReleaseRef {
+            r#ref: release_ref.clone(),
+        },
+        signature,
+        runtime_requirement,
+        entrypoints: entrypoints.clone(),
+    };
+
+    let registry_out = opts
+        .registry_out
+        .clone()
+        .unwrap_or_else(|| cwd.join("tpkg-registry.yaml").display().to_string());
+    let mut registry = if registry_out == "-" {
+        Registry {
+            schema_version: 1,
+            payloads: Vec::new(),
+        }
+    } else {
+        let path = Path::new(&registry_out);
+        match std::fs::read_to_string(path) {
+            Ok(text) => Registry::from_yaml(&text).map_err(|e| {
+                err(
+                    EX_TEBAKO_MANIFEST,
+                    format!("cannot parse {}: {e}", path.display()),
+                )
+            })?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Registry {
+                schema_version: 1,
+                payloads: Vec::new(),
+            },
+            Err(e) => {
+                return Err(err(
+                    EX_TEBAKO_IO,
+                    format!("cannot read {}: {e}", path.display()),
+                ))
+            }
+        }
+    };
+    upsert_registry(&mut registry, &opts.name, version_entry, &mut notes);
+    let registry_text = registry.to_yaml().map_err(|e| {
+        err(
+            EX_TEBAKO_MANIFEST,
+            format!("cannot serialize the registry: {e}"),
+        )
+    })?;
+    let registry_path = if registry_out == "-" {
+        println!("{registry_text}");
+        None
+    } else {
+        let path = PathBuf::from(&registry_out);
+        write_atomic(&path, registry_text.as_bytes())?;
+        Some(path)
+    };
+
+    // ---- 7. the tap formula -------------------------------------------
+    let mut formula = None;
+    let mut formula_path = None;
+    if opts.tap.is_some() {
+        let shas: Vec<(Platform, String)> = opts
+            .standalones
+            .iter()
+            .enumerate()
+            .map(|(i, (p, _))| (*p, standalone_uploads[i].1.clone()))
+            .collect();
+        let rendered = render_formula(opts, &owner, &repo, &version, &shas)?;
+        if let Some(dir) = &opts.tap_dir {
+            let formula_dir = dir.join("Formula");
+            std::fs::create_dir_all(&formula_dir).map_err(|e| {
+                err(
+                    EX_TEBAKO_IO,
+                    format!("cannot create {}: {e}", formula_dir.display()),
+                )
+            })?;
+            let path = formula_dir.join(format!("{}.rb", opts.name));
+            write_atomic(&path, rendered.as_bytes())?;
+            formula_path = Some(path);
+        }
+        formula = Some(rendered);
+    }
+
+    // ---- 8. the built-in verify ----------------------------------------
+    let mut verified = None;
+    if !opts.skip_verify {
+        let verify_registry_text;
+        let registry_ref = match &registry_path {
+            Some(path) => format!("file://{}", path.display()),
+            None => {
+                // the registry went to stdout — the verify reads a temp copy
+                let tmp = std::env::temp_dir().join(format!(
+                    "tebako-publish-registry-{}.yaml",
+                    std::process::id()
+                ));
+                std::fs::write(&tmp, &registry_text).map_err(|e| {
+                    err(EX_TEBAKO_IO, format!("cannot write {}: {e}", tmp.display()))
+                })?;
+                verify_registry_text = tmp;
+                format!("file://{}", verify_registry_text.display())
+            }
+        };
+        let line = verify_install(
+            opts,
+            &version,
+            &registry_ref,
+            &tag,
+            key.as_ref(),
+            shim_binary,
+            universal,
+        )?;
+        verified = Some(line);
+    }
+
+    Ok(PublishOutcome {
+        name: opts.name.clone(),
+        version,
+        tag,
+        artifacts: artifacts
+            .iter()
+            .map(|(n, s, _)| (n.clone(), s.clone()))
+            .chain(
+                standalone_uploads
+                    .iter()
+                    .map(|(n, s, _)| (n.clone(), s.clone())),
+            )
+            .collect(),
+        ascs: ascs.iter().map(|(n, _)| n.clone()).collect(),
+        signer: key.as_ref().map(|k| k.keyid_hex()),
+        registry_path,
+        formula,
+        formula_path,
+        verified,
+        notes,
+    })
+}
+
+/// Upsert the payload's version entry: a re-published version REPLACES
+/// its entry (idempotent re-publish), a new version appends, a new
+/// payload's default starts at its first version.
+fn upsert_registry(
+    registry: &mut Registry,
+    name: &str,
+    entry: RegistryVersion,
+    notes: &mut Vec<String>,
+) {
+    let version = entry.version.clone();
+    match registry.payloads.iter_mut().find(|p| p.name == name) {
+        Some(payload) => {
+            match payload.versions.iter_mut().find(|v| v.version == version) {
+                Some(existing) => {
+                    *existing = entry;
+                    notes.push(format!(
+                        "replaced the registry entry for {name} {version} (re-publish)"
+                    ));
+                }
+                None => payload.versions.push(entry),
+            }
+            if payload.default.is_none() {
+                payload.default = Some(version);
+            }
+        }
+        None => registry.payloads.push(RegistryPayload {
+            name: name.to_string(),
+            kind: tpkg::PayloadKind::App,
+            versions: vec![entry],
+            default: Some(version),
+        }),
+    }
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), TebakoError> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(dir).map_err(|e| {
+        err(
+            EX_TEBAKO_IO,
+            format!("cannot create {}: {e}", dir.display()),
+        )
+    })?;
+    let tmp = dir.join(format!(
+        ".{}.{}.tmp",
+        path.file_name()
+            .map(|n| n.to_string_lossy())
+            .unwrap_or_default(),
+        std::process::id()
+    ));
+    std::fs::write(&tmp, bytes)
+        .map_err(|e| err(EX_TEBAKO_IO, format!("cannot write {}: {e}", tmp.display())))?;
+    std::fs::rename(&tmp, path).map_err(|e| {
+        err(
+            EX_TEBAKO_IO,
+            format!("cannot install {}: {e}", path.display()),
+        )
+    })
+}
+
+/// Verify temp homes are unique per call (parallel tests share the
+/// process's temp dir).
+static VERIFY_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// The built-in verify: a clean-temp-cache `tebako install` of the
+/// just-published payload — fresh TEBAKO_HOME, the just-written registry,
+/// the mirror (or the live release) as the artifact source. Signed
+/// publishes register the signer's public key in the temp keyring first
+/// (the install's strict signature path is part of the proof).
+#[allow(clippy::too_many_arguments)]
+fn verify_install(
+    opts: &PublishOptions,
+    version: &str,
+    registry_ref: &str,
+    tag: &str,
+    key: Option<&tebako_signer::PressKey>,
+    shim_binary: Option<&Path>,
+    universal: bool,
+) -> Result<String, TebakoError> {
+    let tmp = std::env::temp_dir().join(format!(
+        "tebako-publish-verify-{}-{}-{}",
+        opts.name,
+        std::process::id(),
+        VERIFY_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    ));
+    let _ = std::fs::remove_dir_all(&tmp);
+    let home = tmp.join("home");
+    std::fs::create_dir_all(&home).map_err(|e| {
+        err(
+            EX_TEBAKO_IO,
+            format!("cannot create the verify cache {}: {e}", home.display()),
+        )
+    })?;
+    let result = verify_install_at(
+        opts,
+        &home,
+        version,
+        registry_ref,
+        tag,
+        key,
+        shim_binary,
+        universal,
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+fn verify_install_at(
+    opts: &PublishOptions,
+    home: &Path,
+    version: &str,
+    registry_ref: &str,
+    tag: &str,
+    key: Option<&tebako_signer::PressKey>,
+    shim_binary: Option<&Path>,
+    universal: bool,
+) -> Result<String, TebakoError> {
+    if let Some(key) = key {
+        tebako_signer::register_trusted(home, &key.public_key)
+            .map_err(|e| err(EX_TEBAKO_SIGNATURE, format!("the verify keyring: {e}")))?;
+    }
+    let (owner, repo, _) = parse_release_ref(&opts.release)?;
+    let host = if universal {
+        None // the actual host — universal payloads install anywhere
+    } else {
+        // proof on the host's triplet when published, else the first one
+        let actual = Platform::from_release_asset_name(&crate::options::host_platform()?);
+        let first = opts.payloads[0].triplet;
+        Some(
+            actual
+                .filter(|a| opts.payloads.iter().any(|p| p.triplet == Some(*a)))
+                .unwrap_or(first.expect("per-triplet checked")),
+        )
+    };
+    let line = match &opts.upload_mirror {
+        Some(mirror) => {
+            let fetcher =
+                Fetcher::with_transport(MirrorTransport::for_release(&owner, &repo, tag, mirror));
+            verify_with(
+                opts,
+                home,
+                version,
+                registry_ref,
+                host,
+                shim_binary,
+                &fetcher,
+            )?
+        }
+        None => {
+            let fetcher = Fetcher::new();
+            verify_with(
+                opts,
+                home,
+                version,
+                registry_ref,
+                host,
+                shim_binary,
+                &fetcher,
+            )?
+        }
+    };
+    Ok(line)
+}
+
+/// The install proof over an injected fetcher (mirror or live).
+fn verify_with<T: Transport>(
+    opts: &PublishOptions,
+    home: &Path,
+    version: &str,
+    registry_ref: &str,
+    host: Option<Platform>,
+    shim_binary: Option<&Path>,
+    fetcher: &Fetcher<T>,
+) -> Result<String, TebakoError> {
+    crate::install::add_registry_with(home, registry_ref, fetcher)?;
+    // the just-published version explicitly (the registry default may
+    // point at an older line)
+    let target = format!("{}@{version}", opts.name);
+    let outcome = crate::install::install_with(home, &target, host, shim_binary, fetcher)?;
+    let signed = match &outcome.signer {
+        Some(s) => format!(", signed by {s}"),
+        None => String::new(),
+    };
+    Ok(format!(
+        "verified: clean-cache install of {} {} ({} shim(s): {}{})",
+        opts.name,
+        version,
+        outcome.commands.len(),
+        outcome.commands.join(", "),
+        signed
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_urls_and_bodies() {
+        assert_eq!(
+            GithubStore::release_api_url("acme", "app", "1.0"),
+            "https://api.github.com/repos/acme/app/releases/tags/1.0"
+        );
+        assert_eq!(
+            GithubStore::create_release_body("v1.2.3"),
+            "{\"tag_name\":\"v1.2.3\",\"name\":\"v1.2.3\"}"
+        );
+        assert_eq!(
+            GithubStore::upload_url(
+                "https://uploads.github.com/repos/acme/app/releases/42/assets{?name,label}",
+                "app-1.0.tfs"
+            ),
+            "https://uploads.github.com/repos/acme/app/releases/42/assets?name=app-1.0.tfs"
+        );
+        assert_eq!(
+            GithubStore::delete_asset_url("acme", "app", 42),
+            "https://api.github.com/repos/acme/app/releases/assets/42"
+        );
+    }
+
+    #[test]
+    fn release_doc_parses_the_bits_publish_needs() {
+        let doc = ReleaseDoc::parse(
+            r#"{"id":42,"upload_url":"https://uploads.github.com/x{?name,label}",
+               "assets":[{"name":"app-1.0.tfs","id":7},{"name":"app-1.0.tfs.asc","id":8}]}"#,
+        )
+        .unwrap();
+        assert_eq!(doc.upload_url, "https://uploads.github.com/x{?name,label}");
+        assert_eq!(
+            doc.assets,
+            vec![
+                ("app-1.0.tfs".to_string(), 7),
+                ("app-1.0.tfs.asc".to_string(), 8)
+            ]
+        );
+        assert!(ReleaseDoc::parse("not json").is_none());
+    }
+
+    #[test]
+    fn camelize_names() {
+        assert_eq!(camelize("metanorma"), "Metanorma");
+        assert_eq!(camelize("my-app"), "MyApp");
+        assert_eq!(camelize("my_app-2"), "MyApp2");
+    }
+
+    #[test]
+    fn release_ref_forms() {
+        let (o, r, t) = parse_release_ref("tfs:github:acme/app").unwrap();
+        assert_eq!(
+            (o.as_str(), r.as_str(), t.as_deref()),
+            ("acme", "app", None)
+        );
+        let (o, r, t) = parse_release_ref("tfs:github:acme/app:v1.0").unwrap();
+        assert_eq!(
+            (o.as_str(), r.as_str(), t.as_deref()),
+            ("acme", "app", Some("v1.0"))
+        );
+        for (bad, needle) in [
+            ("tfs:gitlab:acme/app", "later milestone"),
+            ("tfs:bb:acme/app", "later milestone"),
+            ("https://github.com/acme/app", "tfs:github:"),
+            ("tfs:github:acme", "<owner>/<repo>"),
+        ] {
+            let msg = parse_release_ref(bad).unwrap_err().message;
+            assert!(msg.contains(needle), "{bad}: expected '{needle}' in {msg}");
+        }
+    }
+
+    #[test]
+    fn artifact_version_derivation() {
+        let p = Path::new("/tmp/app-1.2.3.tfs");
+        assert_eq!(version_from_artifact("app", p).as_deref(), Some("1.2.3"));
+        let p = Path::new("/tmp/app-1.2.3-macos-arm64.tfs");
+        assert_eq!(version_from_artifact("app", p).as_deref(), Some("1.2.3"));
+        let p = Path::new("/tmp/mystery.bin");
+        assert_eq!(version_from_artifact("app", p), None);
+        // a name with dashes keeps the version intact
+        let p = Path::new("/tmp/my-app-2.0-linux-gnu-x86_64.tfs");
+        assert_eq!(version_from_artifact("my-app", p).as_deref(), Some("2.0"));
+    }
+}

--- a/crates/tebako-cli/src/suite.rs
+++ b/crates/tebako-cli/src/suite.rs
@@ -1,0 +1,521 @@
+//! Suite press (spec 03 §6, spec 07 §2.0 multi-command suites — roadmap
+//! 34): `tebako press --suite <suite.yaml>` presses ONE package with N
+//! invocable commands — per-entry imaging, one slot per entry, and the
+//! type-2 package manifest carrying per-entry `runtime_ref`s (the
+//! trailer's 128-byte field keeps entries[0]'s for v1-era loaders).
+//!
+//! The suite file:
+//!
+//! ```yaml
+//! name: metanorma          # optional; default entries[0].name
+//! version: 1.2.3           # optional; default "0.0.0"
+//! entries:
+//!   - name: metanorma      # the command name (a shim/binary link name)
+//!     root: ./metanorma-app
+//!     entry: metanorma     # the entry point inside that root (like -e)
+//!     runtime_ref: ruby@3.4.2;tebako=0.15.9   # optional; falls back to
+//!                              # the press-level -R (+ ;image when the
+//!                              # resolved runtime is image-era)
+//!   - name: mn2pdf
+//!     root: ./mn2pdf-app
+//!     entry: mn2pdf
+//! ```
+//!
+//! Relative `root`s resolve against the suite file's directory. At run
+//! time the bootstrap's argv0 selection (tebako-bootstrap's
+//! [`select_entry`]) mounts only the selected entry's slot — every entry
+//! image shares the scenario mount point by construction. Fat suites are
+//! not a v1 form (one fat payload slot cannot serve per-entry runtimes).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::error::{packaging_error, plain_error, TebakoError};
+use crate::options::{host_platform, PressMode, PressOptions};
+use crate::packager;
+use crate::resolve::{Flavor, Resolved, Resolver};
+use crate::scenario::{self, ruby_version_with_gemfile, ScenarioManager};
+
+// ---------------------------------------------------------------------
+// the suite file
+// ---------------------------------------------------------------------
+
+/// One invocable command of the suite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SuiteEntry {
+    /// The command name (shim/binary link name).
+    pub name: String,
+    /// The application root (as written; resolved against the suite
+    /// file's directory at press time).
+    pub root: String,
+    /// The entry point inside the root (like press's -e).
+    pub entry: String,
+    /// Explicit per-entry runtime reference
+    /// (`ruby@<version>;tebako=<abi>[;image]`); `None` falls back to the
+    /// press-level -R.
+    pub runtime_ref: Option<String>,
+}
+
+/// A parsed + validated suite file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SuiteSpec {
+    pub name: String,
+    pub version: String,
+    pub entries: Vec<SuiteEntry>,
+}
+
+#[derive(Deserialize)]
+struct RawSuite {
+    name: Option<String>,
+    version: Option<serde_yml::Value>,
+    entries: Vec<RawEntry>,
+}
+
+#[derive(Deserialize)]
+struct RawEntry {
+    name: String,
+    root: String,
+    entry: String,
+    runtime_ref: Option<String>,
+}
+
+fn invalid(reason: impl Into<String>) -> TebakoError {
+    packaging_error(65, Some(&reason.into()))
+}
+
+/// Parse and validate a suite file. Named errors everywhere: unknown
+/// shape, duplicate/unsafe names, empty fields, slot overflow.
+pub fn parse_suite(yaml: &str, source: &Path) -> Result<SuiteSpec, TebakoError> {
+    let raw: RawSuite = serde_yml::from_str(yaml).map_err(|e| {
+        invalid(format!(
+            "cannot parse the suite file {} ({e})",
+            source.display()
+        ))
+    })?;
+    if raw.entries.is_empty() {
+        return Err(invalid(format!(
+            "suite file {} lists no entries (N >= 1 required)",
+            source.display()
+        )));
+    }
+    if raw.entries.len() > tpkg::TPKG_MAX_SLOTS as usize {
+        return Err(invalid(format!(
+            "suite file {} lists {} entries but a package carries at most {} slots",
+            source.display(),
+            raw.entries.len(),
+            tpkg::TPKG_MAX_SLOTS
+        )));
+    }
+    let mut entries = Vec::new();
+    for e in &raw.entries {
+        check_component("entry name", &e.name, source)?;
+        if e.root.trim().is_empty() {
+            return Err(invalid(format!(
+                "suite entry \"{}\" has an empty root ({})",
+                e.name,
+                source.display()
+            )));
+        }
+        if e.entry.trim().is_empty() {
+            return Err(invalid(format!(
+                "suite entry \"{}\" has an empty entry ({})",
+                e.name,
+                source.display()
+            )));
+        }
+        if let Some(r) = &e.runtime_ref {
+            check_runtime_ref(&e.name, r, source)?;
+        }
+        entries.push(SuiteEntry {
+            name: e.name.clone(),
+            root: e.root.replace('\\', "/"),
+            entry: e.entry.replace('\\', "/"),
+            runtime_ref: e.runtime_ref.clone(),
+        });
+    }
+    let mut names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    names.sort();
+    if names.windows(2).any(|w| w[0] == w[1]) {
+        return Err(invalid(format!(
+            "suite file {} lists a duplicate entry name",
+            source.display()
+        )));
+    }
+    let name = raw
+        .name
+        .filter(|n| !n.trim().is_empty())
+        .unwrap_or_else(|| entries[0].name.clone());
+    check_component("suite name", &name, source)?;
+    let version = match &raw.version {
+        Some(v) => match v {
+            serde_yml::Value::String(s) => s.clone(),
+            serde_yml::Value::Number(n) => n.to_string(),
+            other => {
+                return Err(invalid(format!(
+                    "suite file {} has a non-string version ({other:?})",
+                    source.display()
+                )))
+            }
+        },
+        None => "0.0.0".to_string(),
+    };
+    check_component("suite version", &version, source)?;
+    Ok(SuiteSpec {
+        name,
+        version,
+        entries,
+    })
+}
+
+/// Entry names become shim/binary file names and the type-2 manifest's
+/// selectors; the rule is the payload cache's key rule.
+fn check_component(what: &str, value: &str, source: &Path) -> Result<(), TebakoError> {
+    let bad = value.is_empty()
+        || value == "."
+        || value == ".."
+        || value
+            .chars()
+            .any(|c| c == '/' || c == '\\' || c.is_control() || c.is_whitespace());
+    if bad {
+        return Err(invalid(format!(
+            "{what} '{value}' must be a single non-empty path component ({})",
+            source.display()
+        )));
+    }
+    Ok(())
+}
+
+/// The per-entry runtime_ref grammar (v1): `ruby@<version>;tebako=<abi>`
+/// with optional trailing `;image`. The `;sha256=` parameter is the FAT
+/// payload's checksum slot — meaningless for lean suite entries and
+/// rejected, never ignored.
+fn check_runtime_ref(
+    entry_name: &str,
+    runtime_ref: &str,
+    source: &Path,
+) -> Result<(), TebakoError> {
+    let err = |reason: &str| {
+        invalid(format!(
+            "suite entry \"{entry_name}\" has an invalid runtime_ref \"{runtime_ref}\" ({reason}; expected \"ruby@<version>;tebako=<abi>[;image]\", {})",
+            source.display()
+        ))
+    };
+    let Some(at) = runtime_ref.find('@') else {
+        return Err(err("missing '@'"));
+    };
+    let (ty, rest) = (&runtime_ref[..at], &runtime_ref[at + 1..]);
+    if ty != "ruby" {
+        return Err(err("the only language in v1 is ruby"));
+    }
+    let Some(semi) = rest.find(";tebako=") else {
+        return Err(err("missing ';tebako='"));
+    };
+    let version = &rest[..semi];
+    let tail = &rest[semi + 8..];
+    let mut parts = tail.split(';');
+    let abi = parts.next().unwrap_or("");
+    if version.is_empty() || abi.is_empty() {
+        return Err(err("empty version or abi"));
+    }
+    for part in [version, abi] {
+        if part
+            .chars()
+            .any(|c| matches!(c, '/' | '\\' | ' ' | '\t' | '\r' | '\n'))
+        {
+            return Err(err("no whitespace or separators in components"));
+        }
+    }
+    for param in parts {
+        match param {
+            "image" => {}
+            p if p.starts_with("sha256=") => {
+                return Err(err(
+                    ";sha256= is the fat-payload checksum — suite presses are lean",
+                ))
+            }
+            _ => return Err(err("unknown parameter")),
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// the type-2 package manifest
+// ---------------------------------------------------------------------
+
+/// The package manifest (ext block type 2) for a suite: one entry per
+/// command, slot i = entries[i]'s image, per-entry runtime refs (already
+/// fallback-resolved).
+pub fn suite_package_manifest(
+    spec: &SuiteSpec,
+    runtime_refs: &[String],
+    created: &str,
+) -> Result<tpkg::PackageManifest, TebakoError> {
+    if runtime_refs.len() != spec.entries.len() {
+        return Err(plain_error(format!(
+            "internal: {} runtime refs for {} suite entries",
+            runtime_refs.len(),
+            spec.entries.len()
+        )));
+    }
+    let manifest = tpkg::PackageManifest {
+        schema_version: tpkg::PACKAGE_SCHEMA_VERSION,
+        package: tpkg::PackageIdentity {
+            name: spec.name.clone(),
+            version: spec.version.clone(),
+            producer: tpkg::Producer {
+                tool: "tebako-cli".to_string(),
+                tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            },
+            created: created.to_string(),
+        },
+        entries: spec
+            .entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| tpkg::PackageEntry {
+                name: e.name.clone(),
+                slot: i as u32,
+                entrypoint: e.name.clone(),
+                runtime_ref: runtime_refs[i].clone(),
+            })
+            .collect(),
+        jail: None,
+        env: BTreeMap::new(),
+    };
+    manifest
+        .validate()
+        .map_err(|e| plain_error(format!("invalid suite package manifest: {e}")))?;
+    Ok(manifest)
+}
+
+// ---------------------------------------------------------------------
+// the press
+// ---------------------------------------------------------------------
+
+/// `tebako press --suite`: per-entry imaging against each entry's own
+/// runtime, then ONE stitch: N slots (all at the scenario mount point —
+/// the bootstrap's argv0 selection mounts only the selected entry's
+/// slot) plus the type-2 package manifest. Lean only (a fat payload
+/// slot cannot serve per-entry runtimes).
+pub fn press_suite(
+    opts: &PressOptions,
+    spec: &SuiteSpec,
+    suite_dir: &Path,
+) -> Result<PathBuf, TebakoError> {
+    if opts.mode == PressMode::Fat {
+        return Err(packaging_error(
+            126,
+            Some("fat suites are not a v1 form (one payload slot cannot serve per-entry runtimes) — press lean"),
+        ));
+    }
+    if opts.mode == PressMode::Runtime || opts.mode == PressMode::Classic {
+        return Err(packaging_error(133, None));
+    }
+    if let Some(requested) = &opts.ruby_requested {
+        scenario::check_ruby_version(requested)?;
+    }
+    for entry in &spec.entries {
+        check_entry_abi(entry, opts)?;
+    }
+    if !opts.devmode {
+        crate::version_cache_check(opts);
+    }
+    suite_warnings(opts, spec, suite_dir);
+    let platform = host_platform()?;
+    let bootstrap_path = match crate::decide_bootstrap(opts) {
+        crate::BootstrapSource::Path(path) => {
+            if !path.is_file() {
+                return Err(packaging_error(
+                    127,
+                    Some(&format!("runtime not found: {}", path.display())),
+                ));
+            }
+            path
+        }
+        crate::BootstrapSource::Download => Resolver::new(Flavor::Bootstrap).resolve(
+            &crate::resolve::default_bootstrap_version(),
+            &platform,
+            &crate::resolve::default_bootstrap_version(),
+        )?,
+    };
+
+    // Per-entry imaging; runtimes resolve once per distinct ruby version.
+    let mut runtimes: BTreeMap<String, Resolved> = BTreeMap::new();
+    let mut images: Vec<(PathBuf, String, u32)> = Vec::new();
+    let mut runtime_refs: Vec<String> = Vec::new();
+    for (i, entry) in spec.entries.iter().enumerate() {
+        let root = entry_root(suite_dir, &entry.root);
+        let mut entry_opts = opts.clone();
+        entry_opts.root_arg = root.to_string_lossy().into_owned();
+        entry_opts.entrance = entry.entry.clone();
+        entry_opts.output = None;
+        entry_opts.suite = None;
+        let mut scenario_mgr = ScenarioManager::new(&entry_opts.root(), &entry_opts.fs_entrance())?;
+        scenario_mgr.configure_scenario()?;
+        let ruby_ver = entry_ruby_version(opts, &scenario_mgr, entry)?;
+        if !runtimes.contains_key(&ruby_ver) {
+            let r = Resolver::new(Flavor::Runtime).resolve_runtime(
+                &ruby_ver,
+                &platform,
+                &opts.tebako_version,
+            )?;
+            runtimes.insert(ruby_ver.clone(), r);
+        }
+        let resolved = &runtimes[&ruby_ver];
+        println!(
+            "-- Suite entry {}/{}: {} (ruby {})",
+            i + 1,
+            spec.entries.len(),
+            entry.name,
+            ruby_ver
+        );
+        let app_image =
+            packager::build_app_image(&entry_opts, &mut scenario_mgr, resolved, &ruby_ver)?;
+        // the next entry's build recreates the packaging environment —
+        // move this entry's image aside first
+        let staged = opts
+            .output_folder()
+            .join(format!("suite-entry-{i}-{}.tfs", entry.name));
+        std::fs::rename(&app_image, &staged).map_err(|e| {
+            plain_error(format!(
+                "cannot stage {} -> {}: {e}",
+                app_image.display(),
+                staged.display()
+            ))
+        })?;
+        images.push((
+            staged,
+            scenario_mgr.fs_mount_point.clone(),
+            tpkg::TPKG_FORMAT_DWARFS,
+        ));
+        runtime_refs.push(entry_runtime_ref(entry, &ruby_ver, opts, resolved));
+    }
+
+    let created = crate::install::rfc3339_utc(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    );
+    let package_manifest = suite_package_manifest(spec, &runtime_refs, &created)?;
+    let package = suite_package_path(opts, spec);
+    crate::stitch(
+        &bootstrap_path,
+        &images,
+        &package,
+        &runtime_refs[0],
+        Some(&package_manifest),
+    )?;
+    println!("Created tebako suite package at \"{package}\"");
+    crate::ensure_version_file(opts);
+    Ok(PathBuf::from(package))
+}
+
+/// An explicit entry runtime_ref must target the tebako abi this press
+/// builds against (one release per press — per-entry abi differences are
+/// a later milestone).
+pub fn check_entry_abi(entry: &SuiteEntry, opts: &PressOptions) -> Result<(), TebakoError> {
+    let Some(r) = &entry.runtime_ref else {
+        return Ok(());
+    };
+    // validated at parse: ruby@<version>;tebako=<abi>[;image]
+    let semi = r.find(";tebako=").expect("runtime_ref validated");
+    let abi = r[semi + 8..].split(';').next().unwrap_or("");
+    if abi != opts.tebako_version {
+        return Err(invalid(format!(
+            "suite entry \"{}\" pins tebako abi {abi} but this press builds against {} — align them (--tebako-version, or drop the abi from the entry's runtime_ref)",
+            entry.name, opts.tebako_version
+        )));
+    }
+    Ok(())
+}
+
+/// The entry's runtime_ref: explicit, else the press-level fallback
+/// (its resolved ruby version + the tebako abi + `;image` when the
+/// resolved runtime is image-era).
+pub fn entry_runtime_ref(
+    entry: &SuiteEntry,
+    ruby_ver: &str,
+    opts: &PressOptions,
+    resolved: &Resolved,
+) -> String {
+    if let Some(r) = &entry.runtime_ref {
+        return r.clone();
+    }
+    let mut r = format!("ruby@{ruby_ver};tebako={}", opts.tebako_version);
+    if resolved.image.is_some() {
+        r.push_str(";image");
+    }
+    r
+}
+
+/// The ruby version an entry presses against: its explicit runtime_ref's
+/// version, else press's exact rule (the entry's Gemfile when present,
+/// else the press-level -R, else the default).
+fn entry_ruby_version(
+    opts: &PressOptions,
+    scenario_mgr: &ScenarioManager,
+    entry: &SuiteEntry,
+) -> Result<String, TebakoError> {
+    if let Some(r) = &entry.runtime_ref {
+        // validated at parse: ruby@<version>;tebako=<abi>
+        let at = r.find('@').expect("runtime_ref validated");
+        let semi = r[at + 1..].find(";tebako=").expect("runtime_ref validated");
+        return Ok(r[at + 1..at + 1 + semi].to_string());
+    }
+    if scenario_mgr.with_gemfile {
+        ruby_version_with_gemfile(opts.ruby_requested.as_deref(), &scenario_mgr.gemfile_path)
+    } else {
+        Ok(opts
+            .ruby_requested
+            .clone()
+            .unwrap_or_else(|| scenario::DEFAULT_RUBY_VERSION.to_string()))
+    }
+}
+
+/// A suite entry's root, resolved against the suite file's directory.
+fn entry_root(suite_dir: &Path, root: &str) -> PathBuf {
+    let p = PathBuf::from(root);
+    if p.is_absolute() {
+        p
+    } else {
+        suite_dir.join(p)
+    }
+}
+
+/// The suite package path: --output, or <cwd>/<suite name> (+ exe suffix).
+fn suite_package_path(opts: &PressOptions, spec: &SuiteSpec) -> String {
+    let package = match &opts.output {
+        Some(o) => o.replace('\\', "/"),
+        None => format!("{}/{}", opts.fs_current.trim_end_matches('/'), spec.name),
+    };
+    if Path::new(&package).is_absolute() {
+        package
+    } else {
+        format!("{}/{}", opts.fs_current.trim_end_matches('/'), package)
+    }
+}
+
+/// The recursive-packaging warnings, per entry root (press's
+/// check_warnings covers one root; a suite has N).
+fn suite_warnings(opts: &PressOptions, spec: &SuiteSpec, suite_dir: &Path) {
+    let package = suite_package_path(opts, spec);
+    for entry in &spec.entries {
+        let root = entry_root(suite_dir, &entry.root);
+        let root_s = root.to_string_lossy().trim_end_matches('/').to_string();
+        let mut probe = PathBuf::from(package.trim_end_matches('/'));
+        loop {
+            if probe == Path::new(&root_s) {
+                println!("{}", crate::WARN);
+                std::thread::sleep(std::time::Duration::from_secs(5));
+                return;
+            }
+            if !probe.pop() {
+                break;
+            }
+        }
+    }
+}

--- a/crates/tebako-cli/templates/app-formula.rb.template
+++ b/crates/tebako-cli/templates/app-formula.rb.template
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Tebako-packaged app formula template (spec 16, persona C).
+# Replace the @@PLACEHOLDER@@ slots. Class name must be the CamelCase of
+# the formula filename (e.g. metanorma.rb -> class Metanorma).
+class @@CAMELAPP@@ < Formula
+  desc "@@APP_DESC@@"
+  homepage "@@APP_HOMEPAGE@@"
+  version "@@APP_VERSION@@"
+  license "@@APP_LICENSE_SPDX@@"
+
+  # Standalone tebako binaries (slim primary): bootstrap + app payload;
+  # the runtime resolves once per machine into ~/.tebako on first run.
+  base = "@@RELEASE_BASE_URL@@/v#{version}"
+
+  on_macos do
+    on_arm do
+      url "#{base}/@@APP@@-#{version}-macos-arm64"
+      sha256 "@@SHA256_MACOS_ARM64@@"
+    end
+    on_intel do
+      url "#{base}/@@APP@@-#{version}-macos-x86_64"
+      sha256 "@@SHA256_MACOS_X86_64@@"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "#{base}/@@APP@@-#{version}-linux-gnu-arm64"
+      sha256 "@@SHA256_LINUX_GNU_ARM64@@"
+    end
+    on_intel do
+      url "#{base}/@@APP@@-#{version}-linux-gnu-x86_64"
+      sha256 "@@SHA256_LINUX_GNU_X86_64@@"
+    end
+  end
+
+  def install
+    bin.install Dir["@@APP@@-*"].first => "@@APP@@"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/@@APP@@ --version")
+  end
+end

--- a/crates/tebako-cli/tests/install.rs
+++ b/crates/tebako-cli/tests/install.rs
@@ -748,6 +748,45 @@ fn plain_bytes_fall_back_to_the_synthesized_mirror_with_a_note() {
     );
 }
 
+#[test]
+fn suite_install_registers_every_entry_shim() {
+    // one suite payload (spec 07 §2.0): TWO entrypoints with DIFFERENT
+    // runtime requirements — tebako install registers all suite shims and
+    // the mirror carries each entry's own requirement (spec 03 §6).
+    let fx = Fixture::new("suiteinstall");
+    let suite_yaml = "identity:\n  schema_version: 1\n  kind: app\n  name: metasuite\n  version: 2.0.0\n  producer: {tool: tebako, tool_version: 0.15.9}\n  created: \"2026-07-26T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n    blob_sha256: \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"\n  signing: {state: unsigned}\n  encryption: {state: none}\nprovides:\n  entrypoints:\n    - name: metanorma\n      path: /app/bin/metanorma\n      runtime_requirement: {engine: ruby, constraint: \"~> 3.3.0\"}\n    - name: mn2pdf\n      path: /app/bin/mn2pdf\n      runtime_requirement: {engine: ruby, constraint: \"~> 3.4.0\"}\n  platforms: universal\n  capabilities: {exec: true, read: true}\n";
+    let image = zip_image_with_manifest(suite_yaml);
+    let payload_ref = fx.payload("metasuite-2.0.0.tfs", &image);
+    let yaml = format!(
+        "schema_version: 1\npayloads:\n  - name: metasuite\n    kind: app\n    versions:\n      - version: 2.0.0\n        platforms: universal\n        release: {{ref: {payload_ref}}}\n        entrypoints: [metanorma, mn2pdf]\n    default: 2.0.0\n"
+    );
+    install::add_registry(&fx.home, &fx.registry("tpkg-registry.yaml", &yaml)).unwrap();
+
+    let out = install::install(&fx.home, "metasuite", None, Some(&fx.shim_binary)).unwrap();
+    assert_eq!(out.commands, vec!["metanorma", "mn2pdf"]);
+    assert_eq!(out.shims.len(), 2);
+    assert!(fx.home.join("shims/metanorma").exists());
+    assert!(fx.home.join("shims/mn2pdf").exists());
+
+    // the mirror carries each entry's own runtime requirement
+    let mirror = tebako_shim::manifest::Manifest::load(
+        &fx.payloads_dir().join("metasuite/2.0.0.manifest.yaml"),
+    )
+    .unwrap();
+    let a = mirror.entrypoint("metanorma").unwrap();
+    let b = mirror.entrypoint("mn2pdf").unwrap();
+    assert_eq!(
+        a.runtime_requirement.as_ref().unwrap().constraint.as_str(),
+        "~> 3.3.0"
+    );
+    assert_eq!(
+        b.runtime_requirement.as_ref().unwrap().constraint.as_str(),
+        "~> 3.4.0"
+    );
+    assert_eq!(a.path, "/app/bin/metanorma");
+    assert_eq!(b.path, "/app/bin/mn2pdf");
+}
+
 // ---------------------------------------------------------------------
 // uninstall
 // ---------------------------------------------------------------------

--- a/crates/tebako-cli/tests/install.rs
+++ b/crates/tebako-cli/tests/install.rs
@@ -141,6 +141,77 @@ fn add_registry_rejects_bad_refs_and_unparsable_registries() {
     assert!(install::list_registries(&fx.home).unwrap().is_empty());
 }
 
+#[test]
+fn add_registry_primes_the_dispatch_cache_for_remote_refs() {
+    let fx = Fixture::new("addregprime");
+    // a GitHub default-branch registry ref, answered by the mock
+    // transport (contents API → raw download URL)
+    let registry_yaml = "schema_version: 1\npayloads: []\n";
+    let contents = r#"{"name":"tpkg-registry.yaml","download_url":"https://raw.example/o/r/HEAD/tpkg-registry.yaml"}"#;
+    let t = MockTransport::new()
+        .with(
+            "https://api.github.com/repos/o/r/contents/tpkg-registry.yaml",
+            contents.as_bytes(),
+        )
+        .with(
+            "https://raw.example/o/r/HEAD/tpkg-registry.yaml",
+            registry_yaml.as_bytes(),
+        );
+    let fetcher = Fetcher::with_transport(t);
+
+    let (outcome, _) = install::add_registry_with(&fx.home, "tfs:github:o/r", &fetcher).unwrap();
+    assert_eq!(outcome, tebako_shim::config::AddRegistryOutcome::Added);
+
+    // the dispatch cache holds exactly the fetched bytes (roadmap 33):
+    // the shim resolves this remote registry without a second fetch
+    let cached = fx
+        .home
+        .join("registries")
+        .join(format!("{}.yaml", sha256_hex(b"tfs:github:o/r")));
+    assert_eq!(fs::read_to_string(&cached).unwrap(), registry_yaml);
+    let fetched_at = fx
+        .home
+        .join("registries")
+        .join(format!("{}.fetched-at", sha256_hex(b"tfs:github:o/r")));
+    assert!(fetched_at.is_file());
+
+    // doctor-side freshness: the cache is fresh
+    assert!(matches!(
+        tebako_shim::regcache::freshness(&fx.home, "tfs:github:o/r"),
+        tebako_shim::regcache::RegistryFreshness::Fresh(_)
+    ));
+}
+
+#[test]
+fn update_registries_refreshes_and_reports() {
+    let fx = Fixture::new("updateregs");
+    // a file:// registry: reported as local, nothing to cache
+    let payload_ref = fx.payload("app-1.0.tfs", b"app-bytes");
+    let reg_ref = fx.registry(
+        "tpkg-registry.yaml",
+        &registry_yaml("app", "1.0", &payload_ref, Some("1.0")),
+    );
+    install::add_registry(&fx.home, &reg_ref).unwrap();
+
+    let out = install::update_registries(&fx.home).unwrap();
+    assert_eq!(out.local, vec![reg_ref.clone()]);
+    assert!(out.refreshed.is_empty());
+    assert!(out.failed.is_empty());
+
+    // a remote registry whose fetch fails lands in `failed`, not a hard
+    // error of the whole run (mock transport: no answers, every GET 404s)
+    fs::write(
+        fx.home.join("config.yaml"),
+        format!("registries:\n  - {reg_ref}\n  - tfs:github:o/unreachable\n"),
+    )
+    .unwrap();
+    let fetcher = Fetcher::with_transport(MockTransport::new());
+    let out = install::update_registries_with(&fx.home, &fetcher).unwrap();
+    assert_eq!(out.local, vec![reg_ref.clone()]);
+    assert_eq!(out.failed.len(), 1);
+    assert_eq!(out.failed[0].0, "tfs:github:o/unreachable");
+}
+
 // ---------------------------------------------------------------------
 // the nickname resolution matrix (spec 16 §3.3)
 // ---------------------------------------------------------------------

--- a/crates/tebako-cli/tests/install.rs
+++ b/crates/tebako-cli/tests/install.rs
@@ -627,7 +627,7 @@ fn embedded_manifest_drives_the_mirror_when_present() {
     assert_eq!(ep.path, "/app/bin/app");
     let req = ep.runtime_requirement.as_ref().unwrap();
     assert_eq!(req.engine, "ruby");
-    assert_eq!(req.constraint, ">= 3.3, < 5.0");
+    assert_eq!(req.constraint.as_str(), ">= 3.3, < 5.0");
 }
 
 #[test]
@@ -672,7 +672,7 @@ fn plain_bytes_fall_back_to_the_synthesized_mirror_with_a_note() {
     let ep = mirror.entrypoint("app-helper").unwrap();
     assert_eq!(ep.path, "/app-helper");
     assert_eq!(
-        ep.runtime_requirement.as_ref().unwrap().constraint,
+        ep.runtime_requirement.as_ref().unwrap().constraint.as_str(),
         "~> 3.3.0"
     );
 }

--- a/crates/tebako-cli/tests/publish.rs
+++ b/crates/tebako-cli/tests/publish.rs
@@ -1,0 +1,434 @@
+//! Publish tests (spec 16 §5, roadmap 41): accept per-triplet payloads →
+//! optional sign → upload (file:// mirrors only — no network) → registry
+//! upsert → tap render → the built-in clean-cache install proof.
+//! Idempotent re-publish is part of the matrix.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::PathBuf;
+
+use tebako_cli::publish::{self, PayloadInput, PublishOptions};
+use tpkg::Platform;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("tebako-cli-publish-{tag}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+struct Fixture {
+    dir: PathBuf,
+    home: PathBuf,
+    work: PathBuf,
+    shim_binary: PathBuf,
+}
+
+impl Fixture {
+    fn new(tag: &str) -> Fixture {
+        let dir = scratch(tag);
+        let home = dir.join("home");
+        let work = dir.join("work");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&work).unwrap();
+        let shim_binary = dir.join("tebako-shim");
+        fs::write(&shim_binary, b"#!/bin/sh\n").unwrap();
+        Fixture {
+            dir,
+            home,
+            work,
+            shim_binary,
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn sha(c: u8) -> String {
+    (0..64)
+        .map(|i| b"0123456789abcdef"[((c + i as u8) % 16) as usize] as char)
+        .collect()
+}
+
+/// The embedded app manifest (spec 03 §1) for the fixture images.
+fn app_manifest_yaml(name: &str, version: &str, entrypoints: &[&str]) -> String {
+    let entries: String = entrypoints
+        .iter()
+        .map(|e| {
+            format!(
+                "    - name: {e}\n      path: /app/bin/{e}\n      runtime_requirement: {{engine: ruby, constraint: \">= 3.3, < 5.0\"}}\n"
+            )
+        })
+        .collect();
+    format!(
+        "identity:\n  schema_version: 1\n  kind: app\n  name: {name}\n  version: \"{version}\"\n  producer: {{tool: tebako, tool_version: 0.15.9}}\n  created: \"2026-07-26T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{}\"\n    blob_sha256: \"{}\"\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n  entrypoints:\n{entries}  platforms: universal\n  capabilities: {{exec: true, read: true}}\n",
+        sha(b'a'),
+        sha(b'b')
+    )
+}
+
+/// A ZIP image carrying the embedded manifest (the tfs ZIP backend reads
+/// it — same fixture discipline as the install tests).
+fn zip_image(manifest_yaml: &str) -> Vec<u8> {
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let options = zip::write::SimpleFileOptions::default();
+    writer
+        .start_file("__tpkg__/manifest.yaml", options)
+        .unwrap();
+    writer.write_all(manifest_yaml.as_bytes()).unwrap();
+    writer.start_file("app/bin/app", options).unwrap();
+    writer.write_all(b"#!/bin/sh\n").unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+fn write_payload(fx: &Fixture, file: &str, manifest_yaml: &str) -> PathBuf {
+    let path = fx.work.join(file);
+    fs::write(&path, zip_image(manifest_yaml)).unwrap();
+    path
+}
+
+fn base_opts(fx: &Fixture, name: &str) -> PublishOptions {
+    PublishOptions {
+        name: name.to_string(),
+        version: None,
+        release: "tfs:github:acme/app:1.0".to_string(),
+        payloads: Vec::new(),
+        standalones: Vec::new(),
+        sign: None,
+        upload_mirror: Some(fx.work.join("mirror")),
+        tap: None,
+        tap_dir: None,
+        license: None,
+        desc: None,
+        homepage: None,
+        registry_out: Some(fx.work.join("tpkg-registry.yaml").display().to_string()),
+        skip_verify: false,
+    }
+}
+
+fn registry_at(fx: &Fixture) -> tebako_resolve::Registry {
+    let text = fs::read_to_string(fx.work.join("tpkg-registry.yaml")).unwrap();
+    tebako_resolve::Registry::from_yaml(&text).unwrap()
+}
+
+#[test]
+fn universal_signed_publish_end_to_end() {
+    let fx = Fixture::new("universal");
+    let payload = write_payload(
+        &fx,
+        "app-1.0.tfs",
+        &app_manifest_yaml("app", "1.0", &["app"]),
+    );
+    let mut opts = base_opts(&fx, "app");
+    opts.payloads.push(PayloadInput {
+        triplet: None,
+        path: payload,
+    });
+    opts.sign = Some(None); // the press-local key
+
+    let outcome = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap();
+    assert_eq!(outcome.version, "1.0");
+    assert_eq!(outcome.tag, "1.0");
+    assert_eq!(outcome.artifacts.len(), 1);
+    assert_eq!(outcome.artifacts[0].0, "app-1.0.tfs");
+    assert_eq!(outcome.ascs, vec!["app-1.0.tfs.asc".to_string()]);
+    let keyid = outcome.signer.clone().unwrap();
+    assert_eq!(keyid.len(), 16);
+
+    // the mirror holds the release layout, idempotent file content
+    let mirror = fx.work.join("mirror/1.0");
+    assert_eq!(
+        fs::read(mirror.join("app-1.0.tfs")).unwrap(),
+        fs::read(fx.work.join("app-1.0.tfs")).unwrap()
+    );
+    assert!(mirror.join("app-1.0.tfs.asc").is_file());
+
+    // the registry records the entry (universal, signature pin, the
+    // github release ref — mirror mode does not leak into the ref)
+    let registry = registry_at(&fx);
+    let app = registry.payload("app").unwrap();
+    assert_eq!(app.default.as_deref(), Some("1.0"));
+    let v = app.version("1.0").unwrap();
+    assert!(matches!(
+        v.platforms,
+        tebako_resolve::RegistryPlatforms::Universal
+    ));
+    assert_eq!(v.release.r#ref, "tfs:github:acme/app:1.0");
+    let sig = v.signature.clone().unwrap();
+    assert_eq!(sig.keyid, keyid);
+    assert_eq!(sig.asc, "app-1.0.tfs.asc");
+    assert_eq!(v.entrypoints, vec!["app"]);
+    assert!(v.runtime_requirement.is_some());
+
+    // the built-in verify ran (clean-cache install proof, signed leg)
+    let verified = outcome.verified.unwrap();
+    assert!(
+        verified.contains("verified: clean-cache install of app 1.0"),
+        "{verified}"
+    );
+    assert!(
+        verified.contains(&format!("signed by {keyid}")),
+        "{verified}"
+    );
+}
+
+#[test]
+fn per_triplet_publish_and_idempotent_republish() {
+    let fx = Fixture::new("triplet");
+    let mac = write_payload(
+        &fx,
+        "app-1.0-macos-arm64.tfs",
+        &app_manifest_yaml("app", "1.0", &["app"]),
+    );
+    let linux = write_payload(
+        &fx,
+        "app-1.0-linux-gnu-x86_64.tfs",
+        &app_manifest_yaml("app", "1.0", &["app"]),
+    );
+    let mut opts = base_opts(&fx, "app");
+    opts.payloads = vec![
+        PayloadInput {
+            triplet: Some(Platform::Aarch64Macos),
+            path: mac,
+        },
+        PayloadInput {
+            triplet: Some(Platform::X86_64LinuxGnu),
+            path: linux,
+        },
+    ];
+
+    let outcome = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap();
+    assert!(outcome.signer.is_none());
+    let registry = registry_at(&fx);
+    let app = registry.payload("app").unwrap();
+    let v = app.version("1.0").unwrap();
+    let tebako_resolve::RegistryPlatforms::PerTriplet(map) = &v.platforms else {
+        panic!("per-triplet platforms");
+    };
+    assert_eq!(map.len(), 2);
+    assert_eq!(
+        map[&Platform::Aarch64Macos].artifact,
+        "app-1.0-macos-arm64.tfs"
+    );
+    assert_eq!(
+        map[&Platform::X86_64LinuxGnu].sha256.len(),
+        64,
+        "sha pinned per triplet"
+    );
+
+    // re-publish: idempotent — one version entry, a "replaced" note
+    let outcome2 = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap();
+    assert!(outcome2.notes.iter().any(|n| n.contains("replaced")));
+    let registry = registry_at(&fx);
+    assert_eq!(registry.payload("app").unwrap().versions.len(), 1);
+
+    // a second version appends; the default stays put
+    let payload11 = write_payload(
+        &fx,
+        "app-1.1-macos-arm64.tfs",
+        &app_manifest_yaml("app", "1.1", &["app"]),
+    );
+    let mut opts11 = base_opts(&fx, "app");
+    opts11.release = "tfs:github:acme/app:1.1".to_string();
+    opts11.payloads = vec![PayloadInput {
+        triplet: Some(Platform::Aarch64Macos),
+        path: payload11,
+    }];
+    publish::publish_full(&opts11, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap();
+    let registry = registry_at(&fx);
+    let app = registry.payload("app").unwrap();
+    assert_eq!(app.versions.len(), 2);
+    assert_eq!(app.default.as_deref(), Some("1.0"));
+}
+
+#[test]
+fn tap_formula_renders_from_the_standalones() {
+    let fx = Fixture::new("tap");
+    let payload = write_payload(
+        &fx,
+        "my-app-2.0.tfs",
+        &app_manifest_yaml("my-app", "2.0", &["my-app"]),
+    );
+    let mut opts = base_opts(&fx, "my-app");
+    opts.payloads.push(PayloadInput {
+        triplet: None,
+        path: payload,
+    });
+    for (p, tag) in [
+        (Platform::Aarch64Macos, b"mac-arm".as_slice()),
+        (Platform::X86_64Macos, b"mac-intel".as_slice()),
+        (Platform::Aarch64LinuxGnu, b"linux-arm".as_slice()),
+        (Platform::X86_64LinuxGnu, b"linux-intel".as_slice()),
+    ] {
+        let path = fx
+            .work
+            .join(format!("my-app-2.0-{}", p.release_asset_name()));
+        fs::write(&path, tag).unwrap();
+        opts.standalones.push((p, path));
+    }
+    opts.tap = Some("acme/homebrew-tap".to_string());
+    opts.tap_dir = Some(fx.work.join("tap"));
+
+    let outcome = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap();
+    let formula_path = fx.work.join("tap/Formula/my-app.rb");
+    let formula = fs::read_to_string(&formula_path).unwrap();
+    assert_eq!(outcome.formula_path.as_ref(), Some(&formula_path));
+    assert!(formula.contains("class MyApp < Formula"), "{formula}");
+    assert!(formula.contains("version \"2.0\""), "{formula}");
+    assert!(
+        formula.contains("https://github.com/acme/app/releases/download"),
+        "{formula}"
+    );
+    for (p, tag) in [
+        (Platform::Aarch64Macos, b"mac-arm".as_slice()),
+        (Platform::X86_64Macos, b"mac-intel".as_slice()),
+        (Platform::Aarch64LinuxGnu, b"linux-arm".as_slice()),
+        (Platform::X86_64LinuxGnu, b"linux-intel".as_slice()),
+    ] {
+        let sha = tebako_resolve::sha256_hex(tag);
+        assert!(formula.contains(&sha), "{p} sha in formula");
+    }
+    assert!(
+        !formula
+            .lines()
+            .any(|l| !l.trim_start().starts_with('#') && l.contains("@@")),
+        "no placeholder survives outside template comments: {formula}"
+    );
+    // standalones uploaded alongside the payloads
+    assert!(fx.work.join("mirror/1.0/my-app-2.0-macos-arm64").is_file());
+}
+
+#[test]
+fn tap_requires_all_template_standalones() {
+    let fx = Fixture::new("tapmissing");
+    let payload = write_payload(
+        &fx,
+        "app-1.0.tfs",
+        &app_manifest_yaml("app", "1.0", &["app"]),
+    );
+    let mut opts = base_opts(&fx, "app");
+    opts.payloads.push(PayloadInput {
+        triplet: None,
+        path: payload,
+    });
+    opts.tap = Some("acme/homebrew-tap".to_string());
+    let err = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap_err();
+    assert!(err.message.contains("standalone"), "{err:?}");
+    assert!(err.message.contains("macos-arm64"), "{err:?}");
+}
+
+#[test]
+fn publish_errors_are_named() {
+    let fx = Fixture::new("puberr");
+    let payload = write_payload(
+        &fx,
+        "app-1.0.tfs",
+        &app_manifest_yaml("app", "1.0", &["app"]),
+    );
+
+    // gitlab write leg: not this milestone
+    let mut opts = base_opts(&fx, "app");
+    opts.release = "tfs:gitlab:acme/app:1.0".to_string();
+    opts.payloads.push(PayloadInput {
+        triplet: None,
+        path: payload.clone(),
+    });
+    let err = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap_err();
+    assert!(err.message.contains("GitHub releases"), "{err:?}");
+
+    // mixing universal + per-triplet
+    let mut opts = base_opts(&fx, "app");
+    opts.payloads = vec![
+        PayloadInput {
+            triplet: None,
+            path: payload.clone(),
+        },
+        PayloadInput {
+            triplet: Some(Platform::Aarch64Macos),
+            path: payload.clone(),
+        },
+    ];
+    let err = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap_err();
+    assert!(err.message.contains("mix"), "{err:?}");
+
+    // duplicate triplet
+    let mut opts = base_opts(&fx, "app");
+    opts.payloads = vec![
+        PayloadInput {
+            triplet: Some(Platform::Aarch64Macos),
+            path: payload.clone(),
+        },
+        PayloadInput {
+            triplet: Some(Platform::Aarch64Macos),
+            path: payload.clone(),
+        },
+    ];
+    let err = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap_err();
+    assert!(err.message.contains("duplicate"), "{err:?}");
+
+    // no embedded manifest
+    let plain = fx.work.join("plain-1.0.tfs");
+    fs::write(&plain, b"not an image").unwrap();
+    let mut opts = base_opts(&fx, "app");
+    opts.version = Some("1.0".to_string());
+    opts.payloads.push(PayloadInput {
+        triplet: None,
+        path: plain,
+    });
+    let err = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap_err();
+    assert!(err.message.contains("embedded manifest"), "{err:?}");
+
+    // name mismatch against the embedded manifest
+    let mut opts = base_opts(&fx, "other-app");
+    opts.version = Some("1.0".to_string());
+    opts.payloads.push(PayloadInput {
+        triplet: None,
+        path: payload.clone(),
+    });
+    let err = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap_err();
+    assert!(err.message.contains("declares app 1.0"), "{err:?}");
+
+    // version not derivable from odd file names and no --version
+    let odd = fx.work.join("mystery.bin");
+    fs::write(&odd, zip_image(&app_manifest_yaml("app", "1.0", &["app"]))).unwrap();
+    let mut opts = base_opts(&fx, "app");
+    opts.payloads.push(PayloadInput {
+        triplet: None,
+        path: odd,
+    });
+    let err = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap_err();
+    assert!(err.message.contains("--version"), "{err:?}");
+
+    // an unknown --sign=<keyid> is a named error
+    let mut opts = base_opts(&fx, "app");
+    opts.payloads.push(PayloadInput {
+        triplet: None,
+        path: payload,
+    });
+    opts.sign = Some(Some("0123456789abcdef".to_string()));
+    let err = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap_err();
+    assert!(err.message.contains("no secret key"), "{err:?}");
+}
+
+#[test]
+fn version_is_derived_from_the_artifact_names() {
+    let fx = Fixture::new("derive");
+    let payload = write_payload(
+        &fx,
+        "app-2.3.4.tfs",
+        &app_manifest_yaml("app", "2.3.4", &["app"]),
+    );
+    let mut opts = base_opts(&fx, "app");
+    opts.release = "tfs:github:acme/app".to_string(); // tag defaults to the version
+    opts.payloads.push(PayloadInput {
+        triplet: None,
+        path: payload,
+    });
+    let outcome = publish::publish_full(&opts, &fx.home, &fx.work, Some(&fx.shim_binary)).unwrap();
+    assert_eq!(outcome.version, "2.3.4");
+    assert_eq!(outcome.tag, "2.3.4");
+}

--- a/crates/tebako-cli/tests/registry_cli.rs
+++ b/crates/tebako-cli/tests/registry_cli.rs
@@ -58,6 +58,12 @@ fn registry_install_uninstall_smoke() {
     assert_eq!(code, 0, "{text}");
     assert!(text.contains(&reg_ref), "{text}");
 
+    // update-registries: a file:// registry is reported as local (nothing
+    // to cache), exit 0
+    let (code, text) = run(&home, &shim, &["update-registries"]);
+    assert_eq!(code, 0, "{text}");
+    assert!(text.contains("nothing to cache"), "{text}");
+
     let (code, text) = run(&home, &shim, &["install", "app"]);
     assert_eq!(code, 0, "{text}");
     assert!(text.contains("installed app 1.0"), "{text}");

--- a/crates/tebako-cli/tests/suite.rs
+++ b/crates/tebako-cli/tests/suite.rs
@@ -1,0 +1,181 @@
+//! Suite press model tests (spec 03 §6, roadmap 34): the suite file's
+//! parse + validation, the type-2 package manifest with per-entry
+//! runtime_refs (press-level -R fallback), and the abi guard. The heavy
+//! per-entry imaging legs ride the gated e2e presses (a runtime is
+//! required); the composition logic is fully covered here.
+
+use std::path::{Path, PathBuf};
+
+use tebako_cli::options::{PressMode, PressOptions};
+use tebako_cli::resolve::Resolved;
+use tebako_cli::suite::{
+    check_entry_abi, entry_runtime_ref, parse_suite, suite_package_manifest, SuiteEntry, SuiteSpec,
+};
+
+fn opts() -> PressOptions {
+    PressOptions {
+        root_arg: String::new(),
+        entrance: String::new(),
+        output: None,
+        prefix: PathBuf::from("/tmp/prefix"),
+        cwd: None,
+        ruby_requested: Some("3.3.7".to_string()),
+        mode: PressMode::Lean,
+        log_level: "error".to_string(),
+        image_specs: Vec::new(),
+        bootstrap: None,
+        tebako_version: tebako_cli::DEFAULT_TEBAKO_VERSION.to_string(),
+        prefer_local: false,
+        verbose: false,
+        devmode: true,
+        fs_current: "/tmp".to_string(),
+        suite: None,
+    }
+}
+
+fn parse(yaml: &str) -> SuiteSpec {
+    parse_suite(yaml, Path::new("suite.yaml")).expect("suite parses")
+}
+
+fn err(yaml: &str) -> String {
+    parse_suite(yaml, Path::new("suite.yaml"))
+        .expect_err("must fail")
+        .message
+}
+
+const GOOD: &str = "name: metanorma\nversion: 1.2.3\nentries:\n  - {name: metanorma, root: ./app, entry: metanorma, runtime_ref: \"ruby@3.4.2;tebako=0.15.9\"}\n  - {name: mn2pdf, root: ./mn2pdf, entry: mn2pdf}\n";
+
+#[test]
+fn parse_accepts_the_spec_shape_and_defaults() {
+    let spec = parse(GOOD);
+    assert_eq!(spec.name, "metanorma");
+    assert_eq!(spec.version, "1.2.3");
+    assert_eq!(spec.entries.len(), 2);
+    assert_eq!(
+        spec.entries[0].runtime_ref.as_deref(),
+        Some("ruby@3.4.2;tebako=0.15.9")
+    );
+    assert_eq!(spec.entries[1].runtime_ref, None);
+
+    // defaults: name from entries[0], version "0.0.0"
+    let spec = parse("entries:\n  - {name: tool, root: ./app, entry: tool}\n");
+    assert_eq!(spec.name, "tool");
+    assert_eq!(spec.version, "0.0.0");
+}
+
+#[test]
+fn parse_rejects_bad_suites_with_named_errors() {
+    for (yaml, needle) in [
+        ("entries: []\n", "no entries"),
+        ("entries:\n  - {name: '', root: r, entry: e}\n", "path component"),
+        (
+            "entries:\n  - {name: 'a/b', root: r, entry: e}\n",
+            "path component",
+        ),
+        ("entries:\n  - {name: a, root: '', entry: e}\n", "empty root"),
+        ("entries:\n  - {name: a, root: r, entry: ''}\n", "empty entry"),
+        (
+            "entries:\n  - {name: a, root: r, entry: e}\n  - {name: a, root: r2, entry: e}\n",
+            "duplicate entry name",
+        ),
+        (
+            "entries:\n  - {name: a, root: r, entry: e, runtime_ref: \"python@3.12;tebako=0.15.9\"}\n",
+            "only language in v1 is ruby",
+        ),
+        (
+            "entries:\n  - {name: a, root: r, entry: e, runtime_ref: \"ruby@3.4.2\"}\n",
+            "missing ';tebako='",
+        ),
+        (
+            "entries:\n  - {name: a, root: r, entry: e, runtime_ref: \"ruby@3.4.2;tebako=0.15.9;sha256=abc\"}\n",
+            "fat-payload checksum",
+        ),
+        (
+            "entries:\n  - {name: a, root: r, entry: e, runtime_ref: \"ruby@3.4.2;tebako=0.15.9;bogus\"}\n",
+            "unknown parameter",
+        ),
+    ] {
+        let msg = err(yaml);
+        assert!(msg.contains(needle), "expected '{needle}' in: {msg}");
+    }
+}
+
+#[test]
+fn parse_rejects_slot_overflow() {
+    let entries = (0..9)
+        .map(|i| format!("  - {{name: e{i}, root: r, entry: e}}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let msg = err(&format!("entries:\n{entries}\n"));
+    assert!(msg.contains("at most 8 slots"), "{msg}");
+}
+
+#[test]
+fn package_manifest_carries_per_entry_refs_and_slots() {
+    let spec = parse(GOOD);
+    let refs = vec![
+        "ruby@3.4.2;tebako=0.15.9".to_string(),
+        "ruby@3.3.7;tebako=0.15.9;image".to_string(),
+    ];
+    let pm = suite_package_manifest(&spec, &refs, "2026-07-27T00:00:00Z").unwrap();
+    assert_eq!(pm.package.name, "metanorma");
+    assert_eq!(pm.package.version, "1.2.3");
+    assert_eq!(pm.entries.len(), 2);
+    assert_eq!(pm.entries[0].name, "metanorma");
+    assert_eq!(pm.entries[0].slot, 0);
+    assert_eq!(pm.entries[0].entrypoint, "metanorma");
+    assert_eq!(pm.entries[0].runtime_ref, refs[0]);
+    assert_eq!(pm.entries[1].name, "mn2pdf");
+    assert_eq!(pm.entries[1].slot, 1);
+    assert_eq!(pm.entries[1].runtime_ref, refs[1]);
+    // the block validates + round-trips (set_package_manifest re-validates)
+    let yaml = pm.to_yaml().unwrap();
+    let back = tpkg::PackageManifest::from_yaml(&yaml).unwrap();
+    assert_eq!(back, pm);
+}
+
+#[test]
+fn runtime_ref_falls_back_to_the_press_level_ruby() {
+    let o = opts();
+    let resolved = Resolved {
+        executable: PathBuf::from("/tmp/ruby"),
+        image: None,
+    };
+    let explicit = SuiteEntry {
+        name: "a".to_string(),
+        root: "r".to_string(),
+        entry: "e".to_string(),
+        runtime_ref: Some("ruby@3.4.2;tebako=0.15.9".to_string()),
+    };
+    assert_eq!(
+        entry_runtime_ref(&explicit, "3.3.7", &o, &resolved),
+        "ruby@3.4.2;tebako=0.15.9"
+    );
+    let fallback = SuiteEntry {
+        runtime_ref: None,
+        ..explicit
+    };
+    assert_eq!(
+        entry_runtime_ref(&fallback, "3.3.7", &o, &resolved),
+        "ruby@3.3.7;tebako=0.15.9"
+    );
+}
+
+#[test]
+fn explicit_refs_must_match_the_press_abi() {
+    let o = opts(); // tebako_version 0.15.9
+    let good = SuiteEntry {
+        name: "a".to_string(),
+        root: "r".to_string(),
+        entry: "e".to_string(),
+        runtime_ref: Some("ruby@3.4.2;tebako=0.15.9".to_string()),
+    };
+    check_entry_abi(&good, &o).unwrap();
+    let bad = SuiteEntry {
+        runtime_ref: Some("ruby@3.4.2;tebako=0.16.0".to_string()),
+        ..good
+    };
+    let e = check_entry_abi(&bad, &o).unwrap_err();
+    assert!(e.message.contains("0.16.0"), "{e:?}");
+    assert!(e.message.contains("abi"), "{e:?}");
+}

--- a/crates/tebako-http/src/lib.rs
+++ b/crates/tebako-http/src/lib.rs
@@ -164,6 +164,61 @@ pub fn get_text(url: &str) -> Result<String, FetchError> {
     String::from_utf8(body).map_err(|e| FetchError::DownloadFailed(format!("{e} decoding {url}")))
 }
 
+fn require_https(url: &str) -> Result<(), FetchError> {
+    if !url.starts_with("https://") {
+        return Err(FetchError::DownloadFailed(format!(
+            "refusing non-HTTPS URL {url} (https:// and file:// are supported)"
+        )));
+    }
+    Ok(())
+}
+
+/// POST `body` to `url` with an optional bearer token (the release-upload
+/// half of the publish channel, spec 16). HTTPS-only — uploads never ride
+/// `file://`. Returns the response body; HTTP errors map like [`get`]'s.
+pub fn post(
+    url: &str,
+    body: &[u8],
+    content_type: &str,
+    bearer: Option<&str>,
+) -> Result<Vec<u8>, FetchError> {
+    require_https(url)?;
+    let mut req = agent()
+        .post(url)
+        .header("Content-Type", content_type)
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "tebako");
+    if let Some(token) = bearer {
+        req = req.header("Authorization", &format!("Bearer {token}"));
+    }
+    let mut response = req.send(body).map_err(map_ureq_error(url))?;
+    response
+        .body_mut()
+        .with_config()
+        .limit(MAX_BODY_SIZE)
+        .read_to_vec()
+        .map_err(|e| FetchError::DownloadFailed(format!("{e} reading {url}")))
+}
+
+/// DELETE `url` with an optional bearer token (asset replacement on
+/// idempotent re-publish). HTTPS-only; 404 is success (the asset is
+/// already gone — replacement stays idempotent).
+pub fn delete(url: &str, bearer: Option<&str>) -> Result<(), FetchError> {
+    require_https(url)?;
+    let mut req = agent()
+        .delete(url)
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "tebako");
+    if let Some(token) = bearer {
+        req = req.header("Authorization", &format!("Bearer {token}"));
+    }
+    match req.call() {
+        Ok(_) => Ok(()),
+        Err(ureq::Error::StatusCode(404)) => Ok(()),
+        Err(e) => Err(map_ureq_error(url)(e)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tebako-info/src/derived.rs
+++ b/crates/tebako-info/src/derived.rs
@@ -142,10 +142,12 @@ pub fn derive(m: &PayloadManifest) -> Derived {
     if let Provides::App(app) = &m.provides {
         for ep in &app.entrypoints {
             shims.push(ep.name.clone());
-            let pair = (
-                ep.runtime_requirement.engine.clone(),
-                ep.runtime_requirement.constraint.clone(),
-            );
+            // Native entrypoints (no runtime_requirement, spec 03 §2.2)
+            // declare no runtime compatibility axis.
+            let Some(req) = &ep.runtime_requirement else {
+                continue;
+            };
+            let pair = (req.engine.clone(), req.constraint.clone());
             if !requirements.contains(&pair) {
                 requirements.push(pair);
             }

--- a/crates/tebako-info/src/manifest_json.rs
+++ b/crates/tebako-info/src/manifest_json.rs
@@ -240,24 +240,26 @@ fn provides_json(p: &Provides) -> Json {
                     app.entrypoints
                         .iter()
                         .map(|e| {
-                            Json::Object(vec![
+                            let mut obj = vec![
                                 ("name".to_string(), s(&e.name)),
                                 ("path".to_string(), s(&e.path)),
                                 (
                                     "args_default".to_string(),
                                     Json::Array(e.args_default.iter().map(|a| s(a)).collect()),
                                 ),
-                                (
+                            ];
+                            // omitted for native entrypoints (the YAML key
+                            // is omitted too — spec 03 §2.2)
+                            if let Some(req) = &e.runtime_requirement {
+                                obj.push((
                                     "runtime_requirement".to_string(),
                                     Json::Object(vec![
-                                        ("engine".to_string(), s(&e.runtime_requirement.engine)),
-                                        (
-                                            "constraint".to_string(),
-                                            s(e.runtime_requirement.constraint.as_str()),
-                                        ),
+                                        ("engine".to_string(), s(&req.engine)),
+                                        ("constraint".to_string(), s(req.constraint.as_str())),
                                     ]),
-                                ),
-                            ])
+                                ));
+                            }
+                            Json::Object(obj)
                         })
                         .collect(),
                 ),

--- a/crates/tebako-info/src/package.rs
+++ b/crates/tebako-info/src/package.rs
@@ -206,11 +206,9 @@ fn slot_summary_line(p: &PayloadInspection) -> String {
                 };
                 let runtimes = eps
                     .iter()
-                    .map(|e| {
-                        format!(
-                            "{} {}",
-                            e.runtime_requirement.engine, e.runtime_requirement.constraint
-                        )
+                    .map(|e| match &e.runtime_requirement {
+                        Some(req) => format!("{} {}", req.engine, req.constraint),
+                        None => "native".to_string(),
                     })
                     .collect::<Vec<_>>()
                     .join("; ");

--- a/crates/tebako-info/src/render.rs
+++ b/crates/tebako-info/src/render.rs
@@ -127,10 +127,13 @@ fn provides_section(m: &PayloadManifest, out: &mut String) {
                 if !ep.args_default.is_empty() {
                     line.push_str(&format!("  args: {}", ep.args_default.join(" ")));
                 }
-                line.push_str(&format!(
-                    "  runtime: {} {}",
-                    ep.runtime_requirement.engine, ep.runtime_requirement.constraint
-                ));
+                match &ep.runtime_requirement {
+                    Some(req) => {
+                        line.push_str(&format!("  runtime: {} {}", req.engine, req.constraint))
+                    }
+                    // spec 03 §2.2: native entrypoint — zero-runtime dispatch
+                    None => line.push_str("  runtime: none (native)"),
+                }
                 out.push_str(&line);
                 out.push('\n');
             }

--- a/crates/tebako-resolve/src/lib.rs
+++ b/crates/tebako-resolve/src/lib.rs
@@ -30,7 +30,8 @@ pub use error::{ReferenceError, RegistryError, ResolveError};
 pub use fetch::{sha256_hex, FetchedPayload, Fetcher};
 pub use reference::{Reference, Service};
 pub use registry::{
-    PlatformSelection, Registry, RegistryPayload, RegistryPlatforms, RegistryRef, RegistryVersion,
+    PlatformSelection, Registry, RegistryPayload, RegistryPlatforms, RegistryRef,
+    RegistryRuntimeRequirement, RegistryVersion, ReleaseRef,
 };
 pub use transport::{HttpTransport, Transport};
 

--- a/crates/tebako-resolve/src/registry.rs
+++ b/crates/tebako-resolve/src/registry.rs
@@ -70,7 +70,11 @@ pub struct RegistryVersion {
     pub release: ReleaseRef,
     /// Opt-in OpenPGP signature of the artifact (spec 09): the signer
     /// keyid (16 lowercase hex) and the detached `.asc` — an asset name
-    /// within the same release, or a full reference.
+    /// within the same release, or a full reference. One signature covers
+    /// exactly one artifact, so per-triplet releases carry one asc per
+    /// artifact by convention (`<artifact>.asc`) and the installer
+    /// verifies the SELECTED artifact against its own asc; `asc` names
+    /// the exact asset only for universal payloads.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signature: Option<SignaturePin>,
     /// The runtime the payload's entrypoints need (spec 03 §2.2);

--- a/crates/tebako-shim/Cargo.toml
+++ b/crates/tebako-shim/Cargo.toml
@@ -11,9 +11,14 @@ keywords = ["tebako", "shim", "dispatcher", "version-manager"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-# The mirrored payload manifest / config / registry / project pins are all
-# YAML (spec 00 invariant 6). serde_yaml 0.9 is the cached, pure-Rust
-# (unsafe-libyaml) choice — no native build, no async, no clap.
+# The unified payload-manifest model (spec 03 — item 40's manifest
+# unify): the dispatch mirror is a tpkg::PayloadManifest; constraint
+# grammar is tpkg's, the dispatcher only evaluates.
+tpkg = { version = "0.1.0", path = "../tpkg" }
+# The authored config / disabled state / project pins are YAML (spec 00
+# invariant 6). serde_yaml 0.9 is the cached, pure-Rust (unsafe-libyaml)
+# choice — no native build, no async, no clap. (The manifest mirror's
+# YAML is parsed by tpkg itself, on serde_yml.)
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 # In-process HTTP for runtime downloads (spec 00 invariant 1) — the same

--- a/crates/tebako-shim/Cargo.toml
+++ b/crates/tebako-shim/Cargo.toml
@@ -15,6 +15,11 @@ categories = ["command-line-utilities"]
 # unify): the dispatch mirror is a tpkg::PayloadManifest; constraint
 # grammar is tpkg's, the dispatcher only evaluates.
 tpkg = { version = "0.1.0", path = "../tpkg" }
+# Remote registry resolution at dispatch time (spec 04 §2 — item 33):
+# every registry form (service contents API, pinned release artifact, git
+# blob, file) behind the per-ref dispatch cache in src/regcache.rs. The
+# shim links tebako-resolve, never tebako-cli.
+tebako-resolve = { version = "0.1.0", path = "../tebako-resolve" }
 # The authored config / disabled state / project pins are YAML (spec 00
 # invariant 6). serde_yaml 0.9 is the cached, pure-Rust (unsafe-libyaml)
 # choice — no native build, no async, no clap. (The manifest mirror's

--- a/crates/tebako-shim/src/config.rs
+++ b/crates/tebako-shim/src/config.rs
@@ -12,17 +12,18 @@
 //!   disable). Kept out of the authored config so `tebako-shim disable`
 //!   never rewrites a hand-maintained file.
 //! - `tpkg-registry.yaml` — the developer-hosted registry (spec 04 §2).
-//!   The CLI (`tebako add-registry | install`, roadmap 28.1) resolves
-//!   every registry form through tebako-resolve; the DISPATCH-time
-//!   registry-default link below still reads `file://` refs and plain
-//!   paths only (a dispatch-time registry cache is PLANNED).
+//!   The registry-default chain link resolves every registry form through
+//!   tebako-resolve behind the dispatch-time cache ([`crate::regcache`]:
+//!   24 h TTL, `tebako update-registries`, `TEBAKO_OFFLINE` = cache-or-
+//!   named-error); the registry model is tebako-resolve's (one model,
+//!   parse + validate).
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use crate::{fail, ShimError, EX_TEBAKO_IO, EX_TEBAKO_MANIFEST};
+use crate::{fail, Ctx, ShimError, EX_TEBAKO_IO, EX_TEBAKO_MANIFEST};
 
 #[derive(Debug, Default, Deserialize)]
 pub struct UserConfig {
@@ -152,73 +153,28 @@ pub fn add_registry(home: &Path, reg_ref: &str) -> Result<AddRegistryOutcome, Sh
 }
 
 // ---------------------------------------------------------------------
-// registry mirror (spec 04 §2) — resolution-relevant fields only
+// the registry-default chain link (spec 07 §2.1, last resort)
 // ---------------------------------------------------------------------
 
-#[derive(Debug, Deserialize)]
-struct Registry {
-    #[serde(default)]
-    payloads: Vec<RegistryPayload>,
-}
-
-#[derive(Debug, Deserialize)]
-struct RegistryPayload {
-    name: String,
-    #[serde(default)]
-    default: Option<String>,
-}
-
 /// The registry default version for `payload_name`, scanning the user's
-/// registered registries in order (first match wins).
+/// registered registries in order (first match wins). Every registry form
+/// of spec 04 §2 resolves through the dispatch-time cache
+/// ([`crate::regcache`]); the registry model is tebako-resolve's.
 pub fn registry_default(
+    home: &Path,
     config: &UserConfig,
     payload_name: &str,
+    ctx: &Ctx,
 ) -> Result<Option<(String, String)>, ShimError> {
     for reg_ref in &config.registries {
-        let path = match local_registry_path(reg_ref) {
-            Some(p) => p,
-            None => {
-                return fail(
-                    EX_TEBAKO_MANIFEST,
-                    format!(
-                        "registry ref \"{reg_ref}\" is not a local file — the dispatch-time registry-default link reads file:// registries only (the CLI resolves remote registries at install; a dispatch-time registry cache is PLANNED)"
-                    ),
-                )
-            }
-        };
-        let text = match std::fs::read_to_string(&path) {
-            Ok(t) => t,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(e) => {
-                return fail(
-                    EX_TEBAKO_IO,
-                    format!("cannot read registry {}: {e}", path.display()),
-                )
-            }
-        };
-        let registry: Registry = serde_yaml::from_str(&text).map_err(|e| {
-            ShimError::new(
-                EX_TEBAKO_MANIFEST,
-                format!("cannot parse registry {} ({e})", path.display()),
-            )
-        })?;
-        if let Some(p) = registry.payloads.iter().find(|p| p.name == payload_name) {
+        let registry = crate::regcache::registry_for(home, reg_ref, ctx)?;
+        if let Some(p) = registry.payload(payload_name) {
             if let Some(default) = &p.default {
                 return Ok(Some((default.clone(), reg_ref.clone())));
             }
         }
     }
     Ok(None)
-}
-
-fn local_registry_path(reg_ref: &str) -> Option<PathBuf> {
-    if let Some(rest) = reg_ref.strip_prefix("file://") {
-        Some(PathBuf::from(rest))
-    } else if reg_ref.starts_with('/') || reg_ref.starts_with("./") || reg_ref.starts_with("../") {
-        Some(PathBuf::from(reg_ref))
-    } else {
-        None
-    }
 }
 
 // ---------------------------------------------------------------------

--- a/crates/tebako-shim/src/dispatch.rs
+++ b/crates/tebako-shim/src/dispatch.rs
@@ -19,7 +19,8 @@
 
 use std::path::PathBuf;
 
-use crate::manifest::Require;
+use tpkg::Requirement;
+
 use crate::resolve::{self, Resolution};
 use crate::runtime::{self, RuntimeResolution};
 use crate::versions;
@@ -59,7 +60,7 @@ fn compose_mounts(res: &Resolution, ctx: &Ctx) -> Result<Vec<MountSpec>, ShimErr
         slot: 0,
         mount: "/".to_string(),
     }];
-    for req in &res.manifest.requires {
+    for req in res.manifest.requires() {
         let dep = dependency_mount(req, &res.tool, ctx)?;
         if let Some(dep) = dep {
             mounts.push(dep);
@@ -72,18 +73,32 @@ fn compose_mounts(res: &Resolution, ctx: &Ctx) -> Result<Vec<MountSpec>, ShimErr
 /// mount point. `kind: language` edges are the runtime axis (resolved via
 /// the entrypoint's `runtime_requirement`) and are never mounted; edges
 /// without a `mount` declare no mount in v1.
-fn dependency_mount(req: &Require, tool: &str, ctx: &Ctx) -> Result<Option<MountSpec>, ShimError> {
-    if req.kind == "language" {
-        return Ok(None);
-    }
-    let (Some(name), Some(mount)) = (&req.name, &req.mount) else {
+fn dependency_mount(
+    req: &Requirement,
+    tool: &str,
+    ctx: &Ctx,
+) -> Result<Option<MountSpec>, ShimError> {
+    let (kind, name, constraint, mount) = match req {
+        Requirement::Language { .. } => return Ok(None),
+        Requirement::Toolkit {
+            name,
+            constraint,
+            mount,
+            ..
+        } => ("toolkit", name, constraint, mount),
+        Requirement::Data {
+            name,
+            constraint,
+            mount,
+        } => ("data", name, constraint, mount),
+    };
+    let Some(mount) = mount else {
         return Ok(None);
     };
     let installed = resolve::installed_versions(&ctx.home, name)?;
-    let constraint = match &req.constraint {
-        Some(c) => versions::parse_constraint(c)?,
-        None => versions::parse_constraint(">= 0")?,
-    };
+    // The constraint was validated at manifest parse (tpkg::Constraint) —
+    // the dispatcher only evaluates it.
+    let constraint = versions::from_validated(constraint);
     let version = installed
         .iter()
         .filter(|v| constraint.matches(v))
@@ -92,8 +107,7 @@ fn dependency_mount(req: &Require, tool: &str, ctx: &Ctx) -> Result<Option<Mount
         return fail(
             EX_TEBAKO_MANIFEST,
             format!(
-                "\"{tool}\" requires {} {name} but no satisfying version is installed (installed: {})\n  install the dependency, or run `tebako-shim doctor`",
-                req.kind,
+                "\"{tool}\" requires {kind} {name} but no satisfying version is installed (installed: {})\n  install the dependency, or run `tebako-shim doctor`",
                 if installed.is_empty() {
                     "none".to_string()
                 } else {

--- a/crates/tebako-shim/src/lib.rs
+++ b/crates/tebako-shim/src/lib.rs
@@ -17,8 +17,13 @@
 //! Discipline: no async, no clap, no logging framework; hand-rolled argv;
 //! named errors and exit codes (spec 06 §4 reused); cache-install mirrors
 //! the bootstrap's flock / tmp+rename / trust-marker discipline (spec 05
-//! §4) without linking the bootstrap crate (which drags in rnp — the shim
-//! stays pure-Rust + tebako-http).
+//! §4) without linking the bootstrap crate (which drags in rnp).
+//!
+//! The dispatch-time registry-default link resolves EVERY registry form
+//! of spec 04 §2 through tebako-resolve (service contents API, pinned
+//! release artifact, git blob, `file://`) behind the per-ref dispatch
+//! cache in [`regcache`] (24 h TTL, `tebako update-registries`,
+//! `TEBAKO_OFFLINE` = cache-or-named-error) — never tebako-cli.
 //!
 //! The installed payload record (the dispatcher-visible mirror, spec 03
 //! §4 tier 3 rationale — resolve without opening every image):
@@ -38,6 +43,7 @@ pub mod config;
 pub mod dispatch;
 pub mod manage;
 pub mod manifest;
+pub mod regcache;
 pub mod resolve;
 pub mod runtime;
 pub mod shell;

--- a/crates/tebako-shim/src/manage.rs
+++ b/crates/tebako-shim/src/manage.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use crate::config;
 use crate::dispatch::{self, ExecPlan};
 use crate::manifest;
+use crate::regcache;
 use crate::resolve::{self, Resolution};
 use crate::runtime::RuntimeResolution;
 use crate::shell::{self, Shell};
@@ -143,6 +144,17 @@ fn cmd_list(ctx: &Ctx) -> Result<Action, ShimError> {
 
 fn first_line(message: &str) -> &str {
     message.lines().next().unwrap_or(message)
+}
+
+/// "<N>m/h/d old" for doctor's registry freshness lines.
+fn human_age(secs: u64) -> String {
+    if secs < 3600 {
+        format!("{}m old", secs / 60)
+    } else if secs < 86_400 {
+        format!("{}h old", secs / 3600)
+    } else {
+        format!("{}d old", secs / 86_400)
+    }
 }
 
 // ---------------------------------------------------------------------
@@ -332,19 +344,32 @@ fn cmd_doctor(ctx: &Ctx) -> Result<Action, ShimError> {
         }
     }
 
-    // authored config + registries parse.
+    // authored config + registries: parse, local existence, and the
+    // dispatch-cache freshness of remote refs (spec 04 §2 + roadmap 33).
     match config::load_config(&ctx.home) {
         Ok(cfg) => {
             for reg in &cfg.registries {
-                let path = reg.strip_prefix("file://").unwrap_or(reg);
-                if reg.starts_with("file://") || reg.starts_with('/') {
-                    if !std::path::Path::new(path).is_file() {
-                        problems.push(format!("registry {reg}: file not found"));
+                match regcache::freshness(&ctx.home, reg) {
+                    regcache::RegistryFreshness::Local => {
+                        let path = reg.strip_prefix("file://").unwrap_or(reg);
+                        if !std::path::Path::new(path).is_file() {
+                            problems.push(format!("registry {reg}: file not found"));
+                        }
                     }
-                } else {
-                    notes.push(format!(
-                        "registry {reg}: remote refs are install-time resolved by the CLI (dispatch-time cache PLANNED; skipped)"
-                    ));
+                    regcache::RegistryFreshness::Fresh(age) => notes.push(format!(
+                        "registry {reg}: dispatch cache fresh ({})",
+                        human_age(age)
+                    )),
+                    regcache::RegistryFreshness::Stale(age) => notes.push(format!(
+                        "registry {reg}: dispatch cache is stale ({}) — the next dispatch refreshes it, or run `tebako update-registries`",
+                        human_age(age)
+                    )),
+                    regcache::RegistryFreshness::Missing => problems.push(format!(
+                        "registry {reg}: not in the dispatch cache — run `tebako update-registries` (online dispatch fetches on demand; TEBAKO_OFFLINE dispatch would fail)"
+                    )),
+                    regcache::RegistryFreshness::BadRef(_) => problems.push(format!(
+                        "registry {reg}: does not parse as a spec 04 §2 registry reference"
+                    )),
                 }
             }
         }

--- a/crates/tebako-shim/src/manage.rs
+++ b/crates/tebako-shim/src/manage.rs
@@ -93,7 +93,7 @@ fn cmd_list(ctx: &Ctx) -> Result<Action, ShimError> {
         if let Some(v) = &newest {
             let record = manifest::payload_record(&ctx.home, name, v);
             if let Ok(m) = manifest::Manifest::load(&record.manifest_mirror) {
-                tools = m.entrypoints.iter().map(|e| e.name.clone()).collect();
+                tools = m.entrypoints().iter().map(|e| e.name.clone()).collect();
             }
         }
         let _ = writeln!(out, "{name}");
@@ -420,10 +420,11 @@ fn check_payload_record(ctx: &Ctx, name: &str, version: &str, problems: &mut Vec
     }
     match manifest::Manifest::load(&record.manifest_mirror) {
         Ok(m) => {
-            if m.name != name || m.version != version {
+            if m.name() != name || m.version() != version {
                 problems.push(format!(
                     "{tag}: manifest mirror declares {} {} — the record is inconsistent",
-                    m.name, m.version
+                    m.name(),
+                    m.version()
                 ));
             }
         }

--- a/crates/tebako-shim/src/manifest.rs
+++ b/crates/tebako-shim/src/manifest.rs
@@ -1,70 +1,34 @@
-//! The minimal payload-manifest surface the dispatcher resolves against.
+//! The installed payload's manifest mirror (spec 03 §4 tier 3 — the
+//! dispatcher resolves without opening every image):
+//! `~/.tebako/payloads/<name>/<version>.manifest.yaml`.
 //!
-//! TODO(manifest-unify): the normative tpkg manifest model (spec 03,
-//! `schema/tpkg-manifest-v1.schema.json`) is being built concurrently on
-//! `feat/manifest-format`. DO NOT couple to that branch: this module
-//! defines exactly the fields spec 07 dispatch needs —
-//! `{name, version, entrypoints[], requires[]}` — and parses them from
-//! the mirrored manifest copy in the installed payload record
-//! (`~/.tebako/payloads/<name>/<version>.manifest.yaml`). When the shared
-//! model lands, replace this module with it and delete this note.
+//! The mirror IS the unified payload manifest — [`tpkg::PayloadManifest`]
+//! (spec 03, `schema/tpkg-manifest-v1.schema.json`), never a parallel
+//! model: the installer (`tebako install`) writes the image's embedded
+//! manifest verbatim-tier here (or synthesizes one from the registry's
+//! tier-3 fields when the image carries none), and the dispatcher reads
+//! exactly the fields spec 07 dispatch needs — `identity.name` /
+//! `identity.version`, the app PROVIDES `entrypoints[]` (each with its
+//! own `runtime_requirement`; `None` = zero-runtime native entrypoint,
+//! spec 03 §2.2), and the DEPENDS `requires[]` edges. Constraint parsing
+//! is the manifest model's (tpkg's [`tpkg::Constraint`] validates at
+//! parse); the dispatcher only EVALUATES constraints ([`crate::versions`]).
 
-use serde::{Deserialize, Serialize};
+use tpkg::{Entrypoint, PayloadKind, PayloadManifest, Provides, Requirement};
 
 use crate::{fail, ShimError, EX_TEBAKO_MANIFEST};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// The dispatcher-visible half of an installed payload record: the parsed
+/// manifest mirror. Wraps the unified model to keep the shim's named
+/// errors (a missing/corrupt mirror points at `tebako-shim doctor`).
+#[derive(Debug, Clone)]
 pub struct Manifest {
-    pub name: String,
-    pub version: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub entrypoints: Vec<Entrypoint>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub requires: Vec<Require>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Entrypoint {
-    /// The command name; the shim registers and dispatches under it.
-    pub name: String,
-    /// The executable inside the payload image (the `--tebako-entry`).
-    pub path: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub args_default: Vec<String>,
-    /// `None` = native / self-contained entrypoint: zero-runtime dispatch
-    /// (spec 03 §2.2 locked); the dispatcher mounts zero runtime payloads.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub runtime_requirement: Option<RuntimeRequirement>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RuntimeRequirement {
-    pub engine: String,
-    /// Range form (`>= 3.3, < 5.0`) for pure-language payloads; abi-line
-    /// form (`~> 3.3.0`) for native-extension payloads (spec 05 §5).
-    pub constraint: String,
-}
-
-/// A DEPENDS edge (spec 03 §2.3). Only the resolution fields the
-/// dispatcher needs are modeled; `mount` is consumer-declared (locked
-/// MOUNT RULE). `kind: language` edges are the runtime axis and are
-/// resolved through the entrypoint's `runtime_requirement`, never mounted.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Require {
-    pub kind: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub engine: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub constraint: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mount: Option<String>,
+    inner: PayloadManifest,
 }
 
 impl Manifest {
     pub fn parse(yaml: &str, source: &std::path::Path) -> Result<Manifest, ShimError> {
-        serde_yaml::from_str(yaml).map_err(|e| {
+        let inner = PayloadManifest::from_yaml(yaml).map_err(|e| {
             ShimError::new(
                 EX_TEBAKO_MANIFEST,
                 format!(
@@ -72,11 +36,12 @@ impl Manifest {
                     source.display()
                 ),
             )
-        })
+        })?;
+        Ok(Manifest { inner })
     }
 
     pub fn entrypoint(&self, name: &str) -> Option<&Entrypoint> {
-        self.entrypoints.iter().find(|e| e.name == name)
+        self.entrypoints().iter().find(|e| e.name == name)
     }
 
     pub fn load(path: &std::path::Path) -> Result<Manifest, ShimError> {
@@ -92,10 +57,49 @@ impl Manifest {
         Manifest::parse(&text, path)
     }
 
+    /// Wrap the unified manifest (the installer's half — embedded or
+    /// synthesized).
+    pub fn from_payload_manifest(inner: PayloadManifest) -> Manifest {
+        Manifest { inner }
+    }
+
+    /// The unified manifest itself (the registry/publish surfaces need
+    /// fields beyond the dispatch minimum).
+    pub fn payload_manifest(&self) -> &PayloadManifest {
+        &self.inner
+    }
+
+    pub fn name(&self) -> &str {
+        &self.inner.identity.name
+    }
+
+    pub fn version(&self) -> &str {
+        &self.inner.identity.version
+    }
+
+    pub fn kind(&self) -> PayloadKind {
+        self.inner.identity.kind
+    }
+
+    /// The app PROVIDES entrypoints (empty for non-app kinds — a data
+    /// payload provides no commands).
+    pub fn entrypoints(&self) -> &[Entrypoint] {
+        match &self.inner.provides {
+            Provides::App(app) => &app.entrypoints,
+            _ => &[],
+        }
+    }
+
+    /// The DEPENDS edges (spec 03 §2.3).
+    pub fn requires(&self) -> &[Requirement] {
+        &self.inner.requires
+    }
+
     /// Write the manifest mirror (the installer's half of the payload
-    /// record): tmp + rename, like every cache-managed file.
+    /// record): tmp + rename, like every cache-managed file. The manifest
+    /// is re-validated on the way out (`to_yaml`).
     pub fn save(&self, path: &std::path::Path) -> Result<(), ShimError> {
-        let text = serde_yaml::to_string(self).map_err(|e| {
+        let text = self.inner.to_yaml().map_err(|e| {
             ShimError::new(
                 EX_TEBAKO_MANIFEST,
                 format!("cannot serialize the manifest mirror: {e}"),

--- a/crates/tebako-shim/src/regcache.rs
+++ b/crates/tebako-shim/src/regcache.rs
@@ -1,0 +1,334 @@
+//! The dispatch-time registry cache (spec 04 §2 + spec 05 §4 discipline,
+//! roadmap 33): the shim's registry-default chain link resolves EVERY
+//! registry form through tebako-resolve — service contents API, pinned
+//! release artifact, git blob, `file://` — and remote registries ride a
+//! per-ref cache so dispatch never blocks on the network twice in a row:
+//!
+//! ```text
+//! ~/.tebako/registries/<sha256-of-canonical-ref>.yaml        # the registry bytes
+//! ~/.tebako/registries/<sha256-of-canonical-ref>.fetched-at  # unix seconds
+//! ```
+//!
+//! Semantics (locked with the item):
+//!
+//! - fresh cache (age < [`REGISTRY_TTL`], 24 h) → read the cache, no fetch;
+//! - stale/missing cache, online → fetch through tebako-resolve, publish
+//!   tmp + rename, then read;
+//! - `TEBAKO_OFFLINE` → the cache (ANY age) or a named error — never a
+//!   fetch attempt;
+//! - `file://` refs (and hand-authored plain paths) read directly, no
+//!   cache at all;
+//! - `tebako update-registries` ([`refresh`]) force-renews the cache;
+//!   `tebako add-registry` primes it with the bytes it already fetched.
+
+use std::path::{Path, PathBuf};
+
+use tebako_resolve::registry::RegistryRef;
+use tebako_resolve::{Fetcher, Registry, ResolveError, Transport};
+
+use crate::{fail, Ctx, ShimError, EX_TEBAKO_IO, EX_TEBAKO_MANIFEST, EX_TEBAKO_UNAVAILABLE};
+
+/// Dispatch-cache freshness window: 24 hours.
+pub const REGISTRY_TTL_SECS: u64 = 24 * 3600;
+
+/// The directory the per-ref cache lives in (`~/.tebako/registries`).
+pub fn registries_dir(home: &Path) -> PathBuf {
+    home.join("registries")
+}
+
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn offline(ctx: &Ctx) -> bool {
+    ctx.env_get("TEBAKO_OFFLINE")
+        .is_some_and(|v| !v.is_empty() && v != "0")
+}
+
+/// `file://` refs and hand-authored plain paths read directly (the
+/// lenient read side — `tebako add-registry` only ever WRITES canonical
+/// refs, but a hand-maintained config.yaml may carry a path).
+fn local_registry_path(reg_ref: &str) -> Option<PathBuf> {
+    if let Some(rest) = reg_ref.strip_prefix("file://") {
+        Some(PathBuf::from(rest))
+    } else if reg_ref.starts_with('/') || reg_ref.starts_with("./") || reg_ref.starts_with("../") {
+        Some(PathBuf::from(reg_ref))
+    } else {
+        None
+    }
+}
+
+fn cache_key(canonical_ref: &str) -> String {
+    tebako_resolve::sha256_hex(canonical_ref.as_bytes())
+}
+
+fn cache_file(home: &Path, canonical_ref: &str) -> PathBuf {
+    registries_dir(home).join(format!("{}.yaml", cache_key(canonical_ref)))
+}
+
+fn fetched_at_file(home: &Path, canonical_ref: &str) -> PathBuf {
+    registries_dir(home).join(format!("{}.fetched-at", cache_key(canonical_ref)))
+}
+
+fn read_fetched_at(home: &Path, canonical_ref: &str) -> Option<u64> {
+    std::fs::read_to_string(fetched_at_file(home, canonical_ref))
+        .ok()
+        .and_then(|t| t.trim().parse().ok())
+}
+
+/// Write the cache (tmp + rename, like every cache-managed file).
+fn prime_unchecked(home: &Path, canonical_ref: &str, bytes: &[u8]) -> Result<(), ShimError> {
+    let dir = registries_dir(home);
+    std::fs::create_dir_all(&dir).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_IO,
+            format!("cannot create {}: {e}", dir.display()),
+        )
+    })?;
+    let file = cache_file(home, canonical_ref);
+    let tmp = dir.join(format!(
+        ".{}.{}.tmp",
+        file.file_name()
+            .map(|n| n.to_string_lossy())
+            .unwrap_or_default(),
+        std::process::id()
+    ));
+    std::fs::write(&tmp, bytes).map_err(|e| {
+        ShimError::new(EX_TEBAKO_IO, format!("cannot write {}: {e}", tmp.display()))
+    })?;
+    std::fs::rename(&tmp, &file).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_IO,
+            format!("cannot install {}: {e}", file.display()),
+        )
+    })?;
+    std::fs::write(
+        fetched_at_file(home, canonical_ref),
+        format!("{}\n", now_unix()),
+    )
+    .map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_IO,
+            format!("cannot write the fetched-at marker: {e}"),
+        )
+    })
+}
+
+/// Prime the cache with already-fetched bytes (the `tebako add-registry`
+/// flow fetched the registry once to validate it — those bytes ARE the
+/// first cache entry). No-op for `file://` refs (they read directly).
+pub fn prime(home: &Path, canonical_ref: &str, bytes: &[u8]) -> Result<(), ShimError> {
+    if local_registry_path(canonical_ref).is_some() {
+        return Ok(());
+    }
+    let parsed = RegistryRef::parse(canonical_ref).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_MANIFEST,
+            format!("cannot prime the registry cache for '{canonical_ref}': {e}"),
+        )
+    })?;
+    if !parsed.is_remote() {
+        return Ok(());
+    }
+    prime_unchecked(home, &parsed.as_canonical_string(), bytes)
+}
+
+fn parse_registry(bytes: &[u8], origin: &str) -> Result<Registry, ShimError> {
+    let text = String::from_utf8(bytes.to_vec()).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_MANIFEST,
+            format!("the registry from {origin} is not UTF-8: {e}"),
+        )
+    })?;
+    Registry::from_yaml(&text).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_MANIFEST,
+            format!("cannot parse the registry from {origin}: {e}"),
+        )
+    })
+}
+
+fn map_resolve(home: &Path, reg_ref: &str, e: ResolveError) -> ShimError {
+    let code = match &e {
+        ResolveError::Sha256Mismatch { .. } => crate::EX_TEBAKO_SHA,
+        ResolveError::LockTimeout { .. } | ResolveError::CacheIo { .. } => EX_TEBAKO_IO,
+        ResolveError::Registry(_) | ResolveError::Reference(_) => EX_TEBAKO_MANIFEST,
+        _ => EX_TEBAKO_UNAVAILABLE,
+    };
+    ShimError::new(
+        code,
+        format!(
+            "cannot resolve registry \"{reg_ref}\" at dispatch time: {e}\n  retry, or run `tebako update-registries`; the dispatch cache lives in {}",
+            registries_dir(home).display()
+        ),
+    )
+}
+
+/// Resolve the registry `reg_ref` names for the dispatch-time chain:
+/// `file://`/plain paths directly, remote refs cache-first (fresh cache,
+/// else fetch + prime; `TEBAKO_OFFLINE` = cache-or-named-error).
+pub fn registry_for(home: &Path, reg_ref: &str, ctx: &Ctx) -> Result<Registry, ShimError> {
+    registry_for_with(home, reg_ref, &Fetcher::new(), offline(ctx), now_unix())
+}
+
+/// The transport/clock-injected half of [`registry_for`] (tests).
+pub fn registry_for_with<T: Transport>(
+    home: &Path,
+    reg_ref: &str,
+    fetcher: &Fetcher<T>,
+    offline: bool,
+    now: u64,
+) -> Result<Registry, ShimError> {
+    // Local forms read directly, no cache (and no fetch).
+    if let Some(path) = local_registry_path(reg_ref) {
+        let bytes = std::fs::read_to_string(&path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                ShimError::new(
+                    EX_TEBAKO_MANIFEST,
+                    format!("registry file {} does not exist", path.display()),
+                )
+            } else {
+                ShimError::new(
+                    EX_TEBAKO_IO,
+                    format!("cannot read registry {}: {e}", path.display()),
+                )
+            }
+        })?;
+        return parse_registry(bytes.as_bytes(), &path.display().to_string());
+    }
+    let parsed = RegistryRef::parse(reg_ref).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_MANIFEST,
+            format!("registry ref \"{reg_ref}\" is invalid: {e}"),
+        )
+    })?;
+    let canonical = parsed.as_canonical_string();
+    let cache = cache_file(home, &canonical);
+    let age = read_fetched_at(home, &canonical).map(|t| now.saturating_sub(t));
+
+    if offline {
+        if cache.is_file() {
+            let bytes = std::fs::read(&cache).map_err(|e| {
+                ShimError::new(
+                    EX_TEBAKO_IO,
+                    format!("cannot read the cached registry {}: {e}", cache.display()),
+                )
+            })?;
+            return parse_registry(&bytes, &format!("the dispatch cache {}", cache.display()));
+        }
+        return fail(
+            EX_TEBAKO_UNAVAILABLE,
+            format!(
+                "registry \"{canonical}\" is not in the dispatch cache ({}) and TEBAKO_OFFLINE is set\n  run `tebako update-registries` while online",
+                registries_dir(home).display()
+            ),
+        );
+    }
+
+    if age.is_some_and(|a| a < REGISTRY_TTL_SECS) && cache.is_file() {
+        let bytes = std::fs::read(&cache).map_err(|e| {
+            ShimError::new(
+                EX_TEBAKO_IO,
+                format!("cannot read the cached registry {}: {e}", cache.display()),
+            )
+        })?;
+        return parse_registry(&bytes, &format!("the dispatch cache {}", cache.display()));
+    }
+
+    // Stale or missing: fetch, publish, read.
+    let bytes = fetcher
+        .fetch_registry(&parsed)
+        .map_err(|e| map_resolve(home, &canonical, e))?;
+    prime_unchecked(home, &canonical, &bytes)?;
+    parse_registry(&bytes, &canonical)
+}
+
+/// What [`refresh`] did with one registry ref.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefreshOutcome {
+    /// `file://`/plain path: reads directly, nothing to cache.
+    LocalSkipped,
+    /// Fetched and (re-)published into the dispatch cache.
+    Refreshed,
+}
+
+/// Force-renew one registry's dispatch cache (`tebako update-registries`).
+pub fn refresh(home: &Path, reg_ref: &str) -> Result<RefreshOutcome, ShimError> {
+    refresh_with(home, reg_ref, &Fetcher::new())
+}
+
+/// The transport-injected half of [`refresh`] (tests).
+pub fn refresh_with<T: Transport>(
+    home: &Path,
+    reg_ref: &str,
+    fetcher: &Fetcher<T>,
+) -> Result<RefreshOutcome, ShimError> {
+    if local_registry_path(reg_ref).is_some() {
+        return Ok(RefreshOutcome::LocalSkipped);
+    }
+    let parsed = RegistryRef::parse(reg_ref).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_MANIFEST,
+            format!("registry ref \"{reg_ref}\" is invalid: {e}"),
+        )
+    })?;
+    let canonical = parsed.as_canonical_string();
+    let bytes = fetcher
+        .fetch_registry(&parsed)
+        .map_err(|e| map_resolve(home, &canonical, e))?;
+    // refresh proves the registry still parses before caching it
+    parse_registry(&bytes, &canonical)?;
+    prime_unchecked(home, &canonical, &bytes)?;
+    Ok(RefreshOutcome::Refreshed)
+}
+
+/// The dispatch-cache state of one registered registry (doctor).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryFreshness {
+    /// `file://`/plain path: no cache involved (the file's existence is
+    /// the doctor's separate check).
+    Local,
+    /// Cached, age below the TTL (seconds).
+    Fresh(u64),
+    /// Cached but older than the TTL (seconds) — the next dispatch
+    /// refreshes it; offline dispatch still resolves from it.
+    Stale(u64),
+    /// Remote and not cached: online dispatch fetches on demand, offline
+    /// dispatch fails — `tebako update-registries` fixes it ahead of time.
+    Missing,
+    /// The configured ref does not parse.
+    BadRef(String),
+}
+
+/// The freshness of one registered registry's dispatch cache.
+pub fn freshness(home: &Path, reg_ref: &str) -> RegistryFreshness {
+    freshness_at(home, reg_ref, now_unix())
+}
+
+/// The clock-injected half of [`freshness`] (tests).
+pub fn freshness_at(home: &Path, reg_ref: &str, now: u64) -> RegistryFreshness {
+    if local_registry_path(reg_ref).is_some() {
+        return RegistryFreshness::Local;
+    }
+    let Ok(parsed) = RegistryRef::parse(reg_ref) else {
+        return RegistryFreshness::BadRef(reg_ref.to_string());
+    };
+    let canonical = parsed.as_canonical_string();
+    if !cache_file(home, &canonical).is_file() {
+        return RegistryFreshness::Missing;
+    }
+    match read_fetched_at(home, &canonical) {
+        Some(t) => {
+            let age = now.saturating_sub(t);
+            if age < REGISTRY_TTL_SECS {
+                RegistryFreshness::Fresh(age)
+            } else {
+                RegistryFreshness::Stale(age)
+            }
+        }
+        None => RegistryFreshness::Missing,
+    }
+}

--- a/crates/tebako-shim/src/resolve.rs
+++ b/crates/tebako-shim/src/resolve.rs
@@ -224,7 +224,8 @@ pub fn resolve(tool: &str, ctx: &Ctx) -> Result<Resolution, ShimError> {
     }
     // 4. registry default
     if picked.is_none() {
-        if let Some((version, reg)) = config::registry_default(&cfg, &payload_name)? {
+        if let Some((version, reg)) = config::registry_default(&ctx.home, &cfg, &payload_name, ctx)?
+        {
             picked = Some((version, VersionSource::RegistryDefault(reg)));
         }
     }

--- a/crates/tebako-shim/src/runtime.rs
+++ b/crates/tebako-shim/src/runtime.rs
@@ -15,8 +15,9 @@
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use tpkg::RuntimeRequirement;
+
 use crate::config::{self, RuntimePref};
-use crate::manifest::RuntimeRequirement;
 use crate::versions::{self, Constraint};
 use crate::{fail, Ctx, ShimError, EX_TEBAKO_IO, EX_TEBAKO_SHA, EX_TEBAKO_UNAVAILABLE};
 
@@ -177,7 +178,9 @@ pub fn resolve_runtime(
     let Some(req) = requirement else {
         return Ok(RuntimeResolution::Zero);
     };
-    let constraint = versions::parse_constraint(&req.constraint)?;
+    // The constraint was validated at manifest parse (tpkg::Constraint) —
+    // the dispatcher only evaluates it against cached/offered versions.
+    let constraint = versions::from_validated(&req.constraint);
     let cached = scan_cached(&ctx.home, &req.engine);
     if let Some(hit) = newest_compatible(&cached, &constraint) {
         return Ok(RuntimeResolution::Ready(hit));

--- a/crates/tebako-shim/src/versions.rs
+++ b/crates/tebako-shim/src/versions.rs
@@ -12,10 +12,16 @@
 //! discipline. Versions are dot-separated components; numeric components
 //! compare numerically, anything else lexicographically, missing
 //! components are zero.
+//!
+//! Constraint GRAMMAR is not re-implemented here: [`tpkg::Constraint`]
+//! validates at manifest parse (spec 03 — the unified model), and
+//! [`from_validated`] only clause-splits that validated string into the
+//! evaluable form. [`parse_constraint`] (for the few raw-string callers)
+//! is validate-then-split.
 
 use std::cmp::Ordering;
 
-use crate::{fail, ShimError, EX_TEBAKO_MANIFEST};
+use crate::{ShimError, EX_TEBAKO_MANIFEST};
 
 fn components(v: &str) -> Vec<&str> {
     v.split('.').collect()
@@ -70,26 +76,26 @@ pub struct Constraint {
     clauses: Vec<Clause>,
 }
 
-/// Constraint versions must be plain dotted numerics (they are authored
-/// in manifests / registries; anything fancier is a named error, never a
-/// silent fallback).
-fn check_constraint_version(v: &str) -> Result<(), ShimError> {
-    if v.is_empty()
-        || !v
-            .split('.')
-            .all(|c| !c.is_empty() && c.bytes().all(|b| b.is_ascii_digit()))
-    {
-        return fail(
+/// Validate a raw constraint string and build the evaluable form. The
+/// grammar is tpkg's (the unified manifest model); anything fancier than
+/// the spec 03 grammar is a named error, never a silent fallback.
+pub fn parse_constraint(source: &str) -> Result<Constraint, ShimError> {
+    let validated = tpkg::Constraint::new(source).map_err(|e| {
+        ShimError::new(
             EX_TEBAKO_MANIFEST,
             format!(
-                "malformed version \"{v}\" in a requirement constraint — expected dotted numerics (e.g. \">= 3.3, < 5.0\" or \"~> 3.3.0\")"
+                "malformed requirement constraint \"{source}\" ({e}) — expected e.g. \">= 3.3, < 5.0\" or \"~> 3.3.0\""
             ),
-        );
-    }
-    Ok(())
+        )
+    })?;
+    Ok(from_validated(&validated))
 }
 
-pub fn parse_constraint(source: &str) -> Result<Constraint, ShimError> {
+/// Clause-split an already-validated constraint into the evaluable form.
+/// The grammar was checked when the [`tpkg::Constraint`] was built (at
+/// manifest parse), so this never fails and never re-validates.
+pub fn from_validated(validated: &tpkg::Constraint) -> Constraint {
+    let source = validated.as_str();
     let mut clauses = Vec::new();
     for raw in source.split(',') {
         let part = raw.trim();
@@ -110,20 +116,15 @@ pub fn parse_constraint(source: &str) -> Result<Constraint, ShimError> {
         } else {
             (Op::Eq, part)
         };
-        let version = rest.trim().to_string();
-        check_constraint_version(&version)?;
-        clauses.push(Clause { op, version });
+        clauses.push(Clause {
+            op,
+            version: rest.trim().to_string(),
+        });
     }
-    if clauses.is_empty() {
-        return fail(
-            EX_TEBAKO_MANIFEST,
-            "empty requirement constraint — expected e.g. \">= 3.3, < 5.0\"",
-        );
-    }
-    Ok(Constraint {
+    Constraint {
         source: source.to_string(),
         clauses,
-    })
+    }
 }
 
 /// The pessimistic upper bound: drop the last component, increment the
@@ -229,5 +230,14 @@ mod tests {
         assert!(parse_constraint(">= ").is_err());
         assert!(parse_constraint("~> 3.x").is_err());
         assert!(parse_constraint("").is_err());
+    }
+
+    #[test]
+    fn from_validated_clause_splits_without_revalidating() {
+        let validated = tpkg::Constraint::new(">= 3.3, < 5.0").unwrap();
+        let c = from_validated(&validated);
+        assert_eq!(c.source(), ">= 3.3, < 5.0");
+        assert!(c.matches("4.0.6"));
+        assert!(!c.matches("5.0.0"));
     }
 }

--- a/crates/tebako-shim/tests/common/mod.rs
+++ b/crates/tebako-shim/tests/common/mod.rs
@@ -70,13 +70,50 @@ pub fn write_payload(home: &Path, name: &str, version: &str, manifest_yaml: &str
     image
 }
 
-pub fn app_manifest(name: &str, version: &str, entrypoints: &str) -> String {
-    format!("schema_version: 1\nkind: app\nname: {name}\nversion: {version}\n{entrypoints}")
+/// The unified payload manifest (spec 03 — the mirror's shape after the
+/// item 40 manifest unify): kind app, with `entrypoints_block` as the
+/// provides.entrypoints body ("  entrypoints:\n    - name: …" at the
+/// provides-level indent).
+pub fn app_manifest(name: &str, version: &str, entrypoints_block: &str) -> String {
+    app_manifest_full(name, version, entrypoints_block, "")
 }
 
-pub const RUBY_ENTRY: &str = "entrypoints:\n  - name: TOOL\n    path: /app/bin/TOOL\n    runtime_requirement: {engine: ruby, constraint: \">= 3.3, < 5.0\"}\n";
+/// An app manifest carrying DEPENDS edges (`requires_block` at the
+/// top-level indent, "requires:\n  - kind: …").
+pub fn app_manifest_requires(
+    name: &str,
+    version: &str,
+    entrypoints_block: &str,
+    requires_block: &str,
+) -> String {
+    app_manifest_full(name, version, entrypoints_block, requires_block)
+}
 
-pub const NATIVE_ENTRY: &str = "entrypoints:\n  - name: TOOL\n    path: /app/bin/TOOL\n";
+fn app_manifest_full(
+    name: &str,
+    version: &str,
+    entrypoints_block: &str,
+    requires_block: &str,
+) -> String {
+    format!(
+        "identity:\n  schema_version: 1\n  kind: app\n  name: {name}\n  version: \"{version}\"\n  producer: {{tool: tebako-shim-tests, tool_version: \"1\"}}\n  created: \"2026-07-27T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{tree}\"\n    blob_sha256: {blob}\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n{entrypoints_block}  platforms: universal\n  capabilities: {{exec: true, read: true}}\n{requires_block}",
+        tree = "a".repeat(64),
+        blob = "b".repeat(64),
+    )
+}
+
+/// A data payload's manifest (dependency fixtures): no entrypoints.
+pub fn data_manifest(name: &str, version: &str) -> String {
+    format!(
+        "identity:\n  schema_version: 1\n  kind: data\n  name: {name}\n  version: \"{version}\"\n  producer: {{tool: tebako-shim-tests, tool_version: \"1\"}}\n  created: \"2026-07-27T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{tree}\"\n    blob_sha256: {blob}\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n  mount_semantics: {{suggested: /usr/share/{name}}}\n  capabilities: {{exec: false, read: true}}\n",
+        tree = "a".repeat(64),
+        blob = "b".repeat(64),
+    )
+}
+
+pub const RUBY_ENTRY: &str = "  entrypoints:\n    - name: TOOL\n      path: /app/bin/TOOL\n      runtime_requirement: {engine: ruby, constraint: \">= 3.3, < 5.0\"}\n";
+
+pub const NATIVE_ENTRY: &str = "  entrypoints:\n    - name: TOOL\n      path: /app/bin/TOOL\n";
 
 pub fn entrypoint_yaml(template: &str, tool: &str) -> String {
     template.replace("TOOL", tool)

--- a/crates/tebako-shim/tests/dispatch.rs
+++ b/crates/tebako-shim/tests/dispatch.rs
@@ -189,3 +189,47 @@ fn which_mode_never_downloads() {
     assert_eq!(err.code, tebako_shim::EX_TEBAKO_UNAVAILABLE);
     assert!(err.message.contains("would download"), "{}", err.message);
 }
+
+/// THE suite proof (spec 07 §2.0 multi-command suites): ONE installed
+/// suite payload, TWO shim commands, EACH resolving its OWN runtime
+/// requirement — two commands of one package run DIFFERENT runtime
+/// versions simultaneously (both dispatch plans are composed and usable
+/// at once; the runtime swap never touches the payload).
+#[test]
+fn suite_commands_run_different_runtime_versions_simultaneously() {
+    let tmp = TempDir::new("suite-two-runtimes");
+    let home = tmp.path().join("home");
+    // one suite payload, two entrypoints with DIFFERENT runtime
+    // requirements (the metanorma/mn2pdf shape, spec 03 §6)
+    write_payload(
+        &home,
+        "metasuite",
+        "2.0.0",
+        &app_manifest(
+            "metasuite",
+            "2.0.0",
+            "  entrypoints:\n    - name: metanorma\n      path: /app/bin/metanorma\n      runtime_requirement: {engine: ruby, constraint: \"~> 3.3.0\"}\n    - name: mn2pdf\n      path: /app/bin/mn2pdf\n      runtime_requirement: {engine: ruby, constraint: \"~> 3.4.0\"}\n",
+        ),
+    );
+    // two cached runtimes, one per abi line
+    let exe_33 = write_runtime(&home, "3.3.9", "0.16.0", false);
+    let exe_34 = write_runtime(&home, "3.4.2", "0.16.0", false);
+    let mut ctx = ctx(&home, tmp.path());
+    pin_env(&mut ctx, "metanorma", "2.0.0");
+    pin_env(&mut ctx, "mn2pdf", "2.0.0");
+
+    // both dispatch plans coexist — the simultaneous case
+    let plan_a = dispatch::dispatch("metanorma", &[], &ctx).unwrap();
+    let plan_b = dispatch::dispatch("mn2pdf", &[], &ctx).unwrap();
+
+    // each resolved its OWN abi line's newest cached runtime
+    assert_eq!(plan_a.program, exe_33);
+    assert_eq!(plan_b.program, exe_34);
+    assert_ne!(plan_a.program, plan_b.program);
+    // …and each hands off its own entrypoint of the SAME payload image
+    let image = home.join("payloads/metasuite/2.0.0.tfs");
+    assert_eq!(plan_a.mounts[0].image, image);
+    assert_eq!(plan_b.mounts[0].image, image);
+    assert!(plan_a.argv.iter().any(|a| a == "/app/bin/metanorma"));
+    assert!(plan_b.argv.iter().any(|a| a == "/app/bin/mn2pdf"));
+}

--- a/crates/tebako-shim/tests/dispatch.rs
+++ b/crates/tebako-shim/tests/dispatch.rs
@@ -33,7 +33,7 @@ fn runtime_entrypoint_composes_the_abi_v1_handoff() {
     let image = seed_tool(
         &home,
         "metanorma",
-        "entrypoints:\n  - name: metanorma\n    path: /app/bin/metanorma\n    args_default: [\"--safe\"]\n    runtime_requirement: {engine: ruby, constraint: \">= 3.3, < 5.0\"}\n",
+        "  entrypoints:\n    - name: metanorma\n      path: /app/bin/metanorma\n      args_default: [\"--safe\"]\n      runtime_requirement: {engine: ruby, constraint: \">= 3.3, < 5.0\"}\n",
         "1.2.3",
     );
     let exe = write_runtime(&home, "4.0.6", "0.16.0", true);
@@ -79,7 +79,7 @@ fn zero_runtime_entrypoint_skips_runtime_resolution() {
     let image = seed_tool(
         &home,
         "inkview",
-        "entrypoints:\n  - name: inkview\n    path: /app/bin/inkview\n",
+        "  entrypoints:\n    - name: inkview\n      path: /app/bin/inkview\n",
         "8.1.0",
     );
     let mut ctx = ctx(&home, tmp.path());
@@ -104,23 +104,28 @@ fn zero_runtime_entrypoint_skips_runtime_resolution() {
 fn declared_dependency_mounts_join_the_mount_set() {
     let tmp = TempDir::new("dep-mounts");
     let home = tmp.path().join("home");
-    let image = seed_tool(
+    let image = write_payload(
         &home,
         "metanorma",
-        "entrypoints:\n  - name: metanorma\n    path: /app/bin/metanorma\n    runtime_requirement: {engine: ruby, constraint: \">= 3.3, < 5.0\"}\nrequires:\n  - kind: data\n    name: iso-codes\n    constraint: \">= 2024.1\"\n    mount: /__app__/share/iso-codes\n",
         "1.2.3",
+        &app_manifest_requires(
+            "metanorma",
+            "1.2.3",
+            "  entrypoints:\n    - name: metanorma\n      path: /app/bin/metanorma\n      runtime_requirement: {engine: ruby, constraint: \">= 3.3, < 5.0\"}\n",
+            "requires:\n  - kind: data\n    name: iso-codes\n    constraint: \">= 2024.1\"\n    mount: /__app__/share/iso-codes\n",
+        ),
     );
     let dep_old = write_payload(
         &home,
         "iso-codes",
         "2024.1",
-        &app_manifest("iso-codes", "2024.1", ""),
+        &data_manifest("iso-codes", "2024.1"),
     );
     let dep_new = write_payload(
         &home,
         "iso-codes",
         "2025.2",
-        &app_manifest("iso-codes", "2025.2", ""),
+        &data_manifest("iso-codes", "2025.2"),
     );
     let _ = dep_old;
     write_runtime(&home, "4.0.6", "0.16.0", false);
@@ -145,11 +150,16 @@ fn declared_dependency_mounts_join_the_mount_set() {
 fn missing_dependency_is_a_named_error() {
     let tmp = TempDir::new("dep-missing");
     let home = tmp.path().join("home");
-    seed_tool(
+    write_payload(
         &home,
         "metanorma",
-        "entrypoints:\n  - name: metanorma\n    path: /app/bin/metanorma\nrequires:\n  - kind: toolkit\n    name: gtk-layer\n    constraint: \">= 3.24\"\n    mount: /__layers__/gtk\n",
         "1.2.3",
+        &app_manifest_requires(
+            "metanorma",
+            "1.2.3",
+            "  entrypoints:\n    - name: metanorma\n      path: /app/bin/metanorma\n",
+            "requires:\n  - kind: toolkit\n    name: gtk-layer\n    constraint: \">= 3.24\"\n    mount: /__layers__/gtk\n",
+        ),
     );
     let mut ctx = ctx(&home, tmp.path());
     pin_env(&mut ctx, "metanorma", "1.2.3");

--- a/crates/tebako-shim/tests/regcache.rs
+++ b/crates/tebako-shim/tests/regcache.rs
@@ -1,0 +1,277 @@
+//! The dispatch-time registry cache (spec 04 §2, roadmap 33): remote
+//! registry forms resolve through tebako-resolve behind a per-ref cache
+//! (24 h TTL, refresh, TEBAKO_OFFLINE = cache-or-named-error); `file://`
+//! reads directly. Mock transports only — no network.
+
+mod common;
+
+use std::cell::Cell;
+use std::collections::HashMap;
+
+use common::*;
+use tebako_resolve::{Fetcher, Transport};
+use tebako_shim::regcache::{self, RefreshOutcome, RegistryFreshness};
+
+const REGISTRY_YAML: &str = "schema_version: 1\npayloads:\n  - name: metanorma\n    kind: app\n    default: 1.2.3\n    versions:\n      - version: 1.2.3\n        platforms: universal\n        release: {ref: file:///metanorma-1.2.3.tfs}\n        entrypoints: [metanorma]\n";
+
+/// A counting mock transport: every GET is recorded, answered from the
+/// map (unknown URL → 404-class error, like the production mapping).
+struct MockTransport {
+    answers: HashMap<String, Vec<u8>>,
+    hits: std::rc::Rc<Cell<u64>>,
+}
+impl MockTransport {
+    fn with(answers: &[(&str, &str)], hits: std::rc::Rc<Cell<u64>>) -> MockTransport {
+        MockTransport {
+            answers: answers
+                .iter()
+                .map(|(u, b)| (u.to_string(), b.as_bytes().to_vec()))
+                .collect(),
+            hits,
+        }
+    }
+}
+impl Transport for MockTransport {
+    fn get(&self, url: &str) -> Result<Vec<u8>, tebako_http::FetchError> {
+        self.hits.set(self.hits.get() + 1);
+        self.answers
+            .get(url)
+            .cloned()
+            .ok_or_else(|| tebako_http::FetchError::IndexUnavailable(url.to_string()))
+    }
+}
+
+/// The GitHub default-branch form (service contents API): the contents
+/// JSON points at a raw download URL.
+fn github_fetcher(registry_bytes: &str) -> (Fetcher<MockTransport>, std::rc::Rc<Cell<u64>>) {
+    let contents = r#"{"name":"tpkg-registry.yaml","download_url":"https://raw.example/o/r/HEAD/tpkg-registry.yaml"}"#;
+    let hits = std::rc::Rc::new(Cell::new(0));
+    let t = MockTransport::with(
+        &[
+            (
+                "https://api.github.com/repos/o/r/contents/tpkg-registry.yaml",
+                contents,
+            ),
+            (
+                "https://raw.example/o/r/HEAD/tpkg-registry.yaml",
+                registry_bytes,
+            ),
+        ],
+        hits.clone(),
+    );
+    (Fetcher::with_transport(t), hits)
+}
+
+const GITHUB_REF: &str = "tfs:github:o/r";
+
+fn cached_file(home: &std::path::Path) -> std::path::PathBuf {
+    regcache::registries_dir(home).join(format!(
+        "{}.yaml",
+        tebako_resolve::sha256_hex(GITHUB_REF.as_bytes())
+    ))
+}
+
+fn fetched_at_file(home: &std::path::Path) -> std::path::PathBuf {
+    regcache::registries_dir(home).join(format!(
+        "{}.fetched-at",
+        tebako_resolve::sha256_hex(GITHUB_REF.as_bytes())
+    ))
+}
+
+fn now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+#[test]
+fn file_refs_read_directly_and_never_touch_the_cache() {
+    let tmp = TempDir::new("regcache-file");
+    let home = tmp.path().join("home");
+    let reg = tmp.path().join("tpkg-registry.yaml");
+    std::fs::write(&reg, REGISTRY_YAML).unwrap();
+
+    let (fetcher, _) = github_fetcher("unused");
+    let registry = regcache::registry_for_with(
+        &home,
+        &format!("file://{}", reg.display()),
+        &fetcher,
+        false,
+        now(),
+    )
+    .unwrap();
+    assert_eq!(registry.payloads.len(), 1);
+    // no cache directory was created and nothing was fetched
+    assert!(!regcache::registries_dir(&home).exists());
+    // a plain hand-authored path resolves the same way
+    let registry =
+        regcache::registry_for_with(&home, &reg.display().to_string(), &fetcher, false, now())
+            .unwrap();
+    assert_eq!(registry.payloads.len(), 1);
+}
+
+#[test]
+fn remote_ref_fetches_once_then_serves_the_fresh_cache() {
+    let tmp = TempDir::new("regcache-remote");
+    let home = tmp.path().join("home");
+    let (fetcher, hits) = github_fetcher(REGISTRY_YAML);
+
+    // miss → fetch + publish
+    let registry = regcache::registry_for_with(&home, GITHUB_REF, &fetcher, false, now()).unwrap();
+    assert_eq!(
+        registry.payload("metanorma").unwrap().default.as_deref(),
+        Some("1.2.3")
+    );
+    assert!(
+        cached_file(&home).is_file(),
+        "the fetch populated the cache"
+    );
+    assert!(fetched_at_file(&home).is_file());
+    let hits_after_first = hits.get();
+
+    // fresh → the cache answers; no second fetch
+    let registry = regcache::registry_for_with(&home, GITHUB_REF, &fetcher, false, now()).unwrap();
+    assert_eq!(registry.payloads.len(), 1);
+    assert_eq!(hits.get(), hits_after_first);
+}
+
+#[test]
+fn stale_cache_refetches_and_renews() {
+    let tmp = TempDir::new("regcache-stale");
+    let home = tmp.path().join("home");
+    let (fetcher, hits) = github_fetcher(REGISTRY_YAML);
+
+    regcache::registry_for_with(&home, GITHUB_REF, &fetcher, false, now()).unwrap();
+    let hits_after_first = hits.get();
+    // backdate the cache beyond the TTL
+    std::fs::write(
+        fetched_at_file(&home),
+        format!("{}\n", now() - regcache::REGISTRY_TTL_SECS - 60),
+    )
+    .unwrap();
+
+    regcache::registry_for_with(&home, GITHUB_REF, &fetcher, false, now()).unwrap();
+    assert!(hits.get() > hits_after_first, "a stale cache refetches");
+    // the fetched-at marker was renewed
+    let at: u64 = std::fs::read_to_string(fetched_at_file(&home))
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert!(now() - at < 60, "renewed fetched-at");
+}
+
+#[test]
+fn offline_is_cache_or_named_error() {
+    let tmp = TempDir::new("regcache-offline");
+    let home = tmp.path().join("home");
+    let (fetcher, hits) = github_fetcher(REGISTRY_YAML);
+
+    // no cache → the named error (and NO fetch attempt)
+    let err = regcache::registry_for_with(&home, GITHUB_REF, &fetcher, true, now()).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_UNAVAILABLE);
+    assert!(err.message.contains("TEBAKO_OFFLINE"), "{}", err.message);
+    assert!(err.message.contains("update-registries"), "{}", err.message);
+    assert_eq!(hits.get(), 0);
+
+    // prime a STALE cache (older than the TTL): offline reads it anyway
+    regcache::registry_for_with(&home, GITHUB_REF, &fetcher, false, now()).unwrap();
+    std::fs::write(fetched_at_file(&home), "1000\n").unwrap();
+    let before = hits.get();
+    let registry = regcache::registry_for_with(&home, GITHUB_REF, &fetcher, true, now()).unwrap();
+    assert_eq!(registry.payloads.len(), 1);
+    assert_eq!(hits.get(), before, "offline never fetches");
+}
+
+#[test]
+fn refresh_force_renews_and_reports_outcomes() {
+    let tmp = TempDir::new("regcache-refresh");
+    let home = tmp.path().join("home");
+    let (fetcher, hits) = github_fetcher(REGISTRY_YAML);
+
+    let outcome = regcache::refresh_with(&home, GITHUB_REF, &fetcher).unwrap();
+    assert_eq!(outcome, RefreshOutcome::Refreshed);
+    assert!(cached_file(&home).is_file());
+    let before = hits.get();
+
+    let outcome = regcache::refresh_with(&home, GITHUB_REF, &fetcher).unwrap();
+    assert_eq!(outcome, RefreshOutcome::Refreshed);
+    assert!(hits.get() > before, "refresh always fetches");
+
+    // file:// refs skip with a distinct outcome
+    let reg = tmp.path().join("tpkg-registry.yaml");
+    std::fs::write(&reg, REGISTRY_YAML).unwrap();
+    let outcome =
+        regcache::refresh_with(&home, &format!("file://{}", reg.display()), &fetcher).unwrap();
+    assert_eq!(outcome, RefreshOutcome::LocalSkipped);
+
+    // a fetched registry that no longer parses is a named error and the
+    // old cache is not clobbered
+    let (bad, _) = github_fetcher("schema_version: 99\n");
+    let err = regcache::refresh_with(&home, GITHUB_REF, &bad).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_MANIFEST);
+    assert!(std::fs::read_to_string(cached_file(&home))
+        .unwrap()
+        .contains("metanorma"));
+}
+
+#[test]
+fn prime_writes_the_cache_and_freshness_reports() {
+    let tmp = TempDir::new("regcache-prime");
+    let home = tmp.path().join("home");
+
+    assert_eq!(
+        regcache::freshness_at(&home, GITHUB_REF, now()),
+        RegistryFreshness::Missing
+    );
+
+    regcache::prime(&home, GITHUB_REF, REGISTRY_YAML.as_bytes()).unwrap();
+    assert!(cached_file(&home).is_file());
+    match regcache::freshness_at(&home, GITHUB_REF, now()) {
+        RegistryFreshness::Fresh(age) => assert!(age < 60),
+        other => panic!("expected Fresh, got {other:?}"),
+    }
+    // stale beyond the TTL
+    std::fs::write(
+        fetched_at_file(&home),
+        format!("{}\n", now() - regcache::REGISTRY_TTL_SECS - 3600),
+    )
+    .unwrap();
+    match regcache::freshness_at(&home, GITHUB_REF, now()) {
+        RegistryFreshness::Stale(age) => assert!(age >= regcache::REGISTRY_TTL_SECS),
+        other => panic!("expected Stale, got {other:?}"),
+    }
+    // local + bad refs
+    assert_eq!(
+        regcache::freshness(&home, "file:///x/tpkg-registry.yaml"),
+        RegistryFreshness::Local
+    );
+    assert!(matches!(
+        regcache::freshness(&home, "not-a-ref"),
+        RegistryFreshness::BadRef(_)
+    ));
+
+    // priming a file:// ref is a no-op (no new cache files beyond the
+    // github ref's .yaml + .fetched-at)
+    regcache::prime(&home, "file:///x/tpkg-registry.yaml", b"ignored").unwrap();
+    assert_eq!(
+        regcache::registries_dir(&home)
+            .read_dir()
+            .map(|d| d.count())
+            .unwrap_or(0),
+        2
+    );
+}
+
+#[test]
+fn registry_default_resolves_through_a_remote_registry() {
+    let tmp = TempDir::new("regcache-default");
+    let home = tmp.path().join("home");
+    let (fetcher, _hits) = github_fetcher(REGISTRY_YAML);
+    // the chain-level lookup with the injected fetcher (the production
+    // path uses Fetcher::new — same code, live transport)
+    let registry = regcache::registry_for_with(&home, GITHUB_REF, &fetcher, false, now()).unwrap();
+    let payload = registry.payload("metanorma").unwrap();
+    assert_eq!(payload.default.as_deref(), Some("1.2.3"));
+}

--- a/crates/tebako-shim/tests/resolve.rs
+++ b/crates/tebako-shim/tests/resolve.rs
@@ -23,7 +23,7 @@ fn seed_registry(root: &std::path::Path, default: &str) -> std::path::PathBuf {
     std::fs::write(
         &reg,
         format!(
-            "schema_version: 1\npayloads:\n  - name: metanorma\n    kind: app\n    default: {default}\n    versions: []\n"
+            "schema_version: 1\npayloads:\n  - name: metanorma\n    kind: app\n    default: {default}\n    versions:\n      - version: {default}\n        platforms: universal\n        release: {{ref: file:///metanorma-{default}.tfs}}\n        entrypoints: [metanorma]\n"
         ),
     )
     .expect("registry");
@@ -206,7 +206,7 @@ fn suite_commands_map_to_their_own_payload() {
     let manifest = app_manifest(
         "metasuite",
         "2.0.0",
-        "entrypoints:\n  - name: alpha\n    path: /app/bin/alpha\n  - name: beta\n    path: /app/bin/beta\n",
+        "  entrypoints:\n    - name: alpha\n      path: /app/bin/alpha\n    - name: beta\n      path: /app/bin/beta\n",
     );
     write_payload(&home, "metasuite", "2.0.0", &manifest);
     let mut ctx = ctx(&home, tmp.path());

--- a/crates/tebako-shim/tests/runtime.rs
+++ b/crates/tebako-shim/tests/runtime.rs
@@ -5,13 +5,13 @@
 mod common;
 
 use common::*;
-use tebako_shim::manifest::RuntimeRequirement;
 use tebako_shim::runtime::{self, RuntimeResolution};
+use tpkg::{Constraint, RuntimeRequirement};
 
 fn req(constraint: &str) -> RuntimeRequirement {
     RuntimeRequirement {
         engine: "ruby".to_string(),
-        constraint: constraint.to_string(),
+        constraint: Constraint::new(constraint).expect("test constraint parses"),
     }
 }
 

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -673,7 +673,11 @@ pub struct Entrypoint {
     pub path: String,
     #[serde(default)]
     pub args_default: Vec<String>,
-    pub runtime_requirement: RuntimeRequirement,
+    /// `None` = a native / self-contained entrypoint: zero-runtime
+    /// dispatch (spec 03 §2.2 locked — the dispatcher mounts zero runtime
+    /// payloads). Omit the key entirely on the wire for those.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_requirement: Option<RuntimeRequirement>,
 }
 
 /// PROVIDES of kind `app`.
@@ -785,10 +789,12 @@ impl AppProvides {
                 &ep.path,
                 "provides.entrypoints[].path must be absolute (inside the image)",
             )?;
-            check_non_empty(
-                &ep.runtime_requirement.engine,
-                "provides.entrypoints[].runtime_requirement.engine must not be empty",
-            )?;
+            if let Some(req) = &ep.runtime_requirement {
+                check_non_empty(
+                    &req.engine,
+                    "provides.entrypoints[].runtime_requirement.engine must not be empty",
+                )?;
+            }
         }
         self.platforms.validate()?;
         let caps = &self.capabilities;
@@ -1289,10 +1295,10 @@ mod tests {
                 name: "x".into(),
                 path: "/x".into(),
                 args_default: vec![],
-                runtime_requirement: RuntimeRequirement {
+                runtime_requirement: Some(RuntimeRequirement {
                     engine: "ruby".into(),
                     constraint: Constraint::new(">= 3.3, < 5.0").unwrap(),
-                },
+                }),
             }],
             platforms: Platforms::Universal,
             capabilities: c,

--- a/crates/tpkg/tests/manifest.rs
+++ b/crates/tpkg/tests/manifest.rs
@@ -151,9 +151,15 @@ fn app_suite_fixture_shape() {
         panic!()
     };
     assert_eq!(e1.name, "metanorma");
-    assert_eq!(e1.runtime_requirement.constraint.as_str(), ">= 3.3, < 5.0");
+    assert_eq!(
+        e1.runtime_requirement.as_ref().unwrap().constraint.as_str(),
+        ">= 3.3, < 5.0"
+    );
     assert_eq!(e2.name, "metanorma-nokogiri");
-    assert_eq!(e2.runtime_requirement.constraint.as_str(), "~> 3.3.0");
+    assert_eq!(
+        e2.runtime_requirement.as_ref().unwrap().constraint.as_str(),
+        "~> 3.3.0"
+    );
     assert_eq!(e1.args_default, vec!["--format", "pretty"]);
     assert_eq!(
         app.platforms,
@@ -185,6 +191,34 @@ fn app_suite_fixture_shape() {
     );
     // the MOUNT RULE: the consumer declares the mount point
     assert_eq!(mount.as_deref(), Some("/__layers__/gtk"));
+}
+
+#[test]
+fn native_entrypoints_omit_runtime_requirement() {
+    // spec 03 §2.2 (locked): an entrypoint whose executable is native (or
+    // self-contained) declares NO runtime_requirement — the dispatcher
+    // mounts zero runtime payloads. The key is omitted on the wire.
+    let text = "identity:\n  schema_version: 1\n  kind: app\n  name: inkview\n  version: \"1.3\"\n\
+        \x20 producer: {tool: tebako-cli, tool_version: 0.16.0}\n  created: \"2026-07-27T00:00:00Z\"\n\
+        \x20 digest:\n    tree_hash: \"sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\"\n\
+        \x20   blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1\n\
+        \x20 signing: {state: unsigned}\n  encryption: {state: none}\n\
+        provides:\n  entrypoints:\n    - name: inkview\n      path: /bin/inkview\n\
+        \x20 platforms: [x86_64-linux-gnu]\n  capabilities: {exec: true, read: true}\n";
+    let m = PayloadManifest::from_yaml(text).unwrap();
+    let Provides::App(app) = &m.provides else {
+        panic!("app provides, got {:?}", m.provides);
+    };
+    assert_eq!(app.entrypoints.len(), 1);
+    assert!(app.entrypoints[0].runtime_requirement.is_none());
+    // serialization omits the key (never writes a null)
+    let yaml = m.to_yaml().unwrap();
+    assert!(
+        !yaml.contains("runtime_requirement"),
+        "omitted on the wire: {yaml}"
+    );
+    // …and the schema agrees (MECE cross-check)
+    assert!(schema_validator().is_valid(&yaml_text_to_json(text)));
 }
 
 #[test]

--- a/crates/tpkg/tests/manifest_props.rs
+++ b/crates/tpkg/tests/manifest_props.rs
@@ -153,10 +153,10 @@ fn arb_provides(kind: PayloadKind) -> impl Strategy<Value = Provides> {
             name,
             path,
             args_default: Vec::new(),
-            runtime_requirement: RuntimeRequirement {
+            runtime_requirement: Some(RuntimeRequirement {
                 engine: "ruby".to_string(),
                 constraint: c,
-            },
+            }),
         });
     let app = (prop::collection::vec(entrypoint, 1..=3), arb_platforms()).prop_map(
         |(entrypoints, platforms)| {

--- a/docs/spec/04-references-and-registry.md
+++ b/docs/spec/04-references-and-registry.md
@@ -3,8 +3,9 @@
 Normative specification of how payloads are named, located, and listed.
 Status: syntax LOCKED (multi-artifact + repo/release-class rules locked
 2026-07-26); resolver + registry listing + `tebako install` SHIPPED
-(roadmap 07/28.1; `tebako publish` and the brew/install.sh channels
-remain PLANNED).
+(roadmap 07/28.1); `tebako publish` SHIPPED (roadmap 41 — GitHub
+releases + file:// mirrors; the GitLab/Bitbucket write legs and the
+brew/install.sh channels remain PLANNED).
 
 ## 1. The reference syntax (MECE, no default service)
 

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -5,12 +5,15 @@ management. Status: PARTIAL — the dispatcher and version manager
 (§2–§4) ship as `crates/tebako-shim` in tebako-rs (roadmap 08; retires
 `mnenv`). Remote registry fetch ships with `tebako add-registry |
 install` (roadmap 28.1 — the CLI resolves every registry form of
-spec 04 §2); still PLANNED: the dispatch-time registry cache (v1: the
-registry-default chain link reads `file://` registry refs only), `tebako
-use` writing the user default (v1: author `~/.tebako/config.yaml`
-directly), jail application (spec 08), and a runtime registry (v1
-downloads resolve through the `runtimes:` preference in `config.yaml`
-as the exact ref).
+spec 04 §2), and the dispatch-time registry cache ships with roadmap 33
+(the registry-default chain link resolves every registry form through
+tebako-resolve behind `~/.tebako/registries/<sha>.yaml` — 24 h TTL,
+`tebako update-registries`, `TEBAKO_OFFLINE` = cache-or-named-error;
+`tebako add-registry` primes the cache with the bytes it fetched).
+Still PLANNED: `tebako use` writing the user default (v1: author
+`~/.tebako/config.yaml` directly), jail application (spec 08), and a
+runtime registry (v1 downloads resolve through the `runtimes:` preference
+in `config.yaml` as the exact ref).
 
 ## 0. v1 concrete choices (normative where the sections above were open)
 

--- a/docs/spec/16-distribution-and-installation.md
+++ b/docs/spec/16-distribution-and-installation.md
@@ -128,8 +128,19 @@ tebako use metanorma@1.2.2                # instant rollback
   tebako-cli (ref + nickname forms, declarative triplet selection,
   registry sha256 pins, OpenPGP verification of signed entries, the
   v1-legacy unsigned warn, audit journal).
-- `tamatebako/homebrew-tap` formula + the app-tap template.
+- ~~the dispatch-time registry cache~~ — SHIPPED (33): the shim resolves
+  every registry form at dispatch behind
+  `~/.tebako/registries/<sha>.yaml` (24 h TTL), `tebako
+  update-registries`, `TEBAKO_OFFLINE` = cache-or-named-error.
+- ~~`tebako publish` helper~~ — SHIPPED (41): press-output payloads →
+  optional sign (per-artifact `<artifact>.asc`, the `<keyid, asc>`
+  registry pin) → upload to the referenced GitHub release (in-process
+  HTTP; file:// mirrors for rehearsal/tests) → `tpkg-registry.yaml`
+  upsert → tap formula render from the vendored template → built-in
+  clean-cache `tebako install` proof. The GitLab/Bitbucket write legs
+  are their adapters' milestone.
+- `tamatebako/homebrew-tap` formula + the app-tap template (the template
+  is vendored and rendered by `tebako publish --tap`; the tap repos
+  themselves stay manual).
 - `install.sh` + its own CI verification.
-- `tebako publish` helper (press → sign → upload → registry commit →
-  tap bump) for persona C.
 - Docs pages (tebako.org, post-gate) mirroring §5 per audience.

--- a/schema/tpkg-manifest-v1.schema.json
+++ b/schema/tpkg-manifest-v1.schema.json
@@ -228,7 +228,7 @@
           "minItems": 1,
           "items": {
             "type": "object",
-            "required": ["name", "path", "runtime_requirement"],
+            "required": ["name", "path"],
             "properties": {
               "name": { "type": "string", "minLength": 1, "description": "The command name (the shim registers under this)." },
               "path": { "$ref": "#/$defs/absPath" },


### PR DESCRIPTION
Remote registries at dispatch with dispatch-time cache (spec 04 §2, TTL+offline), unified tpkg::PayloadManifest everywhere (runtime_requirement Option per spec 03), suite press --suite + argv0 dispatch + per-entry runtimes (two commands on different rubies simultaneously proven), tebako publish (sign → upload → registry upsert → tap render → clean-cache install proof). 244 tests green locally, clippy/fmt clean. Deviations documented in the PR body of feat/install-ux.