### PR TITLE
bootstrap: negotiate the runtime contract version, fail closed (roadmap 45)

### DIFF
--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -87,6 +87,16 @@ pub const EX_TEBAKO_TRUST: u8 = 72;
 /// policy is fail-closed: an unparseable policy never silently runs open).
 pub const EX_TEBAKO_JAIL: u8 = 73;
 pub const EX_TEBAKO_IO: u8 = 74;
+/// The runtime declares a bootstrap↔runtime contract this bootstrap does
+/// not speak (roadmap 45): contract_version in the release manifest is
+/// outside this bootstrap's supported range — fail CLOSED, never a guess.
+pub const EX_TEBAKO_CONTRACT: u8 = 75;
+
+/// The bootstrap↔runtime contract this bootstrap speaks (roadmap 45):
+/// today's env/argv/image-handoff semantics. Min and max are the same
+/// until a second contract version exists (the bump rule: any change to
+/// env/argv/handoff semantics = +1).
+pub const SUPPORTED_CONTRACT: u32 = 1;
 
 const DEFAULT_RELEASES_BASE: &str =
     "https://github.com/tamatebako/tebako-runtime-ruby/releases/download";
@@ -710,6 +720,55 @@ pub fn sha_from_manifest_json(text: &str, asset: &str) -> Result<String, ()> {
     } else {
         Err(())
     }
