### PR TITLE
Jails: capabilities.host + press/dispatch surfaces + audit journal; preload *at/exec/dir coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Layers:
   --no-host`, the same flags on `tebako-shim`) — user policy always wins,
   never loosens. Violations journal to the tebako audit journal
   (`docs/spec/08`).
+- **Native exec** — the preload interposition shim (libtfs-preload)
+  maps the libc file-IO family onto TFS for dynamic native binaries
+  (the `*at` family, dir streams, dlopen, execve/posix_spawn of memfs
+  paths materialized through the dlmap2file host cache; grandchildren
+  stay in the VFS by env propagation, and their IO rides the same jail)
+  (`docs/spec/07` §8).
 
 Repos are few and purpose-split: this one (`tamatebako/tebako`, the
 Rust stack) plus three C/C++ **factories** that only build their own

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Layers:
   Plus opt-in encryption (stacking
   EncBackend, DEK envelopes, HKDF subtree keys) (`docs/spec/09`,
   `docs/spec/10`).
+- **Jails** — host-access policy at the TFS choke point (docker `-v`
+  semantics: `open`/`deny` default, ro/rw mount grants, argument files):
+  payloads declare `capabilities.host`, `tebako press --jail` presses the
+  request into the package manifest, and the bootstrap/dispatch surfaces
+  compose it with the user's tightening (`tebako run --jail/--mount/
+  --no-host`, the same flags on `tebako-shim`) — user policy always wins,
+  never loosens. Violations journal to the tebako audit journal
+  (`docs/spec/08`).
 
 Repos are few and purpose-split: this one (`tamatebako/tebako`, the
 Rust stack) plus three C/C++ **factories** that only build their own
@@ -128,7 +136,8 @@ payloads (inkscape & co.) are feedstocks in the
 
 | command | what it does |
 |---------|--------------|
-| `tebako press` | package an app (lean/fat; `--suite` for multi-command packages) |
+| `tebako press` | package an app (lean/fat; `--suite` for multi-command packages; `--jail` presses a host-access policy) |
+| `tebako run <pkg>` | run a pressed package with a user jail tightening (`--jail`/`--mount`/`--no-host`) |
 | `tebako install <ref\|name@ver>` | install a payload from a registry + register its shims |
 | `tebako use / list / doctor` | manage shims, versions, and health |
 | `tebako publish` | press → sign → upload → registry → tap formula (developer flow) |

--- a/crates/libtfs-preload/src/lib.rs
+++ b/crates/libtfs-preload/src/lib.rs
@@ -24,13 +24,21 @@
 //! the offending token, exit [`spec::EX_CONFIG`] (78).
 //!
 //! Interposed surface: `open`, `openat`, `stat`, `lstat`, `fstat`,
-//! `access`, `faccessat`, `opendir`, `readdir` (+`readdir64` on Linux),
-//! `closedir`, `pread`, `read`, `lseek` (additive — stdio fseek on a
-//! memfs fd must stay on the VFS), `close`, `mkdir`, `unlink`, `rename`,
-//! `dlopen`. Memfs paths are served by the engine; host paths pass
-//! through, gated by the SAME `host_policy` (spec 08 §3 — denied paths
-//! fail `EPERM`, writes against an ro grant `EROFS`). `dlopen` of a memfs
-//! library rides the engine's `dlmap2file` host cache.
+//! `fstatat` (+`fstatat64`/`__xstat`/`__lxstat`/`__fxstat`/`__fxstatat`/
+//! `statx`/`getdents64` and the LFS `open64`/`stat64`/`lstat64`/`fstat64`/
+//! `pread64` family on Linux — roadmap 39), `access`,
+//! `faccessat`, `opendir`, `readdir` (+`readdir64` on Linux),
+//! `readdir_r`, `rewinddir`/`telldir`/`seekdir`, `dirfd`, `closedir`,
+//! `pread`, `read`, `lseek` (additive — stdio fseek on a memfs fd must
+//! stay on the VFS), `close`, `mkdir`, `unlink`, `rename`, `dlopen`, and
+//! `execve`/`posix_spawn`/`posix_spawnp` (memfs paths materialize through
+//! the `dlmap2file` host cache; roadmap 39). Memfs paths are served by
+//! the engine; host paths pass through, gated by the SAME `host_policy`
+//! (spec 08 §3 — denied paths fail `EPERM`, writes against an ro grant
+//! `EROFS`). `dlopen` of a memfs library rides the engine's `dlmap2file`
+//! host cache. Every *at shim gates its fd branch on `dirfd >= 0` —
+//! AT_FDCWD (-100) carries the TEBAKO_FD_FLAG bit, so a bare bit test
+//! would misroute it (pinned by `route::tests::at_fdcwd_is_not_a_memfs_fd`).
 //!
 //! ## Honest scope (v1)
 //!
@@ -39,19 +47,35 @@
 //!   first-class; Windows is roadmap 30 phase 2.
 //! - The process tree stays in the VFS by env propagation: a child
 //!   process inherits the preload variables, so its own IO is interposed
-//!   too. Spawning works with HOST paths (a memfs path is not exec'able —
-//!   `execve` is not virtualized in v1; the `tfs exec` launcher
-//!   materializes the ENTRYPOINT through `dlmap2file`, and children
-//!   re-spawn via `argv[0]`). Platform binaries under SIP (macOS) strip
-//!   `DYLD_*` — they leave the VFS, as does any statically linked child.
+//!   too. Spawning works with HOST paths and — since roadmap 39 — with
+//!   MEMFS paths: execve/posix_spawn of an in-image binary materializes
+//!   it through `dlmap2file` (one copy per exec, gc later); a bare name
+//!   is a host PATH search (memfs dirs are not in it). `exec` of a host
+//!   binary is NOT policy-gated (it is not an IO route in the policy's op
+//!   classes — the child's own IO stays jailed via env propagation).
+//!   Platform binaries under SIP (macOS) strip `DYLD_*` — they leave the
+//!   VFS, as does any statically linked child.
 //! - A mount at `/` is rejected (it would claim every host path and
 //!   bypass the jail). Non-UTF-8 paths always pass to the host (the
 //!   engine itself is UTF-8-only). `dlopen` jail-denials return NULL with
 //!   the cause in errno — `dlerror()` text is not settable portably.
-//! - Not interposed in v1: `execve`/`posix_spawn`, `fstatat`/`statx`,
-//!   `getdents64`, `openat2`, `readdir_r`, `rewinddir`/`telldir`/`seekdir`
-//!   (memfs dir streams support readdir/closedir only), and the
-//!   pre-glibc-2.33 `__xstat` family.
+//! - `dirfd` of a memfs stream answers -1/ENOTSUP (there is no host fd
+//!   behind it; the stream itself works through the readdir family).
+//!   `getdents64` on a memfs fd answers ENOTDIR (memfs fds are regular
+//!   files only — VFS directories enumerate via opendir, never fds).
+//!   glibc exposes NO `openat2` wrapper/symbol, so there is nothing to
+//!   interpose on linux-gnu (a raw `syscall(2)` caller bypasses userland
+//!   interposition by construction).
+//! - Not interposed in v1: `fork`, `openat2` (glibc has no wrapper at
+//!   all — see above), `fstatat64` on macOS (the legacy 32-bit-inode
+//!   layout), the LFS `__xstat64`/`__lxstat64`/
+//!   `__fxstat64`/`__fxstatat64` versioned forms on Linux, `fdopendir`
+//!   (a host fdopendir passes through whole; a memfs directory can never
+//!   be fd-opened, so it never arises), and syscall()-direct IO (raw
+//!   `syscall(2)` calls bypass userland interposition by construction —
+//!   musl/rust-std-on-gnu ride the libc wrappers, which ARE covered).
+//!   Memfs exec materialization leaks one dl-cache copy per exec (gc is
+//!   a later milestone, stated honestly in the spec).
 //!
 //! ## Layout
 //!

--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -259,7 +259,23 @@ fn init_inner() -> Result<(), String> {
         let spec = JailSpec::parse(&jail_spec).map_err(|e| format!("TEBAKO_JAIL: {e}"))?;
         let policy = HostPolicy::bind(spec.default_open, spec.mounts, spec.arg_files)
             .map_err(|e| format!("TEBAKO_JAIL: cannot bind policy: {}", errno_text(e)))?;
-        context().write().unwrap().set_host_policy(policy);
+        // The audit-journal source label: whoever exported TEBAKO_JAIL
+        // names the composition (TEBAKO_JAIL_SOURCE); a direct env install
+        // is attributed to the variable itself. The journal file opens
+        // HERE, before the context guard (see `tfs::journal`).
+        let source = std::env::var("TEBAKO_JAIL_SOURCE")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "TEBAKO_JAIL".to_string());
+        let journal = if policy.never_denies() {
+            None
+        } else {
+            tfs::journal::open_journal()
+        };
+        context()
+            .write()
+            .unwrap()
+            .set_host_policy(policy.with_source(source), journal);
     }
     Ok(())
 }
@@ -399,7 +415,7 @@ mod tests {
         context()
             .write()
             .unwrap()
-            .set_host_policy(HostPolicy::bind(false, vec![], vec![]).unwrap());
+            .set_host_policy(HostPolicy::bind(false, vec![], vec![]).unwrap(), None);
         assert_eq!(
             vfs_open("/etc/definitely-host", libc::O_RDONLY),
             PathRoute::Denied(libc::EPERM)
@@ -434,7 +450,7 @@ mod tests {
         context()
             .write()
             .unwrap()
-            .set_host_policy(HostPolicy::open());
+            .set_host_policy(HostPolicy::open(), None);
         assert_eq!(
             vfs_open("/etc/definitely-host", libc::O_RDONLY),
             PathRoute::Host

--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -198,16 +198,95 @@ pub fn vfs_readdir(id: usize) -> Result<Option<TebakoCDirent>, i32> {
 /// the relative path: under a deny policy the cwd-relative check then
 /// fails closed (EPERM) for anything outside the grants.
 pub fn resolve_at(dirfd: i32, path: &str, base: Option<PathBuf>) -> Result<String, i32> {
+    match resolve_at_strict(dirfd, path, base)? {
+        AtRoute::Routed(p) => Ok(p),
+        // Unknown negative dirfd: keep the relative path (the real call
+        // answers EBADF); the pre-strict behavior is preserved.
+        AtRoute::Real => Ok(path.to_string()),
+    }
+}
+
+/// The *at-family route resolution (roadmap 39). CRITICAL discipline:
+/// `AT_FDCWD` (-100) has the `TEBAKO_FD_FLAG` bit set, so the fd branch of
+/// every *at shim MUST gate on `dirfd >= 0` — a bare
+/// `tebako_fd_is_embedded`-style bit test misroutes AT_FDCWD-relative
+/// paths into the memfs fd table (the exact bug class that broke runtime
+/// builds; pinned by `at_fdcwd_is_not_a_memfs_fd` below).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AtRoute {
+    /// Route this resolved path through the engine/policy.
+    Routed(String),
+    /// Pass the original (dirfd, path) pair to the real libc call
+    /// verbatim (unknown negative dirfd — the kernel answers EBADF).
+    Real,
+}
+
+/// Resolve an *at-family path. Absolute and AT_FDCWD-relative paths route
+/// as given; a memfs dirfd is ENOTDIR; a valid host dirfd joins `base`
+/// (its own path, resolved by the sys layer); any other negative dirfd
+/// passes through untouched.
+pub fn resolve_at_strict(dirfd: i32, path: &str, base: Option<PathBuf>) -> Result<AtRoute, i32> {
     if path.starts_with('/') || dirfd == libc::AT_FDCWD {
-        return Ok(path.to_string());
+        return Ok(AtRoute::Routed(path.to_string()));
+    }
+    if dirfd < 0 {
+        return Ok(AtRoute::Real);
     }
     if is_memfs_fd(dirfd) {
         return Err(libc::ENOTDIR);
     }
-    match base {
-        Some(b) => Ok(b.join(path).to_string_lossy().into_owned()),
-        None => Ok(path.to_string()),
+    Ok(AtRoute::Routed(match base {
+        Some(b) => b.join(path).to_string_lossy().into_owned(),
+        None => path.to_string(),
+    }))
+}
+
+/// telldir on a memfs handle: ordinal of the entry the next readdir
+/// returns (index-based cookies, the engine's contract).
+pub fn vfs_telldir(id: usize) -> Result<i64, i32> {
+    context().read().unwrap().telldir(id)
+}
+
+/// seekdir on a memfs handle (cookies are telldir ordinals; past-the-end
+/// clamps to end-of-directory).
+pub fn vfs_seekdir(id: usize, pos: i64) -> Result<(), i32> {
+    context().write().unwrap().seekdir(id, pos)
+}
+
+/// rewinddir on a memfs handle: back to the first entry.
+pub fn vfs_rewinddir(id: usize) -> Result<(), i32> {
+    context().write().unwrap().rewinddir(id)
+}
+
+/// execve/posix_spawn of a MEMFS path (roadmap 39): materialize the file
+/// through the engine's `dlmap2file` host cache (execve needs a host path
+/// — one copy per exec, gc later, stated honestly in the spec) and force
+/// the exec bit (zip-family backends honestly report 0644). The routing
+/// is the dlopen rule: memfs → the host copy; host-or-denied → the
+/// route's answer (an allowed host path execs the original, a denied one
+/// fails EPERM/EROFS).
+pub fn vfs_materialize_exec(path: &str) -> PathRoute<std::ffi::CString> {
+    let answer = { context().write().unwrap().dlmap2file(path) };
+    match answer {
+        Ok(host) => match ensure_exec_bit(&host) {
+            Ok(()) => PathRoute::Vfs(host),
+            Err(e) => PathRoute::Denied(e),
+        },
+        Err(e) => route_answer::<std::ffi::CString>(Err(e), path, HostAccess::Ro),
     }
+}
+
+/// OR 0111 into the materialized copy's mode (dlmap2file preserves the
+/// image's perms, which may be 0644 — the kernel refuses those for exec).
+fn ensure_exec_bit(host: &std::ffi::CString) -> Result<(), i32> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let path = PathBuf::from(host.to_string_lossy().into_owned());
+    let mode = std::fs::metadata(&path)
+        .map_err(|e| e.raw_os_error().unwrap_or(libc::EIO))?
+        .permissions()
+        .mode();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode | 0o111))
+        .map_err(|e| e.raw_os_error().unwrap_or(libc::EIO))
 }
 
 // ---------------------------------------------------------------------
@@ -411,6 +490,24 @@ mod tests {
         assert_eq!(vfs_write_path(&secret), Err(libc::EROFS));
         assert_eq!(vfs_rename("/tmp/a-x", &secret), Err(libc::EROFS));
 
+        // ---- dir streams: rewind/tell/seek (roadmap 39) ----
+        let PathRoute::Vfs(dir_id) = vfs_opendir(&format!("{mp}/dir")) else {
+            panic!("memfs opendir should route Vfs");
+        };
+        assert!(vfs_readdir(dir_id).unwrap().is_some());
+        assert_eq!(vfs_telldir(dir_id), Ok(1));
+        assert!(vfs_readdir(dir_id).unwrap().is_some());
+        assert_eq!(vfs_telldir(dir_id), Ok(2));
+        assert!(vfs_readdir(dir_id).unwrap().is_none()); // end of stream
+        vfs_rewinddir(dir_id).unwrap();
+        assert_eq!(vfs_telldir(dir_id), Ok(0));
+        assert!(vfs_readdir(dir_id).unwrap().is_some());
+        vfs_seekdir(dir_id, 2).unwrap();
+        assert!(vfs_readdir(dir_id).unwrap().is_none());
+        assert_eq!(vfs_seekdir(dir_id, -1), Err(libc::EINVAL));
+        vfs_closedir(dir_id).unwrap();
+        assert_eq!(vfs_telldir(dir_id), Err(libc::EBADF));
+
         // ---- deny policy: host denied, memfs unaffected ----
         context()
             .write()
@@ -467,5 +564,39 @@ mod tests {
         assert_eq!(resolve_at(flagged, "rel/p", None), Err(libc::ENOTDIR));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The AT_FDCWD regression pin (roadmap 39): `AT_FDCWD` is -100, whose
+    /// two's-complement form has the `TEBAKO_FD_FLAG` bit set — a bare
+    /// `is_memfs_fd` bit test therefore lies for every *at shim. The fd
+    /// branch gates on `dirfd >= 0` instead: AT_FDCWD paths route
+    /// cwd-relative, never into the memfs fd table.
+    #[test]
+    fn at_fdcwd_is_not_a_memfs_fd() {
+        // The trap itself: the bit IS set (this is exactly what made a
+        // naive `tebako_fd_is_embedded(dirfd)` branch misroute).
+        assert_eq!(libc::AT_FDCWD & TEBAKO_FD_FLAG, TEBAKO_FD_FLAG);
+        assert!(is_memfs_fd(libc::AT_FDCWD), "the bit test alone lies");
+        // …so the *at resolution special-cases AT_FDCWD BEFORE any bit
+        // test: cwd-relative routing, never ENOTDIR.
+        assert_eq!(
+            resolve_at_strict(libc::AT_FDCWD, "rel/x", None).unwrap(),
+            AtRoute::Routed("rel/x".to_string())
+        );
+        // Other negative dirfds pass through to the real call (the kernel
+        // answers EBADF) — never near the fd table either.
+        assert_eq!(resolve_at_strict(-5, "rel/x", None).unwrap(), AtRoute::Real);
+        // A genuine memfs fd is still ENOTDIR (memfs fds are regular
+        // files; a memfs directory can never be fd-opened).
+        let flagged = 7 | TEBAKO_FD_FLAG;
+        assert_eq!(
+            resolve_at_strict(flagged, "rel/x", None),
+            Err(libc::ENOTDIR)
+        );
+        // Absolute paths ignore the dirfd entirely.
+        assert_eq!(
+            resolve_at_strict(libc::AT_FDCWD, "/abs/x", None).unwrap(),
+            AtRoute::Routed("/abs/x".to_string())
+        );
     }
 }

--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -10,12 +10,15 @@
 //! (macOS cannot use this mechanism — dyld interpose redirects dlsym
 //! results too — so the real-function plumbing is per-platform.)
 //!
-//! Compatibility note (honest scope): binaries built against glibc ≥ 2.33
-//! call `stat`/`lstat`/`fstat` directly and are covered; binaries built
-//! against older glibc use the versioned `__xstat`/`__lxstat`/`__fxstat`
-//! entry points, which v1 does not interpose (documented in the crate
-//! docs). `open64`/`pread64` are aliases of the 64-bit entry points on
-//! linux-gnu 64-bit targets and are not interposed separately.
+//! Coverage note: binaries built against glibc ≥ 2.33 call
+//! `stat`/`lstat`/`fstat`/`fstatat` directly and are covered; binaries
+//! built against older glibc use the versioned `__xstat`/`__lxstat`/
+//! `__fxstat`/`__fxstatat` entry points, which are interposed as well
+//! (roadmap 39). The LFS `open64`/`stat64`/`lstat64`/`fstat64`/`pread64`
+//! family is interposed too — Rust std and `_FILE_OFFSET_BITS=64` builds
+//! call the 64 variants directly, and they are DISTINCT exported symbols
+//! from the plain names; the LFS `__xstat64`/`__lxstat64`/`__fxstat64`/
+//! `__fxstatat64` versioned forms remain a documented gap.
 
 use std::ffi::{c_char, c_int, c_void};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -136,6 +139,129 @@ real_fn!(
     real_dlopen,
     c"dlopen",
     unsafe extern "C" fn(*const c_char, c_int) -> *mut c_void
+);
+real_fn!(
+    real_fstatat,
+    c"fstatat",
+    unsafe extern "C" fn(c_int, *const c_char, *mut libc::stat, c_int) -> c_int
+);
+real_fn!(
+    real_fstatat64,
+    c"fstatat64",
+    unsafe extern "C" fn(c_int, *const c_char, *mut libc::stat, c_int) -> c_int
+);
+real_fn!(
+    real_statx,
+    c"statx",
+    unsafe extern "C" fn(c_int, *const c_char, c_int, libc::c_uint, *mut libc::statx) -> c_int
+);
+real_fn!(
+    real_getdents64,
+    c"getdents64",
+    unsafe extern "C" fn(c_int, *mut c_void, usize) -> libc::ssize_t
+);
+#[allow(non_snake_case)] // the libc symbol is `__xstat` (versioned pre-glibc-2.33 entry)
+real_fn!(
+    real___xstat,
+    c"__xstat",
+    unsafe extern "C" fn(c_int, *const c_char, *mut libc::stat) -> c_int
+);
+#[allow(non_snake_case)]
+real_fn!(
+    real___lxstat,
+    c"__lxstat",
+    unsafe extern "C" fn(c_int, *const c_char, *mut libc::stat) -> c_int
+);
+#[allow(non_snake_case)]
+real_fn!(
+    real___fxstat,
+    c"__fxstat",
+    unsafe extern "C" fn(c_int, c_int, *mut libc::stat) -> c_int
+);
+#[allow(non_snake_case)]
+real_fn!(
+    real___fxstatat,
+    c"__fxstatat",
+    unsafe extern "C" fn(c_int, c_int, *const c_char, *mut libc::stat, c_int) -> c_int
+);
+real_fn!(
+    real_rewinddir,
+    c"rewinddir",
+    unsafe extern "C" fn(*mut libc::DIR)
+);
+real_fn!(
+    real_open64,
+    c"open64",
+    unsafe extern "C" fn(*const c_char, c_int, ...) -> c_int
+);
+real_fn!(
+    real_stat64,
+    c"stat64",
+    unsafe extern "C" fn(*const c_char, *mut libc::stat) -> c_int
+);
+real_fn!(
+    real_lstat64,
+    c"lstat64",
+    unsafe extern "C" fn(*const c_char, *mut libc::stat) -> c_int
+);
+real_fn!(
+    real_fstat64,
+    c"fstat64",
+    unsafe extern "C" fn(c_int, *mut libc::stat) -> c_int
+);
+real_fn!(
+    real_pread64,
+    c"pread64",
+    unsafe extern "C" fn(c_int, *mut c_void, usize, libc::off_t) -> libc::ssize_t
+);
+real_fn!(
+    real_dirfd,
+    c"dirfd",
+    unsafe extern "C" fn(*mut libc::DIR) -> c_int
+);
+real_fn!(
+    real_telldir,
+    c"telldir",
+    unsafe extern "C" fn(*mut libc::DIR) -> libc::c_long
+);
+real_fn!(
+    real_seekdir,
+    c"seekdir",
+    unsafe extern "C" fn(*mut libc::DIR, libc::c_long)
+);
+real_fn!(
+    real_readdir_r,
+    c"readdir_r",
+    unsafe extern "C" fn(*mut libc::DIR, *mut libc::dirent, *mut *mut libc::dirent) -> c_int
+);
+real_fn!(
+    real_execve,
+    c"execve",
+    unsafe extern "C" fn(*const c_char, *const *mut c_char, *const *mut c_char) -> c_int
+);
+real_fn!(
+    real_posix_spawn,
+    c"posix_spawn",
+    unsafe extern "C" fn(
+        *mut libc::pid_t,
+        *const c_char,
+        *const libc::posix_spawn_file_actions_t,
+        *const libc::posix_spawnattr_t,
+        *const *mut c_char,
+        *const *mut c_char,
+    ) -> c_int
+);
+real_fn!(
+    real_posix_spawnp,
+    c"posix_spawnp",
+    unsafe extern "C" fn(
+        *mut libc::pid_t,
+        *const c_char,
+        *const libc::posix_spawn_file_actions_t,
+        *const libc::posix_spawnattr_t,
+        *const *mut c_char,
+        *const *mut c_char,
+    ) -> c_int
 );
 
 /// Library constructor: establish the namespace before the program's main.

--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -160,25 +160,22 @@ real_fn!(
     c"getdents64",
     unsafe extern "C" fn(c_int, *mut c_void, usize) -> libc::ssize_t
 );
-#[allow(non_snake_case)] // the libc symbol is `__xstat` (versioned pre-glibc-2.33 entry)
+// the libc symbol is `__xstat` (versioned pre-glibc-2.33 entry)
 real_fn!(
     real___xstat,
     c"__xstat",
     unsafe extern "C" fn(c_int, *const c_char, *mut libc::stat) -> c_int
 );
-#[allow(non_snake_case)]
 real_fn!(
     real___lxstat,
     c"__lxstat",
     unsafe extern "C" fn(c_int, *const c_char, *mut libc::stat) -> c_int
 );
-#[allow(non_snake_case)]
 real_fn!(
     real___fxstat,
     c"__fxstat",
     unsafe extern "C" fn(c_int, c_int, *mut libc::stat) -> c_int
 );
-#[allow(non_snake_case)]
 real_fn!(
     real___fxstatat,
     c"__fxstatat",

--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -20,6 +20,13 @@
 //! from the plain names; the LFS `__xstat64`/`__lxstat64`/`__fxstat64`/
 //! `__fxstatat64` versioned forms remain a documented gap.
 
+// The real_* helpers mirror libc symbol names; the versioned ones carry
+// double underscores (`__xstat` & co.), which are intentionally NOT
+// snake_case. Allow that at the module level: per-item attributes on the
+// macro invocations are flagged `unused_attributes` by rustc (attributes
+// on macro calls do not propagate into the expansion).
+#![allow(non_snake_case)]
+
 use std::ffi::{c_char, c_int, c_void};
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -187,11 +187,6 @@ real_fn!(
     unsafe extern "C" fn(*mut libc::DIR)
 );
 real_fn!(
-    real_open64,
-    c"open64",
-    unsafe extern "C" fn(*const c_char, c_int, ...) -> c_int
-);
-real_fn!(
     real_stat64,
     c"stat64",
     unsafe extern "C" fn(*const c_char, *mut libc::stat) -> c_int
@@ -205,11 +200,6 @@ real_fn!(
     real_fstat64,
     c"fstat64",
     unsafe extern "C" fn(c_int, *mut libc::stat) -> c_int
-);
-real_fn!(
-    real_pread64,
-    c"pread64",
-    unsafe extern "C" fn(c_int, *mut c_void, usize, libc::off_t) -> libc::ssize_t
 );
 real_fn!(
     real_dirfd,

--- a/crates/libtfs-preload/src/sys/macos.rs
+++ b/crates/libtfs-preload/src/sys/macos.rs
@@ -23,10 +23,11 @@ struct InterposeTuple {
 // dyld and the volatile readback below.
 unsafe impl Sync for InterposeTuple {}
 
-// The libc crate does not declare `faccessat` for apple targets; the
-// SDK has it since macOS 10.10 (4-arg).
+// The libc crate does not declare `faccessat`/`fstatat` for apple
+// targets; the SDK has them since macOS 10.10.
 extern "C" {
     fn faccessat(dirfd: c_int, path: *const c_char, mode: c_int, flags: c_int) -> c_int;
+    fn fstatat(dirfd: c_int, path: *const c_char, st: *mut libc::stat, flags: c_int) -> c_int;
 }
 
 macro_rules! interpose {
@@ -184,6 +185,83 @@ interpose!(
     super::dlopen,
     libc::dlopen,
     unsafe extern "C" fn(*const c_char, c_int) -> *mut c_void
+);
+interpose!(
+    INTERPOSE_FSTATAT,
+    real_fstatat,
+    super::fstatat,
+    fstatat,
+    unsafe extern "C" fn(c_int, *const c_char, *mut libc::stat, c_int) -> c_int
+);
+interpose!(
+    INTERPOSE_REWINDDIR,
+    real_rewinddir,
+    super::rewinddir,
+    libc::rewinddir,
+    unsafe extern "C" fn(*mut libc::DIR)
+);
+interpose!(
+    INTERPOSE_DIRFD,
+    real_dirfd,
+    super::dirfd,
+    libc::dirfd,
+    unsafe extern "C" fn(*mut libc::DIR) -> c_int
+);
+interpose!(
+    INTERPOSE_TELLDIR,
+    real_telldir,
+    super::telldir,
+    libc::telldir,
+    unsafe extern "C" fn(*mut libc::DIR) -> libc::c_long
+);
+interpose!(
+    INTERPOSE_SEEKDIR,
+    real_seekdir,
+    super::seekdir,
+    libc::seekdir,
+    unsafe extern "C" fn(*mut libc::DIR, libc::c_long)
+);
+interpose!(
+    INTERPOSE_READDIR_R,
+    real_readdir_r,
+    super::readdir_r,
+    libc::readdir_r,
+    unsafe extern "C" fn(*mut libc::DIR, *mut libc::dirent, *mut *mut libc::dirent) -> c_int
+);
+interpose!(
+    INTERPOSE_EXECVE,
+    real_execve,
+    super::execve,
+    libc::execve,
+    unsafe extern "C" fn(*const c_char, *const *mut c_char, *const *mut c_char) -> c_int
+);
+interpose!(
+    INTERPOSE_POSIX_SPAWN,
+    real_posix_spawn,
+    super::posix_spawn,
+    libc::posix_spawn,
+    unsafe extern "C" fn(
+        *mut libc::pid_t,
+        *const c_char,
+        *const libc::posix_spawn_file_actions_t,
+        *const libc::posix_spawnattr_t,
+        *const *mut c_char,
+        *const *mut c_char,
+    ) -> c_int
+);
+interpose!(
+    INTERPOSE_POSIX_SPAWNP,
+    real_posix_spawnp,
+    super::posix_spawnp,
+    libc::posix_spawnp,
+    unsafe extern "C" fn(
+        *mut libc::pid_t,
+        *const c_char,
+        *const libc::posix_spawn_file_actions_t,
+        *const libc::posix_spawnattr_t,
+        *const *mut c_char,
+        *const *mut c_char,
+    ) -> c_int
 );
 
 /// Library constructor: establish the namespace before the program's main.

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -130,6 +130,22 @@ fn resolve_dirfd(dirfd: c_int) -> Option<PathBuf> {
     ))
 }
 
+/// The *at-family dirfd base (roadmap 39): `None` for absolute paths,
+/// AT_FDCWD, memfs dirfds, and unknown negative dirfds — the strict
+/// resolver handles each of those. CRITICAL: the fd branch gates on
+/// `dirfd >= 0` — AT_FDCWD (-100) carries the TEBAKO_FD_FLAG bit, so a
+/// bare bit test misroutes it into the memfs fd table (the bug class that
+/// broke runtime builds; pinned in `route::tests::at_fdcwd_is_not_a_memfs_fd`).
+fn at_base(dirfd: c_int, p: &str) -> Option<PathBuf> {
+    if p.starts_with('/') || dirfd == libc::AT_FDCWD {
+        return None;
+    }
+    if dirfd >= 0 && !route::is_memfs_fd(dirfd) {
+        return resolve_dirfd(dirfd);
+    }
+    None
+}
+
 // ---------------------------------------------------------------------
 // ABI translations (stat + dirent)
 // ---------------------------------------------------------------------
@@ -264,13 +280,11 @@ pub unsafe extern "C" fn openat(
     let Some(p) = (unsafe { c_path(path) }) else {
         return unsafe { plat::real_openat()(dirfd, path, flags, mode) };
     };
-    let base = if p.starts_with('/') || dirfd == libc::AT_FDCWD || route::is_memfs_fd(dirfd) {
-        None
-    } else {
-        resolve_dirfd(dirfd)
-    };
-    let routed = match route::resolve_at(dirfd, p, base) {
-        Ok(rp) => rp,
+    let routed = match route::resolve_at_strict(dirfd, p, at_base(dirfd, p)) {
+        Ok(route::AtRoute::Routed(rp)) => rp,
+        Ok(route::AtRoute::Real) => {
+            return unsafe { plat::real_openat()(dirfd, path, flags, mode) }
+        }
         Err(e) => {
             set_errno(e);
             return -1;
@@ -289,18 +303,19 @@ pub unsafe extern "C" fn openat(
 /// Shared body of stat/lstat.
 ///
 /// # Safety
-/// `orig`/`st` follow the intercepted-call contract.
+/// `orig`/`st` follow the intercepted-call contract; `real` is the
+/// platform's original implementation.
 unsafe fn stat_via(
     p: Option<&str>,
     orig: *const c_char,
     st: *mut libc::stat,
-    real: unsafe extern "C" fn(*const c_char, *mut libc::stat) -> c_int,
+    real: impl FnOnce(*const c_char, *mut libc::stat) -> c_int,
 ) -> c_int {
     let Some(p) = p else {
-        return unsafe { real(orig, st) };
+        return real(orig, st);
     };
     if st.is_null() {
-        return unsafe { real(orig, st) };
+        return real(orig, st);
     }
     match engine_call(|| route::vfs_stat(p)) {
         // SAFETY: st is a valid struct stat pointer per the call contract.
@@ -318,20 +333,20 @@ unsafe fn stat_via(
             set_errno(e);
             -1
         }
-        Some(PathRoute::Host) | None => unsafe { real(orig, st) },
+        Some(PathRoute::Host) | None => real(orig, st),
     }
 }
 
 /// Interposed `stat`.
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn stat(path: *const c_char, st: *mut libc::stat) -> c_int {
-    unsafe { stat_via(c_path(path), path, st, plat::real_stat()) }
+    unsafe { stat_via(c_path(path), path, st, |o, s| plat::real_stat()(o, s)) }
 }
 
 /// Interposed `lstat` (memfs has no symlink duality: lstat == stat).
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn lstat(path: *const c_char, st: *mut libc::stat) -> c_int {
-    unsafe { stat_via(c_path(path), path, st, plat::real_lstat()) }
+    unsafe { stat_via(c_path(path), path, st, |o, s| plat::real_lstat()(o, s)) }
 }
 
 /// Interposed `fstat` (fd-flag dispatch, no path).
@@ -396,13 +411,11 @@ pub unsafe extern "C" fn faccessat(
     let Some(p) = (unsafe { c_path(path) }) else {
         return unsafe { plat::real_faccessat()(dirfd, path, mode, flags) };
     };
-    let base = if p.starts_with('/') || dirfd == libc::AT_FDCWD || route::is_memfs_fd(dirfd) {
-        None
-    } else {
-        resolve_dirfd(dirfd)
-    };
-    let routed = match route::resolve_at(dirfd, p, base) {
-        Ok(rp) => rp,
+    let routed = match route::resolve_at_strict(dirfd, p, at_base(dirfd, p)) {
+        Ok(route::AtRoute::Routed(rp)) => rp,
+        Ok(route::AtRoute::Real) => {
+            return unsafe { plat::real_faccessat()(dirfd, path, mode, flags) }
+        }
         Err(e) => {
             set_errno(e);
             return -1;
@@ -443,6 +456,22 @@ pub unsafe extern "C" fn readdir(dirp: *mut libc::DIR) -> *mut libc::dirent {
         return readdir_memfs(dirp as usize);
     }
     unsafe { plat::real_readdir()(dirp) }
+}
+
+/// Interposed `dirfd` (roadmap 39): a memfs stream has NO host fd behind
+/// it — the POSIX-honest answer is -1/ENOTSUP ("the implementation does
+/// not support the association of a file descriptor with a directory").
+/// Consumers that probe the fd degrade gracefully (Rust's read_dir calls
+/// dirfd in its drop path before closedir); the stream itself keeps
+/// working through the interposed readdir family. Host streams pass
+/// through.
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn dirfd(dirp: *mut libc::DIR) -> c_int {
+    if !dirp.is_null() && engine_call(|| route::dir_is_embedded(dirp as usize)) == Some(true) {
+        set_errno(libc::ENOTSUP);
+        return -1;
+    }
+    unsafe { plat::real_dirfd()(dirp) }
 }
 
 /// Linux: `readdir64` (glibc's LFS alias; same layout on 64-bit).
@@ -565,6 +594,80 @@ pub unsafe extern "C" fn lseek(fd: c_int, offset: libc::off_t, whence: c_int) ->
     unsafe { plat::real_lseek()(fd, offset, whence) }
 }
 
+// ---------------------------------------------------------------------
+// The LFS *64 family (linux) — Rust std and _FILE_OFFSET_BITS=64 builds
+// call the 64 variants directly (open64/stat64/fstat64/…), which are
+// DISTINCT exported glibc symbols from the plain names. Same layouts,
+// same routing — each delegates to its plain-name body.
+// ---------------------------------------------------------------------
+
+/// Linux: `open64` (the LFS alias of `open`).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn open64(path: *const c_char, flags: c_int, mode: c_int) -> c_int {
+    unsafe { open(path, flags, mode) }
+}
+
+/// Linux: `stat64` (the LFS alias of `stat`).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn stat64(path: *const c_char, st: *mut libc::stat) -> c_int {
+    unsafe { stat_via(c_path(path), path, st, |o, s| plat::real_stat64()(o, s)) }
+}
+
+/// Linux: `lstat64` (the LFS alias of `lstat`).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn lstat64(path: *const c_char, st: *mut libc::stat) -> c_int {
+    unsafe { stat_via(c_path(path), path, st, |o, s| plat::real_lstat64()(o, s)) }
+}
+
+/// Linux: `fstat64` (the LFS alias of `fstat`).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn fstat64(fd: c_int, st: *mut libc::stat) -> c_int {
+    if route::is_memfs_fd(fd) {
+        if st.is_null() {
+            set_errno(libc::EFAULT);
+            return -1;
+        }
+        return match engine_call(|| route::vfs_fstat(fd)) {
+            // SAFETY: st is valid per the call contract.
+            Some(Ok(raw)) => match unsafe { fill_stat(&raw) } {
+                Ok(s) => {
+                    unsafe { *st = s };
+                    0
+                }
+                Err(e) => {
+                    set_errno(e);
+                    -1
+                }
+            },
+            Some(Err(e)) => {
+                set_errno(e);
+                -1
+            }
+            None => {
+                set_errno(libc::EIO);
+                -1
+            }
+        };
+    }
+    unsafe { plat::real_fstat64()(fd, st) }
+}
+
+/// Linux: `pread64` (the LFS alias of `pread`).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn pread64(
+    fd: c_int,
+    buf: *mut c_void,
+    nbyte: usize,
+    offset: libc::off_t,
+) -> libc::ssize_t {
+    unsafe { pread(fd, buf, nbyte, offset) }
+}
+
 /// Interposed `close` (fd-flag dispatch; a memfs fd never reaches the
 /// real close).
 #[cfg_attr(target_os = "linux", no_mangle)]
@@ -651,6 +754,402 @@ pub unsafe extern "C" fn dlopen(path: *const c_char, mode: c_int) -> *mut c_void
             std::ptr::null_mut()
         }
         Some(PathRoute::Host) | None => unsafe { plat::real_dlopen()(path, mode) },
+    }
+}
+
+/// Shared body of the *at stat family (fstatat / fstatat64 / __fxstatat):
+/// resolve the (dirfd, path) pair through the one-gate strict resolver,
+/// serve memfs from the engine, pass host through with the ORIGINAL
+/// arguments (`flags` only refines the real call — the VFS answer is the
+/// same; no symlink duality).
+///
+/// # Safety
+/// All pointers follow the intercepted-call contract; `real` is the
+/// pass-through invoking the platform's original with its full arguments.
+unsafe fn fstatat_via(
+    dirfd: c_int,
+    path: *const c_char,
+    st: *mut libc::stat,
+    real: impl FnOnce() -> c_int,
+) -> c_int {
+    let Some(p) = (unsafe { c_path(path) }) else {
+        return real();
+    };
+    if st.is_null() {
+        return real();
+    }
+    let routed = match route::resolve_at_strict(dirfd, p, at_base(dirfd, p)) {
+        Ok(route::AtRoute::Routed(rp)) => rp,
+        Ok(route::AtRoute::Real) => return real(),
+        Err(e) => {
+            set_errno(e);
+            return -1;
+        }
+    };
+    match engine_call(|| route::vfs_stat(&routed)) {
+        // SAFETY: st is a valid struct stat pointer per the call contract.
+        Some(PathRoute::Vfs(raw)) => match unsafe { fill_stat(&raw) } {
+            Ok(s) => {
+                unsafe { *st = s };
+                0
+            }
+            Err(e) => {
+                set_errno(e);
+                -1
+            }
+        },
+        Some(PathRoute::Denied(e)) => {
+            set_errno(e);
+            -1
+        }
+        Some(PathRoute::Host) | None => real(),
+    }
+}
+
+/// Interposed `fstatat` (roadmap 39 — the *at family).
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn fstatat(
+    dirfd: c_int,
+    path: *const c_char,
+    st: *mut libc::stat,
+    flags: c_int,
+) -> c_int {
+    unsafe {
+        fstatat_via(dirfd, path, st, || {
+            plat::real_fstatat()(dirfd, path, st, flags)
+        })
+    }
+}
+
+/// Linux: `fstatat64` (the LFS alias; same layout on 64-bit).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn fstatat64(
+    dirfd: c_int,
+    path: *const c_char,
+    st: *mut libc::stat,
+    flags: c_int,
+) -> c_int {
+    unsafe {
+        fstatat_via(dirfd, path, st, || {
+            plat::real_fstatat64()(dirfd, path, st, flags)
+        })
+    }
+}
+
+/// Linux: `statx` (roadmap 39). The engine's RawStat fills the statx
+/// answer; stx_mask reports exactly the fields written.
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn statx(
+    dirfd: c_int,
+    path: *const c_char,
+    flags: c_int,
+    mask: libc::c_uint,
+    stx: *mut libc::statx,
+) -> c_int {
+    use tfs::backend::EntryType;
+
+    let Some(p) = (unsafe { c_path(path) }) else {
+        return unsafe { plat::real_statx()(dirfd, path, flags, mask, stx) };
+    };
+    if stx.is_null() {
+        return unsafe { plat::real_statx()(dirfd, path, flags, mask, stx) };
+    }
+    let routed = match route::resolve_at_strict(dirfd, p, at_base(dirfd, p)) {
+        Ok(route::AtRoute::Routed(rp)) => rp,
+        Ok(route::AtRoute::Real) => {
+            return unsafe { plat::real_statx()(dirfd, path, flags, mask, stx) }
+        }
+        Err(e) => {
+            set_errno(e);
+            return -1;
+        }
+    };
+    match engine_call(|| route::vfs_stat(&routed)) {
+        Some(PathRoute::Vfs(raw)) => {
+            let type_bits: u32 = match raw.entry_type {
+                EntryType::File => libc::S_IFREG as u32,
+                EntryType::Directory => libc::S_IFDIR as u32,
+                _ => {
+                    set_errno(libc::EINVAL);
+                    return -1;
+                }
+            };
+            // SAFETY: a zeroed struct statx is valid; stx is valid per the
+            // call contract. Field-by-field assignment: statx_timestamp's
+            // padding is private (libc-version dependent).
+            let mut out: libc::statx = unsafe { std::mem::zeroed() };
+            out.stx_mode = (type_bits | raw.perms) as u16;
+            out.stx_size = raw.size as u64;
+            out.stx_nlink = 1;
+            out.stx_mtime.tv_sec = raw.mtime;
+            out.stx_mtime.tv_nsec = 0;
+            out.stx_mask = libc::STATX_TYPE
+                | libc::STATX_MODE
+                | libc::STATX_NLINK
+                | libc::STATX_SIZE
+                | libc::STATX_MTIME;
+            unsafe { *stx = out };
+            0
+        }
+        Some(PathRoute::Denied(e)) => {
+            set_errno(e);
+            -1
+        }
+        Some(PathRoute::Host) | None => unsafe {
+            plat::real_statx()(dirfd, path, flags, mask, stx)
+        },
+    }
+}
+
+/// Linux: `openat2`? — NO: glibc exposes no `openat2` wrapper or symbol
+/// (only `SYS_openat2`), so there is nothing to interpose on linux-gnu; a
+/// raw `syscall(2)` caller bypasses userland interposition by
+/// construction (musl's wrapper is a later consideration).
+
+/// Linux: `getdents64` (roadmap 39). VFS directory enumeration rides
+/// opendir/readdir (a memfs directory can never be fd-opened — open
+/// answers EISDIR), so a memfs fd here is a regular FILE and the honest
+/// answer is ENOTDIR; host fds pass through.
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn getdents64(fd: c_int, dirp: *mut c_void, count: usize) -> libc::ssize_t {
+    if route::is_memfs_fd(fd) {
+        set_errno(libc::ENOTDIR);
+        return -1;
+    }
+    unsafe { plat::real_getdents64()(fd, dirp, count) }
+}
+
+/// Linux: `__xstat` (the pre-glibc-2.33 versioned stat entry — binaries
+/// built against older glibc; roadmap 39).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn __xstat(ver: c_int, path: *const c_char, st: *mut libc::stat) -> c_int {
+    unsafe {
+        stat_via(c_path(path), path, st, |o, s| {
+            plat::real___xstat()(ver, o, s)
+        })
+    }
+}
+
+/// Linux: `__lxstat` (versioned lstat; memfs has no symlink duality).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn __lxstat(ver: c_int, path: *const c_char, st: *mut libc::stat) -> c_int {
+    unsafe {
+        stat_via(c_path(path), path, st, |o, s| {
+            plat::real___lxstat()(ver, o, s)
+        })
+    }
+}
+
+/// Linux: `__fxstat` (versioned fstat — fd-flag dispatch, no path).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn __fxstat(ver: c_int, fd: c_int, st: *mut libc::stat) -> c_int {
+    if route::is_memfs_fd(fd) {
+        if st.is_null() {
+            set_errno(libc::EFAULT);
+            return -1;
+        }
+        return match engine_call(|| route::vfs_fstat(fd)) {
+            // SAFETY: st is valid per the call contract.
+            Some(Ok(raw)) => match unsafe { fill_stat(&raw) } {
+                Ok(s) => {
+                    unsafe { *st = s };
+                    0
+                }
+                Err(e) => {
+                    set_errno(e);
+                    -1
+                }
+            },
+            Some(Err(e)) => {
+                set_errno(e);
+                -1
+            }
+            None => {
+                set_errno(libc::EIO);
+                -1
+            }
+        };
+    }
+    unsafe { plat::real___fxstat()(ver, fd, st) }
+}
+
+/// Linux: `__fxstatat` (versioned fstatat).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn __fxstatat(
+    ver: c_int,
+    dirfd: c_int,
+    path: *const c_char,
+    st: *mut libc::stat,
+    flags: c_int,
+) -> c_int {
+    unsafe {
+        fstatat_via(dirfd, path, st, || {
+            plat::real___fxstatat()(ver, dirfd, path, st, flags)
+        })
+    }
+}
+
+/// Interposed `rewinddir` (roadmap 39): reset a memfs stream to its first
+/// entry. Void — an unknown-handle error is surfaced via errno only.
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn rewinddir(dirp: *mut libc::DIR) {
+    if !dirp.is_null() && engine_call(|| route::dir_is_embedded(dirp as usize)) == Some(true) {
+        if let Some(Err(e)) = engine_call(|| route::vfs_rewinddir(dirp as usize)) {
+            set_errno(e);
+        }
+        return;
+    }
+    unsafe { plat::real_rewinddir()(dirp) }
+}
+
+/// Interposed `telldir` (roadmap 39): the stream's position cookie (the
+/// engine's readdir ordinal).
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn telldir(dirp: *mut libc::DIR) -> libc::c_long {
+    if !dirp.is_null() && engine_call(|| route::dir_is_embedded(dirp as usize)) == Some(true) {
+        return match engine_call(|| route::vfs_telldir(dirp as usize)) {
+            // c_long == i64 on every platform the shim targets.
+            Some(Ok(pos)) => pos,
+            Some(Err(e)) => {
+                set_errno(e);
+                -1
+            }
+            None => {
+                set_errno(libc::EIO);
+                -1
+            }
+        };
+    }
+    unsafe { plat::real_telldir()(dirp) }
+}
+
+/// Interposed `seekdir` (roadmap 39): set the stream's position to a
+/// telldir cookie (clamped to end-of-directory).
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn seekdir(dirp: *mut libc::DIR, pos: libc::c_long) {
+    if !dirp.is_null() && engine_call(|| route::dir_is_embedded(dirp as usize)) == Some(true) {
+        // c_long == i64 on every platform the shim targets.
+        if let Some(Err(e)) = engine_call(|| route::vfs_seekdir(dirp as usize, pos)) {
+            set_errno(e);
+        }
+        return;
+    }
+    unsafe { plat::real_seekdir()(dirp, pos) }
+}
+
+/// Interposed `readdir_r` (roadmap 39; the deprecated reentrant form —
+/// the caller's `entry` is filled directly, no per-handle cache needed).
+/// Returns 0 on success, the errno on error (its own contract, never -1).
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn readdir_r(
+    dirp: *mut libc::DIR,
+    entry: *mut libc::dirent,
+    result: *mut *mut libc::dirent,
+) -> c_int {
+    if entry.is_null() || result.is_null() {
+        return libc::EINVAL;
+    }
+    // SAFETY: result is valid per the call contract (null-checked above).
+    unsafe { *result = std::ptr::null_mut() };
+    if !dirp.is_null() && engine_call(|| route::dir_is_embedded(dirp as usize)) == Some(true) {
+        return match engine_call(|| route::vfs_readdir(dirp as usize)) {
+            // SAFETY: entry is valid per the call contract.
+            Some(Ok(Some(e))) => {
+                unsafe { fill_dirent(&mut *entry, &e) };
+                unsafe { *result = entry };
+                0
+            }
+            Some(Ok(None)) => 0,
+            Some(Err(e)) => e,
+            None => libc::EIO,
+        };
+    }
+    unsafe { plat::real_readdir_r()(dirp, entry, result) }
+}
+
+/// Interposed `execve` (roadmap 39): a MEMFS path is materialized through
+/// the engine's `dlmap2file` host cache and the REAL execve loads that
+/// copy (execve needs a host path); a host path execs the original
+/// ungated — exec of a host binary is not an IO route in the policy's op
+/// classes, and the child's own IO stays jailed via env propagation.
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn execve(
+    path: *const c_char,
+    argv: *const *mut c_char,
+    envp: *const *mut c_char,
+) -> c_int {
+    let Some(p) = (unsafe { c_path(path) }) else {
+        return unsafe { plat::real_execve()(path, argv, envp) };
+    };
+    match engine_call(|| route::vfs_materialize_exec(p)) {
+        // SAFETY: `host` outlives the call; argv/envp forward verbatim.
+        Some(PathRoute::Vfs(host)) => unsafe { plat::real_execve()(host.as_ptr(), argv, envp) },
+        Some(PathRoute::Denied(e)) => {
+            set_errno(e);
+            -1
+        }
+        Some(PathRoute::Host) | None => unsafe { plat::real_execve()(path, argv, envp) },
+    }
+}
+
+/// Interposed `posix_spawn` (roadmap 39): the execve routing with the
+/// spawn contract — the return IS the errno (never -1).
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn posix_spawn(
+    pid: *mut libc::pid_t,
+    path: *const c_char,
+    file_actions: *const libc::posix_spawn_file_actions_t,
+    attrp: *const libc::posix_spawnattr_t,
+    argv: *const *mut c_char,
+    envp: *const *mut c_char,
+) -> c_int {
+    let Some(p) = (unsafe { c_path(path) }) else {
+        return unsafe { plat::real_posix_spawn()(pid, path, file_actions, attrp, argv, envp) };
+    };
+    match engine_call(|| route::vfs_materialize_exec(p)) {
+        Some(PathRoute::Vfs(host)) => unsafe {
+            plat::real_posix_spawn()(pid, host.as_ptr(), file_actions, attrp, argv, envp)
+        },
+        Some(PathRoute::Denied(e)) => e,
+        Some(PathRoute::Host) | None => unsafe {
+            plat::real_posix_spawn()(pid, path, file_actions, attrp, argv, envp)
+        },
+    }
+}
+
+/// Interposed `posix_spawnp` (roadmap 39): an explicit path routes like
+/// posix_spawn; a bare name is a host PATH search (memfs dirs are not in
+/// the host PATH — pass through, stated honestly in the crate docs).
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn posix_spawnp(
+    pid: *mut libc::pid_t,
+    file: *const c_char,
+    file_actions: *const libc::posix_spawn_file_actions_t,
+    attrp: *const libc::posix_spawnattr_t,
+    argv: *const *mut c_char,
+    envp: *const *mut c_char,
+) -> c_int {
+    let Some(p) = (unsafe { c_path(file) }) else {
+        return unsafe { plat::real_posix_spawnp()(pid, file, file_actions, attrp, argv, envp) };
+    };
+    if !p.contains('/') {
+        return unsafe { plat::real_posix_spawnp()(pid, file, file_actions, attrp, argv, envp) };
+    }
+    match engine_call(|| route::vfs_materialize_exec(p)) {
+        Some(PathRoute::Vfs(host)) => unsafe {
+            plat::real_posix_spawnp()(pid, host.as_ptr(), file_actions, attrp, argv, envp)
+        },
+        Some(PathRoute::Denied(e)) => e,
+        Some(PathRoute::Host) | None => unsafe {
+            plat::real_posix_spawnp()(pid, file, file_actions, attrp, argv, envp)
+        },
     }
 }
 

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -868,6 +868,7 @@ pub unsafe extern "C" fn statx(
     };
     match engine_call(|| route::vfs_stat(&routed)) {
         Some(PathRoute::Vfs(raw)) => {
+            #[allow(clippy::unnecessary_cast)] // identity on linux, required on macOS
             let type_bits: u32 = match raw.entry_type {
                 EntryType::File => libc::S_IFREG as u32,
                 EntryType::Directory => libc::S_IFDIR as u32,
@@ -903,10 +904,10 @@ pub unsafe extern "C" fn statx(
     }
 }
 
-/// Linux: `openat2`? — NO: glibc exposes no `openat2` wrapper or symbol
-/// (only `SYS_openat2`), so there is nothing to interpose on linux-gnu; a
-/// raw `syscall(2)` caller bypasses userland interposition by
-/// construction (musl's wrapper is a later consideration).
+// Linux: `openat2`? — NO: glibc exposes no `openat2` wrapper or symbol
+// (only `SYS_openat2`), so there is nothing to interpose on linux-gnu; a
+// raw `syscall(2)` caller bypasses userland interposition by
+// construction (musl's wrapper is a later consideration).
 
 /// Linux: `getdents64` (roadmap 39). VFS directory enumeration rides
 /// opendir/readdir (a memfs directory can never be fd-opened — open

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -39,6 +39,8 @@ struct Fixtures {
     shim: PathBuf,
     /// A host directory with one readable file (jail grant fixture).
     work: PathBuf,
+    /// The Rust dynamic tool (roadmap 39), when rustc is available.
+    rust_tool: Option<PathBuf>,
 }
 
 fn target_dir() -> PathBuf {
@@ -122,8 +124,16 @@ fn build_fixtures() -> Option<Fixtures> {
 
     // Compile the tools (dynamic linking is the default; that is the whole
     // point — the shim interposes the libc they link against).
-    let mut tools: Vec<(String, PathBuf)> = Vec::new();
-    for name in ["print-data", "list-dir", "dl-user", "spawn-self", "mk-dir"] {
+    for name in [
+        "print-data",
+        "list-dir",
+        "dl-user",
+        "spawn-self",
+        "mk-dir",
+        "at-probe",
+        "spawn-helper",
+        "dir-stream",
+    ] {
         let src = src_dir.join(format!("{name}.c"));
         let out = dir.join("bin").join(name);
         std::fs::create_dir_all(out.parent().unwrap()).unwrap();
@@ -133,8 +143,34 @@ fn build_fixtures() -> Option<Fixtures> {
             &[]
         };
         compile("cc", &src, &out, extra);
-        tools.push((name.to_string(), out));
     }
+    // The Rust dynamic tool (roadmap 39's std::fs proof): skipped with a
+    // note when no rustc is on PATH; a rustc that EXISTS but fails is a
+    // hard failure (the documented skip policy).
+    let rust_tool = dir.join("bin").join("rust-tool");
+    let rust_built = Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    let rust_tool = if rust_built {
+        let o = Command::new("rustc")
+            .arg("-O")
+            .arg("-o")
+            .arg(&rust_tool)
+            .arg(src_dir.join("rust-tool.rs"))
+            .output()
+            .unwrap();
+        assert!(
+            o.status.success(),
+            "rustc failed: {}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+        Some(rust_tool)
+    } else {
+        eprintln!("skip: no rustc on PATH (the rust-tool proofs are skipped)");
+        None
+    };
     // The plugin (shared library) for the dlopen proof.
     let libname = if cfg!(target_os = "macos") {
         "libplug.dylib"
@@ -155,7 +191,9 @@ fn build_fixtures() -> Option<Fixtures> {
     std::fs::create_dir_all(&work).unwrap();
     std::fs::write(work.join("hostfile.txt"), b"HOST-FILE\n").unwrap();
 
-    // The test image (zip backend): data, a directory, the plugin.
+    // The test image (zip backend): data, a directory, the plugin, and an
+    // in-image helper binary (print-data — the spawn-helper proofs exec it
+    // straight from the image, roadmap 39).
     let zip_path = dir.join("img.zip");
     {
         let file = std::fs::File::create(&zip_path).unwrap();
@@ -172,6 +210,7 @@ fn build_fixtures() -> Option<Fixtures> {
         zw.add_directory("data/", rx).unwrap();
         zw.add_directory("dir/", rx).unwrap();
         zw.add_directory("lib/", rx).unwrap();
+        zw.add_directory("bin/", rx).unwrap();
         zw.start_file("data/secret.txt", ro).unwrap();
         zw.write_all(SECRET.as_bytes()).unwrap();
         zw.start_file("dir/a.txt", ro).unwrap();
@@ -180,6 +219,9 @@ fn build_fixtures() -> Option<Fixtures> {
         zw.write_all(b"b\n").unwrap();
         zw.start_file(format!("lib/{libname}"), rx).unwrap();
         zw.write_all(&std::fs::read(&plug_out).unwrap()).unwrap();
+        let print_data = dir.join("bin").join("print-data");
+        zw.start_file("bin/print-data", rx).unwrap();
+        zw.write_all(&std::fs::read(&print_data).unwrap()).unwrap();
         zw.finish().unwrap();
     }
 
@@ -188,6 +230,7 @@ fn build_fixtures() -> Option<Fixtures> {
         zip: zip_path,
         shim,
         work,
+        rust_tool,
     })
 }
 
@@ -411,4 +454,207 @@ fn misformatted_env_is_a_named_error() {
     assert_eq!(out.status.code(), Some(tfs_preload::spec::EX_CONFIG));
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("cannot mount"), "stderr: {stderr}");
+}
+
+// ---------------------------------------------------------------------
+// Roadmap 39: the *at family, execve/posix_spawn of memfs paths, dir
+// streams, and the Rust dynamic tool
+// ---------------------------------------------------------------------
+
+/// Run a fixture tool with an explicit cwd (the AT_FDCWD proofs).
+fn run_in_dir(f: &Fixtures, cwd: &Path, tool: &str, args: &[&str], jail: Option<&str>) -> Run {
+    let mut cmd = Command::new(f.dir.join("bin").join(tool));
+    cmd.args(args)
+        .current_dir(cwd)
+        .env(preload_var(), &f.shim)
+        .env("TEBAKO_TFS_MOUNTS", format!("{}:{MOUNT}", f.zip.display()))
+        .env_remove("DYLD_PRINT_LIBRARIES");
+    match jail {
+        Some(j) => {
+            cmd.env("TEBAKO_JAIL", j);
+        }
+        None => {
+            cmd.env_remove("TEBAKO_JAIL");
+        }
+    }
+    let out = cmd.output().unwrap();
+    Run {
+        rc: out.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+#[test]
+fn at_family_serves_memfs_and_gates_at_fdcwd() {
+    let Some(f) = fixtures() else { return };
+    // fstatat on a memfs path: the engine answers (no extraction).
+    let r = run(
+        f,
+        "at-probe",
+        &["fstatat", &format!("{MOUNT}/data/secret.txt")],
+        None,
+    );
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), format!("SIZE:{}", SECRET.len()));
+
+    // dirfd-relative through a HOST dirfd: passes through to the host.
+    let r = run(
+        f,
+        "at-probe",
+        &["fstatat-rel", "hostfile.txt", f.work.to_str().unwrap()],
+        None,
+    );
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), "SIZE:10");
+    let r = run(
+        f,
+        "at-probe",
+        &["openat", "hostfile.txt", f.work.to_str().unwrap()],
+        None,
+    );
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, "HOST-FILE\n");
+
+    // The AT_FDCWD regression pin, e2e form: a cwd-relative fstatat must
+    // resolve against the cwd — never ENOTDIR (the fd-branch bug class
+    // that broke runtime builds).
+    let r = run_in_dir(f, &f.work, "at-probe", &["fstatat", "hostfile.txt"], None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), "SIZE:10");
+    // …and the jail gates the same call (cwd outside the grant → EPERM).
+    let r = run_in_dir(
+        f,
+        &f.work,
+        "at-probe",
+        &["fstatat", "hostfile.txt"],
+        Some("deny"),
+    );
+    assert_eq!(r.rc, libc::EPERM, "stderr: {}", r.stderr);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn at_family_linux_extensions() {
+    let Some(f) = fixtures() else { return };
+    let secret = format!("{MOUNT}/data/secret.txt");
+
+    // statx: the engine's answer in statx form, with the mask reported.
+    let r = run(f, "at-probe", &["statx", &secret], None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert!(
+        r.stdout
+            .starts_with(&format!("SIZE:{} MASK:", SECRET.len())),
+        "stdout: {}",
+        r.stdout
+    );
+
+    // fstatat64 (the LFS alias).
+    let r = run(f, "at-probe", &["fstatat64", &secret], None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), format!("SIZE:{}", SECRET.len()));
+
+    // The versioned pre-glibc-2.33 entry points.
+    let r = run(f, "at-probe", &["__xstat", &secret], None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), format!("SIZE:{}", SECRET.len()));
+    let r = run(f, "at-probe", &["__fxstatat", &secret], None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), format!("SIZE:{}", SECRET.len()));
+
+    // getdents64 on a host directory passes through…
+    let r = run(
+        f,
+        "at-probe",
+        &["getdents64", f.work.to_str().unwrap()],
+        None,
+    );
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert!(r.stdout.starts_with("BYTES:"), "stdout: {}", r.stdout);
+    let bytes: i64 = r
+        .stdout
+        .trim_start_matches("BYTES:")
+        .trim()
+        .parse()
+        .unwrap();
+    assert!(bytes > 0, "stdout: {}", r.stdout);
+    // …and on a memfs REGULAR file fd the honest answer is ENOTDIR (20).
+    let r = run(f, "at-probe", &["getdents64-file", &secret], None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), format!("ERRNO:{}", libc::ENOTDIR));
+}
+
+#[test]
+fn dir_stream_rewind_tell_seek_and_readdir_r() {
+    let Some(f) = fixtures() else { return };
+    let r = run(f, "dir-stream", &[&format!("{MOUNT}/dir")], None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    let expected = "r1:a.txt\ntell:1\nr2:b.txt\nr3:<end>\nafter-rewind:a.txt\nreaddir_r:0:b.txt\nreaddir_r:0:<end>\n";
+    assert_eq!(r.stdout, expected, "stdout:\n{}", r.stdout);
+}
+
+#[test]
+fn execve_of_memfs_helper_runs_without_extraction() {
+    let Some(f) = fixtures() else { return };
+    let helper = format!("{MOUNT}/bin/print-data");
+    let data = format!("{MOUNT}/data/secret.txt");
+    // execve replaces the process: the helper (materialized through the
+    // dlmap2file host cache) prints the memfs data — proof the copy ran
+    // AND the preload env reached it (it re-mounts the same image).
+    let r = run(f, "spawn-helper", &["execve", &helper, &data], None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, SECRET, "stderr: {}", r.stderr);
+}
+
+#[test]
+fn posix_spawn_of_memfs_helper_and_deny_jail_child_io() {
+    let Some(f) = fixtures() else { return };
+    let helper = format!("{MOUNT}/bin/print-data");
+    let data = format!("{MOUNT}/data/secret.txt");
+    let r = run(f, "spawn-helper", &["posix_spawn", &helper, &data], None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, SECRET, "stderr: {}", r.stderr);
+
+    // Under a deny jail the memfs helper still spawns (memfs is
+    // unaffected); the child's HOST read is what fails EPERM.
+    let r = run(
+        f,
+        "spawn-helper",
+        &["posix_spawn", &helper, "/etc/hosts"],
+        Some("deny"),
+    );
+    assert_eq!(r.rc, libc::EPERM, "stderr: {}", r.stderr);
+}
+
+#[test]
+fn rust_tool_reads_in_image_data() {
+    let Some(f) = fixtures() else { return };
+    if f.rust_tool.is_none() {
+        return; // documented skip: no rustc on PATH
+    }
+    // std::fs::read_to_string (open/read/close through the shim).
+    let r = run(
+        f,
+        "rust-tool",
+        &["read", &format!("{MOUNT}/data/secret.txt")],
+        None,
+    );
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, SECRET);
+    // std::fs::metadata (the glibc stat family internally).
+    let r = run(
+        f,
+        "rust-tool",
+        &["metadata", &format!("{MOUNT}/data/secret.txt")],
+        None,
+    );
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), format!("SIZE:{}", SECRET.len()));
+    // std::fs::read_dir (opendir/readdir through the shim).
+    let r = run(f, "rust-tool", &["read_dir", &format!("{MOUNT}/dir")], None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), "a.txt b.txt");
+    // …and the deny jail gates the Rust binary identically.
+    let r = run(f, "rust-tool", &["read", "/etc/hosts"], Some("deny"));
+    assert_eq!(r.rc, libc::EPERM, "stderr: {}", r.stderr);
 }

--- a/crates/libtfs-preload/tests/fixtures/at-probe.c
+++ b/crates/libtfs-preload/tests/fixtures/at-probe.c
@@ -1,0 +1,132 @@
+/* at-probe: the *at family (roadmap 39) — fstatat/fstatat64/openat
+ * everywhere, statx/getdents64/__xstat on linux. Each command prints a
+ * deterministic line or exits with the errno. */
+#ifdef __linux__
+#define _GNU_SOURCE /* statx, getdents64, STATX_* */
+#endif
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#ifdef __linux__
+#include <dirent.h> /* getdents64 (bits/dirent_ext.h) */
+#endif
+
+static int fail(const char *what, const char *path, int e) {
+    dprintf(2, "%s %s: %s\n", what, path, strerror(e));
+    return e;
+}
+
+static int cat_fd(int fd) {
+    char buf[4096];
+    ssize_t n;
+    while ((n = read(fd, buf, sizeof buf)) > 0)
+        write(1, buf, (size_t)n);
+    close(fd);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+        dprintf(2, "usage: at-probe <cmd> <path> [base]\n");
+        return 64;
+    }
+    const char *cmd = argv[1];
+    const char *path = argv[2];
+    struct stat st;
+
+    if (strcmp(cmd, "fstatat") == 0) {
+        if (fstatat(AT_FDCWD, path, &st, 0) < 0)
+            return fail("fstatat", path, errno);
+        dprintf(1, "SIZE:%lld\n", (long long)st.st_size);
+        return 0;
+    }
+    if (strcmp(cmd, "fstatat-rel") == 0) {
+        /* dirfd-relative: the base dir is argv[3], path is the basename. */
+        int dfd = open(argv[3], O_RDONLY | O_DIRECTORY);
+        if (dfd < 0)
+            return fail("open-dir", argv[3], errno);
+        int rc = fstatat(dfd, path, &st, 0) < 0 ? fail("fstatat-rel", path, errno) : 0;
+        close(dfd);
+        if (rc)
+            return rc;
+        dprintf(1, "SIZE:%lld\n", (long long)st.st_size);
+        return 0;
+    }
+    if (strcmp(cmd, "openat") == 0) {
+        int dfd = open(argv[3], O_RDONLY | O_DIRECTORY);
+        if (dfd < 0)
+            return fail("open-dir", argv[3], errno);
+        int fd = openat(dfd, path, O_RDONLY);
+        if (fd < 0)
+            return fail("openat", path, errno);
+        close(dfd);
+        return cat_fd(fd);
+    }
+#ifdef __linux__
+    if (strcmp(cmd, "fstatat64") == 0) {
+        /* stat/stat64 are distinct C types on aarch64 (layout-identical);
+         * the probe names the wrapper's own type. */
+        struct stat64 st64;
+        if (fstatat64(AT_FDCWD, path, &st64, 0) < 0)
+            return fail("fstatat64", path, errno);
+        dprintf(1, "SIZE:%lld\n", (long long)st64.st_size);
+        return 0;
+    }
+    if (strcmp(cmd, "statx") == 0) {
+        struct statx stx;
+        if (statx(AT_FDCWD, path, 0, STATX_BASIC_STATS, &stx) < 0)
+            return fail("statx", path, errno);
+        dprintf(1, "SIZE:%lld MASK:%x\n", (long long)stx.stx_size, stx.stx_mask);
+        return 0;
+    }
+    if (strcmp(cmd, "getdents64") == 0) {
+        /* path names a directory to enumerate via the raw syscall form. */
+        int fd = open(path, O_RDONLY | O_DIRECTORY);
+        if (fd < 0)
+            return fail("open-dir", path, errno);
+        char buf[1024];
+        int n = getdents64(fd, buf, sizeof buf);
+        int e = errno;
+        close(fd);
+        if (n < 0)
+            return fail("getdents64", path, e);
+        dprintf(1, "BYTES:%d\n", n);
+        return 0;
+    }
+    if (strcmp(cmd, "getdents64-file") == 0) {
+        /* path names a memfs REGULAR file: ENOTDIR is the honest answer. */
+        int fd = open(path, O_RDONLY);
+        if (fd < 0)
+            return fail("open", path, errno);
+        char buf[1024];
+        int n = getdents64(fd, buf, sizeof buf);
+        int e = errno;
+        close(fd);
+        if (n >= 0) {
+            dprintf(2, "getdents64 on a file succeeded?!\n");
+            return 1;
+        }
+        dprintf(1, "ERRNO:%d\n", e);
+        return 0;
+    }
+    if (strcmp(cmd, "__xstat") == 0) {
+        extern int __xstat(int ver, const char *path, struct stat *st);
+        if (__xstat(1, path, &st) < 0)
+            return fail("__xstat", path, errno);
+        dprintf(1, "SIZE:%lld\n", (long long)st.st_size);
+        return 0;
+    }
+    if (strcmp(cmd, "__fxstatat") == 0) {
+        extern int __fxstatat(int ver, int dirfd, const char *path, struct stat *st, int flags);
+        if (__fxstatat(1, AT_FDCWD, path, &st, 0) < 0)
+            return fail("__fxstatat", path, errno);
+        dprintf(1, "SIZE:%lld\n", (long long)st.st_size);
+        return 0;
+    }
+#endif
+    dprintf(2, "at-probe: unknown command %s\n", cmd);
+    return 64;
+}

--- a/crates/libtfs-preload/tests/fixtures/dir-stream.c
+++ b/crates/libtfs-preload/tests/fixtures/dir-stream.c
@@ -1,0 +1,38 @@
+/* dir-stream: rewinddir/telldir/seekdir/readdir_r (roadmap 39). Prints a
+ * deterministic transcript of one stream's navigation; the e2e asserts it
+ * line for line. */
+#include <sys/types.h>
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+static void show(const char *tag, struct dirent *e) {
+    dprintf(1, "%s:%s\n", tag, e ? e->d_name : "<end>");
+}
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        dprintf(2, "usage: dir-stream <dir>\n");
+        return 64;
+    }
+    DIR *d = opendir(argv[1]);
+    if (!d) {
+        dprintf(2, "opendir %s: %s\n", argv[1], strerror(errno));
+        return errno;
+    }
+    show("r1", readdir(d));
+    dprintf(1, "tell:%ld\n", telldir(d));
+    show("r2", readdir(d));
+    show("r3", readdir(d)); /* end of stream */
+    rewinddir(d);
+    show("after-rewind", readdir(d));
+    seekdir(d, 1);
+    struct dirent entry, *result;
+    int rc = readdir_r(d, &entry, &result);
+    dprintf(1, "readdir_r:%d:%s\n", rc, result ? entry.d_name : "<end>");
+    rc = readdir_r(d, &entry, &result);
+    dprintf(1, "readdir_r:%d:%s\n", rc, result ? entry.d_name : "<end>");
+    closedir(d);
+    return 0;
+}

--- a/crates/libtfs-preload/tests/fixtures/rust-tool.rs
+++ b/crates/libtfs-preload/tests/fixtures/rust-tool.rs
@@ -1,0 +1,46 @@
+// rust-tool: the dynamic-Rust-binary proof (roadmap 39). std::fs calls
+// ride the interposed libc family on linux-gnu (stat/open64/readdir
+// wrappers) and libSystem (macOS) — the shim must serve in-image paths
+// with no extraction, exactly like the C fixtures.
+use std::process::exit;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        eprintln!("usage: rust-tool <read|metadata|read_dir> <path>");
+        exit(64);
+    }
+    match args[1].as_str() {
+        "read" => match std::fs::read_to_string(&args[2]) {
+            Ok(text) => print!("{text}"),
+            Err(e) => {
+                eprintln!("read {}: {e}", args[2]);
+                exit(e.raw_os_error().unwrap_or(1));
+            }
+        },
+        "metadata" => match std::fs::metadata(&args[2]) {
+            Ok(md) => println!("SIZE:{}", md.len()),
+            Err(e) => {
+                eprintln!("metadata {}: {e}", args[2]);
+                exit(e.raw_os_error().unwrap_or(1));
+            }
+        },
+        "read_dir" => match std::fs::read_dir(&args[2]) {
+            Ok(rd) => {
+                let mut names: Vec<String> = rd
+                    .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+                    .collect();
+                names.sort();
+                println!("{}", names.join(" "));
+            }
+            Err(e) => {
+                eprintln!("read_dir {}: {e}", args[2]);
+                exit(e.raw_os_error().unwrap_or(1));
+            }
+        },
+        other => {
+            eprintln!("rust-tool: unknown command {other}");
+            exit(64);
+        }
+    }
+}

--- a/crates/libtfs-preload/tests/fixtures/spawn-helper.c
+++ b/crates/libtfs-preload/tests/fixtures/spawn-helper.c
@@ -1,0 +1,40 @@
+/* spawn-helper: execve/posix_spawn of a MEMFS path (roadmap 39). The
+ * helper lives inside the image; the shim must materialize it through the
+ * dlmap2file host cache so it runs with no extraction, and the preload
+ * env must reach it (grandchildren stay in the VFS). */
+#include <sys/wait.h>
+#include <spawn.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+extern char **environ;
+
+int main(int argc, char **argv) {
+    if (argc != 4) {
+        dprintf(2, "usage: spawn-helper <execve|posix_spawn> <helper> <arg>\n");
+        return 64;
+    }
+    char *const child_argv[] = {argv[2], argv[3], NULL};
+    if (strcmp(argv[1], "execve") == 0) {
+        execve(argv[2], child_argv, environ);
+        int e = errno;
+        dprintf(2, "execve %s: %s\n", argv[2], strerror(e));
+        return e;
+    }
+    if (strcmp(argv[1], "posix_spawn") == 0) {
+        pid_t pid;
+        int s = posix_spawn(&pid, argv[2], NULL, NULL, child_argv, environ);
+        if (s != 0) {
+            dprintf(2, "posix_spawn %s: %s\n", argv[2], strerror(s));
+            return s;
+        }
+        int status;
+        waitpid(pid, &status, 0);
+        return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    }
+    dprintf(2, "spawn-helper: unknown mode %s\n", argv[1]);
+    return 64;
+}

--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -27,7 +27,16 @@
 //!    SHA256SUMS line fallback), installed READ-ONLY with
 //!    `<image>.sha256`/`<image>.origin` trusted markers, never extracted;
 //!
-//! 6. exec the runtime, launcher ABI v1 (byte-identical handoff; an
+//! 6. apply the package's jail (spec 08 §2/§4): the `jail:` block of the
+//!    type-2 package manifest REQUESTS host access; the user's TEBAKO_JAIL
+//!    env TIGHTENS it — the effective policy (manifest request ∩ user
+//!    tightening, user wins, never loosens) is exported to the driver as
+//!    TEBAKO_JAIL (+ TEBAKO_JAIL_SOURCE for the audit source, and
+//!    TEBAKO_JAIL_JOURNAL pointing at this home's journal.log so the
+//!    driver's violations land in the same audit journal). A malformed
+//!    policy fails closed (exit 73); no policy = byte-identical legacy
+//!    behavior (nothing exported);
+//! 7. exec the runtime, launcher ABI v1 (byte-identical handoff; an
 //!    image-era run additionally exports TEBAKO_RUNTIME_IMAGE):
 //! ```text
 //! <runtime> --tebako-image <self>:<slot>:<mount> ...
