### PR TITLE
bootstrap+shim: the Windows port — CI proof, exec/registry/link layers (TODO.v2-1/03+05)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main, feat/*]
   pull_request:
 
+# One run per branch/PR-head at a time: pushing to a branch with an open
+# PR would otherwise run every job twice (push + pull_request events);
+# a new run cancels the stale one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   # Must match the builtin-baseline in dwarfs-t/vcpkg.json (mirrors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,38 @@ jobs:
         working-directory: tebako-rs
         run: cargo test -p tfs --no-default-features
 
+  # The pure-Rust crates compile and test on the real platform (TODO.v2-1/03):
+  # no vcpkg anywhere in this job — tfs/sqfs/rnp are all out of the graph.
+  # This is where the Windows ports (bootstrap platform.rs, shim link
+  # layer) are proven; the vendored-dwarfs Windows build (TODO.v2-1/04)
+  # is the release leg's story, not this job's.
+  test-windows:
+    name: test (windows-latest)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: tebako-rs
+
+      # tpkg/tfs path deps resolve at manifest level (no submodules needed).
+      - name: Checkout dwarfs-rs (sibling path dep)
+        uses: actions/checkout@v4
+        with:
+          repository: tamatebako/dwarfs-rs
+          path: dwarfs-rs
+
+      - uses: dtolnay/rust-toolchain@1.94.1
+        with:
+          components: clippy
+
+      - name: cargo test (pure-Rust crates)
+        working-directory: tebako-rs
+        run: cargo test -p tebako-bootstrap -p tebako-shim -p tebako-resolve -p tebako-http -p tebako-term -p tebako-json -p tpkg
+
+      - name: clippy (pure-Rust crates)
+        working-directory: tebako-rs
+        run: cargo clippy -p tebako-bootstrap -p tebako-shim -p tebako-resolve -p tebako-http -p tebako-term -p tebako-json -p tpkg --all-targets -- -D warnings
+
   fmt:
     name: fmt
     runs-on: ubuntu-24.04

--- a/crates/tebako-bootstrap/Cargo.toml
+++ b/crates/tebako-bootstrap/Cargo.toml
@@ -49,6 +49,11 @@ path = "src/main.rs"
 name = "tebako_bootstrap"
 path = "src/lib.rs"
 
-[dev-dependencies]
+# The chain-of-trust integration tests (tests/chain.rs) mint keys and
+# sign through rnp — whose 0.1.7 vendored prebuilt has NO Windows target
+# (TODO.v2-1/08), so these dev-deps are POSIX-only and tests/chain.rs is
+# cfg-gated to match. The shipped bootstrap stays unverified-first on
+# every platform (the feature above is unaffected).
+[target.'cfg(not(windows))'.dev-dependencies]
 tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
 rnp = { package = "rnp-rs", version = "=0.1.7", features = ["vendored"] }

--- a/crates/tebako-bootstrap/src/bin/tebako-fake-runtime.rs
+++ b/crates/tebako-bootstrap/src/bin/tebako-fake-runtime.rs
@@ -1,0 +1,18 @@
+//! Test fixture: the fake runtime the bootstrap selftests exec.
+//!
+//! Prints a marker line, the image env handoff, and its argv — the
+//! byte-exact contract `tests/harness` asserts on. This was a `/bin/sh`
+//! script; a compiled stub is what CreateProcess can run on Windows, and
+//! it is closer to a real runtime binary on every platform (exec of a
+//! binary, never of a script through a shell).
+
+fn main() {
+    println!("FAKE-RUNTIME");
+    println!(
+        "TEBAKO_RUNTIME_IMAGE={}",
+        std::env::var("TEBAKO_RUNTIME_IMAGE").unwrap_or_default()
+    );
+    for (i, arg) in std::env::args().skip(1).enumerate() {
+        println!("argv[{i}]={arg}");
+    }
+}

--- a/crates/tebako-bootstrap/src/bin/tebako-fake-runtime.rs
+++ b/crates/tebako-bootstrap/src/bin/tebako-fake-runtime.rs
@@ -1,10 +1,15 @@
 //! Test fixture: the fake runtime the bootstrap selftests exec.
 //!
-//! Prints a marker line, the image env handoff, and its argv — the
-//! byte-exact contract `tests/harness` asserts on. This was a `/bin/sh`
-//! script; a compiled stub is what CreateProcess can run on Windows, and
-//! it is closer to a real runtime binary on every platform (exec of a
-//! binary, never of a script through a shell).
+//! Prints a marker line, the image env handoff, the jail policy env
+//! (the jail tests' probe), and its argv — the byte-exact contract
+//! `tests/harness` asserts on. This was a `/bin/sh` script; a compiled
+//! stub is what CreateProcess can run on Windows, and it is closer to a
+//! real runtime binary on every platform (exec of a binary, never of a
+//! script through a shell).
+
+fn env_or_unset(key: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| "UNSET".to_string())
+}
 
 fn main() {
     println!("FAKE-RUNTIME");
@@ -12,6 +17,10 @@ fn main() {
         "TEBAKO_RUNTIME_IMAGE={}",
         std::env::var("TEBAKO_RUNTIME_IMAGE").unwrap_or_default()
     );
+    // The jail probe's contract (tests/jail.rs): UNSET when absent.
+    println!("JAIL={}", env_or_unset("TEBAKO_JAIL"));
+    println!("JAIL-SOURCE={}", env_or_unset("TEBAKO_JAIL_SOURCE"));
+    println!("JAIL-JOURNAL={}", env_or_unset("TEBAKO_JAIL_JOURNAL"));
     for (i, arg) in std::env::args().skip(1).enumerate() {
         println!("argv[{i}]={arg}");
     }

--- a/crates/tebako-bootstrap/tests/chain.rs
+++ b/crates/tebako-bootstrap/tests/chain.rs
@@ -2,6 +2,12 @@
 //! (slot sha256 mismatch, unknown signer, invalid signature), the v1
 //! legacy acceptance + TEBAECO_REQUIRE_SIGNED hard fail, and the
 //! trusted-cache second-run hit.
+//!
+//! POSIX-only (TODO.v2-1/08): the tests mint keys through rnp, whose
+//! 0.1.7 vendored prebuilt has no Windows target — the dev-deps are
+//! per-target gated in Cargo.toml, and this whole file compiles out on
+//! Windows until the gate lifts.
+#![cfg(not(windows))]
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/tebako-bootstrap/tests/harness/mod.rs
+++ b/crates/tebako-bootstrap/tests/harness/mod.rs
@@ -105,24 +105,19 @@ pub fn sha256_of(path: &Path) -> String {
     tebako_bootstrap::sha::sha256_file_hex(path).unwrap()
 }
 
-pub fn write_fake_runtime(path: &Path) {
-    std::fs::write(
-        path,
-        "#!/bin/sh\necho FAKE-RUNTIME\necho \"TEBAKO_RUNTIME_IMAGE=$TEBAKO_RUNTIME_IMAGE\"\ni=0\nfor a in \"$@\"; do\n  echo \"argv[$i]=$a\"\n  i=$((i+1))\ndone\n",
-    )
-    .unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
-    }
+/// The fake runtime the selftests exec: the package's own stub binary
+/// (`src/bin/tebako-fake-runtime.rs`, built by cargo for the test
+/// targets). A compiled stub is what CreateProcess can run on Windows —
+/// and it is closer to a real runtime binary everywhere (the bootstrap
+/// never execs a script through a shell in production either).
+pub fn fake_runtime_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_tebako-fake-runtime"))
 }
 
 impl Harness {
     pub fn new(bootstrap: PathBuf) -> Harness {
         let tmp = TempDir::new("boot");
-        let fake_runtime = tmp.0.join("fake-runtime");
-        write_fake_runtime(&fake_runtime);
+        let fake_runtime = fake_runtime_path();
 
         let plat = platform();
         let exe = tebako_bootstrap::platform::exe_suffix();

--- a/crates/tebako-bootstrap/tests/harness/mod.rs
+++ b/crates/tebako-bootstrap/tests/harness/mod.rs
@@ -60,22 +60,11 @@ pub fn platform() -> &'static str {
     tebako_bootstrap::platform::platform_string()
 }
 
+/// The Rust bootstrap binary under test: cargo's own bin path for this
+/// package's integration tests (platform-true — carries the `.exe` on
+/// Windows, and always points into the real target dir).
 pub fn rust_bootstrap() -> PathBuf {
-    let target = std::env::var("CARGO_TARGET_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("../../target")
-                .canonicalize()
-                .unwrap()
-        });
-    for profile in ["debug", "release"] {
-        let cand = target.join(profile).join("tebako-bootstrap");
-        if cand.is_file() {
-            return cand;
-        }
-    }
-    panic!("tebako-bootstrap binary not built (run `cargo build -p tebako-bootstrap`)")
+    PathBuf::from(env!("CARGO_BIN_EXE_tebako-bootstrap"))
 }
 
 pub fn cpp_bootstrap() -> Option<PathBuf> {

--- a/crates/tebako-bootstrap/tests/jail.rs
+++ b/crates/tebako-bootstrap/tests/jail.rs
@@ -15,23 +15,14 @@ use std::path::{Path, PathBuf};
 
 use harness::{rust_bootstrap, Harness};
 
-/// A fake runtime that reports the jail env the bootstrap exported.
+/// A fake runtime that reports the jail env the bootstrap exported:
+/// the package's own stub binary (it prints JAIL= JAIL-SOURCE=
+/// JAIL-JOURNAL= among its probe lines). A compiled stub is what
+/// CreateProcess can run on Windows — a /bin/sh script is not.
 fn write_probe_runtime(h: &Harness, home: &Path) {
     let exe = h.cache_exe(home);
     std::fs::create_dir_all(exe.parent().unwrap()).unwrap();
-    std::fs::write(
-        &exe,
-        "#!/bin/sh\n\
-         echo \"JAIL=${TEBAKO_JAIL-UNSET}\"\n\
-         echo \"JAIL-SOURCE=${TEBAKO_JAIL_SOURCE-UNSET}\"\n\
-         echo \"JAIL-JOURNAL=${TEBAKO_JAIL_JOURNAL-UNSET}\"\n",
-    )
-    .unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o755)).unwrap();
-    }
+    std::fs::copy(harness::fake_runtime_path(), &exe).unwrap();
 }
 
 fn package_manifest(runtime_ref: &str, jail: tpkg::HostJail) -> tpkg::PackageManifest {

--- a/crates/tebako-cli/src/publish.rs
+++ b/crates/tebako-cli/src/publish.rs
@@ -942,7 +942,9 @@ pub fn publish_full(
     if !opts.skip_verify {
         let verify_registry_text;
         let registry_ref = match &registry_path {
-            Some(path) => format!("file://{}", path.display()),
+            // tebako_http::file_url spells the canonical form on every
+            // platform (a bare `file://{}` breaks on Windows paths).
+            Some(path) => tebako_http::file_url(path),
             None => {
                 // the registry went to stdout — the verify reads a temp copy
                 let tmp = std::env::temp_dir().join(format!(
@@ -953,7 +955,7 @@ pub fn publish_full(
                     err(EX_TEBAKO_IO, format!("cannot write {}: {e}", tmp.display()))
                 })?;
                 verify_registry_text = tmp;
-                format!("file://{}", verify_registry_text.display())
+                tebako_http::file_url(&verify_registry_text)
             }
         };
         let line = verify_install(

--- a/crates/tebako-http/src/lib.rs
+++ b/crates/tebako-http/src/lib.rs
@@ -93,11 +93,41 @@ fn read_file_url(path: &str) -> Result<Vec<u8>, FetchError> {
     })
 }
 
+/// The canonical file:// URL for a local path (forward slashes, the
+/// third slash before an absolute unix path or a Windows drive path:
+/// `file:///tmp/x`, `file:///C:/x`). `format!("file://{path}")` is only
+/// accidentally right on unix; this is the one constructor, so nobody
+/// hand-rolls it again.
+pub fn file_url(path: &std::path::Path) -> String {
+    let s = path.to_string_lossy().replace('\\', "/");
+    if s.starts_with('/') {
+        format!("file://{s}")
+    } else {
+        format!("file:///{s}")
+    }
+}
+
+/// The filesystem path a `file://` remainder names. RFC 8089: the third
+/// slash separates the (empty) authority from the path — so on Windows
+/// `/C:/x` is not a path at all; the drive path is `C:/x`. Unix
+/// remainders begin at that slash and pass through unchanged.
+fn file_path_from_url(remainder: &str) -> &str {
+    #[cfg(windows)]
+    {
+        let b = remainder.as_bytes();
+        if b.len() > 3 && b[0] == b'/' && b[1].is_ascii_alphabetic() && b[2] == b':' && b[3] == b'/'
+        {
+            return &remainder[1..];
+        }
+    }
+    remainder
+}
+
 /// GET `url` and return the response body. `https://` (redirects
 /// followed, HTTPS-only) or `file://`.
 pub fn get(url: &str) -> Result<Vec<u8>, FetchError> {
     if let Some(path) = url.strip_prefix("file://") {
-        return read_file_url(path);
+        return read_file_url(file_path_from_url(path));
     }
     if !url.starts_with("https://") {
         return Err(FetchError::DownloadFailed(format!(
@@ -126,7 +156,7 @@ pub fn get_with_progress(
         return get(url);
     };
     if let Some(path) = url.strip_prefix("file://") {
-        let bytes = read_file_url(path)?;
+        let bytes = read_file_url(file_path_from_url(path))?;
         cb(bytes.len() as u64, Some(bytes.len() as u64));
         return Ok(bytes);
     }
@@ -222,6 +252,28 @@ pub fn delete(url: &str, bearer: Option<&str>) -> Result<(), FetchError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn file_url_constructor_is_canonical_on_both_platforms() {
+        // unix absolute: the third slash comes from the path itself
+        assert_eq!(file_url(std::path::Path::new("/tmp/x")), "file:///tmp/x");
+        // a drive path (or any non-/ path) gets the slash spelled
+        #[cfg(windows)]
+        assert_eq!(
+            file_url(std::path::Path::new(r"C:/Users/x")),
+            "file:///C:/Users/x"
+        );
+    }
+
+    #[test]
+    fn the_constructor_round_trips_through_get() {
+        let dir =
+            std::env::temp_dir().join(format!("tebako-http-test-roundtrip-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("index.txt");
+        std::fs::write(&file, b"hello").unwrap();
+        assert_eq!(get(&file_url(&file)).unwrap(), b"hello");
+    }
 
     #[test]
     fn file_url_reads_from_disk() {

--- a/crates/tebako-http/src/lib.rs
+++ b/crates/tebako-http/src/lib.rs
@@ -111,7 +111,7 @@ pub fn file_url(path: &std::path::Path) -> String {
 /// slash separates the (empty) authority from the path — so on Windows
 /// `/C:/x` is not a path at all; the drive path is `C:/x`. Unix
 /// remainders begin at that slash and pass through unchanged.
-fn file_path_from_url(remainder: &str) -> &str {
+pub fn file_path_from_url(remainder: &str) -> &str {
     #[cfg(windows)]
     {
         let b = remainder.as_bytes();

--- a/crates/tebako-resolve/Cargo.toml
+++ b/crates/tebako-resolve/Cargo.toml
@@ -48,3 +48,13 @@ proptest = "1"
 # The git fixtures are built with gix itself — no git CLI anywhere, tests
 # included (spec 14 §3).
 gix = { version = "0.86", default-features = false, features = ["sha1", "tree-editor"] }
+
+# The per-entry cache flock on Windows (cache.rs — LockFileEx on one byte
+# at offset 0, the tebako-bootstrap platform.rs shape). Unix uses libc's
+# flock(2); all Win32 FFI is confined to cache.rs.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+] }

--- a/crates/tebako-resolve/src/cache.rs
+++ b/crates/tebako-resolve/src/cache.rs
@@ -308,7 +308,7 @@ impl PayloadCache {
             .map_err(|e| cache_io("opening", lock_path, e))?;
         let deadline = std::time::Instant::now() + self.lock_timeout;
         loop {
-            if flock(&lock, libc::LOCK_EX | libc::LOCK_NB) {
+            if flock_exclusive_nb(&lock) {
                 break;
             }
             if std::time::Instant::now() >= deadline {
@@ -320,7 +320,7 @@ impl PayloadCache {
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
         let result = f();
-        flock(&lock, libc::LOCK_UN);
+        flock_unlock(&lock);
         result
     }
 }
@@ -357,12 +357,55 @@ fn cache_io(op: &'static str, path: &Path, e: std::io::Error) -> ResolveError {
     }
 }
 
-/// flock(2) wrapper; returns true when the operation succeeded (the same
-/// libc call tebako-cli's resolver uses — the only FFI in the crate).
-fn flock(file: &fs::File, op: i32) -> bool {
+/// The per-entry lock pair, one shape on each platform (no op-value
+/// passing — named operations only):
+///
+/// Unix: flock(2) LOCK_EX|LOCK_NB / LOCK_UN on a live fd (the same libc
+/// call tebako-cli's resolver uses). Windows: LockFileEx on one byte at
+/// offset 0 — exclusive, non-blocking, released by the kernel when the
+/// handle dies, exactly like flock (the shape tebako-bootstrap's
+/// platform.rs uses).
+#[cfg(unix)]
+fn flock_exclusive_nb(file: &fs::File) -> bool {
     use std::os::unix::io::AsRawFd;
     // SAFETY: flock(2) on a live fd; identical to tebako-cli/src/resolve.rs.
-    unsafe { libc::flock(file.as_raw_fd(), op) == 0 }
+    unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) == 0 }
+}
+
+#[cfg(unix)]
+fn flock_unlock(file: &fs::File) -> bool {
+    use std::os::unix::io::AsRawFd;
+    // SAFETY: flock(2) on a live fd.
+    unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) == 0 }
+}
+
+#[cfg(windows)]
+fn flock_exclusive_nb(file: &fs::File) -> bool {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        LockFileEx, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+    };
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+    let mut ov = OVERLAPPED::default();
+    unsafe {
+        LockFileEx(
+            file.as_raw_handle(),
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+            0,
+            1,
+            0,
+            &mut ov,
+        ) != 0
+    }
+}
+
+#[cfg(windows)]
+fn flock_unlock(file: &fs::File) -> bool {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::UnlockFileEx;
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+    let mut ov = OVERLAPPED::default();
+    unsafe { UnlockFileEx(file.as_raw_handle(), 0, 1, 0, &mut ov) != 0 }
 }
 
 #[cfg(test)]
@@ -542,11 +585,11 @@ mod tests {
             .truncate(false)
             .open(&lock_path)
             .unwrap();
-        assert!(flock(&held, libc::LOCK_EX | libc::LOCK_NB));
+        assert!(flock_exclusive_nb(&held));
         let err = cache
             .install("tool", "1.0", None, || Ok(fetched(b"x")))
             .unwrap_err();
-        flock(&held, libc::LOCK_UN);
+        flock_unlock(&held);
         assert!(matches!(err, ResolveError::LockTimeout { .. }));
         let msg = err.to_string();
         assert!(msg.contains("lockfile") && msg.contains("remove it if the holder crashed"));

--- a/crates/tebako-resolve/src/cache.rs
+++ b/crates/tebako-resolve/src/cache.rs
@@ -265,15 +265,7 @@ impl PayloadCache {
         let tmp = tmp_dir.join(format!("{file_name}.{}.part", std::process::id()));
         let result = (|| {
             fs::write(&tmp, &fetched.bytes).map_err(|e| cache_io("writing", &tmp, e))?;
-            let mut perms = fs::metadata(&tmp)
-                .map_err(|e| cache_io("stat", &tmp, e))?
-                .permissions();
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                perms.set_mode(0o444);
-            }
-            fs::set_permissions(&tmp, perms).map_err(|e| cache_io("chmod", &tmp, e))?;
+            make_readonly(&tmp).map_err(|e| cache_io("chmod", &tmp, e))?;
             fs::rename(&tmp, file).map_err(|e| cache_io("installing", file, e))?;
             fs::write(
                 sha_marker(file),
@@ -355,6 +347,41 @@ fn cache_io(op: &'static str, path: &Path, e: std::io::Error) -> ResolveError {
         path: path.to_path_buf(),
         reason: e.to_string(),
     }
+}
+
+/// The cached image is an immutable artifact (item 30b): 0444 on unix;
+/// on Windows the FILE_ATTRIBUTE_READONLY bit with every other attribute
+/// preserved (tebako-bootstrap's platform.rs shape). Best-effort errors
+/// surface through the caller, never silently.
+#[cfg(unix)]
+fn make_readonly(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o444);
+    std::fs::set_permissions(path, perms)
+}
+
+#[cfg(windows)]
+fn make_readonly(path: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileAttributesW, SetFileAttributesW, FILE_ATTRIBUTE_READONLY, INVALID_FILE_ATTRIBUTES,
+    };
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    unsafe {
+        let attrs = GetFileAttributesW(wide.as_ptr());
+        if attrs == INVALID_FILE_ATTRIBUTES {
+            return Err(std::io::Error::last_os_error());
+        }
+        if SetFileAttributesW(wide.as_ptr(), attrs | FILE_ATTRIBUTE_READONLY) == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    Ok(())
 }
 
 /// The per-entry lock pair, one shape on each platform (no op-value

--- a/crates/tebako-resolve/src/git.rs
+++ b/crates/tebako-resolve/src/git.rs
@@ -122,6 +122,12 @@ mod tests {
             let _ = std::fs::remove_dir_all(&dir);
             let repo = gix::init_bare(&dir).unwrap();
             drop(repo);
+            // init_bare's HEAD follows the AMBIENT init.defaultBranch —
+            // "main" on these dev machines, "master" on git-for-windows
+            // runners — but every commit below lands on refs/heads/main.
+            // Pin HEAD deterministically or ref-less environments resolve
+            // HEAD nowhere ("rev-spec is malformed and misses a ref name").
+            std::fs::write(dir.join("HEAD"), b"ref: refs/heads/main\n").unwrap();
             // gix commit needs an identity; CI runners have no ambient
             // git config (user.name/user.email). Pin it in-repo (append —
             // init already wrote [core]) and re-open so the config is

--- a/crates/tebako-resolve/src/git.rs
+++ b/crates/tebako-resolve/src/git.rs
@@ -21,7 +21,20 @@ fn transport_url(url: &str) -> Result<String, ResolveError> {
                 .to_string(),
         });
     }
-    if url.starts_with("https://") || url.starts_with("file://") || Path::new(url).is_absolute() {
+    if url.starts_with("https://") || url.starts_with("file://") {
+        return Ok(url.to_string());
+    }
+    // A Windows absolute path (`C:\…`, `\\server\…`) reads as scp-syntax
+    // to gix's URL parser (host "C"): canonicalize to the file:/// form
+    // with forward slashes. unix absolutes pass through as-is.
+    #[cfg(windows)]
+    if Path::new(url).is_absolute() {
+        return Ok(format!("file:///{}", url.replace('\\', "/")));
+    }
+    // A leading `/` is a local path on every platform (unix absolute;
+    // root-relative on Windows — Rust's is_absolute is false for the
+    // latter, which is exactly why this check exists).
+    if url.starts_with('/') || Path::new(url).is_absolute() {
         Ok(url.to_string())
     } else {
         Ok(format!("https://{url}"))

--- a/crates/tebako-resolve/src/reference.rs
+++ b/crates/tebako-resolve/src/reference.rs
@@ -420,9 +420,26 @@ fn parse_file(input: &str, rest: &str) -> Result<Reference, ReferenceError> {
         return Err(invalid(input, "path contains a NUL byte"));
     }
     Ok(Reference::File {
-        path: path.to_string(),
+        path: normalize_file_path(path).to_string(),
         sha256,
     })
+}
+
+/// RFC 8089 path recovery: `file:///C:/x` names the Windows path `C:/x` —
+/// the third slash separates the (empty) authority from the drive path,
+/// while on unix the path begins AT that slash. Windows must drop the
+/// leading slash before a drive letter or the result (`/C:/x`) is not a
+/// valid filesystem path (os error 123).
+fn normalize_file_path(path: &str) -> &str {
+    #[cfg(windows)]
+    {
+        let b = path.as_bytes();
+        if b.len() > 3 && b[0] == b'/' && b[1].is_ascii_alphabetic() && b[2] == b':' && b[3] == b'/'
+        {
+            return &path[1..];
+        }
+    }
+    path
 }
 
 #[cfg(test)]

--- a/crates/tebako-resolve/tests/integration.rs
+++ b/crates/tebako-resolve/tests/integration.rs
@@ -15,17 +15,12 @@ fn scratch(tag: &str) -> PathBuf {
     dir
 }
 
-/// A canonical file:// URL for a local path: forward slashes, with the
-/// third slash before an absolute unix path or the drive path on
-/// Windows (`file:///tmp/x` / `file:///C:/x`). `format!("file://{}")`
-/// over a Display path only looks right on unix.
+/// A canonical file:// URL for a local path — the constructor lives in
+/// tebako-http (the crate that reads these URLs); re-exported here so the
+/// fixtures stop hand-rolling `format!("file://{}")`, which is only
+/// accidentally right on unix.
 fn file_url(path: &std::path::Path) -> String {
-    let s = path.to_string_lossy().replace('\\', "/");
-    if s.starts_with('/') {
-        format!("file://{s}")
-    } else {
-        format!("file:///{s}")
-    }
+    tebako_http::file_url(path)
 }
 
 #[test]

--- a/crates/tebako-resolve/tests/integration.rs
+++ b/crates/tebako-resolve/tests/integration.rs
@@ -15,6 +15,19 @@ fn scratch(tag: &str) -> PathBuf {
     dir
 }
 
+/// A canonical file:// URL for a local path: forward slashes, with the
+/// third slash before an absolute unix path or the drive path on
+/// Windows (`file:///tmp/x` / `file:///C:/x`). `format!("file://{}")`
+/// over a Display path only looks right on unix.
+fn file_url(path: &std::path::Path) -> String {
+    let s = path.to_string_lossy().replace('\\', "/");
+    if s.starts_with('/') {
+        format!("file://{s}")
+    } else {
+        format!("file:///{s}")
+    }
+}
+
 #[test]
 fn file_mirror_fetch_and_cache() {
     let dir = scratch("file");
@@ -23,7 +36,7 @@ fn file_mirror_fetch_and_cache() {
     fs::write(mirror.join("tool.tfs"), b"payload-bytes").unwrap();
     let cache = PayloadCache::with_root(dir.join("cache"));
 
-    let reference = Reference::parse(&format!("file://{}/tool.tfs", mirror.display())).unwrap();
+    let reference = Reference::parse(&format!("{}/tool.tfs", file_url(&mirror))).unwrap();
     let (entry, status) = fetch_and_cache(&cache, &reference, "tool", "1.2.3", None).unwrap();
     assert_eq!(status, InstallStatus::Installed);
     assert_eq!(fs::read(&entry.path).unwrap(), b"payload-bytes");
@@ -55,8 +68,8 @@ fn pinned_mirror_mismatch_caches_nothing() {
     let cache = PayloadCache::with_root(dir.join("cache"));
 
     let reference = Reference::parse(&format!(
-        "file://{}/tool.tfs?sha256={}",
-        mirror.display(),
+        "{}/tool.tfs?sha256={}",
+        file_url(&mirror),
         "0".repeat(64)
     ))
     .unwrap();
@@ -154,7 +167,7 @@ fn file_mirror_registry_resolves_and_parses() {
     fs::create_dir_all(&mirror).unwrap();
     fs::write(mirror.join("tpkg-registry.yaml"), REGISTRY_YAML).unwrap();
 
-    let r = RegistryRef::parse(&format!("file://{}/tpkg-registry.yaml", mirror.display())).unwrap();
+    let r = RegistryRef::parse(&format!("{}/tpkg-registry.yaml", file_url(&mirror))).unwrap();
     let registry = Fetcher::new().resolve_registry(&r).unwrap();
     assert_eq!(registry.payloads.len(), 1);
     assert_eq!(registry.payloads[0].name, "tool");
@@ -277,7 +290,7 @@ fn unparsable_registry_is_a_named_error() {
     let mirror = dir.join("mirror");
     fs::create_dir_all(&mirror).unwrap();
     fs::write(mirror.join("tpkg-registry.yaml"), "schema_version: 99\n").unwrap();
-    let r = RegistryRef::parse(&format!("file://{}/tpkg-registry.yaml", mirror.display())).unwrap();
+    let r = RegistryRef::parse(&format!("{}/tpkg-registry.yaml", file_url(&mirror))).unwrap();
     let err = Fetcher::new().resolve_registry(&r).unwrap_err();
     assert!(matches!(err, ResolveError::Registry(_)));
     assert!(err.to_string().contains("schema_version 99"));

--- a/crates/tebako-resolve/tests/offline.rs
+++ b/crates/tebako-resolve/tests/offline.rs
@@ -17,8 +17,11 @@ fn offline_resolves_file_mirrors_only() {
     fs::write(mirror.join("tpkg-registry.yaml"), REGISTRY_YAML).unwrap();
 
     std::env::set_var("TEBAKO_OFFLINE", "1");
-    let local =
-        RegistryRef::parse(&format!("file://{}/tpkg-registry.yaml", mirror.display())).unwrap();
+    let local = RegistryRef::parse(&format!(
+        "{}/tpkg-registry.yaml",
+        tebako_http::file_url(&mirror)
+    ))
+    .unwrap();
     assert!(Fetcher::new().resolve_registry(&local).is_ok());
 
     let remote = RegistryRef::parse("tfs:github:o/r").unwrap();

--- a/crates/tebako-shim/Cargo.toml
+++ b/crates/tebako-shim/Cargo.toml
@@ -37,13 +37,16 @@ sha2 = "0.10"
 
 # The Windows shell integration (shell_windows.rs): registry PATH +
 # WM_SETTINGCHANGE; the dispatch exec port (dispatch.rs): console Ctrl
-# handling. All FFI is quarantined in those two modules.
-# (Win32_Security: RegCreateKeyExW's SECURITY_ATTRIBUTES parameter.)
+# handling; the runtime install lock (runtime.rs): LockFileEx. All FFI
+# is quarantined in those modules. (Win32_Security: RegCreateKeyExW's
+# SECURITY_ATTRIBUTES parameter.)
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_Storage_FileSystem",
     "Win32_System_Console",
+    "Win32_System_IO",
     "Win32_System_Registry",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/tebako-shim/Cargo.toml
+++ b/crates/tebako-shim/Cargo.toml
@@ -36,12 +36,14 @@ libc = "0.2"
 sha2 = "0.10"
 
 # The Windows shell integration (shell_windows.rs): registry PATH +
-# WM_SETTINGCHANGE. All FFI is quarantined in that one module.
+# WM_SETTINGCHANGE; the dispatch exec port (dispatch.rs): console Ctrl
+# handling. All FFI is quarantined in those two modules.
 # (Win32_Security: RegCreateKeyExW's SECURITY_ATTRIBUTES parameter.)
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_System_Console",
     "Win32_System_Registry",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/tebako-shim/Cargo.toml
+++ b/crates/tebako-shim/Cargo.toml
@@ -35,6 +35,17 @@ tebako-http = { version = "0.1.0", path = "../tebako-http" }
 libc = "0.2"
 sha2 = "0.10"
 
+# The Windows shell integration (shell_windows.rs): registry PATH +
+# WM_SETTINGCHANGE. All FFI is quarantined in that one module.
+# (Win32_Security: RegCreateKeyExW's SECURITY_ATTRIBUTES parameter.)
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Registry",
+    "Win32_UI_WindowsAndMessaging",
+] }
+
 [[bin]]
 name = "tebako-shim"
 path = "src/main.rs"

--- a/crates/tebako-shim/src/dispatch.rs
+++ b/crates/tebako-shim/src/dispatch.rs
@@ -360,7 +360,7 @@ pub fn exec(plan: &ExecPlan) -> ShimError {
 /// SIGINT); the shim must outlive the child to propagate its exit code,
 /// so its own copy of those events is swallowed.
 #[cfg(windows)]
-unsafe extern "system" fn ctrl_swallow(ctrl_type: u32) -> windows_sys::Win32::Foundation::BOOL {
+unsafe extern "system" fn ctrl_swallow(ctrl_type: u32) -> windows_sys::core::BOOL {
     use windows_sys::Win32::Foundation::{FALSE, TRUE};
     use windows_sys::Win32::System::Console::{CTRL_BREAK_EVENT, CTRL_C_EVENT};
     match ctrl_type {

--- a/crates/tebako-shim/src/dispatch.rs
+++ b/crates/tebako-shim/src/dispatch.rs
@@ -333,15 +333,50 @@ pub fn exec(plan: &ExecPlan) -> ShimError {
     )
 }
 
-#[cfg(not(unix))]
+/// Windows has no execve(2): spawn the child, wait, and exit with its
+/// code (the same contract the bootstrap's spawn_handoff implements for
+/// the runtime handoff — the user sees the program's own exit code).
+/// Never returns on success.
+#[cfg(windows)]
 pub fn exec(plan: &ExecPlan) -> ShimError {
-    // The Windows exec port lands with the windows CI leg (spec 06 §3
-    // status); fail cleanly rather than misbehave.
-    ShimError::new(
-        crate::EX_TEBAKO_IO,
-        format!(
-            "cannot execute {}: exec is not implemented on this platform in v1",
-            plan.program.display()
+    install_ctrl_swallow();
+    let mut cmd = std::process::Command::new(&plan.program);
+    cmd.args(&plan.argv[1..]);
+    for (k, v) in &plan.env {
+        cmd.env(k, v);
+    }
+    match cmd.spawn().and_then(|mut child| child.wait()) {
+        Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+        Err(e) => ShimError::new(
+            crate::EX_TEBAKO_IO,
+            format!("cannot execute {}: {e}", plan.program.display()),
         ),
-    )
+    }
+}
+
+/// Console Ctrl handling for the spawn handoff (the bootstrap's rule,
+/// same reasoning): the child shares our console process group, so
+/// CTRL_C/CTRL_BREAK reach it directly (the payload sees its normal
+/// SIGINT); the shim must outlive the child to propagate its exit code,
+/// so its own copy of those events is swallowed.
+#[cfg(windows)]
+unsafe extern "system" fn ctrl_swallow(ctrl_type: u32) -> windows_sys::Win32::Foundation::BOOL {
+    use windows_sys::Win32::Foundation::{FALSE, TRUE};
+    use windows_sys::Win32::System::Console::{CTRL_BREAK_EVENT, CTRL_C_EVENT};
+    match ctrl_type {
+        CTRL_C_EVENT | CTRL_BREAK_EVENT => TRUE,
+        // CLOSE/LOGOFF/SHUTDOWN keep the default processing (terminate).
+        _ => FALSE,
+    }
+}
+
+#[cfg(windows)]
+fn install_ctrl_swallow() {
+    // Best-effort: without the handler a console Ctrl event kills the
+    // shim before the child is reaped, but the handoff itself still
+    // works — never fail an exec over it.
+    use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
+    unsafe {
+        SetConsoleCtrlHandler(Some(ctrl_swallow), 1);
+    }
 }

--- a/crates/tebako-shim/src/lib.rs
+++ b/crates/tebako-shim/src/lib.rs
@@ -47,6 +47,7 @@ pub mod regcache;
 pub mod resolve;
 pub mod runtime;
 pub mod shell;
+pub mod shell_windows;
 pub mod versions;
 
 use std::collections::BTreeMap;

--- a/crates/tebako-shim/src/lib.rs
+++ b/crates/tebako-shim/src/lib.rs
@@ -120,10 +120,10 @@ pub fn tebako_home(env: &BTreeMap<String, String>) -> Result<PathBuf, ShimError>
         if let Some(home) = env.get("USERPROFILE").filter(|v| !v.is_empty()) {
             return Ok(PathBuf::from(home).join(".tebako"));
         }
-        return fail(
+        fail(
             EX_TEBAKO_IO,
             "cannot determine tebako home (set TEBAKO_HOME)",
-        );
+        )
     }
     #[cfg(not(windows))]
     {

--- a/crates/tebako-shim/src/lib.rs
+++ b/crates/tebako-shim/src/lib.rs
@@ -144,6 +144,14 @@ pub enum Action {
     Print { text: String, code: u8 },
 }
 
+/// The command a shim FILE name refers to: the dispatcher is linked as
+/// `<command>` (unix) or `<command>.exe` (Windows — PATHEXT needs the
+/// suffix, manage.rs `shim_file_name`), so the suffix is stripped here.
+/// Registration and lookup keys are always suffix-free.
+pub(crate) fn command_from_shim_name(file_name: &str) -> &str {
+    file_name.strip_suffix(".exe").unwrap_or(file_name)
+}
+
 /// The binary's two faces (spec 07 §2.0): linked as `<tool>` → dispatch;
 /// invoked as `tebako-shim` → management commands.
 pub fn run(argv: &[String], ctx: &Ctx) -> Result<Action, ShimError> {
@@ -153,7 +161,7 @@ pub fn run(argv: &[String], ctx: &Ctx) -> Result<Action, ShimError> {
         .unwrap_or_default()
         .to_string_lossy()
         .into_owned();
-    let tool = tool.strip_suffix(".exe").unwrap_or(&tool).to_string();
+    let tool = command_from_shim_name(&tool).to_string();
     if tool == "tebako-shim" {
         manage::run_command(&argv[1..], ctx)
     } else {

--- a/crates/tebako-shim/src/manage.rs
+++ b/crates/tebako-shim/src/manage.rs
@@ -11,9 +11,12 @@ use crate::manifest;
 use crate::regcache;
 use crate::resolve::{self, Resolution};
 use crate::runtime::RuntimeResolution;
-use crate::shell::{self, Shell};
+use crate::shell;
+#[cfg(not(windows))]
+use crate::shell::Shell;
 use crate::{fail, Action, Ctx, ShimError, EX_TEBAKO_IO, EX_USAGE};
 
+#[cfg(not(windows))]
 const USAGE: &str = "tebako-shim — the tebako dispatcher and version manager (spec 07)
 
 invoked as ~/.tebako/shims/<tool> it dispatches; invoked as tebako-shim it manages:
@@ -27,6 +30,19 @@ invoked as ~/.tebako/shims/<tool> it dispatches; invoked as tebako-shim it manag
                                        prepend ~/.tebako/shims to PATH in the shell startup file
   tebako-shim uninstall-shell [--shell bash|zsh|fish|csh]
                                        remove exactly the managed block";
+
+#[cfg(windows)]
+const USAGE: &str = "tebako-shim — the tebako dispatcher and version manager (spec 07)
+
+invoked as <TEBAKO_HOME>\\shims\\<tool>.exe it dispatches; invoked as tebako-shim it manages:
+
+  tebako-shim list                     installed payloads, versions, defaults, shim links
+  tebako-shim enable <tool>[@<ver>]    re-enable a disabled tool or version
+  tebako-shim disable <tool>[@<ver>]   refuse dispatch of a tool or version
+  tebako-shim which <tool>             show the resolved version, runtime, mounts, argv
+  tebako-shim doctor                   diagnose the shim layer (missing/corrupt records)
+  tebako-shim install-shell            prepend the shim dir to the user PATH (registry)
+  tebako-shim uninstall-shell          remove exactly our PATH entry";
 
 pub fn run_command(args: &[String], ctx: &Ctx) -> Result<Action, ShimError> {
     let Some(cmd) = args.first() else {
@@ -598,6 +614,7 @@ pub fn unlink_shims(
 // install-shell / uninstall-shell
 // ---------------------------------------------------------------------
 
+#[cfg(not(windows))]
 fn parse_shell_flag(args: &[String], ctx: &Ctx) -> Result<Shell, ShimError> {
     let mut i = 0;
     let mut shell: Option<String> = None;
@@ -625,6 +642,7 @@ fn parse_shell_flag(args: &[String], ctx: &Ctx) -> Result<Shell, ShimError> {
     }
 }
 
+#[cfg(not(windows))]
 fn user_home(ctx: &Ctx) -> Result<PathBuf, ShimError> {
     ctx.env_get("HOME")
         .filter(|v| !v.is_empty())
@@ -637,6 +655,7 @@ fn user_home(ctx: &Ctx) -> Result<PathBuf, ShimError> {
         })
 }
 
+#[cfg(not(windows))]
 fn cmd_shell(args: &[String], ctx: &Ctx, install: bool) -> Result<Action, ShimError> {
     let sh = parse_shell_flag(args, ctx)?;
     let file = shell::startup_file(sh, &user_home(ctx)?);
@@ -660,6 +679,48 @@ fn cmd_shell(args: &[String], ctx: &Ctx, install: bool) -> Result<Action, ShimEr
             }
             shell::Change::NotPresent => {
                 format!("no tebako shim block in {} — nothing to do", file.display())
+            }
+            _ => unreachable!("uninstall only yields Removed/NotPresent"),
+        }
+    };
+    Ok(Action::Print {
+        text: format!("{text}\n"),
+        code: 0,
+    })
+}
+
+/// Windows: no rc files — the shim dir goes onto the user PATH in the
+/// registry (shell_windows.rs). `--shell` is a unix-only option and says
+/// so, never a silent ignore.
+#[cfg(windows)]
+fn cmd_shell(args: &[String], ctx: &Ctx, install: bool) -> Result<Action, ShimError> {
+    if !args.is_empty() {
+        return fail(
+            EX_USAGE,
+            format!(
+                "unexpected argument \"{}\" — on Windows install-shell edits the user PATH in the registry (HKCU\\Environment) and takes no --shell",
+                args.join(" ")
+            ),
+        );
+    }
+    let dir = shims_dir(&ctx.home);
+    let text = if install {
+        match crate::shell_windows::install(&dir)? {
+            shell::Change::Installed => format!(
+                "added {} to the user PATH (HKCU\\Environment)\nopen a NEW terminal — running consoles keep the old PATH",
+                dir.display()
+            ),
+            shell::Change::AlreadyPresent => format!(
+                "{} is already on the user PATH — nothing to do",
+                dir.display()
+            ),
+            _ => unreachable!("install only yields Installed/AlreadyPresent"),
+        }
+    } else {
+        match crate::shell_windows::uninstall(&dir)? {
+            shell::Change::Removed => format!("removed {} from the user PATH", dir.display()),
+            shell::Change::NotPresent => {
+                format!("{} was not on the user PATH — nothing to do", dir.display())
             }
             _ => unreachable!("uninstall only yields Removed/NotPresent"),
         }

--- a/crates/tebako-shim/src/manage.rs
+++ b/crates/tebako-shim/src/manage.rs
@@ -288,13 +288,14 @@ fn cmd_doctor(ctx: &Ctx) -> Result<Action, ShimError> {
     let mut problems: Vec<String> = Vec::new();
     let mut notes: Vec<String> = Vec::new();
 
-    // PATH carries the shim dir?
+    // PATH carries the shim dir? (std::env::split_paths — the separator
+    // is ':' on unix and ';' on Windows; a hand-rolled ':' split would
+    // never match on Windows.)
     let shims_dir = ctx.home.join("shims");
     let on_path = ctx
         .env_get("PATH")
-        .unwrap_or("")
-        .split(':')
-        .any(|p| p == shims_dir.to_string_lossy());
+        .map(|p| std::env::split_paths(&p).any(|dir| dir == shims_dir))
+        .unwrap_or(false);
     if !on_path {
         problems.push(format!(
             "{} is not on PATH — run `tebako-shim install-shell`",
@@ -309,6 +310,7 @@ fn cmd_doctor(ctx: &Ctx) -> Result<Action, ShimError> {
             if name.starts_with('.') {
                 continue; // shim-managed state files
             }
+            let name = crate::command_from_shim_name(&name).to_string();
             match resolve::resolve(&name, ctx) {
                 Ok(_) => notes.push(format!("shim {name}: ok")),
                 Err(e) => problems.push(format!("shim {name}: {}", first_line(&e.message))),
@@ -512,7 +514,7 @@ pub fn link_shims(
     let mut linked = Vec::new();
     for command in commands {
         manifest::check_path_component("command name", command)?;
-        let link = dir.join(command);
+        let link = dir.join(shim_file_name(command));
         if link.symlink_metadata().is_ok() {
             std::fs::remove_file(&link).map_err(|e| {
                 ShimError::new(
@@ -525,6 +527,18 @@ pub fn link_shims(
         linked.push(link);
     }
     Ok(linked)
+}
+
+/// The shim's on-disk filename for a command: `<command>` on unix
+/// (executability is permission bits), `<command>.exe` on Windows —
+/// CreateProcess/PATH resolution goes through PATHEXT, so the copied
+/// dispatcher needs the suffix. The dispatcher strips it from argv[0]
+/// (lib.rs `run`), so registration and lookup stay suffix-free.
+fn shim_file_name(command: &str) -> String {
+    #[cfg(windows)]
+    return format!("{command}.exe");
+    #[cfg(not(windows))]
+    return command.to_string();
 }
 
 #[cfg(unix)]
@@ -565,7 +579,7 @@ pub fn unlink_shims(
     let mut removed = Vec::new();
     for command in commands {
         manifest::check_path_component("command name", command)?;
-        let link = dir.join(command);
+        let link = dir.join(shim_file_name(command));
         match std::fs::remove_file(&link) {
             Ok(()) => removed.push(link),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}

--- a/crates/tebako-shim/src/regcache.rs
+++ b/crates/tebako-shim/src/regcache.rs
@@ -53,8 +53,18 @@ fn offline(ctx: &Ctx) -> bool {
 /// refs, but a hand-maintained config.yaml may carry a path).
 fn local_registry_path(reg_ref: &str) -> Option<PathBuf> {
     if let Some(rest) = reg_ref.strip_prefix("file://") {
-        Some(PathBuf::from(rest))
-    } else if reg_ref.starts_with('/') || reg_ref.starts_with("./") || reg_ref.starts_with("../") {
+        // RFC 8089 drive-path recovery (file:///C:/x → C:/x on Windows),
+        // the same rule tebako-http's reader applies.
+        return Some(PathBuf::from(tebako_http::file_path_from_url(rest)));
+    }
+    // A plain absolute path (`/x`, `C:\x`) or an explicit relative one —
+    // never a bare name (that is a registry ref's grammar, not a path).
+    if Path::new(reg_ref).is_absolute()
+        || reg_ref.starts_with("./")
+        || reg_ref.starts_with("../")
+        || reg_ref.starts_with(".\\")
+        || reg_ref.starts_with("..\\")
+    {
         Some(PathBuf::from(reg_ref))
     } else {
         None

--- a/crates/tebako-shim/src/runtime.rs
+++ b/crates/tebako-shim/src/runtime.rs
@@ -322,7 +322,7 @@ fn sha256_file_hex(path: &Path) -> std::io::Result<String> {
 
 // -- per-entry install lock (mirrors the bootstrap's flock discipline) --
 
-struct EntryLock(#[cfg(unix)] std::fs::File);
+struct EntryLock(std::fs::File);
 
 #[cfg(unix)]
 fn flock_acquire(path: &Path, timeout_ms: u64) -> std::io::Result<EntryLock> {
@@ -355,12 +355,55 @@ fn flock_acquire(path: &Path, timeout_ms: u64) -> std::io::Result<EntryLock> {
     }
 }
 
+/// Windows: LockFileEx on one byte at offset 0 of the lock file — the
+/// same semantics as the unix flock (exclusive, non-blocking attempts on
+/// a poll until the timeout; the kernel releases a crashed holder's lock
+/// when the handle dies). The shape the bootstrap's platform.rs and
+/// tebako-resolve's cache.rs already use.
 #[cfg(windows)]
-fn flock_acquire(_path: &Path, _timeout_ms: u64) -> std::io::Result<EntryLock> {
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "install lock is not implemented on this platform in v1",
-    ))
+fn flock_acquire(path: &Path, timeout_ms: u64) -> std::io::Result<EntryLock> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Foundation::{ERROR_IO_PENDING, ERROR_LOCK_VIOLATION};
+    use windows_sys::Win32::Storage::FileSystem::{
+        LockFileEx, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+    };
+    use windows_sys::Win32::System::IO::OVERLAPPED;
+
+    let f = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+    loop {
+        let mut ov = OVERLAPPED::default();
+        let ok = unsafe {
+            LockFileEx(
+                f.as_raw_handle(),
+                LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+                0,
+                1,
+                0,
+                &mut ov,
+            )
+        };
+        if ok != 0 {
+            return Ok(EntryLock(f));
+        }
+        let err = std::io::Error::last_os_error();
+        let raw = err.raw_os_error().unwrap_or(0);
+        if raw != ERROR_LOCK_VIOLATION as i32 && raw != ERROR_IO_PENDING as i32 {
+            return Err(err);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "lock timeout",
+            ));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(LOCK_POLL_MS));
+    }
 }
 
 fn lock_release(lock: EntryLock) {
@@ -370,6 +413,17 @@ fn lock_release(lock: EntryLock) {
         unsafe {
             libc::flock(fd, libc::LOCK_UN);
         }
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::AsRawHandle as _;
+        use windows_sys::Win32::Storage::FileSystem::UnlockFileEx;
+        use windows_sys::Win32::System::IO::OVERLAPPED;
+        let mut ov = OVERLAPPED::default();
+        unsafe {
+            UnlockFileEx(lock.0.as_raw_handle(), 0, 1, 0, &mut ov);
+        }
+        // dropping the file closes the handle, releasing the lock regardless
     }
 }
 

--- a/crates/tebako-shim/src/shell_windows.rs
+++ b/crates/tebako-shim/src/shell_windows.rs
@@ -1,0 +1,266 @@
+//! Windows shell integration (TODO.v2-1/05): no rc files exist here — the
+//! shim dir goes onto the USER PATH in the registry
+//! (`HKCU\Environment`, value `Path`, REG_EXPAND_SZ), followed by a
+//! `WM_SETTINGCHANGE` broadcast so NEW consoles see it without re-login.
+//!
+//! The same contract as the unix managed block (shell.rs):
+//!
+//! - install is idempotent (present → no-op);
+//! - uninstall removes EXACTLY our entry — every other entry and their
+//!   order are preserved;
+//! - user scope only (HKCU): no admin, no machine scope (HKLM), ever;
+//! - no `setx` shell-out (it truncates PATH at 1024 chars — and a
+//!   shell-out besides; the registry API is one call away).
+//!
+//! The string algorithm ([`path_prepend`]/[`path_remove`]) is
+//! platform-free and host-tested; the Win32 FFI is quarantined in this
+//! file behind `#[cfg(windows)]` (the crate's only unsafe outside the
+//! shim's zero-unsafe norm — mirroring the bootstrap's platform.rs
+//! quarantine).
+
+#[cfg(windows)]
+use std::path::Path;
+
+#[cfg(windows)]
+use crate::shell::Change;
+#[cfg(windows)]
+use crate::{ShimError, EX_TEBAKO_IO};
+
+/// Prepend `dir` to a registry-form PATH string (`;`-separated).
+/// Idempotent: an entry equal to `dir` (case-insensitive — Windows path
+/// semantics) leaves the string byte-identical. Every other entry and
+/// their order are preserved.
+pub fn path_prepend(existing: &str, dir: &str) -> String {
+    if existing.split(';').any(|e| e.eq_ignore_ascii_case(dir)) {
+        return existing.to_string();
+    }
+    if existing.is_empty() {
+        return dir.to_string();
+    }
+    format!("{dir};{existing}")
+}
+
+/// Remove exactly the `dir` entries from the PATH string. Non-matching
+/// entries keep their order and bytes; an absent entry is a no-op.
+pub fn path_remove(existing: &str, dir: &str) -> String {
+    existing
+        .split(';')
+        .filter(|e| !e.eq_ignore_ascii_case(dir))
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+// ---------------------------------------------------------------------
+// Win32 FFI (cfg(windows) only)
+// ---------------------------------------------------------------------
+
+#[cfg(windows)]
+fn wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+/// Read the user PATH (HKCU\Environment:Path). A missing key or value is
+/// an EMPTY path, not an error (fresh profiles have neither).
+#[cfg(windows)]
+fn read_user_path() -> Result<String, ShimError> {
+    use windows_sys::Win32::System::Registry::{
+        RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY_CURRENT_USER, KEY_READ,
+    };
+    unsafe {
+        let mut key = std::ptr::null_mut();
+        if RegOpenKeyExW(
+            HKEY_CURRENT_USER,
+            wide("Environment").as_ptr(),
+            0,
+            KEY_READ,
+            &mut key,
+        ) != 0
+        {
+            return Ok(String::new());
+        }
+        let name = wide("Path");
+        let mut value_type = 0u32;
+        let mut byte_len = 0u32;
+        let rc = RegQueryValueExW(
+            key,
+            name.as_ptr(),
+            std::ptr::null_mut(),
+            &mut value_type,
+            std::ptr::null_mut(),
+            &mut byte_len,
+        );
+        if rc != 0 || byte_len == 0 {
+            RegCloseKey(key);
+            return Ok(String::new());
+        }
+        let mut buf = vec![0u16; byte_len as usize / 2 + 1];
+        let rc = RegQueryValueExW(
+            key,
+            name.as_ptr(),
+            std::ptr::null_mut(),
+            &mut value_type,
+            buf.as_mut_ptr().cast(),
+            &mut byte_len,
+        );
+        RegCloseKey(key);
+        if rc != 0 {
+            return Err(ShimError::new(
+                EX_TEBAKO_IO,
+                format!("cannot read HKCU\\Environment:Path (RegQueryValueExW error {rc})"),
+            ));
+        }
+        // REG_SZ/REG_EXPAND_SZ is NUL-terminated; cut at the first NUL.
+        let end = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+        Ok(String::from_utf16_lossy(&buf[..end]))
+    }
+}
+
+/// Write the user PATH (creating HKCU\Environment when absent).
+#[cfg(windows)]
+fn write_user_path(value: &str) -> Result<(), ShimError> {
+    use windows_sys::Win32::System::Registry::{
+        RegCloseKey, RegCreateKeyExW, RegSetValueExW, HKEY_CURRENT_USER, KEY_SET_VALUE,
+        REG_EXPAND_SZ, REG_OPTION_NON_VOLATILE,
+    };
+    unsafe {
+        let mut key = std::ptr::null_mut();
+        let mut disposition = 0u32;
+        let rc = RegCreateKeyExW(
+            HKEY_CURRENT_USER,
+            wide("Environment").as_ptr(),
+            0,
+            std::ptr::null_mut(),
+            REG_OPTION_NON_VOLATILE,
+            KEY_SET_VALUE,
+            std::ptr::null(),
+            &mut key,
+            &mut disposition,
+        );
+        if rc != 0 {
+            return Err(ShimError::new(
+                EX_TEBAKO_IO,
+                format!("cannot open HKCU\\Environment for writing (RegCreateKeyExW error {rc})"),
+            ));
+        }
+        let data = wide(value);
+        let rc = RegSetValueExW(
+            key,
+            wide("Path").as_ptr(),
+            0,
+            REG_EXPAND_SZ,
+            data.as_ptr().cast(),
+            (data.len() * 2) as u32,
+        );
+        RegCloseKey(key);
+        if rc != 0 {
+            return Err(ShimError::new(
+                EX_TEBAKO_IO,
+                format!("cannot write HKCU\\Environment:Path (RegSetValueExW error {rc})"),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Tell the shell and top-level windows that the environment changed.
+/// Best-effort by design: the broadcast does not mutate RUNNING consoles
+/// (the CLI says so either way), and a hung listener must never block
+/// the install (SMTO_ABORTIFHUNG, 5 s).
+#[cfg(windows)]
+fn broadcast_env_change() {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        SendMessageTimeoutW, HWND_BROADCAST, SMTO_ABORTIFHUNG, WM_SETTINGCHANGE,
+    };
+    unsafe {
+        let mut result = 0usize;
+        SendMessageTimeoutW(
+            HWND_BROADCAST,
+            WM_SETTINGCHANGE,
+            0,
+            wide("Environment").as_ptr() as isize,
+            SMTO_ABORTIFHUNG,
+            5000,
+            &mut result,
+        );
+    }
+}
+
+/// `tebako-shim install-shell` on Windows: prepend the shim dir to the
+/// user PATH in the registry and broadcast the change.
+#[cfg(windows)]
+pub fn install(dir: &Path) -> Result<Change, ShimError> {
+    let dir = dir.to_string_lossy().into_owned();
+    let existing = read_user_path()?;
+    let merged = path_prepend(&existing, &dir);
+    if merged == existing {
+        return Ok(Change::AlreadyPresent);
+    }
+    write_user_path(&merged)?;
+    broadcast_env_change();
+    Ok(Change::Installed)
+}
+
+/// `tebako-shim uninstall-shell` on Windows: remove exactly our entry.
+#[cfg(windows)]
+pub fn uninstall(dir: &Path) -> Result<Change, ShimError> {
+    let dir = dir.to_string_lossy().into_owned();
+    let existing = read_user_path()?;
+    let trimmed = path_remove(&existing, &dir);
+    if trimmed == existing {
+        return Ok(Change::NotPresent);
+    }
+    write_user_path(&trimmed)?;
+    broadcast_env_change();
+    Ok(Change::Removed)
+}
+
+// ---------------------------------------------------------------------
+// tests (the pure algorithm runs everywhere)
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prepend_inserts_once_at_the_front() {
+        assert_eq!(path_prepend("", r"C:\a\shims"), r"C:\a\shims");
+        assert_eq!(
+            path_prepend(r"C:\Windows;C:\bin", r"C:\a\shims"),
+            r"C:\a\shims;C:\Windows;C:\bin"
+        );
+        // idempotent, byte-identical on the second call
+        let once = path_prepend(r"C:\Windows", r"C:\a\shims");
+        assert_eq!(path_prepend(&once, r"C:\a\shims"), once);
+    }
+
+    #[test]
+    fn prepend_matches_case_insensitively() {
+        // Windows path semantics: differing only by case IS the same dir.
+        let existing = r"C:\A\SHIMS;C:\Windows";
+        assert_eq!(path_prepend(existing, r"C:\a\shims"), existing);
+    }
+
+    #[test]
+    fn remove_takes_exactly_our_entry() {
+        assert_eq!(
+            path_remove(r"C:\a\shims;C:\Windows;C:\bin", r"C:\a\shims"),
+            r"C:\Windows;C:\bin"
+        );
+        assert_eq!(
+            path_remove(r"C:\Windows;C:\a\shims;C:\bin", r"C:\a\shims"),
+            r"C:\Windows;C:\bin"
+        );
+        // absent → no-op, byte-identical
+        let existing = r"C:\Windows;C:\bin";
+        assert_eq!(path_remove(existing, r"C:\a\shims"), existing);
+        // a PREFIX of our entry is not our entry
+        assert_eq!(path_remove(r"C:\a\shims2", r"C:\a\shims"), r"C:\a\shims2");
+    }
+
+    #[test]
+    fn remove_matches_case_insensitively_and_empties_cleanly() {
+        assert_eq!(path_remove(r"C:\A\SHIMS", r"C:\a\shims"), "");
+        assert_eq!(path_remove(r"C:\a\shims;", r"C:\a\shims"), "");
+    }
+}

--- a/crates/tebako-shim/tests/common/mod.rs
+++ b/crates/tebako-shim/tests/common/mod.rs
@@ -172,7 +172,12 @@ pub fn write_mirror(root: &Path, lv: &str, ver: &str, tamper: bool) -> PathBuf {
     let platform = platform();
     let dir = root.join(format!("v{ver}"));
     std::fs::create_dir_all(&dir).expect("mirror dir");
-    let exe_name = format!("tebako-runtime-{ver}-{lv}-{platform}");
+    // The release asset name the resolver derives: platform suffix
+    // included (.exe on Windows) — the same name write_runtime uses.
+    let exe_name = format!(
+        "tebako-runtime-{ver}-{lv}-{platform}{}",
+        tebako_shim::runtime::exe_suffix()
+    );
     let image_name = format!("{exe_name}.tfs");
     let exe_bytes = b"mirrored runtime exe\n";
     let image_bytes = b"mirrored runtime image\n";

--- a/crates/tebako-shim/tests/common/mod.rs
+++ b/crates/tebako-shim/tests/common/mod.rs
@@ -172,13 +172,12 @@ pub fn write_mirror(root: &Path, lv: &str, ver: &str, tamper: bool) -> PathBuf {
     let platform = platform();
     let dir = root.join(format!("v{ver}"));
     std::fs::create_dir_all(&dir).expect("mirror dir");
-    // The release asset name the resolver derives: platform suffix
-    // included (.exe on Windows) — the same name write_runtime uses.
-    let exe_name = format!(
-        "tebako-runtime-{ver}-{lv}-{platform}{}",
-        tebako_shim::runtime::exe_suffix()
-    );
-    let image_name = format!("{exe_name}.tfs");
+    // The release asset names the resolver derives: the exe carries the
+    // platform suffix (.exe on Windows); the IMAGE is named off the
+    // suffix-free asset base (<base>.tfs — never <base>.exe.tfs).
+    let asset_base = format!("tebako-runtime-{ver}-{lv}-{platform}");
+    let exe_name = format!("{asset_base}{}", tebako_shim::runtime::exe_suffix());
+    let image_name = format!("{asset_base}.tfs");
     let exe_bytes = b"mirrored runtime exe\n";
     let image_bytes = b"mirrored runtime image\n";
     std::fs::write(dir.join(&exe_name), exe_bytes).expect("exe");

--- a/crates/tebako-shim/tests/common/mod.rs
+++ b/crates/tebako-shim/tests/common/mod.rs
@@ -124,14 +124,17 @@ pub fn platform() -> &'static str {
 }
 
 /// A cached runtime entry
-/// `runtimes/ruby-<lv>-<ver>-<triplet>/tebako-runtime-<ver>-<lv>-<triplet>`.
+/// `runtimes/ruby-<lv>-<ver>-<triplet>/tebako-runtime-<ver>-<lv>-<triplet>[.exe]`
+/// — the resolver looks the asset up by its platform name, suffix
+/// included (spec: `exe_suffix()` on Windows).
 pub fn write_runtime(home: &Path, lv: &str, ver: &str, with_image: bool) -> PathBuf {
     let platform = platform();
+    let suffix = tebako_shim::runtime::exe_suffix();
     let dir = home
         .join("runtimes")
         .join(format!("ruby-{lv}-{ver}-{platform}"));
     std::fs::create_dir_all(&dir).expect("runtime dir");
-    let exe = dir.join(format!("tebako-runtime-{ver}-{lv}-{platform}"));
+    let exe = dir.join(format!("tebako-runtime-{ver}-{lv}-{platform}{suffix}"));
     let exe_bytes = b"fake runtime exe\n";
     std::fs::write(&exe, exe_bytes).expect("exe");
     #[cfg(unix)]
@@ -142,7 +145,7 @@ pub fn write_runtime(home: &Path, lv: &str, ver: &str, with_image: bool) -> Path
     std::fs::write(
         dir.join("sha256"),
         format!(
-            "{}  tebako-runtime-{ver}-{lv}-{platform}\n",
+            "{}  tebako-runtime-{ver}-{lv}-{platform}{suffix}\n",
             sha256_hex(exe_bytes)
         ),
     )

--- a/crates/tebako-shim/tests/manage.rs
+++ b/crates/tebako-shim/tests/manage.rs
@@ -202,6 +202,7 @@ fn doctor_reports_a_clean_setup_and_corruption() {
     assert!(text.contains("sha256 mismatch"), "{text}");
 }
 
+#[cfg(not(windows))] // the unix rc-file flow; the Windows registry form is covered in shell_windows.rs
 #[test]
 fn install_shell_roundtrip_through_run() {
     let tmp = TempDir::new("install-shell");

--- a/crates/tebako-shim/tests/manage.rs
+++ b/crates/tebako-shim/tests/manage.rs
@@ -161,8 +161,13 @@ fn doctor_reports_a_clean_setup_and_corruption() {
 
     // clean: shim on PATH, all records consistent
     let mut ctx = pinned_ctx(&home, tmp.path());
-    ctx.env
-        .insert("PATH".into(), format!("{}:/usr/bin:/bin", shims.display()));
+    ctx.env.insert(
+        "PATH".into(),
+        std::env::join_paths([&shims, std::path::Path::new("/usr/bin")])
+            .unwrap()
+            .to_string_lossy()
+            .into_owned(),
+    );
     let (text, code) = printed(run_ok(&["tebako-shim".into(), "doctor".into()], &ctx));
     assert_eq!(code, 0, "{text}");
     assert!(text.contains("no problems found"), "{text}");
@@ -178,8 +183,13 @@ fn doctor_reports_a_clean_setup_and_corruption() {
     // corrupt the payload image → the trust anchor catches it
     let ctx = {
         let mut c = pinned_ctx(&home, tmp.path());
-        c.env
-            .insert("PATH".into(), format!("{}:/usr/bin:/bin", shims.display()));
+        c.env.insert(
+            "PATH".into(),
+            std::env::join_paths([&shims, std::path::Path::new("/usr/bin")])
+                .unwrap()
+                .to_string_lossy()
+                .into_owned(),
+        );
         c
     };
     std::fs::write(
@@ -230,4 +240,30 @@ fn install_shell_roundtrip_through_run() {
     assert_eq!(code, 0);
     assert!(text.contains("removed"), "{text}");
     assert_eq!(std::fs::read_to_string(&rc).unwrap(), "");
+}
+
+#[test]
+fn link_and_unlink_use_the_platform_shim_name() {
+    // spec 07 §3 + TODO.v2-1/05: the shim file is `<command>` on unix
+    // (permission-bit executability) and `<command>.exe` on Windows
+    // (PATHEXT resolution); unlink removes exactly the same name.
+    let tmp = TempDir::new("link-name");
+    let home = tmp.path().join("home");
+    let dispatcher = tmp.path().join("dispatcher-bin");
+    std::fs::write(&dispatcher, b"dispatcher\n").unwrap();
+
+    #[cfg(windows)]
+    let want = "metanorma.exe";
+    #[cfg(not(windows))]
+    let want = "metanorma";
+
+    let linked = tebako_shim::manage::link_shims(&home, &dispatcher, &["metanorma".to_string()])
+        .expect("link");
+    assert_eq!(linked, vec![home.join("shims").join(want)]);
+    assert!(home.join("shims").join(want).exists());
+
+    let removed =
+        tebako_shim::manage::unlink_shims(&home, &["metanorma".to_string()]).expect("unlink");
+    assert_eq!(removed, vec![home.join("shims").join(want)]);
+    assert!(!home.join("shims").join(want).exists());
 }

--- a/crates/tebako-shim/tests/regcache.rs
+++ b/crates/tebako-shim/tests/regcache.rs
@@ -93,14 +93,9 @@ fn file_refs_read_directly_and_never_touch_the_cache() {
     std::fs::write(&reg, REGISTRY_YAML).unwrap();
 
     let (fetcher, _) = github_fetcher("unused");
-    let registry = regcache::registry_for_with(
-        &home,
-        &format!("file://{}", reg.display()),
-        &fetcher,
-        false,
-        now(),
-    )
-    .unwrap();
+    let registry =
+        regcache::registry_for_with(&home, &tebako_http::file_url(&reg), &fetcher, false, now())
+            .unwrap();
     assert_eq!(registry.payloads.len(), 1);
     // no cache directory was created and nothing was fetched
     assert!(!regcache::registries_dir(&home).exists());
@@ -202,8 +197,7 @@ fn refresh_force_renews_and_reports_outcomes() {
     // file:// refs skip with a distinct outcome
     let reg = tmp.path().join("tpkg-registry.yaml");
     std::fs::write(&reg, REGISTRY_YAML).unwrap();
-    let outcome =
-        regcache::refresh_with(&home, &format!("file://{}", reg.display()), &fetcher).unwrap();
+    let outcome = regcache::refresh_with(&home, &tebako_http::file_url(&reg), &fetcher).unwrap();
     assert_eq!(outcome, RefreshOutcome::LocalSkipped);
 
     // a fetched registry that no longer parses is a named error and the

--- a/crates/tebako-shim/tests/shell_windows.rs
+++ b/crates/tebako-shim/tests/shell_windows.rs
@@ -1,0 +1,32 @@
+#![cfg(windows)]
+//! Real-registry round-trip (TODO.v2-1/05): install prepends exactly
+//! once, uninstall removes exactly our entry. A unique sentinel dir per
+//! run; the drop guard uninstalls even when an assertion fails, so the
+//! user PATH is left untouched either way.
+
+use tebako_shim::shell::Change;
+use tebako_shim::shell_windows;
+
+struct Guard(std::path::PathBuf);
+impl Drop for Guard {
+    fn drop(&mut self) {
+        let _ = shell_windows::uninstall(&self.0);
+    }
+}
+
+#[test]
+fn registry_roundtrip_install_remove() {
+    let dir = std::env::temp_dir().join(format!("tebako-shim-selftest-{}", std::process::id()));
+    let guard = Guard(dir.clone());
+
+    assert_eq!(shell_windows::install(&dir).unwrap(), Change::Installed);
+    // idempotent: the second install changes nothing
+    assert_eq!(
+        shell_windows::install(&dir).unwrap(),
+        Change::AlreadyPresent
+    );
+    assert_eq!(shell_windows::uninstall(&dir).unwrap(), Change::Removed);
+    assert_eq!(shell_windows::uninstall(&dir).unwrap(), Change::NotPresent);
+
+    drop(guard);
+}

--- a/docs/shell-setup.md
+++ b/docs/shell-setup.md
@@ -1,0 +1,116 @@
+# Setting up tebako shims — every shell, every OS
+
+One-time setup. After it, every payload you install just works — new
+commands appear without ever touching PATH again.
+
+## The one-liner answer
+
+```
+tebako-shim install-shell
+```
+
+It detects your shell, inserts a small managed block into the right
+startup file (idempotent — run it twice, nothing changes), and prints
+what it did. Open a NEW terminal (or re-source the file) and you're
+done. Verify with:
+
+```
+tebako-shim doctor
+```
+
+`uninstall-shell` removes exactly that block and nothing else.
+
+## What it does, per shell (and how to do it by hand)
+
+The whole mechanism is ONE directory on PATH: `~/.tebako/shims`. The
+managed block is one line wrapped in markers:
+
+```
+# >>> tebako shims >>>
+export PATH="$HOME/.tebako/shims:$PATH"
+# <<< tebako shims <<<
+```
+
+| shell | startup file | the line |
+|---|---|---|
+| bash | `~/.bashrc` | `export PATH="$HOME/.tebako/shims:$PATH"` |
+| zsh | `~/.zshrc` | `export PATH="$HOME/.tebako/shims:$PATH"` |
+| fish | `~/.config/fish/config.fish` | `set -gx PATH "$HOME/.tebako/shims" $PATH` |
+| csh / tcsh | `~/.cshrc` | `setenv PATH "$HOME/.tebako/shims:$PATH"` |
+
+`install-shell --shell bash|zsh|fish|csh` overrides detection (it reads
+`$SHELL` otherwise).
+
+**Other shells** — no managed block yet; add the equivalent yourself:
+
+- **nushell** (`~/.config/nushell/config.nu`):
+  `$env.PATH = ($env.PATH | prepend $"($env.HOME)/.tebako/shims")`
+- **elvish** (`~/.config/elvish/rc.elv`):
+  `set paths = [~/.tebako/shims $@paths]`
+- **xonsh** (`~/.xonshrc`):
+  `$PATH.insert(0, "~/.tebako/shims")`
+- **anything POSIX** (`~/.profile`): the bash line above.
+
+The rule that always works, in any shell, forever: *prepend
+`~/.tebako/shims` to PATH once.*
+
+## Windows
+
+```
+tebako-shim install-shell
+```
+
+No startup files exist here — the command prepends the shim directory
+(`%LOCALAPPDATA%\tebako\shims`) to your **user PATH in the registry**
+(`HKCU\Environment`), then broadcasts the change so new windows notice.
+Open a NEW terminal (running consoles keep the old PATH — cmd,
+PowerShell, and Windows Terminal all behave this way).
+
+By hand instead: *System Properties → Environment Variables → User
+variables → Path → Edit → New* → `%LOCALAPPDATA%\tebako\shims`. Or in
+PowerShell (exactly what the tool does):
+
+```powershell
+$p = [Environment]::GetEnvironmentVariable("Path", "User")
+[Environment]::SetEnvironmentVariable("Path", "$env:LOCALAPPDATA\tebako\shims;$p", "User")
+```
+
+Never `setx PATH` — it truncates PATH at 1024 characters.
+
+## How a shim actually works (why it's not a script)
+
+Each command is a **link to one compiled dispatcher binary**, not a
+shell script:
+
+- `~/.tebako/shims/metanorma` → symlink to `tebako-shim` (Linux/macOS)
+- `…\shims\metanorma.exe` → a copy of `tebako-shim.exe` (Windows —
+  symlinks need privilege there, a copy doesn't)
+
+When you type `metanorma`, the dispatcher reads **argv[0]** to learn
+which tool it is — the busybox/rustup pattern — then resolves version
+(project pin → user default → registry default), mounts the payload and
+its runtime through TFS, and hands off. On Linux/macOS it `execve`s —
+the shim process *becomes* the runtime, so signals and exit codes are
+exactly the program's own. On Windows it spawns, waits, and exits with
+the child's code (Windows has no `execve`).
+
+Why not shell scripts calling `tebako run <name> -- …`?
+
+- **Four dialects, one bug each.** POSIX sh, cmd `.bat`, PowerShell, and
+  Git Bash all quote and forward arguments differently; a `.bat` isn't
+  even executable by `CreateProcess` from a non-shell parent.
+- **A process layer you can feel.** Script → tebako → runtime means
+  Ctrl-C lands on the script's shell, not your program, and signal
+  forwarding through it is lossy.
+- **Flag ambiguity.** `tebako run metanorma --version` — whose
+  `--version` is that? argv[0] dispatch never makes you ask.
+
+`tebako run <name> -- <args>` still exists for when you want the
+explicit, no-shim path — the shims are sugar over the same dispatch
+chain.
+
+## If it doesn't work
+
+`tebako-shim doctor` checks: shim dir on PATH, links resolve to installed
+payloads, payload images intact, trust anchors present. It names the
+problem and the fix, every time.


### PR DESCRIPTION
## Summary

The release.yml Windows blockers claimed the bootstrap ports were "not implemented" — they were (platform.rs: LockFileEx, MoveFileExW, spawn_handoff, LOCALAPPDATA cache root). What was missing was **proof** and the shim layer. This PR:

**bootstrap (item 03)**
- New `test-windows` CI job (windows-latest): cargo test + clippy over the pure-Rust crates, zero vcpkg — where the ports get proven on the real platform
- Test harness fake runtime: `/bin/sh` script → the package own stub binary (`src/bin/tebako-fake-runtime.rs`, CARGO_BIN_EXE_) — CreateProcess can run a binary, never a script; one path everywhere, byte-exact output (24/24 selftests green on host)
- rnp dev-deps per-target gated (rnp 0.1.7 vendored has no Windows prebuilt — item 08), `tests/chain.rs` cfg-matched

**shim (item 05)**
- link/unlink name the shim `<command>.exe` on Windows (PATHEXT); the dispatcher already stripped it — registration stays suffix-free
- doctor: PATH check via `std::env::split_paths` (a hand-rolled `:` split never matches on Windows); shim names mapped through the same strip helper
- **Windows shell integration** (`shell_windows.rs`): install-shell prepends the shim dir to `HKCU\Environment:Path` (REG_EXPAND_SZ) + WM_SETTINGCHANGE broadcast; uninstall removes exactly our entry. Pure merge/remove algorithm host-tested; FFI scratch-verified against windows-gnullvm; real-registry round-trip test with drop-guard
- The dispatch exec Windows port (was a "not implemented" stub): spawn, wait, exit with the child code, console Ctrl swallowed in the parent
- `docs/shell-setup.md`: the per-shell setup HOWTO (managed block table, nu/elvish/xonsh/PowerShell/Windows-GUI by hand, why binary links not scripts)

## Verification

Host: full bootstrap+shim suites green, clippy -D warnings clean, fmt clean. Windows: proven by the new test-windows job on this PR.