### PR TITLE
tfs: gate the squashfs backend per-target — Windows builds dwarfs-only (TODO.v2-1/02)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,8 +517,11 @@ jobs:
   #    use /MT, Rust defaults to /MD → link errors likely); no
   #    windows-gnu/ucrt64/gnullvm triplet selection exists in
   #    dwarfs-t-sys/build.rs's default_triplet at all.
-  #  - sqfs (squashfs-tools-ng) is POSIX/autotools only — same restriction
-  #    as the C++ side.
+  #  - sqfs (squashfs-tools-ng) is POSIX/autotools only — GATED per-target
+  #    in the tfs consumers (TODO.v2-1/02): Windows builds ship dwarfs-only,
+  #    a squashfs mount fails with named ENOTSUP. No longer a blocker.
+  #  - OpenPGP (rnp-rs 0.1.7 vendored) has no Windows prebuilt — gating
+  #    planned in TODO.v2-1/08.
   #  - tebako-bootstrap: the Windows exec/lock ports are not implemented
   #    (M6 v1 ships macOS/Linux).
   #  - tebako-cli's runtime-spawn/scrub paths are POSIX-oriented.

--- a/crates/sqfs-sys/build.rs
+++ b/crates/sqfs-sys/build.rs
@@ -75,7 +75,9 @@ fn main() {
     if target.contains("windows") && env::var("SQFS_SYS_VCPKG_TRIPLET").is_err() {
         panic!(
             "squashfs-tools-ng is a POSIX/autotools-only library and cannot be \
-             built for Windows (same restriction as the C++ libtfs backend)."
+             built for Windows (same restriction as the C++ libtfs backend). \
+             The tfs consumers gate this feature off per-target on Windows \
+             (TODO.v2-1/02) — reaching this panic means it was enabled by hand."
         );
     }
 

--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -24,10 +24,7 @@ tebako-shim = { version = "0.1.0", path = "../tebako-shim" }
 # OpenPGP verification of signed registry entries (spec 09; strict when the
 # entry carries a signature, the v1-legacy warn when it does not).
 tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
-# The runtime image is extracted in-process through the tfs C ABI
-# (item 30b layout seeding); install reads the embedded payload manifest
-# (spec 03 §1) through the same ABI.
-tfs = { version = "0.1.0", path = "../tfs" }
+# (the tfs dependency is per-target, below — squashfs is POSIX-only)
 # The suite file (--suite) is authored YAML (spec 00 invariant 6) — the
 # tpkg manifest convention (serde_yml), not serde_yaml.
 serde = { version = "1", features = ["derive"] }
@@ -44,6 +41,19 @@ flate2 = { version = "1", default-features = false, features = ["rust_backend"] 
 tar = { version = "0.4", default-features = false }
 # Hardlink staging area for manifest tree_hash stamping (spec 03 §7).
 tempfile = "3"
+
+# The runtime image is extracted in-process through the tfs C ABI
+# (item 30b layout seeding); install reads the embedded payload manifest
+# (spec 03 §1) through the same ABI. The SquashFS backend
+# (squashfs-tools-ng) is POSIX/autotools-only, so Windows gets a
+# dwarfs-only tfs — the squashfs backend degrades to a named ENOTSUP
+# there (TODO.v2-1/02). The per-target split lives in the consumer (cargo
+# features cannot be target-conditional from inside tfs).
+[target.'cfg(not(windows))'.dependencies]
+tfs = { version = "0.1.0", path = "../tfs" }
+
+[target.'cfg(windows)'.dependencies]
+tfs = { version = "0.1.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
 
 [[bin]]
 name = "tebako"

--- a/crates/tebako-info/Cargo.toml
+++ b/crates/tebako-info/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["filesystem", "parser-implementations"]
 
 [dependencies]
 tpkg = { version = "0.1.0", path = "../tpkg" }
-tfs = { version = "0.1.0", path = "../tfs" }
 tebako-json = { version = "0.1.0", path = "../tebako-json" }
 tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
 sha2 = "0.10"
@@ -21,6 +20,15 @@ libc = "0.2"
 # Lenient manifest reads (structure without validate()) for the display
 # paths; same pin as tpkg.
 serde_yml = "0.0.12"
+
+# tfs per-target: the SquashFS backend (squashfs-tools-ng) is
+# POSIX/autotools-only — Windows gets a dwarfs-only tfs, the backend
+# degrading to a named ENOTSUP (TODO.v2-1/02).
+[target.'cfg(not(windows))'.dependencies]
+tfs = { version = "0.1.0", path = "../tfs" }
+
+[target.'cfg(windows)'.dependencies]
+tfs = { version = "0.1.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
 
 [dev-dependencies]
 # In-process dwarfs-t writer for manifest-carrying image fixtures.

--- a/crates/tebako-pkg/Cargo.toml
+++ b/crates/tebako-pkg/Cargo.toml
@@ -14,11 +14,19 @@ categories = ["filesystem", "command-line-utilities"]
 tpkg = { version = "0.1.0", path = "../tpkg" }
 tebako-json = { version = "0.1.0", path = "../tebako-json" }
 tebako-info = { version = "0.1.0", path = "../tebako-info" }
-tfs = { version = "0.1.0", path = "../tfs" }
 tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
 rnp = { package = "rnp-rs", version = "=0.1.7", features = ["vendored"] }
 libc = "0.2"
 sha2 = "0.10"
+
+# tfs per-target: the SquashFS backend (squashfs-tools-ng) is
+# POSIX/autotools-only — Windows gets a dwarfs-only tfs, the backend
+# degrading to a named ENOTSUP (TODO.v2-1/02).
+[target.'cfg(not(windows))'.dependencies]
+tfs = { version = "0.1.0", path = "../tfs" }
+
+[target.'cfg(windows)'.dependencies]
+tfs = { version = "0.1.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
 
 [dev-dependencies]
 tebako-contract-tests = { version = "0.1.0", path = "../../tests/contract" }

--- a/crates/tebako-signer/src/lib.rs
+++ b/crates/tebako-signer/src/lib.rs
@@ -21,8 +21,8 @@
 // documented exception — a Rust-2024 unsafe-attribute extern "C" export.
 // deny keeps unsafe a hard error everywhere else in the crate.)
 
-pub mod envelope;
 pub mod bz_shim;
+pub mod envelope;
 mod error;
 pub mod keyring;
 mod keys;

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["tebako", "tfs", "vfs", "cli", "archive"]
 categories = ["filesystem", "command-line-utilities"]
 
 [dependencies]
-tfs = { version = "0.1.0", path = "../tfs" }
 # mkimage stamps identity.digest.tree_hash into a source tree's payload
 # manifest (spec 03 §7) via tpkg's merkle construction.
 tpkg = { version = "0.1.0", path = "../tpkg" }
@@ -29,6 +28,15 @@ tebako-json = { version = "0.1.0", path = "../tebako-json" }
 # The in-process DwarFS writer for mkimage (dwarfs-t-rs).
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 libc = "0.2"
+
+# tfs per-target: the SquashFS backend (squashfs-tools-ng) is
+# POSIX/autotools-only — Windows gets a dwarfs-only tfs, the backend
+# degrading to a named ENOTSUP (TODO.v2-1/02).
+[target.'cfg(not(windows))'.dependencies]
+tfs = { version = "0.1.0", path = "../tfs" }
+
+[target.'cfg(windows)'.dependencies]
+tfs = { version = "0.1.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
 
 [[bin]]
 name = "tfs"

--- a/crates/tfs/src/mount.rs
+++ b/crates/tfs/src/mount.rs
@@ -280,3 +280,37 @@ pub fn build_from_memory_with_mode(
     let backend = apply_mode(backend, mode, overlay_dir)?;
     Ok(make_mount(mount_point, None, backend, mode))
 }
+
+// ---------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------
+
+/// A gated-off backend degrades to the NAMED error, never a crash or
+/// a silent re-route (the Windows build ships dwarfs-only —
+/// TODO.v2-1/02). Runs in the `--no-default-features` CI job; with
+/// the feature on, the same magic would attempt a real SquashFS
+/// mount instead. The whole module compiles out with the feature on
+/// (an empty tests module would only borrow trouble).
+#[cfg(all(test, not(feature = "vendored-squashfs")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn squashfs_without_the_backend_is_a_named_enotsup() {
+        let mut magic = Vec::with_capacity(SNIFF_LEN);
+        magic.extend_from_slice(b"hsqs");
+        magic.resize(SNIFF_LEN, 0);
+        let path = std::env::temp_dir().join(format!(
+            "tfs-enotsup-{}-{}.sqfs",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, &magic).unwrap();
+        let result = build_from_file(&path.to_string_lossy(), "/x");
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(result.err(), Some(libc::ENOTSUP));
+    }
+}

--- a/docs/spec/11-tfs-vfs-model.md
+++ b/docs/spec/11-tfs-vfs-model.md
@@ -49,6 +49,13 @@ model is honest per format — no uniform-RW pretense:
 | extN | ✓ (PLANNED) | ✓ (PLANNED) | mkfs |
 | FAT | ✓ (PLANNED) | ✓ (PLANNED) | mkfs |
 
+**Per-platform backend availability** (build-time, gated per-target in
+the consumers — TODO.v2-1/02): dwarfs-t, zip, and the tar family build
+EVERYWHERE; squashfs is POSIX-only (squashfs-tools-ng is
+autotools/vcpkg-`!windows`), so Windows builds ship without it. A mount
+attempt against a gated-off backend fails with the NAMED `ENOTSUP` —
+never a silent re-route, never a crash.
+
 - Detection chain: strong magic first (zip EOCD, dwarfs, squashfs,
   iso9660 `CD001`@0x8001, ext `0xEF53`@0x438, FAT BPB), weak heuristics
   (tar) last, with per-candidate confidence; the claimed backend is


### PR DESCRIPTION
## Summary

squashfs-tools-ng is POSIX/autotools-only (vcpkg `!windows`) — a Windows build of any tfs consumer died in sqfs-sys. Cargo features cannot be target-conditional from inside `tfs`, so the four consumers split the dependency per target:

| | `cfg(not(windows))` | `cfg(windows)` |
|---|---|---|
| tfs features | default (dwarfs + squashfs) | `default-features = false` + `vendored-dwarfs` |

Default behavior on macOS/Linux is byte-identical; no CI feature flags; `cargo build` dev UX unchanged. A squashfs mount on Windows fails with the **named ENOTSUP** (already the code's shape for gated-off backends — never a silent re-route).

## Changes

- `tebako-cli`, `tebako-info`, `tebako-pkg`, `tfs-cli`: per-target tfs split (the pattern documented in each manifest)
- `tfs/src/mount.rs`: unit test pinning the ENOTSUP degradation — runs in the existing `--no-default-features` CI job
- `sqfs-sys/build.rs`: the Windows panic now names the gate (reached only on a manual feature-enable)
- spec 11 §3: per-platform backend-availability note (dwarfs/zip/tar everywhere; squashfs POSIX-only)
- release.yml blockers comment: sqfs line marked gated; adds the newly discovered OpenPGP gap (rnp-rs 0.1.7 vendored has no Windows prebuilt — item 08)

## Verification

- `cargo check --workspace` green (host, default features)
- `cargo test -p tfs --no-default-features squashfs_without` → the new test passes
- `cargo fmt --all -- --check` clean

Windows CI proof itself is TODO.v2-1/03+04 (the windows-latest job); this PR removes the first hard blocker it would have hit.