@@ -73,6 +82,10 @@ pub const EX_TEBAKO_SHA: u8 = 70;
 pub const EX_TEBAKO_SIGNATURE: u8 = 71;
 /// The signer key of a v2-signed package is not in the trusted keyring.
 pub const EX_TEBAKO_TRUST: u8 = 72;
+/// The jail policy could not be applied: a malformed TEBAKO_JAIL env spec,
+/// or an unusable `jail:` block in the package manifest (spec 08 — the
+/// policy is fail-closed: an unparseable policy never silently runs open).
+pub const EX_TEBAKO_JAIL: u8 = 73;
 pub const EX_TEBAKO_IO: u8 = 74;
 
 const DEFAULT_RELEASES_BASE: &str =
@@ -261,6 +274,83 @@ pub fn resolution_runtime_ref(m: &tpkg::Manifest, argv0: &str) -> Result<String,
         Some((_, entry)) => Ok(entry.runtime_ref),
         None => Ok(m.runtime_ref_str().unwrap_or_default().to_string()),
     }
+}
+
+// ---------------------------------------------------------------------
+// jails (spec 08 §2/§4): manifest request ∩ user tightening = effective
+// ---------------------------------------------------------------------
+
+/// The jail the package REQUESTS (spec 08 §4): the `jail:` block of the
+/// L2 package manifest (ext block type 2, written by `tebako press
+/// --jail`). A block-less package requests nothing — the effective policy
+/// is then the user's tightening alone (or nothing: byte-identical legacy
+/// behavior).
+pub fn package_jail(m: &tpkg::Manifest) -> Result<Option<tpkg::HostJail>, BootError> {
+    match m.package_manifest() {
+        Ok(Some(pm)) => Ok(pm.jail),
+        Ok(None) => Ok(None),
+        Err(e) => fail(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "invalid package manifest (extension block type 2): {e} — re-stitch the package"
+            ),
+        ),
+    }
+}
+
+/// The user's tightening from the environment: `TEBAKO_JAIL` in the spec
+/// 08 §1 env form. Absent/empty = no tightening. A MALFORMED spec is a
+/// named error (EX_TEBAKO_JAIL) — a security policy that cannot be parsed
+/// must never silently run open (fail-closed).
+pub fn user_jail_from_env() -> Result<Option<tpkg::HostJail>, BootError> {
+    let spec = std::env::var("TEBAKO_JAIL").unwrap_or_default();
+    if spec.trim().is_empty() {
+        return Ok(None);
+    }
+    tpkg::HostJail::parse_env_spec(&spec)
+        .map(Some)
+        .map_err(|e| BootError::new(EX_TEBAKO_JAIL, format!("cannot apply the jail policy: {e}")))
+}
+
+/// The effective jail exported to the runtime driver: spec, source label
+/// (for TEBAKO_JAIL_SOURCE and the audit journal), and the journal file
+/// the driver's violations land in (TEBAKO_JAIL_JOURNAL).
+pub struct JailEnv {
+    pub spec: String,
+    pub source: &'static str,
+    pub journal: PathBuf,
+}
+
+/// Compose the effective jail (spec 08 §2, locked: the package's request ∩
+/// the user's tightening — the user TIGHTENS, never loosens) and render it
+/// for the handoff. `argv` includes argv[0]; with `argument_files:
+/// auto-allowed` the user args naming existing files become read-only
+/// grants ("the input file you hand the command is allowed even under
+/// deny"). `Ok(None)` when no policy applies — nothing is exported and the
+/// run is byte-identical to the pre-jails behavior.
+pub fn prepare_jail(
+    m: &tpkg::Manifest,
+    user: Option<&tpkg::HostJail>,
+    argv: &[String],
+    home: &Path,
+) -> Result<Option<JailEnv>, BootError> {
+    let package = package_jail(m)?;
+    let Some((jail, source)) = tpkg::jail::effective(package.as_ref(), user) else {
+        return Ok(None);
+    };
+    if jail.is_trivially_open() {
+        return Ok(None);
+    }
+    let arg_files = if jail.argument_files.auto {
+        tpkg::jail::resolve_argument_files(&argv[1..])
+    } else {
+        Vec::new()
+    };
+    Ok(Some(JailEnv {
+        spec: jail.to_env_spec(&arg_files),
+        source,
+        journal: home.join("journal.log"),
+    }))
 }
 
 // ---------------------------------------------------------------------