+}
+
+/// The `contract_version` of the release-manifest entry for `asset`
+/// (roadmap 45): the same bounding as [`sha_from_manifest_json`], reading
+/// the object's integer "contract_version" when present. `None` when the
+/// field is absent (pre-contract releases, which are contract 1 by
+/// definition) or unparseable.
+pub fn contract_from_manifest_json(text: &str, asset: &str) -> Option<u32> {
+    let needle = format!("\"{asset}\"");
+    let p = text.find(&needle)?;
+    let obj = text[..p].rfind('{')?;
+    let end = text[p..].find('}').map(|e| p + e)?;
+    let body = &text[obj..end];
+    let k = body.find("\"contract_version\"")?;
+    let after = &body[k + 18..];
+    let after = after.trim_start_matches([':', ' ', '\t', '\n', '\r']);
+    let digits: String = after
+        .bytes()
+        .take_while(|b| b.is_ascii_digit())
+        .map(char::from)
+        .collect();
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+/// roadmap 45 negotiation failure (exe and image paths share the message).
+fn contract_mismatch_error(runtime_ref: &str, declared: u32) -> BootError {
+    BootError::new(
+        EX_TEBAKO_CONTRACT,
+        format!(
+            "runtime \"{runtime_ref}\" declares contract_version {declared}, but this tebako-bootstrap speaks contract {SUPPORTED_CONTRACT} — refusing to install or execute\n  the runtime and this bootstrap are from different contract generations; upgrade tebako (or pin an older runtime) and retry"
+        ),
+    )
+}
+
+/// Fail-closed contract gate (roadmap 45): the release manifest's declared
+/// `contract_version` for `asset` must equal [`SUPPORTED_CONTRACT`]. An
+/// absent field means a pre-contract release, which is contract 1 by
+/// definition (accepted while 1 is the supported contract). Returns the
+/// negotiation error to propagate, or `None` when the manifest is
+/// acceptable (matching, or legacy).
+fn contract_gate(runtime_ref: &str, manifest_text: &str, asset: &str) -> Option<BootError> {
+    let declared = contract_from_manifest_json(manifest_text, asset)?;
+    if declared == SUPPORTED_CONTRACT {
+        return None;
+    }
+    Some(contract_mismatch_error(runtime_ref, declared))
 }
 
 /// SHA256SUMS.txt fallback: "<64hex><spaces>[*]<filename>" per line.
@@ -1512,6 +1571,13 @@ fn download_executable(
     if fetch_url(&manifest_url, local, &manifest_tmp).is_ok() {
         diag_manifest = 2;
         if let Ok(text) = std::fs::read_to_string(&manifest_tmp) {
+            // roadmap 45: the runtime's declared contract must be one we
+            // speak — fail CLOSED before any checksum acceptance.
+            if let Some(e) = contract_gate(runtime_ref, &text, asset) {
+                cleanup_tmp_entry(&ins.tmp_dir, asset);
+                lock_release(ins.lock);
+                return Err(e);
+            }
             diag_manifest = 3;
             if let Ok(sha) = sha_from_manifest_json(&text, asset) {
                 diag_manifest = 4;
@@ -1709,6 +1775,13 @@ fn resolve_image(
     if fetch_url(&manifest_url, local, &manifest_tmp).is_ok() {
         diag_manifest = 2;
         if let Ok(text) = std::fs::read_to_string(&manifest_tmp) {
+            // roadmap 45: the image is additive metadata of the same
+            // package entry — the entry's contract_version (anchored by
+            // the executable's filename) governs it. Same fail-closed
+            // gate as the executable path.
+            if let Some(e) = contract_gate(runtime_ref, &text, &layout.asset) {
+                return Err(fail_image(lock, e));
+            }
             diag_manifest = 3;
             if let Ok(sha) = sha_from_manifest_image(&text, &image_asset) {
                 diag_manifest = 4;

--- a/crates/tebako-bootstrap/tests/selftest.rs
+++ b/crates/tebako-bootstrap/tests/selftest.rs
@@ -595,3 +595,117 @@ fn manifest_image_sha_parsing() {
     );
     assert!(tebako_bootstrap::sha_from_manifest_image(text, "nope.tfs").is_err());
 }
+
+// ---------------------------------------------------------------------
+// roadmap 45: bootstrap↔runtime contract negotiation
+// ---------------------------------------------------------------------
+
+#[test]
+fn contract_version_parsing() {
+    use tebako_bootstrap::contract_from_manifest_json as contract;
+    // Realistic post-45 entry: contract_version precedes filename; the
+    // additive image object follows size_bytes.
+    let text = r#"[
+  {
+    "tebako_version": "0.15.9",
+    "contract_version": 1,
+    "ruby_version": "3.3.7",
+    "platform": "macos-arm64",
+    "filename": "tebako-runtime-0.15.9-3.3.7-macos-arm64",
+    "sha256": "604e87a1b1d74a6868b35ecdbb11c4e3db01b23286cea9f078636fdf246172b8",
+    "size_bytes": 24191976,
+    "image": {"filename": "tebako-runtime-0.15.9-3.3.7-macos-arm64.tfs", "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "size_bytes": 20410208}
+  }
+]"#;
+    let exe = "tebako-runtime-0.15.9-3.3.7-macos-arm64";
+    assert_eq!(contract(text, exe), Some(1));
+
+    // A declared 2 is reported (the gate, not the parser, refuses it).
+    let text2 = text.replace("\"contract_version\": 1", "\"contract_version\": 2");
+    assert_eq!(contract(&text2, exe), Some(2));
+
+    // Absent field = pre-contract release = None (legacy contract 1).
+    let legacy = text.replace("    \"contract_version\": 1,\n", "");
+    assert!(!legacy.contains("contract_version"));
+    assert_eq!(contract(&legacy, exe), None);
+
+    // A non-integer value parses as absent.
+    let bad = text.replace("\"contract_version\": 1", "\"contract_version\": \"1\"");
+    assert_eq!(contract(&bad, exe), None);
+
+    // Unknown asset.
+    assert_eq!(contract(text, "nope"), None);
+}
+
+#[test]
+fn s15_contract_negotiation_accept_then_refuse() {
+    // Declared contract 1 (this bootstrap's generation): accepted.
+    let h1 = h();
+    let manifest = h1
+        .mirror_root
+        .join(format!("v{TEBAKO_VER}"))
+        .join("manifest.json");
+    let declared1 = std::fs::read_to_string(&manifest).unwrap().replace(
+        "\"tebako_version\":",
+        "\"contract_version\": 1,\n    \"tebako_version\":",
+    );
+    std::fs::write(&manifest, declared1).unwrap();
+    let pkg = h1.lean_pkg("myapp");
+    let home = h1.home("home-c1");
+    let (rc, out, err) = h1.run(&pkg, &home, &[], &["hello"]);
+    assert_eq!((rc, err.as_str()), (0, ""), "{err}");
+    assert!(out.contains("FAKE-RUNTIME"), "{out}");
+
+    // Declared contract 2 (a future generation): fail CLOSED, exit 75,
+    // nothing enters the cache.
+    let h2 = h();
+    let manifest2 = h2
+        .mirror_root
+        .join(format!("v{TEBAKO_VER}"))
+        .join("manifest.json");
+    let declared2 = std::fs::read_to_string(&manifest2).unwrap().replace(
+        "\"tebako_version\":",
+        "\"contract_version\": 2,\n    \"tebako_version\":",
+    );
+    std::fs::write(&manifest2, declared2).unwrap();
+    let pkg2 = h2.lean_pkg("myapp");
+    let home2 = h2.home("home-c2");
+    let (rc, _, err) = h2.run(&pkg2, &home2, &[], &[]);
+    assert_eq!(rc, 75, "{err}");
+    assert!(err.contains("contract_version 2"), "{err}");
+    assert!(err.contains("speaks contract 1"), "{err}");
+    assert!(
+        !home2.join("runtimes").join(&h2.entry).exists(),
+        "a refused-contract runtime entered the cache"
+    );
+}
+
+#[test]
+fn s16_image_contract_mismatch_refused() {
+    // The image path applies the same gate (the package entry's
+    // contract_version governs its additive image too). Warm the
+    // executable cache first so the image path is the one negotiating.
+    let h = h();
+    let home = h.home("home-ci");
+    let warm = h.lean_pkg("warmapp");
+    assert_eq!(h.run(&warm, &home, &[], &[]).0, 0, "warm-up install");
+
+    let manifest = h
+        .mirror_root
+        .join(format!("v{TEBAKO_VER}"))
+        .join("manifest.json");
+    let declared2 = std::fs::read_to_string(&manifest).unwrap().replace(
+        "\"tebako_version\":",
+        "\"contract_version\": 2,\n    \"tebako_version\":",
+    );
+    std::fs::write(&manifest, declared2).unwrap();
+
+    let pkg = h.lean_pkg_image("imgapp");
+    let (rc, _, err) = h.run(&pkg, &home, &[], &[]);
+    assert_eq!(rc, 75, "{err}");
+    assert!(err.contains("contract_version 2"), "{err}");
+    assert!(
+        !h.cache_image(&home).exists(),
+        "a refused-contract image entered the cache"
+    );
+}

--- a/crates/tebako-signer/src/lib.rs
+++ b/crates/tebako-signer/src/lib.rs
@@ -21,8 +21,8 @@
 // documented exception — a Rust-2024 unsafe-attribute extern "C" export.
 // deny keeps unsafe a hard error everywhere else in the crate.)
 
-pub mod envelope;
 pub mod bz_shim;
+pub mod envelope;
 mod error;
 pub mod keyring;
 mod keys;

--- a/docs/spec/05-resolution-and-cache.md
+++ b/docs/spec/05-resolution-and-cache.md
@@ -22,7 +22,8 @@ machine cache. Status: SHIPPED for runtimes (M6–M8); payload cache PARTIAL
 ## 2. Release index (runtime factory releases)
 
 - `manifest.json` — machine index; per-asset entries plus the additive
-  image-era key `image: {filename, sha256, size_bytes}`.
+  image-era key `image: {filename, sha256, size_bytes}` and the additive
+  `contract_version` key (bootstrap↔runtime contract, spec 06 §6).
 - `SHA256SUMS.txt` — line-index fallback (`<sha>  <file>`), carries the
   `<asset>.tfs` lines in the image era.
 - Base URL:

--- a/docs/spec/06-launcher-abi.md
+++ b/docs/spec/06-launcher-abi.md
@@ -50,7 +50,8 @@ republish of v1-era runtimes needed.
      downgraded to unverified.
    - **Unsigned (v1)**: loud warning + audit journal (or exit 71 under
      `TEBAKO_REQUIRE_SIGNED=1`).
-4. Resolve the runtime per spec 05 §5.
+4. Resolve the runtime per spec 05 §5 — negotiating the contract version
+   (§6) fail-closed before any checksum acceptance.
 5. Image-era: ensure `<asset>.tfs` + trust markers in the cache entry
    (fetch + verify on miss), install read-only.
 6. Exec the handoff. Never returns on success.
@@ -68,6 +69,7 @@ republish of v1-era runtimes needed.
 | 72 | `EX_TEBAKO_TRUST` | signer key not in the trusted keyring |
 | 73 | `EX_TEBAKO_JAIL` | jail policy could not be applied (malformed `TEBAKO_JAIL`; fail-closed — spec 08) |
 | 74 | `EX_TEBAKO_IO` | filesystem/lock/install failure |
+| 75 | `EX_TEBAKO_CONTRACT` | runtime declares an unsupported `contract_version` (§6) |
 
 stderr body: `tebako-bootstrap: <message>\n` — message bodies match the
 C++ reference bootstrap 1:1 (golden parity).
@@ -98,3 +100,42 @@ the benefit. Rules:
   tebako-cli reuse it (no third copy). tebako-http gains an
   `on_progress(bytes_so_far, content_length)` callback hooking the
   stream — the bar is transport-accurate, not estimated.
+
+## 6. Bootstrap↔runtime contract negotiation (roadmap 45)
+
+The launcher ABI (§1–§2) is the wire format; the **contract version** is
+its semantics version, declared by the runtime and enforced by the
+bootstrap. It exists so a future handoff change (env names, argv shape,
+image-handoff semantics) can be introduced without old bootstraps
+silently mis-executing new runtimes.
+
+| contract | semantics |
+|---------:|-----------|
+| 1 | this document, §1–§5: `--tebako-image`/`--tebako-entry` argv, `TEBAKO_RUNTIME_IMAGE` env handoff, trailer/ABI gating as in §3 |
+
+**Bump rule.** Any change to env/argv/handoff semantics — a renamed or
+repurposed variable, a new loader-consumed flag, a change in image
+precedence — increments the contract version by exactly 1. Additive
+payload-side changes that v1 runtimes may ignore (like §2's env image
+for v1 runtimes) do NOT bump the contract.
+
+**Declaration.** The runtime release manifest's per-package entry carries
+`"contract_version": <uint>` (spec 05 §5's manifest.json; additive —
+older consumers ignore it). The runtime driver has the same value
+compiled in (`TEBAKO_CONTRACT_VERSION`); the runtime repo's CI fails any
+release where the manifest and the driver disagree.
+
+**Negotiation rule (bootstrap, fail-closed).** During runtime/image
+resolution, before any checksum acceptance:
+
+1. Manifest entry declares `contract_version == SUPPORTED_CONTRACT`
+   (currently 1) → proceed.
+2. Field absent or unparseable → a pre-contract release, which is
+   contract 1 by definition → proceed while 1 is the supported contract.
+3. Any other declared value → refuse: nothing is installed, the cache is
+   untouched, exit 75 (`EX_TEBAKO_CONTRACT`) naming both generations and
+   the remedy (upgrade tebako, or pin an older runtime).
+
+A negotiation failure is never a crash and never a silent accept: it is
+a clean, explained refusal. When contract 2 exists, `SUPPORTED_CONTRACT`
+becomes a range and rule 1 accepts any value in it.


### PR DESCRIPTION
## Summary

Bootstrap half of roadmap 45 (runtime half: tebako-runtime-ruby#21, merged). The bootstrap now enforces the runtime's declared `contract_version` before any checksum acceptance, on **both** download paths (executable and image):

| manifest says | bootstrap does |
|---|---|
| `contract_version == 1` (SUPPORTED_CONTRACT) | proceed |
| field absent / unparseable | pre-contract release = contract 1 → proceed |
| any other value | **exit 75 (`EX_TEBAKO_CONTRACT`)** — cache untouched, message names both generations + remedy |

## Changes

- `contract_from_manifest_json` parser (same object-bounding style as `sha_from_manifest_json`; anchored on the executable filename so the additive `image` entry is governed by its package's contract)
- `contract_gate` shared by `download_executable` and `resolve_image` (DRY — one message, one policy)
- spec 06 §6: contract table, bump rule (+1 on any env/argv/handoff semantic change), fail-closed negotiation; §4 exit-code row 75
- spec 05 §2: the additive `contract_version` manifest key documented

## Tests

24/24 pass (`cargo test -p tebako-bootstrap`), incl. new:
- `contract_version_parsing` — present/absent/malformed/unknown-asset
- `s15_contract_negotiation_accept_then_refuse` — declared 1 accepted end-to-end; declared 2 → rc 75, nothing cached
- `s16_image_contract_mismatch_refused` — warmed exe cache, poisoned manifest → image path refuses with rc 75

clippy `-D warnings` clean, fmt clean.