@@ -1768,6 +1858,7 @@ fn exec_runtime(
     m: &tpkg::Manifest,
     selection: Option<&(tpkg::PackageManifest, tpkg::PackageEntry)>,
     argv: &[String],
+    jail: Option<&JailEnv>,
 ) -> BootError {
     use std::os::unix::process::CommandExt;
 
@@ -1779,6 +1870,14 @@ fn exec_runtime(
         // drivers mount it instead of an embedded image, v1 drivers
         // ignore it. The handoff options themselves are unchanged.
         cmd.env("TEBAKO_RUNTIME_IMAGE", image);
+    }
+    if let Some(jail) = jail {
+        // spec 08: the effective jail (manifest request ∩ user
+        // tightening) reaches the driver through its policy env; the
+        // driver's violations journal into this home's journal.log.
+        cmd.env("TEBAKO_JAIL", &jail.spec);
+        cmd.env("TEBAKO_JAIL_SOURCE", jail.source);
+        cmd.env("TEBAKO_JAIL_JOURNAL", &jail.journal);
     }
     let err = cmd.exec();
     BootError::new(
@@ -1802,9 +1901,10 @@ fn exec_runtime(
     m: &tpkg::Manifest,
     selection: Option<&(tpkg::PackageManifest, tpkg::PackageEntry)>,
     argv: &[String],
+    jail: Option<&JailEnv>,
 ) -> BootError {
     let nargv = handoff_argv(runtime, self_path, m, selection, argv);
-    let err = platform::spawn_handoff(runtime, &nargv[1..], image);
+    let err = platform::spawn_handoff(runtime, &nargv[1..], image, jail);
     BootError::new(
         EX_TEBAKO_IO,
         format!("cannot execute runtime {}: {err}", runtime.display()),
@@ -1886,6 +1986,16 @@ pub fn run(argv: &[String]) -> Result<std::convert::Infallible, BootError> {
     }
     let rr = parse_runtime_ref(&runtime_ref)?;
 
+    // Jails (spec 08 §2/§4): the package's `jail:` request ∩ the user's
+    // TEBAKO_JAIL tightening = the effective policy, exported to the
+    // driver as TEBAKO_JAIL (+ TEBAKO_JAIL_SOURCE / TEBAKO_JAIL_JOURNAL)
+    // at handoff. Fail-closed: a malformed policy never runs open.
+    let jail = {
+        let user = user_jail_from_env()?;
+        let home = cache_root()?;
+        prepare_jail(&m, user.as_ref(), argv, &home)?
+    };
+
     let (runtime, image) = resolve_runtime(&runtime_ref, &rr, &self_path, &m)?;
     Err(exec_runtime(
         &runtime,
@@ -1894,5 +2004,6 @@ pub fn run(argv: &[String]) -> Result<std::convert::Infallible, BootError> {
         &m,
         selection.as_ref(),
         argv,
+        jail.as_ref(),
     ))
 }

--- a/crates/tebako-bootstrap/src/platform.rs
+++ b/crates/tebako-bootstrap/src/platform.rs
@@ -333,7 +333,12 @@ pub fn lock_release(lock: EntryLock) {
 /// the caller onto EX_TEBAKO_IO with the same message body as the unix
 /// exec failure ("cannot execute runtime …").
 #[cfg(windows)]
-pub fn spawn_handoff(runtime: &Path, args: &[String], image: Option<&Path>) -> io::Error {
+pub fn spawn_handoff(
+    runtime: &Path,
+    args: &[String],
+    image: Option<&Path>,
+    jail: Option<&crate::JailEnv>,
+) -> io::Error {
     install_ctrl_swallow();
     let mut cmd = std::process::Command::new(runtime);
     cmd.args(args);
@@ -342,6 +347,13 @@ pub fn spawn_handoff(runtime: &Path, args: &[String], image: Option<&Path>) -> i
         // drivers mount it instead of an embedded image, v1 drivers
         // ignore it. The handoff options themselves are unchanged.
         cmd.env("TEBAKO_RUNTIME_IMAGE", image);
+    }
+    if let Some(jail) = jail {
+        // spec 08: the effective jail rides the environment (the unix
+        // exec path exports the same triple).
+        cmd.env("TEBAKO_JAIL", &jail.spec);
+        cmd.env("TEBAKO_JAIL_SOURCE", jail.source);
+        cmd.env("TEBAKO_JAIL_JOURNAL", &jail.journal);
     }
     let status = match cmd.spawn().and_then(|mut child| child.wait()) {
         Ok(status) => status,

--- a/crates/tebako-bootstrap/tests/harness/mod.rs
+++ b/crates/tebako-bootstrap/tests/harness/mod.rs
@@ -323,7 +323,13 @@ impl Harness {
             // Deterministic env: no ambient knobs leaking in.
             .env_remove("TEBAKO_OFFLINE")
             .env_remove("TEBAKO_NO_PROGRESS")
-            .env_remove("NO_COLOR");
+            .env_remove("NO_COLOR")
+            // Jail knobs (roadmap 35): an ambient TEBAKO_JAIL would
+            // otherwise reach the handoff and change every fixture's
+            // behavior.
+            .env_remove("TEBAKO_JAIL")
+            .env_remove("TEBAKO_JAIL_SOURCE")
+            .env_remove("TEBAKO_JAIL_JOURNAL");
         for (k, v) in extra_env {
             cmd.env(k, v);
         }

--- a/crates/tebako-bootstrap/tests/jail.rs
+++ b/crates/tebako-bootstrap/tests/jail.rs
@@ -1,0 +1,361 @@
+//! Jail application e2e (spec 08 §2/§4): the bootstrap composes the
+//! package's `jail:` request (type-2 block) with the user's TEBAKO_JAIL
+//! tightening — manifest request ∩ user policy, the user TIGHTENS, never
+//! loosens — and hands the effective policy to the runtime driver through
+//! the policy env (TEBAKO_JAIL + TEBAKO_JAIL_SOURCE + TEBAKO_JAIL_JOURNAL,
+//! spec 17 §2). A fake runtime echoes the env it receives; enforcement of
+//! the env form itself is the tfs/preload suites' proof.
+
+// The harness is shared with selftest/progress/chain; this suite uses a
+// subset of its API — silence per-binary unused-function warnings.
+#[allow(dead_code)]
+mod harness;
+
+use std::path::{Path, PathBuf};
+
+use harness::{rust_bootstrap, Harness};
+
+/// A fake runtime that reports the jail env the bootstrap exported.
+fn write_probe_runtime(h: &Harness, home: &Path) {
+    let exe = h.cache_exe(home);
+    std::fs::create_dir_all(exe.parent().unwrap()).unwrap();
+    std::fs::write(
+        &exe,
+        "#!/bin/sh\n\
+         echo \"JAIL=${TEBAKO_JAIL-UNSET}\"\n\
+         echo \"JAIL-SOURCE=${TEBAKO_JAIL_SOURCE-UNSET}\"\n\
+         echo \"JAIL-JOURNAL=${TEBAKO_JAIL_JOURNAL-UNSET}\"\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+fn package_manifest(runtime_ref: &str, jail: tpkg::HostJail) -> tpkg::PackageManifest {
+    tpkg::PackageManifest {
+        schema_version: tpkg::PACKAGE_SCHEMA_VERSION,
+        package: tpkg::PackageIdentity {
+            name: "jailtest".to_string(),
+            version: "1.0.0".to_string(),
+            producer: tpkg::Producer {
+                tool: "tebako-cli".to_string(),
+                tool_version: "0.16.0".to_string(),
+            },
+            created: "2026-07-27T00:00:00Z".to_string(),
+        },
+        entries: vec![tpkg::PackageEntry {
+            name: "jailtest".to_string(),
+            slot: 0,
+            entrypoint: "jailtest".to_string(),
+            runtime_ref: runtime_ref.to_string(),
+        }],
+        jail: Some(jail),
+        env: Default::default(),
+    }
+}
+
+/// The harness stitch, plus an optional type-2 package manifest block.
+fn stitch_pkg(h: &Harness, name: &str, jail: Option<tpkg::HostJail>) -> PathBuf {
+    let out = h.tmp.0.join(name);
+    let mut m = tpkg::Manifest {
+        package_flags: 0,
+        launcher_abi: 0,
+        ..Default::default()
+    };
+    m.set_runtime_ref(h.runtime_ref.as_bytes());
+    let img = h.fake_image();
+    let mut pos = std::fs::metadata(&h.bootstrap).unwrap().len();
+    let size = std::fs::metadata(&img).unwrap().len();
+    let slot = tpkg::Slot::new(pos, size, tpkg::TPKG_FORMAT_DWARFS, "/__tebako_memfs__");
+    pos += size;
+    let _ = pos;
+    m.slots.push(slot);
+    if let Some(jail) = jail {
+        m.set_package_manifest(&package_manifest(&h.runtime_ref, jail))
+            .unwrap();
+    }
+    let mut outf = std::fs::File::create(&out).unwrap();
+    {
+        use std::io::Write as _;
+        outf.write_all(&std::fs::read(&h.bootstrap).unwrap())
+            .unwrap();
+        outf.write_all(&std::fs::read(&img).unwrap()).unwrap();
+    }
+    tpkg::write_to(&mut outf, &m).unwrap();
+    drop(outf);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&out, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    out
+}
+
+fn line<'a>(stdout: &'a str, key: &str) -> &'a str {
+    stdout
+        .lines()
+        .find_map(|l| l.strip_prefix(key))
+        .unwrap_or_else(|| panic!("{key} missing from stdout:\n{stdout}"))
+}
+
+#[test]
+fn package_jail_is_applied_via_the_policy_env() {
+    let h = Harness::new(rust_bootstrap());
+    let home = h.home("home1");
+    write_probe_runtime(&h, &home);
+    let input = h.tmp.0.join("input.csv");
+    std::fs::write(&input, b"a,b\n").unwrap();
+    let pkg = stitch_pkg(
+        &h,
+        "pkg-deny-arg",
+        Some(tpkg::HostJail::deny_with_arg_files()),
+    );
+
+    let (rc, stdout, _stderr) = h.run(&pkg, &home, &[], &[input.to_str().unwrap()]);
+    assert_eq!(rc, 0);
+    assert_eq!(line(&stdout, "JAIL="), format!("deny;@{}", input.display()));
+    assert_eq!(line(&stdout, "JAIL-SOURCE="), "manifest");
+    assert_eq!(
+        line(&stdout, "JAIL-JOURNAL="),
+        home.join("journal.log").to_string_lossy()
+    );
+}
+
+#[test]
+fn user_tebako_jail_intersects_never_loosens() {
+    let h = Harness::new(rust_bootstrap());
+    let home = h.home("home2");
+    write_probe_runtime(&h, &home);
+    let mut package = tpkg::HostJail::deny();
+    package.mounts.push(tpkg::JailMount {
+        host: "/data".to_string(),
+        mount: "/data".to_string(),
+        access: tpkg::JailAccess::Ro,
+    });
+    let pkg = stitch_pkg(&h, "pkg-deny-data", Some(package));
+
+    // The user tightens to --no-host: the request's grant is dropped.
+    let (rc, stdout, _stderr) = h.run(&pkg, &home, &[("TEBAKO_JAIL", "deny")], &[]);
+    assert_eq!(rc, 0);
+    assert_eq!(line(&stdout, "JAIL="), "deny");
+    assert_eq!(line(&stdout, "JAIL-SOURCE="), "manifest+user");
+
+    // The user asking for open does NOT loosen the manifest's deny
+    // (tighter wins; wider latitude comes by trust policy, never a flag).
+    let (rc, stdout, _stderr) = h.run(&pkg, &home, &[("TEBAKO_JAIL", "open")], &[]);
+    assert_eq!(rc, 0);
+    assert_eq!(line(&stdout, "JAIL="), "deny;/data:/data:ro");
+    assert_eq!(line(&stdout, "JAIL-SOURCE="), "manifest+user");
+}
+
+#[test]
+fn user_tebako_jail_alone_when_the_package_is_silent() {
+    let h = Harness::new(rust_bootstrap());
+    let home = h.home("home3");
+    write_probe_runtime(&h, &home);
+    let pkg = stitch_pkg(&h, "pkg-silent", None);
+
+    let (rc, stdout, _stderr) = h.run(&pkg, &home, &[("TEBAKO_JAIL", "deny;/etc:/etc:ro")], &[]);
+    assert_eq!(rc, 0);
+    assert_eq!(line(&stdout, "JAIL="), "deny;/etc:/etc:ro");
+    assert_eq!(line(&stdout, "JAIL-SOURCE="), "user");
+}
+
+#[test]
+fn no_policy_anywhere_exports_nothing() {
+    let h = Harness::new(rust_bootstrap());
+    let home = h.home("home4");
+    write_probe_runtime(&h, &home);
+    let pkg = stitch_pkg(&h, "pkg-legacy", None);
+
+    let (rc, stdout, _stderr) = h.run(&pkg, &home, &[], &[]);
+    assert_eq!(rc, 0);
+    // Byte-identical legacy behavior: no jail env reaches the driver.
+    assert_eq!(line(&stdout, "JAIL="), "UNSET");
+    assert_eq!(line(&stdout, "JAIL-SOURCE="), "UNSET");
+    assert_eq!(line(&stdout, "JAIL-JOURNAL="), "UNSET");
+}
+
+#[test]
+fn malformed_tebako_jail_fails_closed() {
+    let h = Harness::new(rust_bootstrap());
+    let home = h.home("home5");
+    write_probe_runtime(&h, &home);
+    let pkg = stitch_pkg(&h, "pkg-badenv", None);
+
+    let (rc, _stdout, stderr) = h.run(&pkg, &home, &[("TEBAKO_JAIL", "frob")], &[]);
+    assert_eq!(rc, tebako_bootstrap::EX_TEBAKO_JAIL as i32);
+    assert!(stderr.contains("invalid jail spec"), "stderr: {stderr}");
+}
+
+#[test]
+fn auto_allowed_resolves_only_existing_argv_files() {
+    let h = Harness::new(rust_bootstrap());
+    let home = h.home("home6");
+    write_probe_runtime(&h, &home);
+    let input = h.tmp.0.join("real.csv");
+    std::fs::write(&input, b"x\n").unwrap();
+    let pkg = stitch_pkg(&h, "pkg-auto", Some(tpkg::HostJail::deny_with_arg_files()));
+
+    let (rc, stdout, _stderr) = h.run(
+        &pkg,
+        &home,
+        &[],
+        &[input.to_str().unwrap(), "missing-file-xyz", "--verbose"],
+    );
+    assert_eq!(rc, 0);
+    // Only the existing file is granted (flags and missing names skipped).
+    assert_eq!(line(&stdout, "JAIL="), format!("deny;@{}", input.display()));
+}
+
+// ---------------------------------------------------------------------
+// The whole-chain confinement proof: pressed jail → bootstrap compose →
+// driver policy env → the preload shim ENFORCES + JOURNALS (spec 08 §2)
+// ---------------------------------------------------------------------
+
+fn preload_dylib() -> Option<PathBuf> {
+    let name = if cfg!(target_os = "macos") {
+        "libtfs_preload.dylib"
+    } else {
+        "libtfs_preload.so"
+    };
+    let target = std::env::var("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../target")
+                .canonicalize()
+                .unwrap()
+        });
+    for profile in ["debug", "release"] {
+        for cand in [
+            target.join(profile).join(name),
+            target.join(profile).join("deps").join(name),
+        ] {
+            if cand.is_file() {
+                return Some(cand);
+            }
+        }
+    }
+    None
+}
+
+fn cc_available() -> bool {
+    std::process::Command::new("cc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// A driver that honors the policy env through the preload shim (the spec
+/// 17 §2 contract): everything before `--tebako-entry` is the loader's;
+/// the user args ride to a preload-injected native tool.
+fn write_enforcing_runtime(h: &Harness, home: &Path, shim: &Path, tool: &Path) {
+    let exe = h.cache_exe(home);
+    std::fs::create_dir_all(exe.parent().unwrap()).unwrap();
+    let preload_var = if cfg!(target_os = "macos") {
+        "DYLD_INSERT_LIBRARIES"
+    } else {
+        "LD_PRELOAD"
+    };
+    std::fs::write(
+        &exe,
+        format!(
+            "#!/bin/sh\n\
+             while [ \"$1\" != \"--tebako-entry\" ]; do shift; done\n\
+             shift\n\
+             shift\n\
+             exec env {preload_var}={} {} \"$@\"\n",
+            shim.display(),
+            tool.display()
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+/// Compile the shared print-data proof tool (exit code = errno).
+fn compile_print_data(dir: &Path) -> PathBuf {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../libtfs-preload/tests/fixtures/print-data.c")
+        .canonicalize()
+        .unwrap();
+    let out = dir.join("print-data");
+    let o = std::process::Command::new("cc")
+        .arg("-O2")
+        .arg("-o")
+        .arg(&out)
+        .arg(&src)
+        .output()
+        .unwrap();
+    assert!(
+        o.status.success(),
+        "cc failed: {}",
+        String::from_utf8_lossy(&o.stderr)
+    );
+    out
+}
+
+/// Pressed with `--jail deny`, the package RUNS CONFINED: a host read
+/// fails EPERM end-to-end (bootstrap compose → driver env → preload
+/// enforcement), and the violation lands in the audit journal with the
+/// manifest source. Pressed with `deny:arg`, the argument file is the one
+/// allowed read (the auto-allowed grant enforced through the shim).
+/// Skip policy (documented): no `cc` or no built preload shim.
+#[test]
+fn pressed_jail_package_runs_confined_and_journals() {
+    let Some(shim) = preload_dylib() else {
+        eprintln!("skip: libtfs_preload cdylib not built");
+        return;
+    };
+    if !cc_available() {
+        eprintln!("skip: no C compiler on PATH");
+        return;
+    }
+    let h = Harness::new(rust_bootstrap());
+    let home = h.home("home7");
+    let tool = compile_print_data(&h.tmp.0);
+    write_enforcing_runtime(&h, &home, &shim, &tool);
+    let pkg = stitch_pkg(&h, "pkg-confined", Some(tpkg::HostJail::deny()));
+
+    // Outside every grant: EPERM, end to end.
+    let (rc, _stdout, _stderr) = h.run(&pkg, &home, &[], &["/etc/hosts"]);
+    assert_eq!(rc, libc::EPERM);
+
+    // …and the violation is in the tebako audit journal of the run's home
+    // (the bootstrap exported TEBAKO_JAIL_JOURNAL; the shim's tfs layer
+    // journaled the denial with the manifest source).
+    let journal = std::fs::read_to_string(home.join("journal.log")).unwrap();
+    let deny: Vec<&str> = journal
+        .lines()
+        .filter(|l| l.contains("event=jail-deny"))
+        .collect();
+    assert_eq!(deny.len(), 1, "journal:\n{journal}");
+    let (ts, rest) = deny[0].split_once(' ').unwrap();
+    assert!(!ts.is_empty() && ts.bytes().all(|b| b.is_ascii_digit()));
+    assert_eq!(
+        rest,
+        "event=jail-deny path=/etc/hosts op=read source=manifest"
+    );
+
+    // The argument file is the one allowed read (deny:arg auto-allowed,
+    // enforced — not just composed).
+    let pkg_arg = stitch_pkg(
+        &h,
+        "pkg-confined-arg",
+        Some(tpkg::HostJail::deny_with_arg_files()),
+    );
+    let input = h.tmp.0.join("input.csv");
+    std::fs::write(&input, b"CONFINED-OK\n").unwrap();
+    let (rc, stdout, _stderr) = h.run(&pkg_arg, &home, &[], &[input.to_str().unwrap()]);
+    assert_eq!(rc, 0);
+    assert_eq!(stdout, "CONFINED-OK\n");
+}

--- a/crates/tebako-bootstrap/tests/jail.rs
+++ b/crates/tebako-bootstrap/tests/jail.rs
@@ -332,14 +332,19 @@ fn pressed_jail_package_runs_confined_and_journals() {
 
     // …and the violation is in the tebako audit journal of the run's home
     // (the bootstrap exported TEBAKO_JAIL_JOURNAL; the shim's tfs layer
-    // journaled the denial with the manifest source).
+    // journaled the denial with the manifest source). Assert the SPECIFIC
+    // probe, not the global count: under a deny-all jail the runtime may
+    // legitimately trip extra denials from environment lookups (e.g.
+    // /etc/localtime on hosts without TZ set — seen on CI runners).
     let journal = std::fs::read_to_string(home.join("journal.log")).unwrap();
-    let deny: Vec<&str> = journal
+    let deny_hosts: Vec<&str> = journal
         .lines()
-        .filter(|l| l.contains("event=jail-deny"))
+        .filter(|l| {
+            l.contains("event=jail-deny") && l.contains("path=/etc/hosts op=read source=manifest")
+        })
         .collect();
-    assert_eq!(deny.len(), 1, "journal:\n{journal}");
-    let (ts, rest) = deny[0].split_once(' ').unwrap();
+    assert_eq!(deny_hosts.len(), 1, "journal:\n{journal}");
+    let (ts, rest) = deny_hosts[0].split_once(' ').unwrap();
     assert!(!ts.is_empty() && ts.bytes().all(|b| b.is_ascii_digit()));
     assert_eq!(
         rest,

--- a/crates/tebako-cli/README.md
+++ b/crates/tebako-cli/README.md
@@ -8,10 +8,31 @@ design): a port of the reference Ruby gem's lean/fat press
 $ tebako press -r <root> -e <entry> [-o <output>] [-p <prefix>]
                [-c <cwd>] [-R <ruby>] [-m lean|fat] [-l error|warn|debug|trace]
                [--image <path>:<mount>]... [--bootstrap <path>]
-               [--tebako-version <v>] [--prefer-local]
+               [--tebako-version <v>] [--prefer-local] [--jail <spec>]
+$ tebako run <pkg> [--jail <spec>] [--mount <host:mount:ro|rw>]... [--no-host]
+               [--] [<args>...]
 $ tebako cache list
 $ tebako cache prune [--all] [--older-than Nd]
 ```
+
+## Jails (spec 08)
+
+`tebako press --jail <spec>` presses a host-access REQUEST into the
+package: `<spec>` is `open` (today's behavior), `deny` (every host path
+outside the grants fails EPERM), `deny:arg` (deny, but the input files
+the command is handed are allowed), a YAML file with the spec 08 §1 block
+(`default` / `mounts` / `argument_files`), or the `TEBAKO_JAIL` env
+grammar itself. The policy lands in the type-2 package manifest's `jail:`
+block; packages pressed without `--jail` are byte-identical to before.
+
+`tebako run <pkg>` dispatches a pressed package with the user's
+TIGHTENING — `--jail`, `--mount <host:mount:ro|rw>` (repeatable),
+`--no-host` — composed against the package's request: manifest request ∩
+user policy = effective jail, the user always wins, and the composition
+never loosens (a `--no-host` drops request grants; asking for `open`
+against a `deny` request stays denied). The effective policy rides
+TEBAKO_JAIL to the package's bootstrap; violations journal to the tebako
+audit journal (`$TEBAKO_HOME/journal.log`, spec 08 §2).
 
 ## Lean press flow
 

--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -681,6 +681,7 @@ fn synthesize_manifest(
                     exec: true,
                     read: true,
                     runtime: None,
+                    host: None,
                 },
             })
         }
@@ -696,6 +697,7 @@ fn synthesize_manifest(
                 exec: false,
                 read: true,
                 runtime: None,
+                host: None,
             },
         }),
         other => {

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -62,6 +62,7 @@ pub mod options;
 pub mod packager;
 pub mod publish;
 pub mod resolve;
+pub mod run;
 pub mod runner;
 pub mod scenario;
 pub mod sdk;
@@ -155,6 +156,21 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
         check_ruby_version(requested)?;
     }
 
+    // spec 08: --jail is validated before any heavy work (a bad spec must
+    // not cost a runtime download). The parsed policy becomes the type-2
+    // package manifest's `jail:` block at stitch time — the package's
+    // host-access REQUEST (the user can tighten it at run time, never
+    // loosen it).
+    let jail = match &opts.jail {
+        Some(spec) => Some(tpkg::HostJail::from_cli_spec(spec).map_err(|e| {
+            packaging_error(
+                130,
+                Some(&format!("invalid --jail specification '{spec}': {e}")),
+            )
+        })?),
+        None => None,
+    };
+
     // Cli#bootstrap: the cache version guard runs before the press
     // (skipped in devmode, like the gem).
     if !opts.devmode {
@@ -238,7 +254,19 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     }
 
     let package = format!("{}{}", opts.package(), scenario.exe_suffix);
-    stitch(&bootstrap_path, &images, &package, &runtime_ref, None)?;
+    // spec 08: a --jail press embeds the policy as the type-2 package
+    // manifest's `jail:` block — the package's host-access REQUEST (the
+    // user tightens it at run time, never loosens it; block-less packages
+    // keep the exact v1 shape).
+    let package_manifest =
+        jail.map(|j| press_package_manifest(&package, &runtime_ref, &opts.tebako_version, j));
+    stitch(
+        &bootstrap_path,
+        &images,
+        &package,
+        &runtime_ref,
+        package_manifest.as_ref(),
+    )?;
     println!("Created tebako package at \"{package}\"");
     ensure_version_file(opts);
     Ok(PathBuf::from(package))
@@ -311,7 +339,9 @@ fn check_bootstrap_version() -> Result<(), TebakoError> {
 /// `runtime_ref` is the trailer's 128-byte field as built by the caller
 /// (suites: entries[0]'s ref — the type-2 manifest carries the per-entry
 /// refs, spec 02 §5b / spec 03 §6). `package_manifest`, when present, is
-/// embedded as extension block type 2.
+/// embedded as extension block type 2 (a `--jail` press embeds the policy
+/// this way, spec 08 §4); `None` keeps the package block-less
+/// (byte-identical pre-jails shape).
 pub(crate) fn stitch(
     bootstrap_path: &Path,
     images: &[(PathBuf, String, u32)],
@@ -407,6 +437,10 @@ pub(crate) fn stitch(
         runtime_ref: runtime_ref.to_string(),
         package_flags: tpkg::TPKG_FLAG_LEAN,
         launcher_abi: LAUNCHER_ABI,
+        // The L2 package manifest rides along only when the press declares
+        // one (today: a --jail policy); block-less packages keep the exact
+        // v1 shape. The entry's runtime_ref mirrors the trailer's, so old
+        // and new loaders resolve identically (spec 02 §5b).
         package_manifest: package_manifest.cloned(),
         ..Default::default()
     };
@@ -415,6 +449,72 @@ pub(crate) fn stitch(
     chmod_755(output);
     resign_if_needed(output);
     Ok(())
+}
+
+/// The L2 package manifest a `tebako press --jail` writes (spec 03 §6 /
+/// spec 02 §5b): minimal identity (press has no package-version input —
+/// a --package-version flag is a later milestone), one entry naming the
+/// package, `runtime_ref` mirroring the trailer field, and the jail
+/// request. The bootstrap reads this block and composes the jail with the
+/// user's tightening at handoff (spec 08 §2).
+fn press_package_manifest(
+    package: &str,
+    runtime_ref: &str,
+    tebako_version: &str,
+    jail: tpkg::HostJail,
+) -> tpkg::PackageManifest {
+    let stem = Path::new(package)
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| package.to_string());
+    tpkg::PackageManifest {
+        schema_version: tpkg::PACKAGE_SCHEMA_VERSION,
+        package: tpkg::PackageIdentity {
+            name: stem.clone(),
+            version: "0.0.0".to_string(),
+            producer: tpkg::Producer {
+                tool: "tebako-cli".to_string(),
+                tool_version: tebako_version.to_string(),
+            },
+            created: rfc3339_now(),
+        },
+        entries: vec![tpkg::PackageEntry {
+            name: stem.clone(),
+            slot: 0,
+            entrypoint: stem,
+            runtime_ref: runtime_ref.to_string(),
+        }],
+        jail: Some(jail),
+        env: Default::default(),
+    }
+}
+
+/// RFC 3339 UTC rendering of now (the manifest `created` convention; no
+/// chrono in the tree — the civil-from-days algorithm is Howard
+/// Hinnant's).
+fn rfc3339_now() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    rfc3339_utc(secs)
+}
+
+fn rfc3339_utc(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+    let (h, mi, s) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
 }
 
 fn chmod_755(path: &Path) {
@@ -679,5 +779,44 @@ fn human_age(installed_at: std::time::SystemTime) -> String {
         format!("{}h ago", age / 3600)
     } else {
         format!("{}d ago", age / 86_400)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3339_utc_known_dates() {
+        assert_eq!(rfc3339_utc(0), "1970-01-01T00:00:00Z");
+        assert_eq!(rfc3339_utc(951_782_400), "2000-02-29T00:00:00Z"); // leap day
+        assert_eq!(rfc3339_utc(1_704_067_200), "2024-01-01T00:00:00Z");
+        assert_eq!(rfc3339_utc(1_767_225_600), "2026-01-01T00:00:00Z");
+        assert_eq!(rfc3339_utc(86_399), "1970-01-01T23:59:59Z");
+    }
+
+    #[test]
+    fn press_package_manifest_carries_the_jail_and_mirrors_the_trailer() {
+        let jail = tpkg::HostJail::from_cli_spec("deny:arg").unwrap();
+        let m = press_package_manifest(
+            "/tmp/out/hello",
+            "ruby@3.4.2;tebako=0.15.9;image",
+            "0.15.9",
+            jail,
+        );
+        // Valid per the tpkg discipline (schema version, N>=1 entries, the
+        // jail block's own validation).
+        m.validate().unwrap();
+        assert_eq!(m.package.name, "hello");
+        assert_eq!(m.package.producer.tool, "tebako-cli");
+        assert_eq!(m.entries.len(), 1);
+        assert_eq!(m.entries[0].slot, 0);
+        assert_eq!(m.entries[0].runtime_ref, "ruby@3.4.2;tebako=0.15.9;image");
+        let jail = m.jail.as_ref().unwrap();
+        assert!(!jail.default_open);
+        assert!(jail.argument_files.auto);
+        // The YAML form survives a round trip (the block embeds as YAML).
+        let back = tpkg::PackageManifest::from_yaml(&m.to_yaml().unwrap()).unwrap();
+        assert_eq!(back, m);
     }
 }

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -12,9 +12,11 @@ const USAGE: &str = "Usage:
   tebako press -r <root> -e <entry> [-o <output>] [-p <prefix>] [-c <cwd>]
                [-R <ruby>] [-m lean|fat] [-l error|warn|debug|trace]
                [--image <path>:<mount>]... [--bootstrap <path>]
-               [--tebako-version <v>] [--prefer-local]
+               [--tebako-version <v>] [--prefer-local] [--jail <spec>]
   tebako press --suite <suite.yaml> [-o <output>] [-p <prefix>] [-R <ruby>]
                one package, N commands (spec 03 §6: per-entry slots + type-2 manifest)
+  tebako run <pkg> [--jail <spec>] [--mount <host:mount:ro|rw>]... [--no-host]
+               [--] [<args>...]
   tebako cache list [--json]
   tebako cache prune [--all] [--older-than Nd]
   tebako add-registry <ref>            register a tpkg-registry.yaml (spec 04 §2)
@@ -85,6 +87,7 @@ fn run(args: &[String]) -> Result<(), CliExit> {
             press(&opts)?;
             Ok(())
         }
+        "run" => run_package(rest),
         "cache" => run_cache(rest),
         "add-registry" => run_add_registry(rest),
         "list-registries" => run_list_registries(rest),
@@ -371,6 +374,19 @@ fn run_publish(args: &[String]) -> Result<(), CliExit> {
     Ok(())
 }
 
+/// `tebako run <pkg> [--jail <spec>] [--mount <host:mount:ro|rw>]...
+/// [--no-host] [--] [<args>...]` — the dispatch surface for a pressed
+/// package (spec 08 §2): the flags are the USER tightening; the package's
+/// own `jail:` request is composed in (manifest request ∩ user policy)
+/// and the effective jail rides TEBAKO_JAIL to the package's bootstrap.
+/// Never returns on success on unix (the process is replaced).
+fn run_package(args: &[String]) -> Result<(), CliExit> {
+    let parsed = tebako_cli::run::parse_run_args(args).map_err(CliExit::Usage)?;
+    let plan = tebako_cli::run::plan_run(&parsed).map_err(CliExit::Error)?;
+    let err = tebako_cli::run::exec_plan(&plan);
+    Err(CliExit::Error(err))
+}
+
 fn run_cache(args: &[String]) -> Result<(), CliExit> {
     let Some(action) = args.first() else {
         return Err(CliExit::Usage(
@@ -437,6 +453,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
     let mut prefer_local = false;
     let mut devmode = false;
     let mut suite: Option<PathBuf> = None;
+    let mut jail: Option<String> = None;
 
     let mut i = 0;
     while i < args.len() {
@@ -471,6 +488,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
             "--tebako-version" => tebako_version = take_value(&mut i)?,
             "--prefer-local" => prefer_local = true,
             "--suite" => suite = Some(PathBuf::from(take_value(&mut i)?)),
+            "--jail" => jail = Some(take_value(&mut i)?),
             "-D" | "--devmode" => devmode = true,
             "-t" | "--tebafile" => {
                 let _ = take_value(&mut i)?;
@@ -534,5 +552,6 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
         devmode,
         fs_current,
         suite,
+        jail,
     })
 }

--- a/crates/tebako-cli/src/options.rs
+++ b/crates/tebako-cli/src/options.rs
@@ -73,6 +73,10 @@ pub struct PressOptions {
     /// entry points come from the suite file; -r/-e are not accepted with
     /// it.
     pub suite: Option<PathBuf>,
+    /// --jail <spec> (spec 08): `open` | `deny` | `deny:arg` | a YAML file
+    /// | the TEBAKO_JAIL env grammar. Written into the type-2 package
+    /// manifest's `jail:` block — the package's host-access REQUEST.
+    pub jail: Option<String>,
 }
 
 impl PressOptions {

--- a/crates/tebako-cli/src/packager.rs
+++ b/crates/tebako-cli/src/packager.rs
@@ -781,6 +781,7 @@ mod tests {
             devmode: false,
             fs_current: "/tmp".to_string(),
             suite: None,
+            jail: None,
         }
     }
 

--- a/crates/tebako-cli/src/run.rs
+++ b/crates/tebako-cli/src/run.rs
@@ -1,0 +1,324 @@
+//! `tebako run <pkg>` — the dispatch surface for a pressed package
+//! (spec 08 §2): the user's tightening (`--jail`, `--mount`, `--no-host`)
+//! composed with the package's own `jail:` request — manifest request ∩
+//! user policy = effective jail, the user TIGHTENS, never loosens. The
+//! composed policy rides TEBAKO_JAIL to the package's bootstrap (which
+//! composes once more against its own manifest read — the algebra is
+//! idempotent, so old and new bootstraps behave identically) and the
+//! runtime driver enforces it (spec 17 §2).
+//!
+//! Flags before `--` are this surface's; everything after `--` (or after
+//! the first non-flag token) is the payload's, verbatim.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{packaging_error, plain_error, TebakoError};
+
+/// The parsed `tebako run` argv.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunArgs {
+    /// The package file to execute.
+    pub package: String,
+    /// Raw `--jail` spec (`open` | `deny` | `deny:arg` | a YAML file | the
+    /// TEBAKO_JAIL env grammar).
+    pub jail: Option<String>,
+    /// Raw `--mount host:mount:ro|rw` grants (repeatable).
+    pub mounts: Vec<String>,
+    /// `--no-host`: tighten to a deny default.
+    pub no_host: bool,
+    /// Payload args, verbatim.
+    pub args: Vec<String>,
+}
+
+/// The composed hand-off: the package, its args, and the jail env to
+/// export (empty when no policy applies — byte-identical legacy runs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunPlan {
+    pub program: PathBuf,
+    pub args: Vec<String>,
+    /// (key, value) pairs exported on top of the inherited environment.
+    pub env: Vec<(String, String)>,
+}
+
+/// Parse the `run` argv. Usage errors name the offending token (spec 14
+/// §3's named errors on malformed input).
+pub fn parse_run_args(args: &[String]) -> Result<RunArgs, String> {
+    let Some(package) = args.first() else {
+        return Err(
+            "usage: tebako run <pkg> [--jail <spec>] [--mount <host:mount:ro|rw>]... [--no-host] [--] [<args>...]"
+                .to_string(),
+        );
+    };
+    let mut jail = None;
+    let mut mounts = Vec::new();
+    let mut no_host = false;
+    let mut payload: Vec<String> = Vec::new();
+    let mut i = 1;
+    while i < args.len() {
+        let arg = &args[i];
+        let (flag, inline) = match arg.split_once('=') {
+            Some((f, v)) if f.starts_with("--") => (f, Some(v.to_string())),
+            _ => (arg.as_str(), None),
+        };
+        match flag {
+            "--" => {
+                payload.extend_from_slice(&args[i + 1..]);
+                break;
+            }
+            "--jail" | "--mount" => {
+                let value = match inline {
+                    Some(v) => v,
+                    None => {
+                        i += 1;
+                        args.get(i)
+                            .cloned()
+                            .ok_or_else(|| format!("option '{flag}' requires a value"))?
+                    }
+                };
+                if flag == "--jail" {
+                    jail = Some(value);
+                } else {
+                    mounts.push(value);
+                }
+            }
+            "--no-host" => {
+                if inline.is_some() {
+                    return Err("option '--no-host' takes no value".to_string());
+                }
+                no_host = true;
+            }
+            _ if flag.starts_with("--") => {
+                return Err(format!(
+                    "unknown run option '{flag}' (payload options ride after `--`)"
+                ));
+            }
+            _ => {
+                // The first non-flag token starts the payload's argv.
+                payload.extend_from_slice(&args[i..]);
+                break;
+            }
+        }
+        i += 1;
+    }
+    Ok(RunArgs {
+        package: package.clone(),
+        jail,
+        mounts,
+        no_host,
+        args: payload,
+    })
+}
+
+/// The user's tightening from the parsed flags (the shared
+/// dispatch-surface composer, `tpkg::jail::HostJail::from_dispatch_flags`).
+/// `None` when no flag was given at all.
+fn user_jail(parsed: &RunArgs) -> Result<Option<tpkg::HostJail>, TebakoError> {
+    tpkg::HostJail::from_dispatch_flags(parsed.jail.as_deref(), &parsed.mounts, parsed.no_host)
+        .map_err(|e| packaging_error(130, Some(&e.to_string())))
+}
+
+/// The package's jail request (the type-2 block's `jail:`); `None` for a
+/// block-less or trailer-less package (classic bundles dispatch with the
+/// user's tightening alone).
+fn package_jail(package: &Path) -> Result<Option<tpkg::HostJail>, TebakoError> {
+    let mut f = std::fs::File::open(package).map_err(|e| {
+        plain_error(format!(
+            "cannot open the package {}: {e}",
+            package.display()
+        ))
+    })?;
+    match tpkg::read_from(&mut f) {
+        Ok(m) => match m.package_manifest() {
+            Ok(pm) => Ok(pm.and_then(|pm| pm.jail)),
+            Err(e) => Err(plain_error(format!(
+                "invalid package manifest (extension block type 2) in {}: {e}",
+                package.display()
+            ))),
+        },
+        Err(tpkg::TpkgError::NoTrailer) => Ok(None),
+        Err(e) => Err(plain_error(format!(
+            "corrupt tebako manifest trailer in {} ({})",
+            package.display(),
+            tpkg::strerror(e.code())
+        ))),
+    }
+}
+
+/// Compose the run plan: package jail request ∩ user tightening, rendered
+/// to the TEBAKO_JAIL env pair. With `argument_files: auto-allowed` the
+/// payload args naming existing files become read-only grants (resolved
+/// against this process's cwd, which the child inherits). The composed
+/// policy is bind-validated NOW — a grant naming a missing host path is a
+/// named error here, not a surprise inside the package.
+pub fn plan_run(parsed: &RunArgs) -> Result<RunPlan, TebakoError> {
+    let program = PathBuf::from(&parsed.package);
+    if !program.is_file() {
+        return Err(packaging_error(
+            127,
+            Some(&format!("package not found: {}", parsed.package)),
+        ));
+    }
+    let user = user_jail(parsed)?;
+    let package = package_jail(&program)?;
+    let mut env = Vec::new();
+    if let Some((jail, source)) = tpkg::jail::effective(package.as_ref(), user.as_ref()) {
+        if !jail.is_trivially_open() {
+            let arg_files = if jail.argument_files.auto {
+                tpkg::jail::resolve_argument_files(&parsed.args)
+            } else {
+                Vec::new()
+            };
+            let spec = jail.to_env_spec(&arg_files);
+            validate_binds(&spec)?;
+            env.push(("TEBAKO_JAIL".to_string(), spec));
+            env.push(("TEBAKO_JAIL_SOURCE".to_string(), source.to_string()));
+        }
+    }
+    Ok(RunPlan {
+        program,
+        args: parsed.args.clone(),
+        env,
+    })
+}
+
+/// Bind-check the composed env spec (grant paths must exist at dispatch
+/// time — the same fail-early contract as `tfs exec --jail`).
+#[cfg(unix)]
+fn validate_binds(spec: &str) -> Result<(), TebakoError> {
+    let parsed = tfs::policy::JailSpec::parse(spec)
+        .map_err(|e| packaging_error(130, Some(&e.to_string())))?;
+    tfs::policy::HostPolicy::bind(parsed.default_open, parsed.mounts, parsed.arg_files).map_err(
+        |e| {
+            let text = String::from_utf8_lossy(tfs::errno::strerror(e)).into_owned();
+            packaging_error(
+                130,
+                Some(&format!("--jail/--mount: cannot bind policy: {text}")),
+            )
+        },
+    )?;
+    Ok(())
+}
+
+/// Non-unix platforms skip the eager bind (the driver validates at install;
+/// the preload/exec path is unix-first, spec 07 §8).
+#[cfg(not(unix))]
+fn validate_binds(_spec: &str) -> Result<(), TebakoError> {
+    Ok(())
+}
+
+/// Execute the plan, replacing the process (unix). Never returns on
+/// success; the error return is the spawn failure.
+#[cfg(unix)]
+pub fn exec_plan(plan: &RunPlan) -> TebakoError {
+    use std::os::unix::process::CommandExt;
+    let mut cmd = std::process::Command::new(&plan.program);
+    cmd.args(&plan.args);
+    for (k, v) in &plan.env {
+        cmd.env(k, v);
+    }
+    let err = cmd.exec();
+    plain_error(format!(
+        "cannot execute the package {}: {err}",
+        plan.program.display()
+    ))
+}
+
+/// Windows has no execve(2): spawn, wait, and propagate the child's exit
+/// code (the bootstrap's own handoff rule).
+#[cfg(not(unix))]
+pub fn exec_plan(plan: &RunPlan) -> TebakoError {
+    let mut cmd = std::process::Command::new(&plan.program);
+    cmd.args(&plan.args);
+    for (k, v) in &plan.env {
+        cmd.env(k, v);
+    }
+    match cmd.spawn().and_then(|mut child| child.wait()) {
+        Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+        Err(e) => plain_error(format!(
+            "cannot execute the package {}: {e}",
+            plan.program.display()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(tokens: &[&str]) -> Vec<String> {
+        tokens.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_flags_and_payload_split() {
+        let p = parse_run_args(&args(&[
+            "pkg",
+            "--jail",
+            "deny",
+            "--mount",
+            "/a:/a:ro",
+            "--mount=/b:/b:rw",
+            "--no-host",
+            "--",
+            "-x",
+            "in.csv",
+        ]))
+        .unwrap();
+        assert_eq!(p.package, "pkg");
+        assert_eq!(p.jail, Some("deny".to_string()));
+        assert_eq!(
+            p.mounts,
+            vec!["/a:/a:ro".to_string(), "/b:/b:rw".to_string()]
+        );
+        assert!(p.no_host);
+        assert_eq!(p.args, vec!["-x".to_string(), "in.csv".to_string()]);
+
+        // No `--`: the first non-flag token starts the payload argv.
+        let p = parse_run_args(&args(&["pkg", "--no-host", "input.csv", "--verbose"])).unwrap();
+        assert!(p.no_host);
+        assert_eq!(
+            p.args,
+            vec!["input.csv".to_string(), "--verbose".to_string()]
+        );
+
+        // No flags at all.
+        let p = parse_run_args(&args(&["pkg"])).unwrap();
+        assert_eq!(p.jail, None);
+        assert!(p.args.is_empty());
+
+        // Errors.
+        assert!(parse_run_args(&args(&[])).is_err());
+        assert!(parse_run_args(&args(&["pkg", "--jail"])).is_err());
+        assert!(parse_run_args(&args(&["pkg", "--frobnicate"])).is_err());
+        assert!(parse_run_args(&args(&["pkg", "--no-host=x"])).is_err());
+    }
+
+    #[test]
+    fn user_jail_composition() {
+        // --no-host alone: deny.
+        let p = parse_run_args(&args(&["pkg", "--no-host"])).unwrap();
+        assert_eq!(user_jail(&p).unwrap(), Some(tpkg::HostJail::deny()));
+        // --no-host tightens even an explicit --jail open (never loosens).
+        let p = parse_run_args(&args(&["pkg", "--jail", "open", "--no-host"])).unwrap();
+        assert_eq!(user_jail(&p).unwrap(), Some(tpkg::HostJail::deny()));
+        // --mount under an open default keeps the access bit (docker-style).
+        let p = parse_run_args(&args(&["pkg", "--mount", "/a:/work:ro"])).unwrap();
+        let user = user_jail(&p).unwrap().unwrap();
+        assert!(user.default_open);
+        assert_eq!(user.mounts.len(), 1);
+        assert_eq!(user.mounts[0].access, tpkg::jail::JailAccess::Ro);
+        // --jail deny:arg + --mount.
+        let p =
+            parse_run_args(&args(&["pkg", "--jail", "deny:arg", "--mount", "/a:/w:rw"])).unwrap();
+        let user = user_jail(&p).unwrap().unwrap();
+        assert!(!user.default_open);
+        assert!(user.argument_files.auto);
+        assert_eq!(user.mounts.len(), 1);
+        // No flags: no tightening.
+        let p = parse_run_args(&args(&["pkg"])).unwrap();
+        assert_eq!(user_jail(&p).unwrap(), None);
+        // A malformed grant is a named (130) error.
+        let p = parse_run_args(&args(&["pkg", "--mount", "frob"])).unwrap();
+        assert_eq!(user_jail(&p).unwrap_err().code, 130);
+    }
+}

--- a/crates/tebako-cli/tests/run.rs
+++ b/crates/tebako-cli/tests/run.rs
@@ -1,0 +1,223 @@
+//! `tebako run` e2e (spec 08 §2 — the dispatch surface): the user's
+//! tightening flags composed with the package's own `jail:` request reach
+//! the package as TEBAKO_JAIL (+ the audit source label). The fixture
+//! "package" is a shell script with a tpkg trailer stitched on — the
+//! kernel execs the shebang and the script reports the env; the trailer
+//! bytes after `exit 0` are never read. Unix only (shebang exec).
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn tebako_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_tebako"))
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "tebako-run-e2e-{tag}-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+const PROBE: &str = "#!/bin/sh\n\
+echo \"JAIL=${TEBAKO_JAIL-UNSET}\"\n\
+echo \"JAIL-SOURCE=${TEBAKO_JAIL_SOURCE-UNSET}\"\n\
+exit 0\n";
+
+fn package_manifest(jail: tpkg::HostJail) -> tpkg::PackageManifest {
+    tpkg::PackageManifest {
+        schema_version: tpkg::PACKAGE_SCHEMA_VERSION,
+        package: tpkg::PackageIdentity {
+            name: "probe".to_string(),
+            version: "1.0.0".to_string(),
+            producer: tpkg::Producer {
+                tool: "tebako-cli".to_string(),
+                tool_version: "0.15.9".to_string(),
+            },
+            created: "2026-07-27T00:00:00Z".to_string(),
+        },
+        entries: vec![tpkg::PackageEntry {
+            name: "probe".to_string(),
+            slot: 0,
+            entrypoint: "probe".to_string(),
+            runtime_ref: "ruby@9.9.9;tebako=9.9.9".to_string(),
+        }],
+        jail: Some(jail),
+        env: Default::default(),
+    }
+}
+
+/// The probe script + one dummy slot + optional type-2 jail block.
+fn script_pkg(dir: &Path, name: &str, jail: Option<tpkg::HostJail>) -> PathBuf {
+    let pkg = dir.join(name);
+    std::fs::write(&pkg, PROBE).unwrap();
+    let payload = dir.join(format!("{name}.payload"));
+    std::fs::write(&payload, b"fake image payload").unwrap();
+
+    let mut m = tpkg::Manifest {
+        package_flags: 0,
+        launcher_abi: 0,
+        ..Default::default()
+    };
+    m.set_runtime_ref(b"ruby@9.9.9;tebako=9.9.9");
+    let base = std::fs::metadata(&pkg).unwrap().len();
+    let size = std::fs::metadata(&payload).unwrap().len();
+    m.slots.push(tpkg::Slot::new(
+        base,
+        size,
+        tpkg::TPKG_FORMAT_DWARFS,
+        "/__tebako_memfs__",
+    ));
+    if let Some(jail) = jail {
+        m.set_package_manifest(&package_manifest(jail)).unwrap();
+    }
+    {
+        use std::io::Write as _;
+        let mut f = std::fs::OpenOptions::new().append(true).open(&pkg).unwrap();
+        f.write_all(&std::fs::read(&payload).unwrap()).unwrap();
+        tpkg::write_to(&mut f, &m).unwrap();
+    }
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&pkg, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    pkg
+}
+
+struct Run {
+    rc: i32,
+    stdout: String,
+    stderr: String,
+}
+
+fn tebako_run(args: &[&str]) -> Run {
+    let out = Command::new(tebako_bin())
+        .arg("run")
+        .args(args)
+        .output()
+        .unwrap();
+    Run {
+        rc: out.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+fn line<'a>(stdout: &'a str, key: &str) -> &'a str {
+    stdout
+        .lines()
+        .find_map(|l| l.strip_prefix(key))
+        .unwrap_or_else(|| panic!("{key} missing from stdout:\n{stdout}"))
+}
+
+#[test]
+fn run_package_jail_alone_maps_to_tebako_jail() {
+    let dir = workdir("manifest");
+    let input = dir.join("in.csv");
+    std::fs::write(&input, b"x").unwrap();
+    let pkg = script_pkg(&dir, "pkg1", Some(tpkg::HostJail::deny_with_arg_files()));
+
+    let r = tebako_run(&[pkg.to_str().unwrap(), "--", input.to_str().unwrap()]);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(
+        line(&r.stdout, "JAIL="),
+        format!("deny;@{}", input.display())
+    );
+    assert_eq!(line(&r.stdout, "JAIL-SOURCE="), "manifest");
+}
+
+#[test]
+fn run_user_tightening_intersects_never_loosens() {
+    let dir = workdir("precedence");
+    let mut package = tpkg::HostJail::deny();
+    package.mounts.push(tpkg::JailMount {
+        host: "/data".to_string(),
+        mount: "/data".to_string(),
+        access: tpkg::JailAccess::Ro,
+    });
+    let pkg = script_pkg(&dir, "pkg2", Some(package));
+
+    // --no-host caps the manifest's grant (the user TIGHTENS, wins).
+    let r = tebako_run(&[pkg.to_str().unwrap(), "--no-host"]);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(line(&r.stdout, "JAIL="), "deny");
+    assert_eq!(line(&r.stdout, "JAIL-SOURCE="), "manifest+user");
+}
+
+#[test]
+fn run_user_flags_alone_when_the_package_is_silent() {
+    let dir = workdir("user");
+    let pkg = script_pkg(&dir, "pkg3", None);
+    let work = dir.join("work");
+    std::fs::create_dir_all(&work).unwrap();
+
+    let spec = format!("{}:/work:rw", work.display());
+    let r = tebako_run(&[pkg.to_str().unwrap(), "--jail", "deny", "--mount", &spec]);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(
+        line(&r.stdout, "JAIL="),
+        format!("deny;{}:/work:rw", work.display())
+    );
+    assert_eq!(line(&r.stdout, "JAIL-SOURCE="), "user");
+}
+
+#[test]
+fn run_no_policy_anywhere_exports_nothing() {
+    let dir = workdir("legacy");
+    let pkg = script_pkg(&dir, "pkg4", None);
+
+    let r = tebako_run(&[pkg.to_str().unwrap()]);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(line(&r.stdout, "JAIL="), "UNSET");
+    assert_eq!(line(&r.stdout, "JAIL-SOURCE="), "UNSET");
+}
+
+#[test]
+fn run_mount_with_a_missing_host_fails_at_dispatch() {
+    let dir = workdir("bindfail");
+    let pkg = script_pkg(&dir, "pkg5", None);
+
+    let r = tebako_run(&[
+        pkg.to_str().unwrap(),
+        "--jail",
+        "deny",
+        "--mount",
+        "/no/such/dir-xyz:/w:ro",
+    ]);
+    assert_eq!(r.rc, 130, "stdout: {} stderr: {}", r.stdout, r.stderr);
+    assert!(
+        r.stdout.contains("cannot bind policy"),
+        "stdout: {}",
+        r.stdout
+    );
+}
+
+#[test]
+fn run_rejects_unknown_options_and_missing_values() {
+    let dir = workdir("usage");
+    let pkg = script_pkg(&dir, "pkg6", None);
+
+    let r = tebako_run(&[pkg.to_str().unwrap(), "--frobnicate"]);
+    assert_eq!(r.rc, 1);
+    assert!(
+        r.stderr.contains("unknown run option"),
+        "stderr: {}",
+        r.stderr
+    );
+
+    let r = tebako_run(&[pkg.to_str().unwrap(), "--jail"]);
+    assert_eq!(r.rc, 1);
+    assert!(
+        r.stderr.contains("requires a value"),
+        "stderr: {}",
+        r.stderr
+    );
+}

--- a/crates/tebako-cli/tests/suite.rs
+++ b/crates/tebako-cli/tests/suite.rs
@@ -30,6 +30,7 @@ fn opts() -> PressOptions {
         devmode: true,
         fs_current: "/tmp".to_string(),
         suite: None,
+        jail: None,
     }
 }
 

--- a/crates/tebako-pkg/src/lib.rs
+++ b/crates/tebako-pkg/src/lib.rs
@@ -40,8 +40,8 @@ pub enum SignRequest {
 
 /// Package-level options (trailer fields besides the slots).
 ///
-/// `Eq` is deliberately not derived: `package_manifest` carries YAML
-/// values (spec 08's `jail` block) which are `PartialEq` only.
+/// `Eq` is deliberately not derived: `package_manifest`'s semantic equality
+/// is a YAML-level question; structural equality is all bundling needs.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct PackageOptions {
     pub runtime_ref: String,

--- a/crates/tebako-shim/Cargo.toml
+++ b/crates/tebako-shim/Cargo.toml
@@ -13,7 +13,10 @@ categories = ["command-line-utilities"]
 [dependencies]
 # The unified payload-manifest model (spec 03 — item 40's manifest
 # unify): the dispatch mirror is a tpkg::PayloadManifest; constraint
-# grammar is tpkg's, the dispatcher only evaluates.
+# grammar is tpkg's, the dispatcher only evaluates. tpkg::jail is the
+# spec 08 jail model (the mirror's capabilities.host, composed with the
+# dispatch flags into TEBAKO_JAIL — the engine stays out of the
+# dispatcher).
 tpkg = { version = "0.1.0", path = "../tpkg" }
 # Remote registry resolution at dispatch time (spec 04 §2 — item 33):
 # every registry form (service contents API, pinned release artifact, git

--- a/crates/tebako-shim/src/dispatch.rs
+++ b/crates/tebako-shim/src/dispatch.rs
@@ -127,7 +127,9 @@ fn dependency_mount(
 /// runtime → compose the mount set → the ABI v1 exec plan.
 pub fn dispatch(tool: &str, user_args: &[String], ctx: &Ctx) -> Result<ExecPlan, ShimError> {
     let res = resolve::resolve(tool, ctx)?;
-    plan(&res, user_args, ctx, true)
+    let (flags, args) = parse_jail_flags(user_args)?;
+    let jail_env = compose_jail_env(&res, &flags, &args, ctx)?;
+    plan(&res, &args, ctx, true, jail_env)
 }
 
 /// The plan behind [`dispatch`], parameterized so `which` can resolve
@@ -137,6 +139,7 @@ pub fn plan(
     user_args: &[String],
     ctx: &Ctx,
     allow_download: bool,
+    jail_env: Vec<(String, String)>,
 ) -> Result<ExecPlan, ShimError> {
     let entry = res
         .manifest
@@ -194,6 +197,10 @@ pub fn plan(
     argv.extend(entry.args_default.iter().cloned());
     argv.extend(user_args.iter().cloned());
 
+    // spec 08: the dispatcher's computed jail env always wins over every
+    // manifest/host value (spec 07 §9 env composition).
+    env.extend(jail_env);
+
     Ok(ExecPlan {
         program,
         argv,
@@ -201,6 +208,113 @@ pub fn plan(
         mounts,
         runtime,
     })
+}
+
+// ---------------------------------------------------------------------
+// Jail flags (spec 08 §2 — the dispatcher's tightening surface)
+// ---------------------------------------------------------------------
+
+/// The dispatcher's jail flags: `--jail <spec>` (`open` | `deny` |
+/// `deny:arg` | a YAML file | the TEBAKO_JAIL env grammar), `--mount
+/// <host:mount:ro|rw>` (repeatable), `--no-host`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct JailFlags {
+    pub jail: Option<String>,
+    pub mounts: Vec<String>,
+    pub no_host: bool,
+}
+
+/// Split the dispatcher's flags from the payload's argv. Only the exact
+/// known tokens are consumed; anything else — unknown flags included —
+/// stops the scan and rides to the payload verbatim (a shim's whole job
+/// is forwarding argv). `--` ends the scan; everything after it is the
+/// payload's (the escape hatch for payload args literally named
+/// `--jail`/`--mount`/`--no-host`).
+pub fn parse_jail_flags(args: &[String]) -> Result<(JailFlags, Vec<String>), ShimError> {
+    let mut flags = JailFlags::default();
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        let (flag, inline) = match arg.split_once('=') {
+            Some((f, v)) if f.starts_with("--") => (f, Some(v.to_string())),
+            _ => (arg.as_str(), None),
+        };
+        match flag {
+            "--" => return Ok((flags, args[i + 1..].to_vec())),
+            "--jail" | "--mount" => {
+                let value = match inline {
+                    Some(v) => v,
+                    None => {
+                        i += 1;
+                        args.get(i).cloned().ok_or_else(|| {
+                            ShimError::new(
+                                crate::EX_USAGE,
+                                format!("option '{flag}' requires a value"),
+                            )
+                        })?
+                    }
+                };
+                if flag == "--jail" {
+                    flags.jail = Some(value);
+                } else {
+                    flags.mounts.push(value);
+                }
+            }
+            "--no-host" => {
+                if inline.is_some() {
+                    return fail(crate::EX_USAGE, "option '--no-host' takes no value");
+                }
+                flags.no_host = true;
+            }
+            _ => {
+                // A non-flag token or an unknown flag: the payload's,
+                // verbatim (a shim's whole job is forwarding argv; unknown
+                // flags belong to payload CLIs).
+                return Ok((flags, args[i..].to_vec()));
+            }
+        }
+        i += 1;
+    }
+    Ok((flags, Vec::new()))
+}
+
+/// Compose the dispatch-time jail env (spec 08 §2/§4): the payload
+/// mirror's `capabilities.host` REQUEST ∩ the user's tightening flags =
+/// the effective jail, exported as TEBAKO_JAIL with the audit source
+/// (TEBAKO_JAIL_SOURCE) and the journal pointer (TEBAKO_JAIL_JOURNAL →
+/// this home's journal.log, the bootstrap's convention). With
+/// `argument_files: auto-allowed` the payload args naming existing files
+/// become read-only grants. Empty when no policy applies (byte-identical
+/// legacy dispatch).
+pub fn compose_jail_env(
+    res: &Resolution,
+    flags: &JailFlags,
+    args: &[String],
+    ctx: &Ctx,
+) -> Result<Vec<(String, String)>, ShimError> {
+    let request = res.manifest.host_jail();
+    let user =
+        tpkg::HostJail::from_dispatch_flags(flags.jail.as_deref(), &flags.mounts, flags.no_host)
+            .map_err(|e| ShimError::new(crate::EX_USAGE, format!("{e}")))?;
+    let Some((jail, source)) = tpkg::jail::effective(request, user.as_ref()) else {
+        return Ok(Vec::new());
+    };
+    if jail.is_trivially_open() {
+        return Ok(Vec::new());
+    }
+    let arg_files = if jail.argument_files.auto {
+        tpkg::jail::resolve_argument_files(args)
+    } else {
+        Vec::new()
+    };
+    Ok(vec![
+        ("TEBAKO_JAIL".to_string(), jail.to_env_spec(&arg_files)),
+        ("TEBAKO_JAIL_SOURCE".to_string(), source.to_string()),
+        (
+            "TEBAKO_JAIL_JOURNAL".to_string(),
+            ctx.home.join("journal.log").to_string_lossy().into_owned(),
+        ),
+    ])
 }
 
 /// Exec the plan, replacing the process (unix). Never returns on success.

--- a/crates/tebako-shim/src/manage.rs
+++ b/crates/tebako-shim/src/manage.rs
@@ -235,7 +235,7 @@ fn cmd_which(args: &[String], ctx: &Ctx) -> Result<Action, ShimError> {
         return fail(EX_USAGE, "usage: tebako-shim which <tool>");
     };
     let res: Resolution = resolve::resolve(tool, ctx)?;
-    let plan: ExecPlan = dispatch::plan(&res, &[], ctx, false)?;
+    let plan: ExecPlan = dispatch::plan(&res, &[], ctx, false, Vec::new())?;
     let entry = res
         .manifest
         .entrypoint(tool)

--- a/crates/tebako-shim/src/manifest.rs
+++ b/crates/tebako-shim/src/manifest.rs
@@ -95,6 +95,16 @@ impl Manifest {
         &self.inner.requires
     }
 
+    /// The payload's declared host-access request (spec 08 §4 — the app
+    /// PROVIDES `capabilities.host`; the dispatcher composes it with the
+    /// user's tightening flags, spec 08 §2).
+    pub fn host_jail(&self) -> Option<&tpkg::HostJail> {
+        match &self.inner.provides {
+            Provides::App(app) => app.capabilities.host.as_ref(),
+            _ => None,
+        }
+    }
+
     /// Write the manifest mirror (the installer's half of the payload
     /// record): tmp + rename, like every cache-managed file. The manifest
     /// is re-validated on the way out (`to_yaml`).

--- a/crates/tebako-shim/tests/dispatch.rs
+++ b/crates/tebako-shim/tests/dispatch.rs
@@ -185,7 +185,7 @@ fn which_mode_never_downloads() {
     let mut ctx = ctx(&home, tmp.path());
     pin_env(&mut ctx, "metanorma", "1.2.3");
     let res = tebako_shim::resolve::resolve("metanorma", &ctx).unwrap();
-    let err = dispatch::plan(&res, &[], &ctx, false).unwrap_err();
+    let err = dispatch::plan(&res, &[], &ctx, false, Vec::new()).unwrap_err();
     assert_eq!(err.code, tebako_shim::EX_TEBAKO_UNAVAILABLE);
     assert!(err.message.contains("would download"), "{}", err.message);
 }
@@ -232,4 +232,213 @@ fn suite_commands_run_different_runtime_versions_simultaneously() {
     assert_eq!(plan_b.mounts[0].image, image);
     assert!(plan_a.argv.iter().any(|a| a == "/app/bin/metanorma"));
     assert!(plan_b.argv.iter().any(|a| a == "/app/bin/mn2pdf"));
+}
+
+// ---------------------------------------------------------------------
+// Jail flags (spec 08 §2/§4 — the dispatcher's tightening surface)
+// ---------------------------------------------------------------------
+
+fn env_get<'a>(plan: &'a dispatch::ExecPlan, key: &str) -> Option<&'a str> {
+    plan.env
+        .iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.as_str())
+}
+
+/// An app manifest mirror whose `capabilities.host` declares the jail
+/// request (spec 08 §4) in the unified payload-manifest shape.
+fn jailed_manifest(tool: &str, version: &str, host_yaml: &str) -> String {
+    format!(
+        "identity:\n  schema_version: 1\n  kind: app\n  name: {tool}\n  version: \"{version}\"\n  producer: {{tool: tebako-shim-tests, tool_version: \"1\"}}\n  created: \"2026-07-27T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{}\"\n    blob_sha256: {}\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n  entrypoints:\n    - name: {tool}\n      path: /app/bin/{tool}\n      runtime_requirement: {{engine: ruby, constraint: \">= 3.3, < 5.0\"}}\n  platforms: universal\n  capabilities: {{exec: true, read: true, host: {host_yaml}}}\n",
+        "a".repeat(64),
+        "b".repeat(64),
+    )
+}
+
+fn seed_jailed_tool(
+    home: &std::path::Path,
+    tool: &str,
+    host_yaml: &str,
+    version: &str,
+) -> std::path::PathBuf {
+    write_payload(
+        home,
+        tool,
+        version,
+        &jailed_manifest(tool, version, host_yaml),
+    )
+}
+
+#[test]
+fn jail_flags_split_from_payload_args() {
+    let args: Vec<String> = [
+        "--no-host",
+        "--jail=deny",
+        "--mount",
+        "/a:/a:ro",
+        "in.csv",
+        "--verbose",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    let (flags, rest) = dispatch::parse_jail_flags(&args).unwrap();
+    assert!(flags.no_host);
+    assert_eq!(flags.jail.as_deref(), Some("deny"));
+    assert_eq!(flags.mounts, vec!["/a:/a:ro".to_string()]);
+    assert_eq!(rest, vec!["in.csv".to_string(), "--verbose".to_string()]);
+
+    // `--` ends the scan; a payload arg literally named --jail survives.
+    let args: Vec<String> = ["--no-host", "--", "--jail", "x"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let (flags, rest) = dispatch::parse_jail_flags(&args).unwrap();
+    assert!(flags.no_host);
+    assert_eq!(rest, vec!["--jail".to_string(), "x".to_string()]);
+
+    // Unknown flags are the payload's (a shim forwards argv).
+    let args: Vec<String> = ["--verbose", "--no-host"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let (flags, rest) = dispatch::parse_jail_flags(&args).unwrap();
+    assert!(!flags.no_host);
+    assert_eq!(rest.len(), 2);
+
+    // A missing value is a named usage error.
+    let args: Vec<String> = vec!["--jail".to_string()];
+    let err = dispatch::parse_jail_flags(&args).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_USAGE);
+}
+
+#[test]
+fn dispatch_no_jail_anywhere_exports_no_jail_env() {
+    let tmp = TempDir::new("jail-none");
+    let home = tmp.path().join("home");
+    seed_tool(
+        &home,
+        "metanorma",
+        &entrypoint_yaml(RUBY_ENTRY, "metanorma"),
+        "1.2.3",
+    );
+    write_runtime(&home, "4.0.6", "0.16.0", false);
+    let mut ctx = ctx(&home, tmp.path());
+    pin_env(&mut ctx, "metanorma", "1.2.3");
+
+    let plan = dispatch::dispatch("metanorma", &["doc.xml".into()], &ctx).unwrap();
+    assert_eq!(env_get(&plan, "TEBAKO_JAIL"), None);
+    assert_eq!(env_get(&plan, "TEBAKO_JAIL_SOURCE"), None);
+    assert_eq!(env_get(&plan, "TEBAKO_JAIL_JOURNAL"), None);
+}
+
+#[test]
+fn dispatch_manifest_request_alone_maps_to_tebako_jail() {
+    let tmp = TempDir::new("jail-manifest");
+    let home = tmp.path().join("home");
+    seed_jailed_tool(
+        &home,
+        "metanorma",
+        "{default: deny, argument_files: auto-allowed}",
+        "1.2.3",
+    );
+    write_runtime(&home, "4.0.6", "0.16.0", false);
+    let mut ctx = ctx(&home, tmp.path());
+    pin_env(&mut ctx, "metanorma", "1.2.3");
+
+    // An existing payload arg becomes the argument-file grant.
+    let input = tmp.path().join("doc.xml");
+    std::fs::write(&input, b"<doc/>").unwrap();
+    let plan = dispatch::dispatch(
+        "metanorma",
+        &["compile".into(), input.to_string_lossy().into_owned()],
+        &ctx,
+    )
+    .unwrap();
+    assert_eq!(
+        env_get(&plan, "TEBAKO_JAIL"),
+        Some(format!("deny;@{}", input.display()).as_str())
+    );
+    assert_eq!(env_get(&plan, "TEBAKO_JAIL_SOURCE"), Some("manifest"));
+    assert_eq!(
+        env_get(&plan, "TEBAKO_JAIL_JOURNAL"),
+        Some(home.join("journal.log").to_string_lossy().as_ref())
+    );
+    // The payload args pass through untouched.
+    assert_eq!(
+        plan.argv.last().unwrap(),
+        &input.to_string_lossy().into_owned()
+    );
+}
+
+#[test]
+fn dispatch_user_tightening_intersects_never_loosens() {
+    let tmp = TempDir::new("jail-precedence");
+    let home = tmp.path().join("home");
+    // The manifest requests /data ro under deny; --no-host caps it.
+    seed_jailed_tool(
+        &home,
+        "metanorma",
+        "{default: deny, mounts: [{host: /data, mount: /data, access: ro}]}",
+        "1.2.3",
+    );
+    write_runtime(&home, "4.0.6", "0.16.0", false);
+    let mut ctx = ctx(&home, tmp.path());
+    pin_env(&mut ctx, "metanorma", "1.2.3");
+
+    let plan = dispatch::dispatch("metanorma", &["--no-host".into()], &ctx).unwrap();
+    assert_eq!(env_get(&plan, "TEBAKO_JAIL"), Some("deny"));
+    assert_eq!(env_get(&plan, "TEBAKO_JAIL_SOURCE"), Some("manifest+user"));
+    // And --no-host survives as a dispatcher flag, never reaching argv.
+    assert!(!plan.argv.iter().any(|a| a == "--no-host"));
+}
+
+#[test]
+fn dispatch_user_flags_alone_apply_when_the_manifest_is_silent() {
+    let tmp = TempDir::new("jail-user");
+    let home = tmp.path().join("home");
+    seed_tool(
+        &home,
+        "metanorma",
+        &entrypoint_yaml(RUBY_ENTRY, "metanorma"),
+        "1.2.3",
+    );
+    write_runtime(&home, "4.0.6", "0.16.0", false);
+    let mut ctx = ctx(&home, tmp.path());
+    pin_env(&mut ctx, "metanorma", "1.2.3");
+
+    let work = tmp.path().join("work");
+    std::fs::create_dir_all(&work).unwrap();
+    let spec = format!("--mount={}:/work:rw", work.display());
+    let plan = dispatch::dispatch(
+        "metanorma",
+        &["--jail".into(), "deny".into(), spec, "compile".into()],
+        &ctx,
+    )
+    .unwrap();
+    assert_eq!(
+        env_get(&plan, "TEBAKO_JAIL"),
+        Some(format!("deny;{}:/work:rw", work.display()).as_str())
+    );
+    assert_eq!(env_get(&plan, "TEBAKO_JAIL_SOURCE"), Some("user"));
+    assert_eq!(plan.argv.last().unwrap(), "compile");
+}
+
+#[test]
+fn dispatch_malformed_jail_flag_is_a_usage_error() {
+    let tmp = TempDir::new("jail-bad");
+    let home = tmp.path().join("home");
+    seed_tool(
+        &home,
+        "metanorma",
+        &entrypoint_yaml(RUBY_ENTRY, "metanorma"),
+        "1.2.3",
+    );
+    write_runtime(&home, "4.0.6", "0.16.0", false);
+    let mut ctx = ctx(&home, tmp.path());
+    pin_env(&mut ctx, "metanorma", "1.2.3");
+
+    let err = dispatch::dispatch("metanorma", &["--jail".into(), "frob".into()], &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_USAGE);
+    assert!(err.message.contains("invalid jail spec"), "{}", err.message);
 }

--- a/crates/tfs-cli/src/lib.rs
+++ b/crates/tfs-cli/src/lib.rs
@@ -1132,10 +1132,14 @@ fn exec_child(
         .env_remove(preload_var())
         .env_remove("TEBAKO_TFS_MOUNTS")
         .env_remove("TEBAKO_JAIL")
+        .env_remove("TEBAKO_JAIL_SOURCE")
         .env(preload_var(), shim)
         .env("TEBAKO_TFS_MOUNTS", mounts_env);
     if let Some(j) = jail_env {
         command.env("TEBAKO_JAIL", j);
+        // The audit-journal source label (spec 08 §2): this policy came
+        // from the exec surface's --jail flag.
+        command.env("TEBAKO_JAIL_SOURCE", "tfs exec --jail");
     }
     let err = command.exec(); // returns only on failure
     Err((format!("Error: cannot exec {cmd}: {err}"), 1))

--- a/crates/tfs-cli/tests/exec.rs
+++ b/crates/tfs-cli/tests/exec.rs
@@ -288,6 +288,47 @@ fn exec_deny_jail_eperm_and_plain_ok() {
     assert!(!r.stdout.is_empty());
 }
 
+/// The native-tool path end to end (spec 08 §2/§5): a dynamic tool inside
+/// the payload image runs under the preload shim, the `--jail` policy
+/// confines its host reads, and the violation lands in the audit journal
+/// with the surface's source label.
+#[test]
+fn exec_deny_jail_journals_the_violation() {
+    let Some(f) = fixtures() else { return };
+    let log = f.dir.join("audit").join("journal.log");
+    let mut cmd = Command::new(bin().unwrap());
+    cmd.args([
+        "exec",
+        &format!("{}:{MOUNT}", f.zip.display()),
+        "--jail",
+        "deny",
+        "--",
+        "/tfs/bin/print-data",
+        "/etc/hosts",
+    ])
+    .env_remove("DYLD_INSERT_LIBRARIES")
+    .env_remove("LD_PRELOAD")
+    .env_remove("TEBAKO_TFS_MOUNTS")
+    .env_remove("TEBAKO_JAIL")
+    .env("TEBAKO_TFS_PRELOAD", &f.shim)
+    .env("TEBAKO_JAIL_JOURNAL", &log);
+    let out = cmd.output().unwrap();
+    assert_eq!(out.status.code(), Some(libc::EPERM));
+
+    let text = std::fs::read_to_string(&log).unwrap();
+    let lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines.len(), 1, "journal: {lines:?}");
+    let (ts, rest) = lines[0].split_once(' ').unwrap();
+    assert!(
+        !ts.is_empty() && ts.bytes().all(|b| b.is_ascii_digit()),
+        "{lines:?}"
+    );
+    assert_eq!(
+        rest,
+        "event=jail-deny path=/etc/hosts op=read source=tfs exec --jail"
+    );
+}
+
 #[test]
 fn exec_grandchild_stays_in_vfs() {
     let Some(f) = fixtures() else { return };

--- a/crates/tfs-cli/tests/exec.rs
+++ b/crates/tfs-cli/tests/exec.rs
@@ -316,7 +316,17 @@ fn exec_deny_jail_journals_the_violation() {
     assert_eq!(out.status.code(), Some(libc::EPERM));
 
     let text = std::fs::read_to_string(&log).unwrap();
-    let lines: Vec<&str> = text.lines().collect();
+    // Assert the SPECIFIC probe, not the global count: under a deny-all
+    // jail the child may legitimately trip extra denials from environment
+    // lookups (e.g. /etc/localtime on hosts without TZ set — seen on CI
+    // runners; the same class fixed in tebako-bootstrap's jail e2e).
+    let lines: Vec<&str> = text
+        .lines()
+        .filter(|l| {
+            l.contains("event=jail-deny")
+                && l.contains("path=/etc/hosts op=read source=tfs exec --jail")
+        })
+        .collect();
     assert_eq!(lines.len(), 1, "journal: {lines:?}");
     let (ts, rest) = lines[0].split_once(' ').unwrap();
     assert!(

--- a/crates/tfs-cli/tests/exec.rs
+++ b/crates/tfs-cli/tests/exec.rs
@@ -135,7 +135,7 @@ fn build_fixtures() -> Option<Fixtures> {
     let dir = std::fs::canonicalize(&dir).unwrap();
 
     let mut binaries: Vec<(String, PathBuf)> = Vec::new();
-    for name in ["print-data", "spawn-self", "dl-user"] {
+    for name in ["print-data", "spawn-self", "dl-user", "spawn-helper"] {
         let src = src_dir.join(format!("{name}.c"));
         let out = dir.join("bin").join(name);
         let extra: &[&str] = if name == "dl-user" && cfg!(target_os = "linux") {
@@ -348,6 +348,40 @@ fn exec_dlopen_memfs_library() {
     );
     assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
     assert_eq!(r.stdout.trim(), "42", "stdout: {}", r.stdout);
+}
+
+/// Roadmap 39: execve/posix_spawn of a MEMFS path is virtualized through
+/// the dlmap2file host cache — a tool spawns an in-image helper with no
+/// extraction, and the grandchild stays in the VFS.
+#[test]
+fn exec_spawns_in_image_helper() {
+    let Some(f) = fixtures() else { return };
+    // posix_spawn of the in-image helper.
+    let r = tfs_exec(
+        f,
+        &[
+            "--",
+            "/tfs/bin/spawn-helper",
+            "posix_spawn",
+            "/tfs/bin/print-data",
+            "/tfs/data/secret.txt",
+        ],
+    );
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, SECRET, "stderr: {}", r.stderr);
+    // execve replaces the tool outright.
+    let r = tfs_exec(
+        f,
+        &[
+            "--",
+            "/tfs/bin/spawn-helper",
+            "execve",
+            "/tfs/bin/print-data",
+            "/tfs/data/secret.txt",
+        ],
+    );
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, SECRET, "stderr: {}", r.stderr);
 }
 
 #[test]

--- a/crates/tfs/src/c_api.rs
+++ b/crates/tfs/src/c_api.rs
@@ -1019,7 +1019,26 @@ pub unsafe extern "C" fn tebako_fs_host_policy(
         Ok(p) => p,
         Err(e) => return fail(e),
     };
-    context().write().unwrap().set_host_policy(policy);
+    // The audit-journal source label: the installer names itself via
+    // TEBAKO_JAIL_SOURCE (the bootstrap/dispatch surfaces label the
+    // composition `manifest` / `user` / `manifest+user`); a bare C-ABI
+    // install is attributed to the entry point itself. The journal file is
+    // resolved and opened HERE, before the context guard — a denial under
+    // the lock is then a bare write(2) (see `crate::journal`; a policy
+    // that can never deny gets no file).
+    let source = std::env::var("TEBAKO_JAIL_SOURCE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "tebako_fs_host_policy".to_string());
+    let journal = if policy.never_denies() {
+        None
+    } else {
+        crate::journal::open_journal()
+    };
+    context()
+        .write()
+        .unwrap()
+        .set_host_policy(policy.with_source(source), journal);
     set_errno(0);
     0
 }

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -121,6 +121,13 @@ pub struct FsContext {
     /// `unmount()` deliberately does NOT reset it (fail-closed); only the
     /// `tebako_fs_host_policy` C entry replaces it.
     host_policy: HostPolicy,
+    /// The open audit-journal file for policy denials (spec 08 §2),
+    /// resolved and opened by the policy installer BEFORE the context
+    /// guard was taken — a denial is then a bare write(2), never a path
+    /// operation under the lock (see `crate::journal` for the deadlock
+    /// rationale). Follows the policy: replaced alongside it, left alone
+    /// by `unmount()`.
+    journal: Option<std::fs::File>,
 }
 
 impl FsContext {
@@ -136,6 +143,7 @@ impl FsContext {
             dl_tmpdir: None,
             dl_cache: BTreeMap::new(),
             host_policy: HostPolicy::open(),
+            journal: None,
         }
     }
 
@@ -143,20 +151,37 @@ impl FsContext {
     // Host-access policy (spec 08)
     // ---------------------------------------------------------------
 
-    /// Install the host-access policy, replacing the current one.
-    pub fn set_host_policy(&mut self, policy: HostPolicy) {
+    /// Install the host-access policy, replacing the current one. The
+    /// audit-journal file for denials (spec 08 §2) rides alongside —
+    /// resolved and opened by the CALLER before the context guard was
+    /// taken (`crate::journal::open_journal`), so a denial under the lock
+    /// is a bare write(2), never a re-entrant path operation.
+    pub fn set_host_policy(&mut self, policy: HostPolicy, journal: Option<std::fs::File>) {
         self.host_policy = policy;
+        self.journal = journal;
     }
 
     /// Gate one host-passthrough path decision against the policy.
     /// Ok(()) = allowed (answer ENOENT, the consumer passes through to the
     /// host fs as today); Err(EPERM)/Err(EROFS) = the jail's answer.
+    /// Denials are journaled (spec 08 §2 — the audit journal records the
+    /// path, the op class and the policy's source label) via the cached,
+    /// pre-opened file: a bare write(2), no path operation under the lock.
     pub fn host_check<P: AsRef<std::path::Path>>(
         &self,
         path: P,
         need: HostAccess,
     ) -> Result<(), i32> {
-        self.host_policy.check(path.as_ref(), need)
+        let path = path.as_ref();
+        match self.host_policy.check(path, need) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                if let Some(journal) = &self.journal {
+                    crate::journal::journal_deny(journal, path, need, self.host_policy.source());
+                }
+                Err(e)
+            }
+        }
     }
 
     // ---------------------------------------------------------------

--- a/crates/tfs/src/journal.rs
+++ b/crates/tfs/src/journal.rs
@@ -1,0 +1,178 @@
+//! The tebako audit journal for jail violations (spec 08 §2: "Violations
+//! are logged to the tebako audit journal with path + syscall class").
+//!
+//! One line per denied host-passthrough decision, appended to the tebako
+//! journal — the same file and line shape the bootstrap uses
+//! (`$TEBAKO_HOME/journal.log`, `<unix seconds> <fields>`):
+//!
+//! ```text
+//! <ts> event=jail-deny path=<path> op=read|write source=<policy source>
+//! ```
+//!
+//! The location resolves as `$TEBAKO_JAIL_JOURNAL` (an explicit override —
+//! also the test seam), else `$TEBAKO_HOME/journal.log`, else the platform
+//! default tebako home (mirroring the bootstrap's cache-root rule).
+//!
+//! **The fd discipline (deadlock freedom):** the journal file is resolved
+//! and opened ONCE, at policy-install time, by the caller BEFORE the
+//! context guard is taken ([`open_journal`]); a denial is then a bare
+//! `write(2)` on the cached file ([`journal_deny`]). No path operation
+//! ever runs under the context lock — path syscalls are exactly what the
+//! preload shim interposes, so journaled IO inside the guard would
+//! re-enter the engine and self-deadlock (the roadmap-39 linux leg caught
+//! precisely this in the statically-linked test binary). `write(2)` is not
+//! part of the interposed surface, so the denial path can never re-enter.
+//! Journaling is best-effort BY DESIGN: a violation is reported to the
+//! caller as EPERM/EROFS regardless, and a journal that cannot be opened
+//! never fails the operation it audits.
+//!
+//! Pure safe Rust over std::fs.
+
+use std::path::{Path, PathBuf};
+
+use crate::policy::HostAccess;
+
+/// The event name every jail-denial line carries.
+pub const JAIL_DENY_EVENT: &str = "jail-deny";
+
+/// Resolve and open the journal file for append (creating the tebako home
+/// if needed). Call it at POLICY-INSTALL time, BEFORE the context guard is
+/// taken — never from inside a `host_check` (see the module docs). `None`
+/// when no home resolves or the open fails (journaling then simply stays
+/// silent — the jail's answers are unaffected).
+pub fn open_journal() -> Option<std::fs::File> {
+    let journal = journal_path(|k| std::env::var(k).ok())?;
+    if let Some(dir) = journal.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(journal)
+        .ok()
+}
+
+/// Append one jail-denial line to the already-open journal `file`. A bare
+/// `write(2)` per event — never a path operation (see the module docs);
+/// best-effort: write failures are swallowed.
+pub fn journal_deny(file: &std::fs::File, path: &Path, need: HostAccess, source: &str) {
+    use std::io::Write as _;
+    let op = match need {
+        HostAccess::Ro => "read",
+        HostAccess::Rw => "write",
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let line = format!(
+        "{now} event={} path={} op={} source={}\n",
+        JAIL_DENY_EVENT,
+        path.display(),
+        op,
+        if source.is_empty() { "unattributed" } else { source }
+    );
+    let _ = (&*file).write_all(line.as_bytes());
+}
+
+/// The journal file under a tebako home (the bootstrap's convention).
+pub fn journal_file_of(home: &Path) -> PathBuf {
+    home.join("journal.log")
+}
+
+/// Resolution of the journal path: the explicit override, then
+/// `$TEBAKO_HOME`, then the platform default home. `lookup` abstracts the
+/// environment so tests never mutate it.
+fn journal_path(lookup: impl Fn(&str) -> Option<String>) -> Option<PathBuf> {
+    if let Some(explicit) = lookup("TEBAKO_JAIL_JOURNAL").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(explicit));
+    }
+    tebako_home(lookup).map(|h| journal_file_of(&h))
+}
+
+/// The tebako home: `$TEBAKO_HOME` > the platform default (the bootstrap's
+/// cache-root rule: `%LOCALAPPDATA%\tebako` / `%USERPROFILE%\.tebako` on
+/// Windows, `~/.tebako` elsewhere).
+fn tebako_home(lookup: impl Fn(&str) -> Option<String>) -> Option<PathBuf> {
+    if let Some(home) = lookup("TEBAKO_HOME").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(home));
+    }
+    #[cfg(windows)]
+    {
+        if let Some(home) = lookup("LOCALAPPDATA").filter(|v| !v.is_empty()) {
+            return Some(PathBuf::from(home).join("tebako"));
+        }
+        if let Some(home) = lookup("USERPROFILE").filter(|v| !v.is_empty()) {
+            return Some(PathBuf::from(home).join(".tebako"));
+        }
+        None
+    }
+    #[cfg(not(windows))]
+    {
+        lookup("HOME")
+            .filter(|v| !v.is_empty())
+            .map(|home| PathBuf::from(home).join(".tebako"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn lookup_of(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: BTreeMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        move |k| map.get(k).cloned()
+    }
+
+    #[test]
+    fn journal_path_prefers_the_explicit_override() {
+        let p = journal_path(lookup_of(&[
+            ("TEBAKO_JAIL_JOURNAL", "/tmp/explicit.log"),
+            ("TEBAKO_HOME", "/home/t"),
+        ]));
+        assert_eq!(p, Some(PathBuf::from("/tmp/explicit.log")));
+    }
+
+    #[test]
+    fn journal_path_uses_tebako_home_then_the_default() {
+        let p = journal_path(lookup_of(&[("TEBAKO_HOME", "/home/t")]));
+        assert_eq!(p, Some(PathBuf::from("/home/t/journal.log")));
+        #[cfg(not(windows))]
+        {
+            let p = journal_path(lookup_of(&[("HOME", "/home/u")]));
+            assert_eq!(p, Some(PathBuf::from("/home/u/.tebako/journal.log")));
+            assert_eq!(journal_path(lookup_of(&[])), None);
+        }
+    }
+
+    #[test]
+    fn journal_line_shape() {
+        let dir = std::env::temp_dir().join(format!("tfs-journal-test-{}", std::process::id()));
+        let log = dir.join("journal.log");
+        std::env::set_var("TEBAKO_JAIL_JOURNAL", &log);
+        let file = open_journal().expect("journal opens");
+        std::env::remove_var("TEBAKO_JAIL_JOURNAL");
+        journal_deny(&file, Path::new("/etc/hosts"), HostAccess::Ro, "manifest");
+        journal_deny(&file, Path::new("/x"), HostAccess::Rw, "user");
+        drop(file);
+        let text = std::fs::read_to_string(&log).unwrap();
+        let mut lines = text.lines();
+        let line = lines.next().unwrap();
+        let (ts, rest) = line.split_once(' ').unwrap();
+        assert!(
+            ts.bytes().all(|b| b.is_ascii_digit()) && !ts.is_empty(),
+            "{line}"
+        );
+        assert_eq!(rest, "event=jail-deny path=/etc/hosts op=read source=manifest");
+        assert_eq!(
+            lines.next().unwrap().split_once(' ').unwrap().1,
+            "event=jail-deny path=/x op=write source=user"
+        );
+        assert!(lines.next().is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/tfs/src/journal.rs
+++ b/crates/tfs/src/journal.rs
@@ -70,7 +70,11 @@ pub fn journal_deny(file: &std::fs::File, path: &Path, need: HostAccess, source:
         JAIL_DENY_EVENT,
         path.display(),
         op,
-        if source.is_empty() { "unattributed" } else { source }
+        if source.is_empty() {
+            "unattributed"
+        } else {
+            source
+        }
     );
     let _ = (&*file).write_all(line.as_bytes());
 }
@@ -167,7 +171,10 @@ mod tests {
             ts.bytes().all(|b| b.is_ascii_digit()) && !ts.is_empty(),
             "{line}"
         );
-        assert_eq!(rest, "event=jail-deny path=/etc/hosts op=read source=manifest");
+        assert_eq!(
+            rest,
+            "event=jail-deny path=/etc/hosts op=read source=manifest"
+        );
         assert_eq!(
             lines.next().unwrap().split_once(' ').unwrap().1,
             "event=jail-deny path=/x op=write source=user"

--- a/crates/tfs/src/lib.rs
+++ b/crates/tfs/src/lib.rs
@@ -56,7 +56,8 @@
 //! installs the host-access policy gating every host-passthrough path
 //! decision (`crates/tfs/src/policy.rs`); denied paths fail EPERM, writes
 //! against an ro grant EROFS, allowed paths keep today's ENOENT
-//! pass-through.
+//! pass-through, and every denial is journaled to the tebako audit
+//! journal (`crates/tfs/src/journal.rs` — path, op class, policy source).
 //!
 //! ## PLANNED (next milestones)
 //!
@@ -77,6 +78,7 @@ pub mod backends_zip;
 pub mod c_api;
 pub mod context;
 pub mod errno;
+pub mod journal;
 pub mod mount;
 pub mod mount_spec;
 pub mod policy;

--- a/crates/tfs/src/policy.rs
+++ b/crates/tfs/src/policy.rs
@@ -76,6 +76,10 @@ pub struct HostPolicy {
     default_open: bool,
     mounts: Vec<HostMount>,
     arg_files: Vec<PathBuf>,
+    /// Who installed the policy (`manifest`, `user`, `manifest+user`,
+    /// `TEBAKO_JAIL`, …), recorded in the audit journal on every denial
+    /// (spec 08 §2: violations are logged with path + syscall class).
+    source: String,
 }
 
 impl Default for HostPolicy {
@@ -92,7 +96,29 @@ impl HostPolicy {
             default_open: true,
             mounts: Vec::new(),
             arg_files: Vec::new(),
+            source: String::new(),
         }
+    }
+
+    /// Record who installed the policy (the audit-journal `source=` field,
+    /// spec 08 §2): the bootstrap/dispatch surfaces label the composition
+    /// (`manifest`, `user`, `manifest+user`), direct installers name their
+    /// channel (`TEBAKO_JAIL`, `tebako_fs_host_policy`, …).
+    pub fn with_source(mut self, source: impl Into<String>) -> Self {
+        self.source = source.into();
+        self
+    }
+
+    /// The installer's label (empty when never attributed).
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// True when this policy can never deny anything (open default with no
+    /// mounts — argument files only ever ALLOW). Installers skip opening
+    /// the audit journal for it: there would never be a violation to log.
+    pub fn never_denies(&self) -> bool {
+        self.default_open && self.mounts.is_empty()
     }
 
     /// Bind a policy: canonicalize every host path (mount sources and
@@ -126,6 +152,7 @@ impl HostPolicy {
             default_open,
             mounts: bound_mounts,
             arg_files: bound_files,
+            source: String::new(),
         })
     }
 

--- a/crates/tfs/tests/jails.rs
+++ b/crates/tfs/tests/jails.rs
@@ -506,3 +506,115 @@ fn policy_survives_unmount_fail_closed() {
     assert!(opendir_str("/").is_null());
     assert_eq!(errno(), libc::EPERM);
 }
+
+// --- the audit journal (spec 08 §2) -------------------------------------
+
+/// Read the journal file's lines, asserting the shared shape: `<unix
+/// seconds> event=jail-deny path=<p> op=<read|write> source=<s>`.
+fn journal_lines(log: &Path) -> Vec<String> {
+    let text = std::fs::read_to_string(log).unwrap();
+    text.lines().map(|l| l.to_string()).collect()
+}
+
+fn assert_line_shape(line: &str, path: &Path, op: &str, source: &str) {
+    let (ts, rest) = line.split_once(' ').unwrap();
+    assert!(
+        !ts.is_empty() && ts.bytes().all(|b| b.is_ascii_digit()),
+        "line must start with the unix seconds: {line}"
+    );
+    assert_eq!(
+        rest,
+        format!(
+            "event=jail-deny path={} op={} source={}",
+            path.display(),
+            op,
+            source
+        )
+    );
+}
+
+#[test]
+fn violations_are_journaled_with_path_op_and_source() {
+    let f = setup("journal");
+    let log = f.input.parent().unwrap().join("audit").join("journal.log");
+    std::env::set_var("TEBAKO_JAIL_JOURNAL", &log);
+    std::env::set_var("TEBAKO_JAIL_SOURCE", "manifest+user");
+    let cleanup = || {
+        std::env::remove_var("TEBAKO_JAIL_JOURNAL");
+        std::env::remove_var("TEBAKO_JAIL_SOURCE");
+    };
+
+    // deny: a read, a stat and a write are three denials, three lines.
+    assert_eq!(install_policy(0, &[], &[]), 0);
+    assert_eq!(open(&f.sibling.join("secret.txt"), libc::O_RDONLY), -1);
+    assert_eq!(errno(), libc::EPERM);
+    assert_eq!(stat(&f.sibling.join("secret.txt")), -1);
+    assert_eq!(errno(), libc::EPERM);
+    assert_eq!(
+        open(&f.work.join("new.txt"), libc::O_WRONLY | libc::O_CREAT),
+        -1
+    );
+    assert_eq!(errno(), libc::EPERM);
+
+    let lines = journal_lines(&log);
+    assert_eq!(lines.len(), 3, "journal: {lines:?}");
+    assert_line_shape(
+        &lines[0],
+        &f.sibling.join("secret.txt"),
+        "read",
+        "manifest+user",
+    );
+    assert_line_shape(
+        &lines[1],
+        &f.sibling.join("secret.txt"),
+        "read",
+        "manifest+user",
+    );
+    assert_line_shape(&lines[2], &f.work.join("new.txt"), "write", "manifest+user");
+
+    // An ro-write refusal (EROFS) is a violation too — journaled with the
+    // same shape; allowed passes never journal.
+    assert_eq!(install_policy(1, &[(&f.rodir, "/ro", 0)], &[]), 0);
+    assert_eq!(open(&f.rodir.join("ro.txt"), libc::O_RDONLY), -1);
+    assert_eq!(errno(), libc::ENOENT, "allowed read keeps the pass-through");
+    assert_eq!(
+        open(&f.rodir.join("new.txt"), libc::O_WRONLY | libc::O_CREAT),
+        -1
+    );
+    assert_eq!(errno(), libc::EROFS);
+
+    let lines = journal_lines(&log);
+    assert_eq!(lines.len(), 4, "journal: {lines:?}");
+    assert_line_shape(
+        &lines[3],
+        &f.rodir.join("new.txt"),
+        "write",
+        "manifest+user",
+    );
+
+    cleanup();
+}
+
+#[test]
+fn no_policy_no_journal_and_the_journal_never_fails_the_op() {
+    let f = setup("journal-quiet");
+    let log = f.input.parent().unwrap().join("audit2").join("journal.log");
+    std::env::set_var("TEBAKO_JAIL_JOURNAL", &log);
+
+    // The open policy never denies — and never journals.
+    let host_file = f.sibling.join("secret.txt");
+    assert_eq!(open(&host_file, libc::O_RDONLY), -1);
+    assert_eq!(errno(), libc::ENOENT);
+    assert!(!log.exists(), "no policy, no journal file");
+
+    // An UNWRITABLE journal target (a directory) does not change the
+    // denial's answer: EPERM stands, best-effort journaling is swallowed.
+    std::env::set_var("TEBAKO_JAIL_JOURNAL", f.rodir.as_path());
+    std::env::set_var("TEBAKO_JAIL_SOURCE", "TEBAKO_JAIL");
+    assert_eq!(install_policy(0, &[], &[]), 0);
+    assert_eq!(open(&host_file, libc::O_RDONLY), -1);
+    assert_eq!(errno(), libc::EPERM);
+
+    std::env::remove_var("TEBAKO_JAIL_JOURNAL");
+    std::env::remove_var("TEBAKO_JAIL_SOURCE");
+}

--- a/crates/tpkg/src/jail.rs
+++ b/crates/tpkg/src/jail.rs
@@ -1,0 +1,968 @@
+//! The host-access jail model (spec 08 — jails): the single owner of the
+//! authored policy shape shared by every surface.
+//!
+//! Two wire forms, one model:
+//!
+//! - **YAML** (manifests — the payload manifest's `capabilities.host`,
+//!   spec 08 §4, and the package manifest's `jail:` block, spec 03 §6):
+//!
+//!   ```yaml
+//!   default: open | deny          # open = today's behavior (cwd + writes pass through)
+//!   mounts:
+//!     - host: $HOME/sources
+//!       mount: /work
+//!       access: ro | rw
+//!   argument_files: auto-allowed  # the input file you hand the command is allowed even under deny
+//!   ```
+//!
+//! - **env** (`TEBAKO_JAIL`, spec 08 §1 — the form the runtime driver and
+//!   the preload shim consume): `open|deny` + `;host:mount:ro|rw` grants +
+//!   `;@file` argument files, e.g. `deny;/home/u/src:/work:rw;@/home/u/in.csv`.
+//!
+//! This module is the AUTHORED model: it parses, validates, serializes and
+//! composes policies; it never touches the filesystem for enforcement.
+//! Binding (realpath canonicalization) and per-path gating live in the
+//! engine (`tfs::policy`), which consumes the env form this module emits.
+//!
+//! **Precedence (locked, spec 08 §2/§4):** the package's manifest REQUESTS
+//! access (`capabilities.host` / the package `jail:` block); the user can
+//! always TIGHTEN it (`tebako run --jail pkg`, `--mount src:/work:rw`,
+//! `--no-host`) — user policy always wins, and it intersects, never
+//! loosens: [`effective`] composes request ∩ tightening so the tighter
+//! answer for every path survives (deny defaults win; each side's mount
+//! grants are capped by the other side's allowance at the same prefix;
+//! argument files union, `auto-allowed` honored when either side asks).
+//!
+//! Pure safe Rust; the only IO is reading a `--jail <file.yaml>` and
+//! probing argv entries for the `auto-allowed` resolution.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// A mount's grant bit (`access: ro | rw`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JailAccess {
+    /// Read-only.
+    Ro,
+    /// Read-write.
+    Rw,
+}
+
+impl JailAccess {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            JailAccess::Ro => "ro",
+            JailAccess::Rw => "rw",
+        }
+    }
+
+    /// The tighter of two grants (ro caps rw).
+    fn tighter(self, other: JailAccess) -> JailAccess {
+        match (self, other) {
+            (JailAccess::Ro, _) | (_, JailAccess::Ro) => JailAccess::Ro,
+            _ => JailAccess::Rw,
+        }
+    }
+}
+
+impl Serialize for JailAccess {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for JailAccess {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<JailAccess, D::Error> {
+        let s = String::deserialize(d)?;
+        match s.as_str() {
+            "ro" => Ok(JailAccess::Ro),
+            "rw" => Ok(JailAccess::Rw),
+            other => Err(serde::de::Error::custom(format_args!(
+                "jail mount access must be ro|rw, got {other:?}"
+            ))),
+        }
+    }
+}
+
+/// One host-mount grant (`{host, mount, access}`, docker `-v` semantics).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JailMount {
+    /// Host directory the grant covers (prefix-matched on path-component
+    /// boundaries; realpath-canonicalized at bind time by the engine).
+    pub host: String,
+    /// Virtual mount point the host dir is exposed at (must be absolute).
+    pub mount: String,
+    pub access: JailAccess,
+}
+
+/// The `argument_files:` block: EITHER the scalar `auto-allowed` (dispatch
+/// surfaces resolve the argv entries that name existing files into
+/// read-only grants) OR an explicit list of granted paths. The model keeps
+/// both flags separately because the composed policy (request ∩
+/// tightening, [`intersect`]) may carry an `auto` request AND explicit
+/// files; the YAML authored form is always one or the other.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ArgumentFiles {
+    /// `auto-allowed` — resolve argv files into read grants at dispatch.
+    pub auto: bool,
+    /// Explicit read-only grants (honored even under deny).
+    pub files: Vec<String>,
+}
+
+impl ArgumentFiles {
+    fn is_empty(&self) -> bool {
+        !self.auto && self.files.is_empty()
+    }
+}
+
+impl Serialize for ArgumentFiles {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        if self.auto && self.files.is_empty() {
+            s.serialize_str("auto-allowed")
+        } else {
+            // The authored list form. (The composed auto+files state is not
+            // representable in the spec's YAML shape; composed policies
+            // travel via the env form, which carries @files explicitly.)
+            self.files.serialize(s)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ArgumentFiles {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<ArgumentFiles, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Auto(String),
+            List(Vec<String>),
+        }
+        match Repr::deserialize(d)? {
+            Repr::Auto(s) if s == "auto-allowed" => Ok(ArgumentFiles {
+                auto: true,
+                files: Vec::new(),
+            }),
+            Repr::Auto(s) => Err(serde::de::Error::custom(format_args!(
+                "argument_files must be \"auto-allowed\" or a path list, got {s:?}"
+            ))),
+            Repr::List(files) => Ok(ArgumentFiles { auto: false, files }),
+        }
+    }
+}
+
+/// The host-access jail of a payload or package (spec 08 §1/§4).
+///
+/// The default is `open` with no mounts and no argument files — today's
+/// behavior, so a manifest without the block and a package pressed without
+/// `--jail` behave byte-identically to before.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostJail {
+    /// `default: open | deny` (serde renders the bool as the locked words).
+    #[serde(
+        rename = "default",
+        with = "default_mode",
+        default = "default_open_true"
+    )]
+    pub default_open: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mounts: Vec<JailMount>,
+    #[serde(default, skip_serializing_if = "ArgumentFiles::is_empty")]
+    pub argument_files: ArgumentFiles,
+}
+
+fn default_open_true() -> bool {
+    true
+}
+
+/// `default:` serde: `open` ↔ true, `deny` ↔ false.
+mod default_mode {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(open: &bool, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(if *open { "open" } else { "deny" })
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<bool, D::Error> {
+        let s = String::deserialize(d)?;
+        match s.as_str() {
+            "open" => Ok(true),
+            "deny" => Ok(false),
+            other => Err(serde::de::Error::custom(format_args!(
+                "jail default must be open|deny, got {other:?}"
+            ))),
+        }
+    }
+}
+
+/// Error of the jail surfaces.
+///
+/// Deliberately separate from [`crate::ManifestError`] and
+/// [`crate::PackageManifestError`]: the jail model serves the bootstrap
+/// and the dispatch surfaces too, which never see a manifest.
+#[derive(Debug)]
+pub enum JailError {
+    /// YAML parse/serialize failure of the block form.
+    Yaml(serde_yml::Error),
+    /// Env/cli spec parse failure (the message quotes the offending spec).
+    Spec(String),
+    /// Semantic validation failure (`validate()`), or an unreadable
+    /// `--jail <file.yaml>`.
+    Invalid(String),
+}
+
+impl fmt::Display for JailError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            JailError::Yaml(e) => write!(f, "jail yaml error: {e}"),
+            JailError::Spec(m) => write!(f, "invalid jail spec: {m}"),
+            JailError::Invalid(m) => write!(f, "invalid jail: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for JailError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            JailError::Yaml(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<serde_yml::Error> for JailError {
+    fn from(e: serde_yml::Error) -> JailError {
+        JailError::Yaml(e)
+    }
+}
+
+impl Default for HostJail {
+    fn default() -> Self {
+        Self::open()
+    }
+}
+
+impl HostJail {
+    /// The open jail (today's behavior; the model's zero value).
+    pub const fn open() -> HostJail {
+        HostJail {
+            default_open: true,
+            mounts: Vec::new(),
+            argument_files: ArgumentFiles {
+                auto: false,
+                files: Vec::new(),
+            },
+        }
+    }
+
+    /// `deny`: every host path outside the grants fails EPERM.
+    pub const fn deny() -> HostJail {
+        HostJail {
+            default_open: false,
+            mounts: Vec::new(),
+            argument_files: ArgumentFiles {
+                auto: false,
+                files: Vec::new(),
+            },
+        }
+    }
+
+    /// `deny:arg`: the file-scoped tight jail (spec 08 §1 profile 3) —
+    /// deny everything, then let the dispatch surface allow the input
+    /// files the command was handed.
+    pub const fn deny_with_arg_files() -> HostJail {
+        HostJail {
+            default_open: false,
+            mounts: Vec::new(),
+            argument_files: ArgumentFiles {
+                auto: true,
+                files: Vec::new(),
+            },
+        }
+    }
+
+    /// True when the policy is indistinguishable from no policy at all
+    /// (open default, no grants — `auto-allowed` under an open default
+    /// grants nothing the default does not already allow). Surfaces skip
+    /// exporting such a policy, keeping the no-policy path byte-identical.
+    pub fn is_trivially_open(&self) -> bool {
+        self.default_open && self.mounts.is_empty() && self.argument_files.files.is_empty()
+    }
+
+    /// Parse and validate the YAML block form.
+    pub fn from_yaml(text: &str) -> Result<HostJail, JailError> {
+        let jail: HostJail = serde_yml::from_str(text)?;
+        jail.validate()?;
+        Ok(jail.normalized())
+    }
+
+    /// Validate and serialize to the YAML block form.
+    pub fn to_yaml(&self) -> Result<String, JailError> {
+        self.validate()?;
+        Ok(serde_yml::to_string(self)?)
+    }
+
+    /// Semantic checks beyond the serde structure: non-empty hosts,
+    /// absolute mount points, non-empty argument-file entries. Unknown
+    /// keys are tolerated (the manifest convention).
+    pub fn validate(&self) -> Result<(), JailError> {
+        for m in &self.mounts {
+            if m.host.is_empty() {
+                return Err(JailError::Invalid(
+                    "mounts[].host must not be empty".to_string(),
+                ));
+            }
+            if !m.mount.starts_with('/') {
+                return Err(JailError::Invalid(format!(
+                    "mounts[].mount {:?} is not absolute",
+                    m.mount
+                )));
+            }
+        }
+        if self.argument_files.files.iter().any(|f| f.is_empty()) {
+            return Err(JailError::Invalid(
+                "argument_files entries must not be empty".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Trailing-slash normalization of mount hosts ("/a/" ≡ "/a"; the root
+    /// keeps its slash) so composition dedup/coalescing compares like with
+    /// like. Enforcement canonicalizes at bind regardless — this only
+    /// keeps the composed grant set tidy.
+    fn normalized(mut self) -> HostJail {
+        for m in &mut self.mounts {
+            while m.host.len() > 1 && m.host.ends_with('/') {
+                m.host.pop();
+            }
+        }
+        self
+    }
+
+    /// Parse a `--jail` spec (press/run/shim surfaces): the profiles
+    /// `open` | `deny` | `deny:arg`, a YAML file carrying the block form,
+    /// or the `TEBAKO_JAIL` env grammar itself (spec 08 §1).
+    pub fn from_cli_spec(spec: &str) -> Result<HostJail, JailError> {
+        match spec {
+            "open" => return Ok(HostJail::open()),
+            "deny" => return Ok(HostJail::deny()),
+            "deny:arg" => return Ok(HostJail::deny_with_arg_files()),
+            _ => {}
+        }
+        let path = Path::new(spec);
+        if path.is_file() {
+            let text = std::fs::read_to_string(path).map_err(|e| {
+                JailError::Invalid(format!("cannot read the jail file {spec:?}: {e}"))
+            })?;
+            return HostJail::from_yaml(&text);
+        }
+        Self::parse_env_spec(spec)
+    }
+
+    /// The dispatch flags → the user's tightening, shared by `tebako run`
+    /// and `tebako-shim` (spec 08 §2): `--jail` supplies the base policy
+    /// (open when absent), `--no-host` tightens the default to deny, each
+    /// `--mount` adds a grant. `Ok(None)` when no flag was given at all
+    /// (the surface then dispatches the manifest's request alone — or
+    /// nothing).
+    pub fn from_dispatch_flags(
+        jail: Option<&str>,
+        mounts: &[String],
+        no_host: bool,
+    ) -> Result<Option<HostJail>, JailError> {
+        let mut user: Option<HostJail> = jail.map(HostJail::from_cli_spec).transpose()?;
+        if no_host {
+            let base = user.take().unwrap_or_else(HostJail::open);
+            user = Some(intersect(&base, &HostJail::deny()));
+        }
+        for m in mounts {
+            let mount = parse_mount_directive(m)?;
+            user.get_or_insert_with(HostJail::open).mounts.push(mount);
+        }
+        Ok(user)
+    }
+
+    /// Parse the `TEBAKO_JAIL` env form (spec 08 §1):
+    ///
+    /// ```text
+    /// jail      = directive *( ";" directive )
+    /// directive = "open" | "deny"          # namespace default (default: open)
+    ///           | host ":" mount ":" mode  # docker -v grant; mount absolute
+    ///           | "@" path                 # argument file (read-only grant)
+    /// mode      = "ro" | "rw"
+    /// ```
+    ///
+    /// Errors on: empty spec, conflicting or duplicated `open`/`deny`,
+    /// unknown access modes, non-absolute mount points, empty
+    /// hosts/mounts/argument files, and unrecognised directive shapes. The
+    /// messages mirror the engine's `tfs::policy::JailSpec` parser — one
+    /// grammar, one message set.
+    pub fn parse_env_spec(spec: &str) -> Result<HostJail, JailError> {
+        let err = |msg: String| JailError::Spec(format!("{msg} in {spec:?}"));
+        if spec.trim().is_empty() {
+            return Err(JailError::Spec("empty spec".to_string()));
+        }
+        let mut default_open: Option<bool> = None;
+        let mut mounts = Vec::new();
+        let mut files = Vec::new();
+        for token in spec.split(';') {
+            if token.is_empty() {
+                return Err(err("empty directive (stray ';')".to_string()));
+            }
+            match token {
+                "open" | "deny" => {
+                    let value = token == "open";
+                    if default_open.is_some() {
+                        return Err(err(format!(
+                            "duplicate/conflicting default directive {token:?}"
+                        )));
+                    }
+                    default_open = Some(value);
+                }
+                _ if token.starts_with('@') => {
+                    let path = &token[1..];
+                    if path.is_empty() {
+                        return Err(err("empty argument file".to_string()));
+                    }
+                    files.push(path.to_string());
+                }
+                _ => {
+                    mounts.push(parse_mount_directive(token).map_err(|m| err(m.to_string()))?);
+                }
+            }
+        }
+        Ok(HostJail {
+            default_open: default_open.unwrap_or(true),
+            mounts,
+            argument_files: ArgumentFiles { auto: false, files },
+        }
+        .normalized())
+    }
+
+    /// Serialize to the `TEBAKO_JAIL` env form. `resolved_arg_files` are
+    /// the dispatch surface's resolution of `auto-allowed` (argv entries
+    /// naming existing files — see [`resolve_argument_files`]); they are
+    /// unioned with the explicit list, deduplicated, in first-seen order.
+    pub fn to_env_spec(&self, resolved_arg_files: &[PathBuf]) -> String {
+        let mut out = String::from(if self.default_open { "open" } else { "deny" });
+        for m in &self.mounts {
+            out.push(';');
+            out.push_str(&m.host);
+            out.push(':');
+            out.push_str(&m.mount);
+            out.push(':');
+            out.push_str(m.access.as_str());
+        }
+        let mut emitted = std::collections::BTreeSet::new();
+        for f in &self.argument_files.files {
+            if emitted.insert(f.clone()) {
+                out.push(';');
+                out.push('@');
+                out.push_str(f);
+            }
+        }
+        for f in resolved_arg_files {
+            let s = f.to_string_lossy().into_owned();
+            if emitted.insert(s.clone()) {
+                out.push(';');
+                out.push('@');
+                out.push_str(&s);
+            }
+        }
+        out
+    }
+}
+
+/// Parse one `host:mount:ro|rw` grant (a single env-form directive; the
+/// `--mount` flag of the dispatch surfaces takes exactly this shape).
+/// Splits from the RIGHT so host paths containing ':' survive.
+pub fn parse_mount_directive(token: &str) -> Result<JailMount, JailError> {
+    let Some((head, access)) = token.rsplit_once(':') else {
+        return Err(JailError::Spec(format!(
+            "directive {token:?} is not open|deny, @file, or host:mount:ro|rw"
+        )));
+    };
+    let access = match access {
+        "ro" => JailAccess::Ro,
+        "rw" => JailAccess::Rw,
+        other => {
+            return Err(JailError::Spec(format!(
+                "unknown access mode {other:?} (want ro|rw)"
+            )))
+        }
+    };
+    let Some((host, mount)) = head.rsplit_once(':') else {
+        return Err(JailError::Spec(format!(
+            "grant {token:?} needs the host:mount:ro|rw shape"
+        )));
+    };
+    if host.is_empty() {
+        return Err(JailError::Spec(format!("empty host in grant {token:?}")));
+    }
+    if !mount.starts_with('/') {
+        return Err(JailError::Spec(format!(
+            "mount point {mount:?} is not absolute"
+        )));
+    }
+    Ok(JailMount {
+        host: host.to_string(),
+        mount: mount.to_string(),
+        access,
+    })
+}
+
+/// Policy Q's allowance at `host`: the longest of Q's grants covering the
+/// path (component-boundary prefix), else Q's default (`None` = denied).
+fn allowance_at(q: &HostJail, host: &str) -> Option<JailAccess> {
+    let host_path = Path::new(host);
+    let best = q
+        .mounts
+        .iter()
+        .filter(|m| host_path.starts_with(Path::new(&m.host)))
+        .max_by_key(|m| m.host.len());
+    match best {
+        Some(m) => Some(m.access),
+        None if q.default_open => Some(JailAccess::Rw),
+        None => None,
+    }
+}
+
+/// Tighten one grant against the other policy: dropped when that policy
+/// denies the grant's prefix outright; clamped to ro when it allows reads
+/// but not writes there.
+fn tighten_mount(m: &JailMount, q: &HostJail) -> Option<JailMount> {
+    let allowance = allowance_at(q, &m.host)?;
+    Some(JailMount {
+        host: m.host.clone(),
+        mount: m.mount.clone(),
+        access: m.access.tighter(allowance),
+    })
+}
+
+/// Request ∩ tightening (spec 08 §2/§4 — the user TIGHTENS the package's
+/// request, never loosens). The composition is exact for the mount model:
+/// the default is deny when either side denies; each side's grants survive
+/// only capped by the other side's allowance at the same prefix (so a
+/// `--no-host` drops every request grant the user did not re-allow, and an
+/// ro bind stays ro under every combination); identical host prefixes
+/// coalesce to the tighter access; argument files union and `auto-allowed`
+/// is honored when either side asks. Associative and idempotent, so a
+/// surface and the bootstrap may compose in sequence with no drift.
+pub fn intersect(request: &HostJail, tightening: &HostJail) -> HostJail {
+    let mut mounts: Vec<JailMount> = Vec::new();
+    for m in &tightening.mounts {
+        if let Some(m) = tighten_mount(m, request) {
+            mounts.push(m);
+        }
+    }
+    for m in &request.mounts {
+        if let Some(m) = tighten_mount(m, tightening) {
+            mounts.push(m);
+        }
+    }
+    let mut coalesced: Vec<JailMount> = Vec::new();
+    for m in mounts {
+        match coalesced.iter_mut().find(|c| c.host == m.host) {
+            Some(c) => c.access = c.access.tighter(m.access),
+            None => coalesced.push(m),
+        }
+    }
+    let mut files = tightening.argument_files.files.clone();
+    for f in &request.argument_files.files {
+        if !files.contains(f) {
+            files.push(f.clone());
+        }
+    }
+    HostJail {
+        default_open: request.default_open && tightening.default_open,
+        mounts: coalesced,
+        argument_files: ArgumentFiles {
+            auto: request.argument_files.auto || tightening.argument_files.auto,
+            files,
+        },
+    }
+}
+
+/// The locked composition of the two policy sources (spec 08 §2): the
+/// package's manifest REQUEST and the user's tightening. Returns the
+/// effective jail and the audit source label (`manifest` / `user` /
+/// `manifest+user`) recorded as `TEBAKO_JAIL_SOURCE` and in the journal.
+pub fn effective(
+    request: Option<&HostJail>,
+    tightening: Option<&HostJail>,
+) -> Option<(HostJail, &'static str)> {
+    match (request, tightening) {
+        (None, None) => None,
+        (Some(r), None) => Some((r.clone(), "manifest")),
+        (None, Some(t)) => Some((t.clone(), "user")),
+        (Some(r), Some(t)) => Some((intersect(r, t), "manifest+user")),
+    }
+}
+
+/// Resolve `auto-allowed` argument files against an argv: entries that
+/// name an existing file or directory become absolute read-only grants
+/// (relative names resolve against the process cwd; entries starting with
+/// `-` are flags, never files). Non-existent entries are skipped. The
+/// engine canonicalizes at bind, so lexical absolutes are fine here.
+pub fn resolve_argument_files(args: &[String]) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    for a in args {
+        if a.starts_with('-') {
+            continue;
+        }
+        let p = PathBuf::from(a);
+        let abs = if p.is_absolute() {
+            p
+        } else {
+            match std::env::current_dir() {
+                Ok(cwd) => cwd.join(p),
+                Err(_) => continue,
+            }
+        };
+        if abs.exists() && !out.contains(&abs) {
+            out.push(abs);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mount(host: &str, mount: &str, access: JailAccess) -> JailMount {
+        JailMount {
+            host: host.to_string(),
+            mount: mount.to_string(),
+            access,
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // YAML block form
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn yaml_block_round_trip() {
+        let text = "default: deny\n\
+                    mounts:\n\
+                    \x20 - {host: /home/u/sources, mount: /work, access: rw}\n\
+                    \x20 - {host: /data, mount: /data, access: ro}\n\
+                    argument_files: auto-allowed\n";
+        let jail = HostJail::from_yaml(text).unwrap();
+        assert!(!jail.default_open);
+        assert_eq!(jail.mounts.len(), 2);
+        assert_eq!(jail.mounts[0].access, JailAccess::Rw);
+        assert!(jail.argument_files.auto);
+        let rendered = jail.to_yaml().unwrap();
+        let back = HostJail::from_yaml(&rendered).unwrap();
+        assert_eq!(back, jail);
+    }
+
+    #[test]
+    fn yaml_argument_files_list_form() {
+        let jail =
+            HostJail::from_yaml("default: deny\nargument_files: [/in/a.csv, /in/b.csv]\n").unwrap();
+        assert!(!jail.argument_files.auto);
+        assert_eq!(
+            jail.argument_files.files,
+            vec!["/in/a.csv".to_string(), "/in/b.csv".to_string()]
+        );
+        let back = HostJail::from_yaml(&jail.to_yaml().unwrap()).unwrap();
+        assert_eq!(back, jail);
+    }
+
+    #[test]
+    fn yaml_minimal_block_defaults_to_open() {
+        let jail = HostJail::from_yaml("{}\n").unwrap();
+        assert_eq!(jail, HostJail::open());
+        // …and an omitted default serializes explicitly (self-describing).
+        assert!(jail.to_yaml().unwrap().contains("default: open"));
+    }
+
+    #[test]
+    fn yaml_rejections() {
+        for (text, frag) in [
+            ("default: strict\n", "open|deny"),
+            (
+                "mounts: [{host: /h, mount: rel, access: ro}]\n",
+                "not absolute",
+            ),
+            ("mounts: [{host: /h, mount: /m, access: xo}]\n", "ro|rw"),
+            ("argument_files: sometimes\n", "auto-allowed"),
+        ] {
+            let e = HostJail::from_yaml(text).unwrap_err();
+            assert!(
+                e.to_string().contains(frag),
+                "{text:?}: error {e} should mention {frag:?}"
+            );
+        }
+        // Unknown keys tolerated (the manifest convention).
+        let jail = HostJail::from_yaml("default: deny\nfuture: yes\n").unwrap();
+        assert!(!jail.default_open);
+    }
+
+    // ---------------------------------------------------------------
+    // env form (spec 08 §1 — one grammar with tfs::policy::JailSpec)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn env_spec_parses_all_directive_kinds() {
+        let j =
+            HostJail::parse_env_spec("deny;/home/u/src:/work:rw;@/home/u/in.csv;/data:/data:ro")
+                .unwrap();
+        assert!(!j.default_open);
+        assert_eq!(
+            j.mounts,
+            vec![
+                mount("/home/u/src", "/work", JailAccess::Rw),
+                mount("/data", "/data", JailAccess::Ro),
+            ]
+        );
+        assert_eq!(j.argument_files.files, vec!["/home/u/in.csv".to_string()]);
+    }
+
+    #[test]
+    fn env_spec_defaults_to_open_and_tolerates_colons_in_hosts() {
+        let j = HostJail::parse_env_spec("/Volumes/a:b/work:/w:rw").unwrap();
+        assert!(j.default_open);
+        assert_eq!(j.mounts[0].host, "/Volumes/a:b/work");
+    }
+
+    #[test]
+    fn env_spec_rejections_mirror_the_engine() {
+        for (spec, frag) in [
+            ("", "empty spec"),
+            ("   ", "empty spec"),
+            ("open;deny", "duplicate/conflicting"),
+            ("deny;deny", "duplicate/conflicting"),
+            ("deny;;/h:/w:ro", "empty directive"),
+            ("/h:/w:xx", "unknown access mode"),
+            ("/h:w:ro", "not absolute"),
+            ("/h:/w", "unknown access mode"),
+            ("frob", "host:mount:ro|rw"),
+            (":/w:ro", "empty host"),
+            ("@", "empty argument file"),
+        ] {
+            let e = HostJail::parse_env_spec(spec).unwrap_err();
+            assert!(
+                e.to_string().contains(frag),
+                "spec {spec:?}: error {e} should mention {frag:?}"
+            );
+        }
+        assert!(HostJail::parse_env_spec("frob")
+            .unwrap_err()
+            .to_string()
+            .contains("\"frob\""));
+    }
+
+    #[test]
+    fn env_spec_round_trip() {
+        let j = HostJail::parse_env_spec("deny;/a:/work:rw;@/in.csv").unwrap();
+        let env = j.to_env_spec(&[]);
+        assert_eq!(env, "deny;/a:/work:rw;@/in.csv");
+        let back = HostJail::parse_env_spec(&env).unwrap();
+        assert_eq!(back, j);
+        assert_eq!(HostJail::open().to_env_spec(&[]), "open");
+    }
+
+    #[test]
+    fn to_env_spec_unions_resolved_argument_files() {
+        let mut j = HostJail::deny_with_arg_files();
+        j.argument_files.files = vec!["/explicit".to_string()];
+        let env = j.to_env_spec(&[PathBuf::from("/resolved"), PathBuf::from("/explicit")]);
+        assert_eq!(env, "deny;@/explicit;@/resolved");
+    }
+
+    // ---------------------------------------------------------------
+    // --jail cli spec forms
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn cli_spec_profiles() {
+        assert_eq!(HostJail::from_cli_spec("open").unwrap(), HostJail::open());
+        assert_eq!(HostJail::from_cli_spec("deny").unwrap(), HostJail::deny());
+        let j = HostJail::from_cli_spec("deny:arg").unwrap();
+        assert!(!j.default_open);
+        assert!(j.argument_files.auto);
+    }
+
+    #[test]
+    fn cli_spec_yaml_file() {
+        let dir = std::env::temp_dir().join(format!("tpkg-jail-cli-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("jail.yaml");
+        std::fs::write(
+            &file,
+            "default: deny\nmounts: [{host: /h, mount: /m, access: ro}]\n",
+        )
+        .unwrap();
+        let j = HostJail::from_cli_spec(file.to_str().unwrap()).unwrap();
+        assert!(!j.default_open);
+        assert_eq!(j.mounts, vec![mount("/h", "/m", JailAccess::Ro)]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cli_spec_env_grammar_passthrough() {
+        let j = HostJail::from_cli_spec("deny;/data:/data:ro").unwrap();
+        assert_eq!(j.mounts, vec![mount("/data", "/data", JailAccess::Ro)]);
+        assert!(HostJail::from_cli_spec("frob").is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // intersect / effective — the locked precedence (spec 08 §2/§4)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn intersect_deny_wins_either_side() {
+        let open = HostJail::open();
+        let deny = HostJail::deny();
+        assert!(!intersect(&open, &deny).default_open);
+        assert!(!intersect(&deny, &open).default_open);
+        assert!(intersect(&open, &open).default_open);
+    }
+
+    #[test]
+    fn intersect_user_no_host_drops_request_grants() {
+        // The manifest requests /a ro; the user says deny with no grants:
+        // the effective policy allows NOTHING (the user's tightening caps
+        // the request — never the reverse).
+        let mut request = HostJail::deny();
+        request.mounts = vec![mount("/a", "/a", JailAccess::Ro)];
+        let eff = intersect(&request, &HostJail::deny());
+        assert!(!eff.default_open);
+        assert!(eff.mounts.is_empty(), "{eff:?}");
+    }
+
+    #[test]
+    fn intersect_user_grant_capped_by_request_deny() {
+        // The user adds /x rw under an open user default; the manifest
+        // denies everything outside /a: /x must NOT survive (the manifest
+        // request is a ceiling — wider latitude comes by trust policy,
+        // never by a flag).
+        let mut request = HostJail::deny();
+        request.mounts = vec![mount("/a", "/a", JailAccess::Rw)];
+        let mut user = HostJail::open();
+        user.mounts = vec![mount("/x", "/x", JailAccess::Rw)];
+        let eff = intersect(&request, &user);
+        assert!(!eff.default_open);
+        assert_eq!(eff.mounts, vec![mount("/a", "/a", JailAccess::Rw)]);
+    }
+
+    #[test]
+    fn intersect_ro_is_sticky_across_combinations() {
+        // ro bind in the request, rw at the same prefix in the tightening:
+        // the tighter access wins (docker-style, never loosened).
+        let mut request = HostJail::deny();
+        request.mounts = vec![mount("/a", "/a", JailAccess::Ro)];
+        let mut user = HostJail::deny();
+        user.mounts = vec![mount("/a", "/a", JailAccess::Rw)];
+        let eff = intersect(&request, &user);
+        assert_eq!(eff.mounts, vec![mount("/a", "/a", JailAccess::Ro)]);
+    }
+
+    #[test]
+    fn intersect_nested_prefixes_clamp_to_the_covering_allowance() {
+        // request grants /a/b rw; the tightening grants /a ro: /a/b clamps
+        // to ro, and the request's broader context is capped to /a/b.
+        let mut request = HostJail::deny();
+        request.mounts = vec![mount("/a/b", "/b", JailAccess::Rw)];
+        let mut user = HostJail::deny();
+        user.mounts = vec![mount("/a", "/a", JailAccess::Ro)];
+        let eff = intersect(&request, &user);
+        assert_eq!(eff.mounts, vec![mount("/a/b", "/b", JailAccess::Ro)]);
+    }
+
+    #[test]
+    fn intersect_open_request_keeps_user_grants_verbatim() {
+        // No manifest request (open): the user's policy is applied as-is.
+        let mut user = HostJail::deny();
+        user.mounts = vec![mount("/work", "/work", JailAccess::Rw)];
+        let eff = intersect(&HostJail::open(), &user);
+        assert_eq!(eff, user);
+    }
+
+    #[test]
+    fn intersect_argument_files_union_and_auto_either_side() {
+        let mut request = HostJail::deny_with_arg_files();
+        request.argument_files.files = vec!["/a".to_string()];
+        let mut user = HostJail::deny();
+        user.argument_files.files = vec!["/b".to_string(), "/a".to_string()];
+        let eff = intersect(&request, &user);
+        assert!(eff.argument_files.auto);
+        assert_eq!(
+            eff.argument_files.files,
+            vec!["/b".to_string(), "/a".to_string()]
+        );
+    }
+
+    #[test]
+    fn intersect_is_idempotent_and_recomposition_stable() {
+        // A surface composes, then the bootstrap composes the result with
+        // the manifest again: no drift (the double-compose property the
+        // `tebako run` → bootstrap chain relies on).
+        let mut request = HostJail::deny();
+        request.mounts = vec![mount("/a", "/a", JailAccess::Rw)];
+        request.argument_files.auto = true;
+        let mut user = HostJail::deny();
+        user.mounts = vec![
+            mount("/a", "/a", JailAccess::Ro),
+            mount("/b", "/b", JailAccess::Rw),
+        ];
+        let once = intersect(&request, &user);
+        let twice = intersect(&request, &once);
+        assert_eq!(once, twice);
+        assert_eq!(intersect(&once, &once), once);
+    }
+
+    #[test]
+    fn effective_labels_the_source() {
+        let deny = HostJail::deny();
+        assert!(effective(None, None).is_none());
+        assert_eq!(effective(Some(&deny), None).unwrap().1, "manifest");
+        assert_eq!(effective(None, Some(&deny)).unwrap().1, "user");
+        assert_eq!(
+            effective(Some(&deny), Some(&deny)).unwrap().1,
+            "manifest+user"
+        );
+    }
+
+    #[test]
+    fn trivially_open_detection() {
+        assert!(HostJail::open().is_trivially_open());
+        assert!(!HostJail::deny_with_arg_files().is_trivially_open());
+        let mut j = HostJail::open();
+        j.mounts = vec![mount("/a", "/a", JailAccess::Ro)];
+        assert!(!j.is_trivially_open());
+        // auto-allowed under an open default grants nothing extra.
+        j.mounts.clear();
+        j.argument_files.auto = true;
+        assert!(j.is_trivially_open());
+    }
+
+    #[test]
+    fn resolve_argument_files_picks_existing_entries() {
+        let dir = std::env::temp_dir().join(format!("tpkg-jail-args-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("input.csv");
+        std::fs::write(&file, b"x").unwrap();
+        let args = vec![
+            file.to_string_lossy().into_owned(),
+            "--verbose".to_string(),
+            dir.join("missing").to_string_lossy().into_owned(),
+            file.to_string_lossy().into_owned(), // duplicate
+        ];
+        let resolved = resolve_argument_files(&args);
+        assert_eq!(resolved, vec![file]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn trailing_slashes_normalize() {
+        let j = HostJail::parse_env_spec("deny;/a/:/w:ro").unwrap();
+        assert_eq!(j.mounts[0].host, "/a");
+        let j = HostJail::parse_env_spec("deny;/:/w:rw").unwrap();
+        assert_eq!(j.mounts[0].host, "/");
+    }
+}

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -139,6 +139,7 @@ mod envelope;
 mod error;
 mod ext;
 mod io;
+pub mod jail;
 mod manifest;
 pub mod merkle;
 pub mod merkle_host;
@@ -154,6 +155,7 @@ pub use envelope::{EnvelopeManifest, Grant, Suite, ENVELOPES_PATH, ENVELOPES_SCH
 pub use error::{strerror, TpkgError};
 pub use ext::{ExtBlock, ExtError};
 pub use io::{read_from, write_to};
+pub use jail::{ArgumentFiles, HostJail, JailAccess, JailError, JailMount};
 pub use manifest::{
     AppProvides, BuiltFrom, Capabilities, Constraint, DataProvides, Digest, Encryption,
     EncryptionPart, EncryptionState, EngineProvides, Entrypoint, Identity, ManifestError,

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -40,6 +40,9 @@ pub enum ManifestError {
     Yaml(serde_yml::Error),
     /// Semantic validation failure (`validate()`).
     Invalid(&'static str),
+    /// The `capabilities.host` jail block failed its own validation
+    /// (spec 08 §4 — the reason travels with the jail error).
+    Jail(crate::jail::JailError),
 }
 
 impl fmt::Display for ManifestError {
@@ -47,6 +50,7 @@ impl fmt::Display for ManifestError {
         match self {
             ManifestError::Yaml(e) => write!(f, "payload manifest yaml error: {e}"),
             ManifestError::Invalid(m) => write!(f, "invalid payload manifest: {m}"),
+            ManifestError::Jail(e) => write!(f, "invalid payload manifest capabilities.host: {e}"),
         }
     }
 }
@@ -56,6 +60,7 @@ impl std::error::Error for ManifestError {
         match self {
             ManifestError::Yaml(e) => Some(e),
             ManifestError::Invalid(_) => None,
+            ManifestError::Jail(e) => Some(e),
         }
     }
 }
@@ -646,12 +651,31 @@ fn check_tree_hash(s: &str) -> Result<(), ManifestError> {
 /// §2.2) and enforced by [`PayloadManifest::validate`]:
 /// app `{exec: true, read: true}`, runtime `{exec: true, read: true,
 /// runtime: true}`, data `{exec: false, read: true}`.
+///
+/// `host` (spec 08 §4) is orthogonal to the truth table and may ride any
+/// kind: the host access the payload was BUILT TO NEED (e.g. metanorma:
+/// read the input file's directory, write the output directory). It is a
+/// REQUEST, never a grant to itself — dispatch surfaces compose it with
+/// the user's tightening (`manifest request ∩ user policy = effective
+/// jail`, spec 08 §2). Absent = the open default (today's behavior).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Capabilities {
     pub exec: bool,
     pub read: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<crate::jail::HostJail>,
+}
+
+impl Capabilities {
+    /// The spec 08 §4 block validates itself (mount-point shape etc.).
+    fn validate_host(&self) -> Result<(), ManifestError> {
+        if let Some(host) = &self.host {
+            host.validate().map_err(ManifestError::Jail)?;
+        }
+        Ok(())
+    }
 }
 
 /// An entrypoint's runtime requirement (`{engine, constraint}`): a range
@@ -803,6 +827,7 @@ impl AppProvides {
                 "provides.capabilities for kind app is exactly {exec: true, read: true}",
             ));
         }
+        caps.validate_host()?;
         Ok(())
     }
 }
@@ -846,6 +871,7 @@ impl RuntimeProvides {
                 "provides.capabilities for kind runtime is exactly {exec: true, read: true, runtime: true}",
             ));
         }
+        caps.validate_host()?;
         Ok(())
     }
 }
@@ -867,6 +893,7 @@ impl DataProvides {
                 "provides.capabilities for kind data is exactly {exec: false, read: true}",
             ));
         }
+        caps.validate_host()?;
         Ok(())
     }
 }
@@ -1289,6 +1316,7 @@ mod tests {
             exec,
             read,
             runtime,
+            host: None,
         };
         let base = |c: Capabilities| AppProvides {
             entrypoints: vec![Entrypoint {
@@ -1306,6 +1334,48 @@ mod tests {
         assert!(base(caps(true, true, None)).validate().is_ok());
         assert!(base(caps(false, true, None)).validate().is_err());
         assert!(base(caps(true, true, Some(true))).validate().is_err());
+    }
+
+    #[test]
+    fn capabilities_host_block_round_trips_and_validates() {
+        // spec 08 §4: capabilities.host rides the truth-table kinds as the
+        // payload's declared host-access REQUEST.
+        let mut app = AppProvides {
+            entrypoints: vec![Entrypoint {
+                name: "x".into(),
+                path: "/x".into(),
+                args_default: vec![],
+                runtime_requirement: Some(RuntimeRequirement {
+                    engine: "ruby".into(),
+                    constraint: Constraint::new(">= 3.3, < 5.0").unwrap(),
+                }),
+            }],
+            platforms: Platforms::Universal,
+            capabilities: Capabilities {
+                exec: true,
+                read: true,
+                runtime: None,
+                host: Some(crate::jail::HostJail::from_yaml(
+                    "default: deny\nmounts: [{host: /work, mount: /work, access: rw}]\nargument_files: auto-allowed\n",
+                ).unwrap()),
+            },
+        };
+        app.validate().unwrap();
+        let y = serde_yml::to_string(&app).unwrap();
+        assert!(y.contains("host:"), "{y}");
+        assert!(y.contains("default: deny"), "{y}");
+        let back: AppProvides = serde_yml::from_str(&y).unwrap();
+        assert_eq!(back, app);
+        // A bad jail block surfaces as the Jail error kind.
+        app.capabilities.host = Some(crate::jail::HostJail {
+            mounts: vec![crate::jail::JailMount {
+                host: "/h".into(),
+                mount: "relative".into(),
+                access: crate::jail::JailAccess::Ro,
+            }],
+            ..crate::jail::HostJail::deny()
+        });
+        assert!(matches!(app.validate(), Err(ManifestError::Jail(_))));
     }
 
     #[test]

--- a/crates/tpkg/src/package.rs
+++ b/crates/tpkg/src/package.rs
@@ -16,15 +16,17 @@
 //! Same authored-YAML discipline as the payload manifest
 //! ([`crate::manifest`]): reading is two-step ([`PackageManifest::from_yaml`]
 //! does serde structure, then [`PackageManifest::validate`] semantics),
-//! unknown keys are tolerated for forward compatibility (only `jail` is
-//! preserved verbatim — its shape is spec 08's, not this schema's), and
-//! the versioned JSON Schema `schema/tpkg-package-manifest-v1.schema.json`
-//! pins the structure.
+//! unknown keys are tolerated for forward compatibility, and the versioned
+//! JSON Schema `schema/tpkg-package-manifest-v1.schema.json` pins the
+//! structure. The `jail` block is typed ([`crate::jail::HostJail`]) — spec
+//! 08 §1 owns its shape, and the bootstrap composes it with the user's
+//! tightening at handoff (spec 08 §2).
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;
 
+use crate::jail::HostJail;
 use crate::manifest::Producer;
 use crate::TPKG_MAX_SLOTS;
 
@@ -44,6 +46,9 @@ pub enum PackageManifestError {
     Yaml(serde_yml::Error),
     /// Semantic validation failure (`validate()`).
     Invalid(&'static str),
+    /// The `jail:` block failed the spec 08 validation (the reason travels
+    /// with the jail error).
+    Jail(crate::jail::JailError),
 }
 
 impl fmt::Display for PackageManifestError {
@@ -51,6 +56,7 @@ impl fmt::Display for PackageManifestError {
         match self {
             PackageManifestError::Yaml(e) => write!(f, "package manifest yaml error: {e}"),
             PackageManifestError::Invalid(m) => write!(f, "invalid package manifest: {m}"),
+            PackageManifestError::Jail(e) => write!(f, "invalid package manifest jail: {e}"),
         }
     }
 }
@@ -60,6 +66,7 @@ impl std::error::Error for PackageManifestError {
         match self {
             PackageManifestError::Yaml(e) => Some(e),
             PackageManifestError::Invalid(_) => None,
+            PackageManifestError::Jail(e) => Some(e),
         }
     }
 }
@@ -114,10 +121,12 @@ pub struct PackageManifest {
     pub package: PackageIdentity,
     /// One entry per invocable command (N >= 1).
     pub entries: Vec<PackageEntry>,
-    /// Package-level jail request (spec 08 owns the shape — preserved
-    /// verbatim, not interpreted here).
+    /// Package-level jail request (spec 08 §1 owns the shape): the access
+    /// the package was pressed with (`tebako press --jail`). The bootstrap
+    /// composes it with the user's tightening at handoff — manifest
+    /// request ∩ user policy = effective jail (spec 08 §2).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub jail: Option<BTreeMap<String, serde_yml::Value>>,
+    pub jail: Option<HostJail>,
     /// Package-level env (composition rules: spec 07).
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub env: BTreeMap<String, String>,
@@ -140,7 +149,8 @@ impl PackageManifest {
     /// Semantic checks beyond the serde structure: schema version,
     /// non-empty identity/entry fields, N >= 1 entries, slot indexes
     /// inside the container's slot capacity, unique entry names, non-empty
-    /// env keys. Unknown keys are tolerated (only `jail` is lossless).
+    /// env keys, and the spec 08 jail block's own validation. Unknown keys
+    /// are tolerated at every level.
     pub fn validate(&self) -> Result<(), PackageManifestError> {
         if self.schema_version != PACKAGE_SCHEMA_VERSION {
             return Err(PackageManifestError::Invalid(
@@ -185,6 +195,9 @@ impl PackageManifest {
         }
         if self.env.keys().any(|k| k.is_empty()) {
             return Err(PackageManifestError::Invalid("env keys must not be empty"));
+        }
+        if let Some(jail) = &self.jail {
+            jail.validate().map_err(PackageManifestError::Jail)?;
         }
         Ok(())
     }
@@ -288,16 +301,45 @@ mod tests {
     }
 
     #[test]
-    fn jail_is_preserved_verbatim() {
+    fn jail_block_is_typed_and_round_trips() {
         let text = "schema_version: 1\n\
                     package: {name: x, version: 1.0.0, producer: {tool: t, tool_version: 1}, created: now}\n\
                     entries:\n  - {name: x, slot: 0, entrypoint: x, runtime_ref: ruby@3.4.2;tebako=0.15.9}\n\
-                    jail: {profile: strict, allow: [read, write]}\n";
+                    jail:\n\
+                    \x20 default: deny\n\
+                    \x20 mounts:\n\
+                    \x20   - {host: /home/u/src, mount: /work, access: rw}\n\
+                    \x20 argument_files: auto-allowed\n";
         let m = PackageManifest::from_yaml(text).unwrap();
         let jail = m.jail.as_ref().unwrap();
-        assert!(jail.contains_key("profile"));
+        assert!(!jail.default_open);
+        assert_eq!(jail.mounts.len(), 1);
+        assert_eq!(jail.mounts[0].access, crate::jail::JailAccess::Rw);
+        assert!(jail.argument_files.auto);
         let rendered = m.to_yaml().unwrap();
         let back = PackageManifest::from_yaml(&rendered).unwrap();
         assert_eq!(back, m);
+    }
+
+    #[test]
+    fn jail_block_validates() {
+        let mut m = minimal();
+        m.jail = Some(HostJail {
+            mounts: vec![crate::jail::JailMount {
+                host: "/h".to_string(),
+                mount: "relative".to_string(),
+                access: crate::jail::JailAccess::Ro,
+            }],
+            ..HostJail::deny()
+        });
+        assert!(matches!(m.validate(), Err(PackageManifestError::Jail(_))));
+        // Unknown keys inside the block are tolerated (forward-compat);
+        // the block's declared shape still parses.
+        let text = "schema_version: 1\n\
+                    package: {name: x, version: 1.0.0, producer: {tool: t, tool_version: 1}, created: now}\n\
+                    entries:\n  - {name: x, slot: 0, entrypoint: x, runtime_ref: ruby@3.4.2;tebako=0.15.9}\n\
+                    jail: {default: deny, future: yes}\n";
+        let m = PackageManifest::from_yaml(text).unwrap();
+        assert!(!m.jail.as_ref().unwrap().default_open);
     }
 }

--- a/crates/tpkg/tests/manifest_props.rs
+++ b/crates/tpkg/tests/manifest_props.rs
@@ -167,6 +167,7 @@ fn arb_provides(kind: PayloadKind) -> impl Strategy<Value = Provides> {
                     exec: true,
                     read: true,
                     runtime: None,
+                    host: None,
                 },
             })
         },
@@ -194,6 +195,7 @@ fn arb_provides(kind: PayloadKind) -> impl Strategy<Value = Provides> {
                     exec: true,
                     read: true,
                     runtime: Some(true),
+                    host: None,
                 },
             })
         });
@@ -205,6 +207,7 @@ fn arb_provides(kind: PayloadKind) -> impl Strategy<Value = Provides> {
                 exec: false,
                 read: true,
                 runtime: None,
+                host: None,
             },
         })
     });

--- a/docs/spec/03-payload-manifest.md
+++ b/docs/spec/03-payload-manifest.md
@@ -54,6 +54,11 @@ entrypoints:                          # ARRAY — multi-entry suites; N=1 for si
                                                 # universal only for pure-language
 capabilities: {exec: true, read: true}
 ```
+`capabilities` may also carry **`host`** (any kind): the host-access jail
+the payload was built to need — a REQUEST the dispatch surfaces compose
+with the user's tightening, never a grant to itself. spec 08 §4 is
+normative for its shape (`default`, `mounts`, `argument_files`).
+
 **Zero-runtime entrypoints (locked):** an entrypoint whose executable is
 native (or self-contained) needs NO interpreter payload — inkscape-class
 slices, static binaries, shell-free tools. Such apps declare no

--- a/docs/spec/06-launcher-abi.md
+++ b/docs/spec/06-launcher-abi.md
@@ -66,6 +66,7 @@ republish of v1-era runtimes needed.
 | 70 | `EX_TEBAKO_SHA` | sha256 mismatch (runtime or image) |
 | 71 | `EX_TEBAKO_SIGNATURE` | invalid signature; or unsigned under `TEBAKO_REQUIRE_SIGNED=1` |
 | 72 | `EX_TEBAKO_TRUST` | signer key not in the trusted keyring |
+| 73 | `EX_TEBAKO_JAIL` | jail policy could not be applied (malformed `TEBAKO_JAIL`; fail-closed — spec 08) |
 | 74 | `EX_TEBAKO_IO` | filesystem/lock/install failure |
 
 stderr body: `tebako-bootstrap: <message>\n` — message bodies match the

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -134,20 +134,35 @@ The locked model is three tiers — **interposition-first, never FUSE**:
    (spec 08). Limit: dynamic binaries only; the shim is a TFS consumer,
    never a format. **SHIPPED (roadmap 30): `crates/libtfs-preload` +
    `tfs exec <image>[:mount] [--image …] [--jail <spec>] -- <cmd>` in
-   tfs-cli — macOS and linux-gnu first-class, windows later. v1 concrete
-   choices:** interposed surface open/openat/stat/lstat/fstat/access/
-   faccessat/opendir/readdir(+readdir64)/closedir/pread/read/lseek/
-   close/mkdir/unlink/rename + dlopen; `TEBAKO_JAIL` carries the spec 08
-   §1 env form (`open|deny` + `host:mount:ro|rw` grants + `@` argument
-   files); the ENTRYPOINT (when in-image) is materialized through
-   `dlmap2file` (execve needs a host path — one copy per exec, gc
-   later); execve/posix_spawn of memfs paths is NOT virtualized in v1
-   (children re-spawn via `argv[0]`; the process tree stays in the VFS
-   by env propagation; SIP platform binaries strip `DYLD_*` and leave
-   it); a mount at `/` is refused (it would claim every host path and
-   bypass the jail); not interposed in v1: execve/posix_spawn,
-   fstatat/statx, getdents64, openat2, readdir_r,
-   rewinddir/telldir/seekdir, the pre-glibc-2.33 `__xstat` family.
+   tfs-cli — macOS and linux-gnu first-class, windows later. Coverage
+   (roadmap 39):** interposed surface open/openat/stat/
+   lstat/fstat/fstatat(+fstatat64/statx/__xstat/__lxstat/__fxstat/
+   __fxstatat and the LFS open64/stat64/lstat64/fstat64/pread64 family
+   on linux)/access/faccessat/opendir/readdir(+readdir64)/
+   readdir_r/rewinddir/telldir/seekdir/dirfd/closedir/pread/read/lseek/
+   close/mkdir/unlink/rename + dlopen + execve/posix_spawn/posix_spawnp;
+   `TEBAKO_JAIL` carries the spec 08 §1 env form (`open|deny` +
+   `host:mount:ro|rw` grants + `@` argument files); the ENTRYPOINT (when
+   in-image) is materialized through `dlmap2file` (execve needs a host
+   path — one copy per exec, gc later), and execve/posix_spawn of MEMFS
+   paths materialize the same way (a tool spawning an in-image helper
+   needs no extraction; environ propagates, so grandchildren stay in the
+   VFS); every *at shim gates its fd branch on `dirfd >= 0` (AT_FDCWD
+   carries the fd-flag bit — the runtime-builds regression class, pinned
+   by tests); exec of a HOST binary is not policy-gated (not an IO route
+   in the policy's op classes — the child's own IO stays jailed via env
+   propagation); SIP platform binaries strip `DYLD_*` and leave it; a
+   mount at `/` is refused (it would claim every host path and bypass
+   the jail); not interposed: fork, `openat2` (glibc exposes no wrapper
+   or symbol on linux-gnu — nothing to interpose; a raw `syscall(2)`
+   caller bypasses userland interposition by construction), fstatat64 on
+   macOS (the legacy
+   32-bit-inode layout), the LFS `__xstat64` versioned forms on linux,
+   fdopendir (memfs directories are never fd-opened), and
+   syscall()-direct IO (raw syscalls bypass userland interposition by
+   construction); `dirfd` of a memfs stream answers -1/ENOTSUP;
+   `getdents64` on a memfs fd answers ENOTDIR (VFS directories enumerate
+   via opendir, never fds).
 2. **Static/self-contained tools**: tebako is the EXECUTOR, not an
    injector — it spawns and owns every child, so mediating a child's
    syscalls is the execution contract itself, not hijacking (a

--- a/docs/spec/08-jails.md
+++ b/docs/spec/08-jails.md
@@ -1,15 +1,19 @@
 # Spec 08 — Jails: host-access policy
 
 Normative specification of host-filesystem access control for running
-payloads. Status: PARTIAL (roadmap 09) — the TFS enforcement point (§1–§3)
-is SHIPPED in `crates/tfs` (policy model, `tebako_fs_host_policy`,
-per-route EPERM/EROFS gating, symlink re-validation, jail acceptance
-suite); the `TEBAKO_JAIL` env form of the policy (§1) is SHIPPED with
-roadmap 30's preload shim (`tfs exec --jail` carries it to native
-binaries); manifest integration (§4), the remaining dispatch-surface
-flags and the audit-journal logging of violations remain PLANNED.
-Enforcement exists because every file access already flows through the
-TFS layer — one choke point covers every consumer.
+payloads. Status: SHIPPED (roadmaps 09 + 30 + 35) — the TFS enforcement
+point (§1–§3) is SHIPPED in `crates/tfs` (policy model,
+`tebako_fs_host_policy`, per-route EPERM/EROFS gating, symlink
+re-validation, jail acceptance suite); the `TEBAKO_JAIL` env form of the
+policy (§1) is SHIPPED with roadmap 30's preload shim (`tfs exec --jail`
+carries it to native binaries); manifest integration (§4 —
+`capabilities.host` in `crates/tpkg`), the press/dispatch surfaces
+(`tebako press --jail` writing the package manifest's `jail:` block,
+`tebako run`/`tebako-shim` `--jail|--mount|--no-host`), the bootstrap's
+manifest∩user composition at handoff, and the audit-journal logging of
+violations (`event=jail-deny`) are SHIPPED with roadmap 35. Enforcement
+exists because every file access already flows through the TFS layer —
+one choke point covers every consumer.
 
 ## 1. Policy model (docker `-v` semantics)
 
@@ -91,6 +95,35 @@ The payload manifest (spec 03) gains `capabilities.host` — the access the
 payload was built to need (e.g. metanorma: read the input file's
 directory, write the output directory). Dispatch surfaces (spec 07)
 compose: manifest request ∩ user policy = effective jail.
+
+### Shipped surfaces (roadmap 35)
+
+- **Model:** `crates/tpkg/src/jail.rs` owns the authored shape (YAML
+  block ↔ `TEBAKO_JAIL` env form ↔ `--jail` cli spec: `open` | `deny` |
+  `deny:arg` | a YAML file | the env grammar) and the locked precedence
+  algebra (`intersect` / `effective`): deny defaults win; each side's
+  grants are capped by the other side's allowance at the same prefix (ro
+  is sticky, a user `--no-host` drops request grants); argument files
+  union and `auto-allowed` resolves argv files into read-only grants at
+  dispatch. The payload manifest's `capabilities.host` and the package
+  manifest's `jail:` block are both this type.
+- **Press:** `tebako press --jail <spec>` writes the policy into the
+  type-2 package manifest's `jail:` block (spec 02 §5b / spec 03 §6);
+  block-less packages are byte-identical to before.
+- **Bootstrap:** composes package `jail:` ∩ `TEBAKO_JAIL` at handoff and
+  exports the effective policy as `TEBAKO_JAIL` (+ `TEBAKO_JAIL_SOURCE`
+  = `manifest` | `user` | `manifest+user`, + `TEBAKO_JAIL_JOURNAL` →
+  `$TEBAKO_HOME/journal.log`). Malformed policy fails closed, exit 73
+  (`EX_TEBAKO_JAIL`). No policy: nothing exported (legacy byte-identical).
+- **Dispatch:** `tebako run <pkg> [--jail <spec>] [--mount
+  <host:mount:ro|rw>]... [--no-host] [--] [args...]` and the same flags on
+  `tebako-shim` (consumed before `--`; the payload mirror carries
+  `capabilities.host` from install time).
+- **Audit journal (§2):** every denial in the TFS layer appends `<ts>
+  event=jail-deny path=<p> op=read|write source=<s>` to the tebako
+  journal (`TEBAKO_JAIL_JOURNAL` > `$TEBAKO_HOME/journal.log` >
+  `~/.tebako/journal.log`), best-effort — journaling never fails the
+  operation it audits.
 
 ## 5. Scope (honest, locked 2026-07-26)
 

--- a/docs/spec/17-runtime-driver-contract.md
+++ b/docs/spec/17-runtime-driver-contract.md
@@ -28,6 +28,8 @@ exact contract (roadmap 22's "add a language" playbook).
 | `TEBAKO_RUNTIME_IMAGE` | image-era: absolute path of the runtime's own `.tfs` (driver mounts it instead of any embedded image) |
 | `TEBAKO_TFS_MOUNTS` | `image:mount,…` — mounts to establish (preload-shim path) |
 | `TEBAKO_JAIL` | jail policy env form (spec 08) — the driver/preload enforces it |
+| `TEBAKO_JAIL_SOURCE` | audit label of the policy's origin (`manifest` / `user` / `manifest+user`, or the exporting surface) — journaled with every denial (spec 08 §2) |
+| `TEBAKO_JAIL_JOURNAL` | explicit audit-journal path (default: `$TEBAKO_HOME/journal.log`) |
 
 ## 3. File IO semantics
 

--- a/schema/tpkg-manifest-v1.schema.json
+++ b/schema/tpkg-manifest-v1.schema.json
@@ -189,7 +189,8 @@
       "required": ["exec", "read"],
       "properties": {
         "exec": { "const": true },
-        "read": { "const": true }
+        "read": { "const": true },
+        "host": { "$ref": "#/$defs/hostJail" }
       },
       "not": { "required": ["runtime"] }
     },
@@ -199,7 +200,8 @@
       "properties": {
         "exec": { "const": true },
         "read": { "const": true },
-        "runtime": { "const": true }
+        "runtime": { "const": true },
+        "host": { "$ref": "#/$defs/hostJail" }
       }
     },
     "capabilitiesData": {
@@ -207,9 +209,37 @@
       "required": ["exec", "read"],
       "properties": {
         "exec": { "const": false },
-        "read": { "const": true }
+        "read": { "const": true },
+        "host": { "$ref": "#/$defs/hostJail" }
       },
       "not": { "required": ["runtime"] }
+    },
+    "hostJail": {
+      "type": "object",
+      "description": "capabilities.host (spec 08 §4): the host access the payload was BUILT TO NEED — a REQUEST the dispatch surfaces compose with the user's tightening (manifest request ∩ user policy = effective jail, spec 08 §2). Absent = open (today's behavior).",
+      "properties": {
+        "default": { "enum": ["open", "deny"] },
+        "mounts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/hostJailMount" }
+        },
+        "argument_files": {
+          "description": "EITHER the scalar \"auto-allowed\" (dispatch resolves argv files into read-only grants) OR an explicit path list (read-only grants, honored even under deny).",
+          "anyOf": [
+            { "const": "auto-allowed" },
+            { "type": "array", "items": { "type": "string", "minLength": 1 } }
+          ]
+        }
+      }
+    },
+    "hostJailMount": {
+      "type": "object",
+      "required": ["host", "mount", "access"],
+      "properties": {
+        "host": { "type": "string", "minLength": 1 },
+        "mount": { "$ref": "#/$defs/absPath" },
+        "access": { "enum": ["ro", "rw"] }
+      }
     },
     "runtimeRequirement": {
       "type": "object",

--- a/schema/tpkg-package-manifest-v1.schema.json
+++ b/schema/tpkg-package-manifest-v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tebako.org/schemas/tpkg-package-manifest-v1.schema.json",
   "title": "tpkg package manifest v1",
-  "description": "The L2 package manifest (spec 03 §6), carried as tpkg extension block type 2 (spec 02 §5b) — YAML in the container, OUTSIDE every payload image, readable without backend knowledge. It owns composition (identity, entrypoint/suite entries, package-level jail + env, per-entry runtime refs); payload manifests stay inside images and own self-description. This schema is the STRUCTURAL contract; the tpkg crate's PackageManifest::validate() is the semantic gate (unique entry names, slot-capacity bound, non-empty fields). Unknown keys are tolerated at every level for forward compatibility; only jail is guaranteed lossless (its shape is spec 08's).",
+  "description": "The L2 package manifest (spec 03 §6), carried as tpkg extension block type 2 (spec 02 §5b) — YAML in the container, OUTSIDE every payload image, readable without backend knowledge. It owns composition (identity, entrypoint/suite entries, package-level jail + env, per-entry runtime refs); payload manifests stay inside images and own self-description. This schema is the STRUCTURAL contract; the tpkg crate's PackageManifest::validate() is the semantic gate (unique entry names, slot-capacity bound, non-empty fields, the spec 08 jail block's own validation). Unknown keys are tolerated at every level for forward compatibility.",
   "type": "object",
   "required": ["schema_version", "package", "entries"],
   "properties": {
@@ -15,8 +15,7 @@
       "description": "One entry per invocable command (N=1 for simple apps; N entries for suites). Entry names are unique (enforced by the crate's validate())."
     },
     "jail": {
-      "type": "object",
-      "description": "Package-level jail request. Opaque here: spec 08 owns the shape; the block is preserved verbatim."
+      "$ref": "#/$defs/hostJail"
     },
     "env": {
       "type": "object",
@@ -25,6 +24,32 @@
     }
   },
   "$defs": {
+    "hostJail": {
+      "type": "object",
+      "description": "Package-level jail request (spec 08 §1 owns the shape; spec 03 §6 seats it here): the access the package was pressed with (`tebako press --jail`). The bootstrap composes it with the user's tightening at handoff — manifest request ∩ user policy = effective jail (spec 08 §2). Unknown keys are tolerated (forward-compat).",
+      "properties": {
+        "default": { "enum": ["open", "deny"] },
+        "mounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["host", "mount", "access"],
+            "properties": {
+              "host": { "type": "string", "minLength": 1 },
+              "mount": { "type": "string", "pattern": "^/" },
+              "access": { "enum": ["ro", "rw"] }
+            }
+          }
+        },
+        "argument_files": {
+          "description": "EITHER the scalar \"auto-allowed\" (the input files the command is handed are allowed even under deny) OR an explicit path list (read-only grants).",
+          "anyOf": [
+            { "const": "auto-allowed" },
+            { "type": "array", "items": { "type": "string", "minLength": 1 } }
+          ]
+        }
+      }
+    },
     "packageIdentity": {
       "type": "object",
       "required": ["name", "version", "producer", "created"],


### PR DESCRIPTION
Agent-159's enforcement stack, rebased onto main (2f9c2f1) and fully green locally.

## What lands

**Roadmap 35 — jail surfaces + capabilities.host (spec 08):**
- `HostJail` model + validation + schema in tpkg (`capabilities.host`), the YAML block ↔ `TEBAKO_JAIL` env ↔ `--jail` spec forms with intersect/effective precedence.
- `tebako press --jail <spec>` (type-2 PackageManifest with the jail block).
- Bootstrap applies the package jail; user tightening intersects, never loosens; malformed policy fails closed (exit 73 EX_TEBAKO_JAIL).
- `tebako run <pkg> [--jail/--mount/--no-host]` + the same flags in tebako-shim.
- **Audit journal**: `<ts> event=jail-deny path=<p> op=read|write source=<s>` at $TEBAKO_HOME/journal.log; opened once at policy-install time (the self-deadlock class: per-denial create_dir_all under the write-guard re-entered the interposed mkdir — fixed).

**Roadmap 39 — preload-shim coverage (spec 07 §8):**
- *at family: fstatat (macOS+linux), fstatat64/statx/getdents64/__xstat/__lxstat/__fxstat/__fxstatat + the LFS open64/stat64 family (linux).
- execve/posix_spawn/posix_spawnp of memfs paths materialized via the dlmap2file host cache + exec-bit fix; AT_FDCWD regression pinned (dirfd >= 0 gate).
- rewinddir/telldir/seekdir/readdir_r + dirfd (memfs dirfd answers -1/ENOTSUP).
- openat2 documented as impossible-by-construction on linux-gnu (glibc exposes no wrapper; raw syscall bypasses interposition by design).

## Evidence
- macOS arm64: 40/40 suites green (tpkg, tfs, libtfs-preload, tfs-cli, tebako-bootstrap, tebako-shim incl. jail e2e with EPERM proof + journal lines; cli_e2e 12/12; tebako run e2e 6/6).
- Linux (docker bookworm aarch64): libtfs-preload 15/15 e2e (all *at probes, dir-stream transcript, exec under deny, rustc-built tool).
- Post-rebase onto main: tpkg/tfs/bootstrap/shim/libtfs-preload suites all green; clippy + fmt clean; release bootstrap 1,974,384 B (< 3 MB gate).