### PR TITLE
the explicit install verb: tebako install <path> + TPKG_FLAG_NO_INSTALL (TODO.v2-1/12)

### DIFF
--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -91,6 +91,11 @@ pub const EX_TEBAKO_IO: u8 = 74;
 /// not speak (roadmap 45): contract_version in the release manifest is
 /// outside this bootstrap's supported range — fail CLOSED, never a guess.
 pub const EX_TEBAKO_CONTRACT: u8 = 75;
+/// The explicit install verb (TODO.v2-1/12) was refused
+/// (`TPKG_FLAG_NO_INSTALL` — the publisher froze the package) or needs
+/// the tebako CLI (the manifest read wants the TFS engine the
+/// size-capped bootstrap deliberately does not carry).
+pub const EX_TEBAKO_INSTALL: u8 = 76;
 
 /// The bootstrap↔runtime contract this bootstrap speaks (roadmap 45):
 /// today's env/argv/image-handoff semantics. Min and max are the same
@@ -2036,6 +2041,31 @@ pub fn run(argv: &[String]) -> Result<std::convert::Infallible, BootError> {
             format!(
                 "package requires launcher ABI {} but this tebako-bootstrap {VERSION} supports ABI {LAUNCHER_ABI} —\n  refresh the runtime via tebako cache, or re-bundle with a current tebako-bootstrap",
                 m.launcher_abi
+            ),
+        );
+    }
+
+    // The explicit install verb (TODO.v2-1/12): a run is a run — payload
+    // slices land in the local store only when asked. The manifest read
+    // needs the TFS engine the size-capped bootstrap deliberately does
+    // not carry, so the verb refuses (frozen package) or guides to the
+    // CLI. Placed after the chain + ABI gates: an install attempt is
+    // verified exactly like a run.
+    if argv.get(1).map(String::as_str) == Some("--tebako-install") {
+        if m.package_flags & tpkg::TPKG_FLAG_NO_INSTALL != 0 {
+            return fail(
+                EX_TEBAKO_INSTALL,
+                format!(
+                    "{} was built non-installable (TPKG_FLAG_NO_INSTALL — the publisher froze it); it runs standalone",
+                    self_path.display()
+                ),
+            );
+        }
+        return fail(
+            EX_TEBAKO_INSTALL,
+            format!(
+                "to install this package's slices into the local store, run:\n  tebako install {}\n(the manifest read needs the TFS engine the bootstrap deliberately does not carry — the CLI does it for you)",
+                self_path.display()
             ),
         );
     }

--- a/crates/tebako-bootstrap/tests/harness/mod.rs
+++ b/crates/tebako-bootstrap/tests/harness/mod.rs
@@ -165,8 +165,22 @@ impl Harness {
         launcher_abi: u32,
         out: &Path,
     ) {
+        self.stitch_flags(base, parts, runtime_ref, launcher_abi, 0, out);
+    }
+
+    /// [`stitch`] with explicit `package_flags` (TPKG_FLAG_NO_INSTALL
+    /// fixtures — every other caller keeps the default 0).
+    pub fn stitch_flags(
+        &self,
+        base: &Path,
+        parts: &[(PathBuf, u32, &str)],
+        runtime_ref: &str,
+        launcher_abi: u32,
+        package_flags: u32,
+        out: &Path,
+    ) {
         let mut m = tpkg::Manifest {
-            package_flags: 0,
+            package_flags,
             launcher_abi,
             ..Default::default()
         };

--- a/crates/tebako-bootstrap/tests/selftest.rs
+++ b/crates/tebako-bootstrap/tests/selftest.rs
@@ -709,3 +709,57 @@ fn s16_image_contract_mismatch_refused() {
         "a refused-contract image entered the cache"
     );
 }
+
+// ---------------------------------------------------------------------
+// TODO.v2-1/12: the explicit install verb + run-never-seeds
+// ---------------------------------------------------------------------
+
+#[test]
+fn s17_install_verb_guides_and_the_flag_refuses() {
+    // A normal package: the verb guides to the CLI (exit 76, actionable).
+    let h1 = h();
+    let pkg = h1.lean_pkg("myapp");
+    let (rc, _, err) = h1.run(&pkg, &h1.home("h-inst"), &[], &["--tebako-install"]);
+    assert_eq!(rc, 76, "{err}");
+    assert!(err.contains("tebako install"), "{err}");
+    assert!(
+        !h1.home("h-inst").join("payloads").exists(),
+        "the verb wrote into the payloads store"
+    );
+
+    // A frozen package (TPKG_FLAG_NO_INSTALL): the named refusal.
+    let h2 = h();
+    let img = h2.fake_image();
+    let frozen = h2.tmp.0.join("frozen");
+    h2.stitch_flags(
+        &h2.bootstrap,
+        &[(img, tpkg::TPKG_FORMAT_DWARFS, "/__tebako_memfs__")],
+        &h2.runtime_ref,
+        0,
+        tpkg::TPKG_FLAG_NO_INSTALL,
+        &frozen,
+    );
+    let (rc, _, err) = h2.run(&frozen, &h2.home("h-frozen"), &[], &["--tebako-install"]);
+    assert_eq!(rc, 76, "{err}");
+    assert!(err.contains("non-installable"), "{err}");
+}
+
+#[test]
+fn s18_a_run_never_seeds_the_store() {
+    // TODO.v2-1/12's core law: a run is a run — the runtime cache fills
+    // (intrinsic to executing) but NO payload slice touches the store.
+    let h = h();
+    let pkg = h.lean_pkg("myapp");
+    let home = h.home("home-run");
+    let (rc, out, err) = h.run(&pkg, &home, &[], &["hello"]);
+    assert_eq!((rc, err.as_str()), (0, ""), "{err}");
+    assert!(out.contains("FAKE-RUNTIME"), "{out}");
+    assert!(
+        h.cache_exe(&home).is_file(),
+        "the runtime cache is intrinsic"
+    );
+    assert!(
+        !home.join("payloads").exists(),
+        "a plain run seeded the payloads store"
+    );
+}

--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -255,6 +255,302 @@ fn looks_like_reference(target: &str) -> bool {
     target.contains("://") || target.starts_with("tfs:")
 }
 
+// ---- the local-package form (TODO.v2-1/12) ----------------------------
+
+/// The exit code for a refused or impossible package install (spec 06 §4).
+const EX_TEBAKO_INSTALL: i32 = 76;
+
+/// True when `path` is a pressed tebako package (a readable tpkg
+/// trailer) — the local-install discriminator (sniff the trailer, never
+/// guess by extension).
+pub fn is_tpkg_package(path: &Path) -> bool {
+    std::fs::File::open(path)
+        .map(|mut f| tpkg::read_from(&mut f).is_ok())
+        .unwrap_or(false)
+}
+
+/// One installed slice of a local package.
+#[derive(Debug)]
+pub struct LocalInstalled {
+    pub name: String,
+    pub version: String,
+    pub status: InstallStatus,
+    pub path: PathBuf,
+    pub sha256: String,
+    pub commands: Vec<String>,
+}
+
+/// The local-package install report (a package may carry several payload
+/// slices).
+#[derive(Debug)]
+pub struct LocalInstallOutcome {
+    pub installed: Vec<LocalInstalled>,
+    pub shims: Vec<PathBuf>,
+    pub notes: Vec<String>,
+}
+
+/// `tebako install <path>` (TODO.v2-1/12): install every payload slice
+/// of a local pressed package (fat or lean) into the store. Trust
+/// anchors: the signed trailer's per-slot digest for v2 packages, the
+/// computed digest for unsigned ones — exactly the run's own
+/// enforcement strength, never upgraded (spec 06 §3's honesty).
+/// Shims link only when explicitly asked (`--shims`) — a one-off
+/// install never claims PATH names (the owner rule).
+pub fn install_local(
+    home: &Path,
+    path: &Path,
+    link_shims: bool,
+    shim_binary: Option<&Path>,
+) -> Result<LocalInstallOutcome, TebakoError> {
+    let mut f = std::fs::File::open(path)
+        .map_err(|e| err(EX_TEBAKO_IO, format!("cannot open {}: {e}", path.display())))?;
+    let m = tpkg::read_from(&mut f).map_err(|e| {
+        err(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "corrupt tebako manifest trailer in {} ({})",
+                path.display(),
+                tpkg::strerror(e.code())
+            ),
+        )
+    })?;
+    if m.package_flags & tpkg::TPKG_FLAG_NO_INSTALL != 0 {
+        return Err(err(
+            EX_TEBAKO_INSTALL,
+            format!(
+                "{} was built non-installable (TPKG_FLAG_NO_INSTALL — the publisher froze it); it runs standalone",
+                path.display()
+            ),
+        ));
+    }
+    let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let cache = PayloadCache::with_root(home);
+    let mut outcome = LocalInstallOutcome {
+        installed: Vec::new(),
+        shims: Vec::new(),
+        notes: Vec::new(),
+    };
+    let tmp_root = std::env::temp_dir().join(format!(
+        "tebako-install-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    let _ = std::fs::remove_dir_all(&tmp_root);
+    std::fs::create_dir_all(&tmp_root).map_err(|e| {
+        err(
+            EX_TEBAKO_IO,
+            format!("cannot create {}: {e}", tmp_root.display()),
+        )
+    })?;
+    let result = (|| {
+        for (i, slot) in m.slots.iter().enumerate() {
+            if slot.format_id == tpkg::TPKG_FORMAT_RUNTIME {
+                outcome.notes.push(
+                    "the runtime slot is not store-installed; it resolves into the runtime cache on first run (unchanged)"
+                        .to_string(),
+                );
+                continue;
+            }
+            let slice = install_local_slot(
+                home,
+                &cache,
+                &abs,
+                &m,
+                i,
+                slot,
+                &tmp_root,
+                &mut outcome.notes,
+            )?;
+            outcome.installed.push(slice);
+        }
+        Ok::<(), TebakoError>(())
+    })();
+    let _ = std::fs::remove_dir_all(&tmp_root);
+    result?;
+
+    // Shims: an explicit ask only.
+    if link_shims {
+        let commands: Vec<String> = outcome
+            .installed
+            .iter()
+            .flat_map(|s| s.commands.clone())
+            .collect();
+        if !commands.is_empty() {
+            let binary = resolve_shim_binary(shim_binary)?;
+            outcome.shims = manage::link_shims(home, &binary, &commands).map_err(map_shim)?;
+        }
+    }
+    Ok(outcome)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn install_local_slot(
+    home: &Path,
+    cache: &PayloadCache,
+    abs_pkg: &Path,
+    m: &tpkg::Manifest,
+    index: usize,
+    slot: &tpkg::Slot,
+    tmp_root: &Path,
+    notes: &mut Vec<String>,
+) -> Result<LocalInstalled, TebakoError> {
+    // 1. the slot bytes, out of the package
+    let tmp = tmp_root.join(format!("slot-{index}.tfs"));
+    extract_file_region(abs_pkg, slot.offset, slot.size, &tmp)?;
+
+    // 2. identity from the embedded manifest (authoritative, spec 03 §1)
+    let text = image_manifest::read_embedded_manifest(&tmp)?.ok_or_else(|| {
+        err(
+            EX_TEBAKO_INSTALL,
+            format!(
+                "slot {index} of {} carries no embedded manifest (/__tpkg__/manifest.yaml) — cannot derive the payload identity; press the payload with a manifest",
+                abs_pkg.display()
+            ),
+        )
+    })?;
+    let embedded = tpkg::PayloadManifest::from_yaml(&text).map_err(|e| {
+        err(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "the embedded manifest of slot {index} in {} does not parse: {e}",
+                abs_pkg.display()
+            ),
+        )
+    })?;
+    let name = embedded.identity.name.clone();
+    let version = embedded.identity.version.clone();
+    manifest::check_path_component("payload name", &name).map_err(map_shim)?;
+    manifest::check_path_component("payload version", &version).map_err(map_shim)?;
+
+    // 3. the trust anchor
+    let computed = sha256_file(&tmp)?;
+    let (expected, signed_by) = match &m.v2 {
+        Some(v2) => (
+            v2.slot_digest(index).map(|d| hex_lower(d)),
+            Some(v2.signer_keyid_hex()),
+        ),
+        None => (None, None),
+    };
+
+    // 4. the drift rule: same name+version → same content skips
+    // silently; DIFFERENT content never overwrites (loud note, doctor
+    // surfaces it). The Hit still reports the mirror's commands — an
+    // explicit --shims after a plain install must link, not no-op.
+    if let Some(entry) = cache.get(&name, &version).map_err(map_resolve)? {
+        if entry.sha256.eq_ignore_ascii_case(&computed) {
+            notes.push(format!(
+                "{name} {version} is already installed ({}); skipping",
+                entry.path.display()
+            ));
+        } else {
+            notes.push(format!(
+                "WARNING: {name} {version} is already installed with DIFFERENT content\n  installed: {}\n  this package: {}\n  keeping the installed one — inspect with `tebako doctor`",
+                entry.sha256, computed
+            ));
+        }
+        let record: PayloadRecord = manifest::payload_record(home, &name, &version);
+        let commands = Manifest::load(&record.manifest_mirror)
+            .map(|m| m.entrypoints().iter().map(|e| e.name.clone()).collect())
+            .unwrap_or_default();
+        return Ok(LocalInstalled {
+            name,
+            version,
+            status: InstallStatus::Hit,
+            path: entry.path,
+            sha256: entry.sha256,
+            commands,
+        });
+    }
+
+    // 5. install into the store (provenance rides the origin marker)
+    let origin = match &signed_by {
+        Some(keyid) => format!(
+            "payload={} slot={index} signed_by={keyid}",
+            abs_pkg.display()
+        ),
+        None => format!("payload={} slot={index}", abs_pkg.display()),
+    };
+    let bytes = std::fs::read(&tmp)
+        .map_err(|e| err(EX_TEBAKO_IO, format!("cannot read {}: {e}", tmp.display())))?;
+    let sha_for_closure = computed.clone();
+    let (entry, status) = cache
+        .install(&name, &version, expected.as_deref(), || {
+            Ok(FetchedPayload {
+                bytes,
+                origin: origin.clone(),
+                sha256: sha_for_closure,
+            })
+        })
+        .map_err(map_resolve)?;
+
+    // 6. the manifest mirror (the embedded manifest IS the authoritative
+    // record — spec 03 §4 tier 1)
+    let mirror = Manifest::from_payload_manifest(embedded);
+    let record: PayloadRecord = manifest::payload_record(home, &name, &version);
+    mirror.save(&record.manifest_mirror).map_err(map_shim)?;
+    let commands: Vec<String> = mirror
+        .entrypoints()
+        .iter()
+        .map(|e| e.name.clone())
+        .collect();
+
+    journal(
+        home,
+        &format!(
+            "event=payload-installed name={name} version={version} sha256={} origin={origin}",
+            entry.sha256
+        ),
+    );
+    Ok(LocalInstalled {
+        name,
+        version,
+        status,
+        path: entry.path,
+        sha256: entry.sha256,
+        commands,
+    })
+}
+
+fn extract_file_region(src: &Path, offset: u64, size: u64, dst: &Path) -> Result<(), TebakoError> {
+    use std::io::{Read, Seek, SeekFrom, Write};
+    let mut f = std::fs::File::open(src)
+        .map_err(|e| err(EX_TEBAKO_IO, format!("cannot open {}: {e}", src.display())))?;
+    f.seek(SeekFrom::Start(offset))
+        .map_err(|e| err(EX_TEBAKO_IO, format!("cannot seek {}: {e}", src.display())))?;
+    let mut limited = f.take(size);
+    let mut out = std::fs::File::create(dst).map_err(|e| {
+        err(
+            EX_TEBAKO_IO,
+            format!("cannot create {}: {e}", dst.display()),
+        )
+    })?;
+    std::io::copy(&mut limited, &mut out).map_err(|e| {
+        err(
+            EX_TEBAKO_IO,
+            format!("cannot extract to {}: {e}", dst.display()),
+        )
+    })?;
+    out.flush()
+        .map_err(|e| err(EX_TEBAKO_IO, format!("cannot write {}: {e}", dst.display())))
+}
+
+fn sha256_file(path: &Path) -> Result<String, TebakoError> {
+    use sha2::Digest as _;
+    let mut f = std::fs::File::open(path)
+        .map_err(|e| err(EX_TEBAKO_IO, format!("cannot open {}: {e}", path.display())))?;
+    let mut h = sha2::Sha256::new();
+    std::io::copy(&mut f, &mut h)
+        .map_err(|e| err(EX_TEBAKO_IO, format!("cannot hash {}: {e}", path.display())))?;
+    Ok(hex_lower(&h.finalize()))
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
 // ---- the ref form -----------------------------------------------------
 
 fn plan_from_reference(target: &str) -> Result<InstallPlan, TebakoError> {

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -266,6 +266,7 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
         &package,
         &runtime_ref,
         package_manifest.as_ref(),
+        opts.no_install,
     )?;
     println!("Created tebako package at \"{package}\"");
     ensure_version_file(opts);
@@ -348,6 +349,7 @@ pub(crate) fn stitch(
     package: &str,
     runtime_ref: &str,
     package_manifest: Option<&tpkg::PackageManifest>,
+    no_install: bool,
 ) -> Result<(), TebakoError> {
     if images.is_empty() {
         return Err(packaging_error(126, Some("at least one image is required")));
@@ -435,7 +437,13 @@ pub(crate) fn stitch(
         .collect();
     let pkg_options = tebako_pkg::PackageOptions {
         runtime_ref: runtime_ref.to_string(),
-        package_flags: tpkg::TPKG_FLAG_LEAN,
+        // TPKG_FLAG_LEAN always; TPKG_FLAG_NO_INSTALL when the press
+        // froze the package (--no-install, TODO.v2-1/12).
+        package_flags: if no_install {
+            tpkg::TPKG_FLAG_LEAN | tpkg::TPKG_FLAG_NO_INSTALL
+        } else {
+            tpkg::TPKG_FLAG_LEAN
+        },
         launcher_abi: LAUNCHER_ABI,
         // The L2 package manifest rides along only when the press declares
         // one (today: a --jail policy); block-less packages keep the exact
@@ -818,5 +826,48 @@ mod tests {
         // The YAML form survives a round trip (the block embeds as YAML).
         let back = tpkg::PackageManifest::from_yaml(&m.to_yaml().unwrap()).unwrap();
         assert_eq!(back, m);
+    }
+
+    #[test]
+    fn stitch_bakes_the_no_install_flag_only_when_asked() {
+        // TODO.v2-1/12: --no-install freezes the package in the trailer
+        // (TPKG_FLAG_NO_INSTALL); the default press leaves the bit clear
+        // (installable-on-request, pre-era shape).
+        let dir = std::env::temp_dir().join(format!("tebako-cli-stitch-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let base = dir.join("bootstrap");
+        std::fs::write(&base, b"BASE").unwrap();
+        let img = dir.join("img.tfs");
+        std::fs::write(&img, b"IMG").unwrap();
+
+        let frozen = dir.join("frozen");
+        stitch(
+            &base,
+            &[(img.clone(), "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+            frozen.to_str().unwrap(),
+            "ruby@3.3.7;tebako=9.9.9",
+            None,
+            true,
+        )
+        .unwrap();
+        let mut f = std::fs::File::open(&frozen).unwrap();
+        let m = tpkg::read_from(&mut f).unwrap();
+        assert!(m.package_flags & tpkg::TPKG_FLAG_NO_INSTALL != 0);
+        assert!(m.package_flags & tpkg::TPKG_FLAG_LEAN != 0);
+
+        let plain = dir.join("plain");
+        stitch(
+            &base,
+            &[(img, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+            plain.to_str().unwrap(),
+            "ruby@3.3.7;tebako=9.9.9",
+            None,
+            false,
+        )
+        .unwrap();
+        let mut f = std::fs::File::open(&plain).unwrap();
+        let m = tpkg::read_from(&mut f).unwrap();
+        assert_eq!(m.package_flags & tpkg::TPKG_FLAG_NO_INSTALL, 0);
     }
 }

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -187,11 +187,63 @@ fn run_update_registries(args: &[String]) -> Result<(), CliExit> {
 }
 
 fn run_install(args: &[String]) -> Result<(), CliExit> {
-    let [target] = args else {
+    let mut target: Option<&String> = None;
+    let mut link_shims = false;
+    for arg in args {
+        match arg.as_str() {
+            "--shims" => link_shims = true,
+            _ if target.is_none() => target = Some(arg),
+            _ => {
+                return Err(CliExit::Usage(
+                    "usage: tebako install <ref | name[@version] | ./package> [--shims]"
+                        .to_string(),
+                ))
+            }
+        }
+    }
+    let Some(target) = target else {
         return Err(CliExit::Usage(
-            "usage: tebako install <ref | name[@version]>".to_string(),
+            "usage: tebako install <ref | name[@version] | ./package> [--shims]".to_string(),
         ));
     };
+    // A local pressed package (fat or lean): slot-wise install from its
+    // own bytes (TODO.v2-1/12) — never a registry flow. Shims link only
+    // via the explicit --shims.
+    let path = std::path::Path::new(target);
+    if path.is_file() && tebako_cli::install::is_tpkg_package(path) {
+        let outcome = tebako_cli::install::install_local(&tebako_home()?, path, link_shims, None)?;
+        for note in &outcome.notes {
+            eprintln!("tebako: note: {note}");
+        }
+        for slice in &outcome.installed {
+            match slice.status {
+                tebako_resolve::InstallStatus::Hit => {
+                    println!(
+                        "{} {} already present ({})",
+                        slice.name,
+                        slice.version,
+                        slice.path.display()
+                    )
+                }
+                tebako_resolve::InstallStatus::Installed => println!(
+                    "installed {} {} -> {}",
+                    slice.name,
+                    slice.version,
+                    slice.path.display()
+                ),
+            }
+        }
+        for shim in &outcome.shims {
+            println!("  shim {}", shim.display());
+        }
+        return Ok(());
+    }
+    if link_shims {
+        return Err(CliExit::Usage(
+            "--shims only applies to a local package install (registry installs always register shims)"
+                .to_string(),
+        ));
+    }
     let outcome = tebako_cli::install::install(&tebako_home()?, target, None, None)?;
     for note in &outcome.notes {
         eprintln!("tebako: note: {note}");
@@ -454,6 +506,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
     let mut devmode = false;
     let mut suite: Option<PathBuf> = None;
     let mut jail: Option<String> = None;
+    let mut no_install = false;
 
     let mut i = 0;
     while i < args.len() {
@@ -489,6 +542,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
             "--prefer-local" => prefer_local = true,
             "--suite" => suite = Some(PathBuf::from(take_value(&mut i)?)),
             "--jail" => jail = Some(take_value(&mut i)?),
+            "--no-install" => no_install = true,
             "-D" | "--devmode" => devmode = true,
             "-t" | "--tebafile" => {
                 let _ = take_value(&mut i)?;
@@ -553,5 +607,6 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
         fs_current,
         suite,
         jail,
+        no_install,
     })
 }

--- a/crates/tebako-cli/src/options.rs
+++ b/crates/tebako-cli/src/options.rs
@@ -77,6 +77,11 @@ pub struct PressOptions {
     /// | the TEBAKO_JAIL env grammar. Written into the type-2 package
     /// manifest's `jail:` block — the package's host-access REQUEST.
     pub jail: Option<String>,
+    /// --no-install (TODO.v2-1/12): bake TPKG_FLAG_NO_INSTALL — the package
+    /// RUNS standalone but every install attempt (`--tebako-install`,
+    /// `tebako install <path>`) is refused with a named error. Off by
+    /// default (installable on explicit request).
+    pub no_install: bool,
 }
 
 impl PressOptions {

--- a/crates/tebako-cli/src/packager.rs
+++ b/crates/tebako-cli/src/packager.rs
@@ -782,6 +782,7 @@ mod tests {
             fs_current: "/tmp".to_string(),
             suite: None,
             jail: None,
+            no_install: false,
         }
     }
 

--- a/crates/tebako-cli/src/suite.rs
+++ b/crates/tebako-cli/src/suite.rs
@@ -408,6 +408,7 @@ pub fn press_suite(
         &package,
         &runtime_refs[0],
         Some(&package_manifest),
+        opts.no_install,
     )?;
     println!("Created tebako suite package at \"{package}\"");
     crate::ensure_version_file(opts);

--- a/crates/tebako-cli/tests/install_local.rs
+++ b/crates/tebako-cli/tests/install_local.rs
@@ -1,0 +1,293 @@
+//! `tebako install <path>` — the local-package install (TODO.v2-1/12):
+//! slices land from the package's own bytes with the trailer's digests
+//! as anchors, idempotent skip, the drift rule, the NO_INSTALL refusal,
+//! runtime-slot skipping, and explicit-only shims. No network, temp
+//! TEBAKO_HOMEs throughout.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use tebako_cli::install;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "tebako-cli-install-local-{tag}-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn sha(byte: u8) -> String {
+    use sha2::Digest as _;
+    tpkg_hex(&sha2::Sha256::digest([byte; 32]))
+}
+
+fn tpkg_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn sha256_of(path: &Path) -> String {
+    use sha2::Digest as _;
+    tpkg_hex(&sha2::Sha256::digest(fs::read(path).unwrap()))
+}
+
+/// A ZIP image carrying an embedded manifest (mountable by the tfs zip
+/// backend) — the same fixture shape the registry install tests use.
+fn zip_image_with_manifest(manifest_yaml: &str) -> Vec<u8> {
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let options = zip::write::SimpleFileOptions::default();
+    writer
+        .start_file("__tpkg__/manifest.yaml", options)
+        .unwrap();
+    writer.write_all(manifest_yaml.as_bytes()).unwrap();
+    writer.start_file("app/bin/app", options).unwrap();
+    writer.write_all(b"#!/bin/sh\n").unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+fn embedded_manifest_yaml(name: &str, version: &str) -> String {
+    format!(
+        "identity:\n  schema_version: 1\n  kind: app\n  name: {name}\n  version: {version}\n  producer: {{tool: tebako, tool_version: 0.15.9}}\n  created: \"2026-07-26T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{}\"\n    blob_sha256: \"{}\"\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n  entrypoints:\n    - name: {name}\n      path: /app/bin/{name}\n      runtime_requirement: {{engine: ruby, constraint: \">= 3.3, < 5.0\"}}\n  platforms: universal\n  capabilities: {{exec: true, read: true}}\n",
+        sha(b'a'),
+        sha(b'b')
+    )
+}
+
+/// Stitch a tpkg package (fake base bytes + slots) with the given flags.
+fn pressed_package(
+    dir: &Path,
+    name: &str,
+    images: &[(PathBuf, String, u32)],
+    package_flags: u32,
+) -> PathBuf {
+    let base = dir.join(format!("{name}.base"));
+    fs::write(&base, b"FAKE-BASE-BYTES").unwrap();
+    let out = dir.join(name);
+    let pkg_images: Vec<tebako_pkg::PackageImage> = images
+        .iter()
+        .map(|(path, mount, format_id)| tebako_pkg::PackageImage {
+            path: path.clone(),
+            mount_point: mount.clone(),
+            format_id: *format_id,
+        })
+        .collect();
+    let options = tebako_pkg::PackageOptions {
+        runtime_ref: "ruby@3.3.7;tebako=9.9.9".to_string(),
+        package_flags,
+        launcher_abi: 1,
+        ..Default::default()
+    };
+    tebako_pkg::bundle_exact(&base, &pkg_images, &out, &options).unwrap();
+    out
+}
+
+fn payload_image(dir: &Path, file: &str, name: &str, version: &str) -> PathBuf {
+    let path = dir.join(file);
+    fs::write(
+        &path,
+        zip_image_with_manifest(&embedded_manifest_yaml(name, version)),
+    )
+    .unwrap();
+    path
+}
+
+fn payloads_dir(home: &Path) -> PathBuf {
+    home.join("payloads")
+}
+
+#[test]
+fn install_lands_the_slice_with_markers_and_mirror() {
+    let dir = scratch("lands");
+    let home = dir.join("home");
+    fs::create_dir_all(&home).unwrap();
+    let img = payload_image(&dir, "app.tfs", "app", "1.0");
+    let pkg = pressed_package(
+        &dir,
+        "myapp",
+        &[(img, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+        0,
+    );
+
+    let outcome = install::install_local(&home, &pkg, false, None).unwrap();
+    assert_eq!(outcome.installed.len(), 1);
+    let slice = &outcome.installed[0];
+    assert_eq!(
+        (slice.name.as_str(), slice.version.as_str()),
+        ("app", "1.0")
+    );
+    assert_eq!(slice.status, tebako_resolve::InstallStatus::Installed);
+    assert_eq!(slice.commands, vec!["app".to_string()]);
+
+    let cached = payloads_dir(&home).join("app").join("1.0.tfs");
+    assert!(cached.is_file());
+    // the trust anchor is the computed digest (unsigned package)
+    assert_eq!(slice.sha256, sha256_of(&cached));
+    assert!(cached.with_file_name("1.0.tfs.sha256").is_file());
+    let origin = fs::read_to_string(cached.with_file_name("1.0.tfs.origin")).unwrap();
+    assert!(origin.contains("payload="), "{origin}");
+    assert!(origin.contains("slot=0"), "{origin}");
+    // the manifest mirror mirrors the embedded manifest
+    let mirror = tebako_shim::manifest::Manifest::load(
+        &payloads_dir(&home).join("app").join("1.0.manifest.yaml"),
+    )
+    .unwrap();
+    assert_eq!(mirror.entrypoint("app").unwrap().path, "/app/bin/app");
+    // no shims without the explicit ask
+    assert!(outcome.shims.is_empty());
+    assert!(!home.join("shims").join("app").exists());
+}
+
+#[test]
+fn reinstall_is_a_skip_and_drift_never_overwrites() {
+    let dir = scratch("drift");
+    let home = dir.join("home");
+    fs::create_dir_all(&home).unwrap();
+    let img = payload_image(&dir, "app.tfs", "app", "1.0");
+    let pkg = pressed_package(
+        &dir,
+        "myapp",
+        &[(img, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+        0,
+    );
+    install::install_local(&home, &pkg, false, None).unwrap();
+
+    // second install of the same package: silent skip
+    let again = install::install_local(&home, &pkg, false, None).unwrap();
+    assert_eq!(
+        again.installed[0].status,
+        tebako_resolve::InstallStatus::Hit
+    );
+    assert!(
+        again.notes.iter().any(|n| n.contains("already installed")),
+        "{:?}",
+        again.notes
+    );
+
+    // same identity, DIFFERENT bytes: loud warning, never overwrite
+    let other_img = dir.join("app2.tfs");
+    let mut bytes = zip_image_with_manifest(&embedded_manifest_yaml("app", "1.0"));
+    bytes.extend_from_slice(b"DRIFT");
+    fs::write(&other_img, bytes).unwrap();
+    let pkg2 = pressed_package(
+        &dir,
+        "myapp2",
+        &[(other_img, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+        0,
+    );
+    let third = install::install_local(&home, &pkg2, false, None).unwrap();
+    assert!(
+        third.notes.iter().any(|n| n.contains("DIFFERENT content")),
+        "{:?}",
+        third.notes
+    );
+    let first_sha = install::install_local(&home, &pkg, false, None)
+        .unwrap()
+        .installed[0]
+        .sha256
+        .clone();
+    assert_eq!(
+        third.installed[0].sha256, first_sha,
+        "the installed slice was replaced"
+    );
+}
+
+#[test]
+fn no_install_flag_refuses_with_zero_writes() {
+    let dir = scratch("refused");
+    let home = dir.join("home");
+    fs::create_dir_all(&home).unwrap();
+    let img = payload_image(&dir, "app.tfs", "app", "1.0");
+    let pkg = pressed_package(
+        &dir,
+        "frozen",
+        &[(img, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+        tpkg::TPKG_FLAG_NO_INSTALL,
+    );
+    let err = install::install_local(&home, &pkg, false, None).unwrap_err();
+    assert_eq!(err.code, 76, "{err}");
+    assert!(err.to_string().contains("non-installable"), "{err}");
+    assert!(
+        !payloads_dir(&home).exists(),
+        "a refused install wrote into the store"
+    );
+}
+
+#[test]
+fn lean_package_installs_and_the_runtime_slot_is_skipped_with_a_note() {
+    let dir = scratch("lean");
+    let home = dir.join("home");
+    fs::create_dir_all(&home).unwrap();
+    let img = payload_image(&dir, "app.tfs", "app", "1.0");
+    let runtime_blob = dir.join("runtime.bin");
+    fs::write(&runtime_blob, b"FAKE RUNTIME").unwrap();
+    let pkg = pressed_package(
+        &dir,
+        "leanpkg",
+        &[
+            (img, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS),
+            (runtime_blob, String::new(), tpkg::TPKG_FORMAT_RUNTIME),
+        ],
+        tpkg::TPKG_FLAG_LEAN,
+    );
+    let outcome = install::install_local(&home, &pkg, false, None).unwrap();
+    assert_eq!(
+        outcome.installed.len(),
+        1,
+        "only the payload slice installs"
+    );
+    assert!(
+        outcome.notes.iter().any(|n| n.contains("runtime slot")),
+        "{:?}",
+        outcome.notes
+    );
+}
+
+#[test]
+fn a_slot_without_an_embedded_manifest_is_a_named_error() {
+    let dir = scratch("nomanifest");
+    let home = dir.join("home");
+    fs::create_dir_all(&home).unwrap();
+    let bare = dir.join("bare.tfs");
+    // a zip image WITHOUT /__tpkg__/manifest.yaml
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    writer
+        .start_file("app/bin/app", zip::write::SimpleFileOptions::default())
+        .unwrap();
+    writer.write_all(b"#!/bin/sh\n").unwrap();
+    fs::write(&bare, writer.finish().unwrap().into_inner()).unwrap();
+    let pkg = pressed_package(
+        &dir,
+        "bare",
+        &[(bare, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+        0,
+    );
+    let err = install::install_local(&home, &pkg, false, None).unwrap_err();
+    assert_eq!(err.code, 76, "{err}");
+    assert!(err.to_string().contains("no embedded manifest"), "{err}");
+}
+
+#[test]
+fn shims_link_only_with_the_explicit_flag() {
+    let dir = scratch("shims");
+    let home = dir.join("home");
+    fs::create_dir_all(&home).unwrap();
+    let shim_binary = dir.join("tebako-shim");
+    fs::write(&shim_binary, b"#!/bin/sh\n").unwrap();
+    let img = payload_image(&dir, "app.tfs", "app", "1.0");
+    let pkg = pressed_package(
+        &dir,
+        "myapp",
+        &[(img, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+        0,
+    );
+
+    let plain = install::install_local(&home, &pkg, false, None).unwrap();
+    assert!(plain.shims.is_empty());
+
+    let with = install::install_local(&home, &pkg, true, Some(&shim_binary)).unwrap();
+    assert_eq!(with.shims.len(), 1);
+    assert!(home.join("shims").join("app").exists());
+}

--- a/crates/tebako-cli/tests/suite.rs
+++ b/crates/tebako-cli/tests/suite.rs
@@ -31,6 +31,7 @@ fn opts() -> PressOptions {
         fs_current: "/tmp".to_string(),
         suite: None,
         jail: None,
+        no_install: false,
     }
 }
 

--- a/crates/tebako-info/src/format.rs
+++ b/crates/tebako-info/src/format.rs
@@ -103,7 +103,7 @@ fn dwarfs_flavor(backend_json: Option<&str>) -> DwarfsFlavor {
     DwarfsFlavor::FlatBuffers
 }
 
-/// The `format_id` hint rendered for humans (spec 02 §5: 4 is a legacy
+/// The `format_id` hint rendered for humans (spec 02 §6: 4 is a legacy
 /// ROLE riding in the format field, reported as such).
 pub fn hint_name(format_id: u32) -> &'static str {
     match format_id {

--- a/crates/tebako-info/src/package.rs
+++ b/crates/tebako-info/src/package.rs
@@ -144,7 +144,7 @@ pub fn inspect_package(
     for (i, s) in trailer.slots.iter().enumerate() {
         let mount = s.mount_point_str().unwrap_or_default().to_string();
         // Runtime payload slots (the v1 legacy role) are never mounted —
-        // they are launchers, not image payloads (spec 02 §5, spec 15 §3).
+        // they are launchers, not image payloads (spec 02 §6, spec 15 §3).
         let payload = if depth >= Depth::Manifests
             && s.format_id != tpkg::TPKG_FORMAT_RUNTIME
             && only_slot.map_or(true, |n| n == i)
@@ -258,11 +258,17 @@ fn slot_summary_line(p: &PayloadInspection) -> String {
 pub fn render_full(p: &PackageInspection, depth: Depth, trust_outcome: Option<&str>) -> String {
     let mut out = String::new();
     let lean = if p.trailer.is_lean() { ", lean" } else { "" };
+    let frozen = if p.trailer.package_flags & tpkg::TPKG_FLAG_NO_INSTALL != 0 {
+        ", no-install"
+    } else {
+        ""
+    };
     out.push_str(&format!(
-        "package: {} (tpkg v{}{}, launcher_abi {})\n",
+        "package: {} (tpkg v{}{}{}, launcher_abi {})\n",
         p.package_name(),
         p.trailer.version,
         lean,
+        frozen,
         p.trailer.launcher_abi
     ));
     let n_slots = p.trailer.slots.len();
@@ -452,6 +458,9 @@ pub fn package_json(p: &PackageInspection, depth: Depth, trust_outcome: Option<&
     }
     if p.trailer.v2.is_some() {
         flags.push(Json::String("signed-v2".to_string()));
+    }
+    if p.trailer.package_flags & tpkg::TPKG_FLAG_NO_INSTALL != 0 {
+        flags.push(Json::String("no-install".to_string()));
     }
     let (state, keyid) = p.trust();
     let mut trust = vec![

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -15,7 +15,7 @@
 //!   offset  size  field
 //!      0    10    magic "TEBAKOTFS\0" (10 bytes, NUL-terminated)
 //!     10     4    u32 version (TPKG_VERSION = 1)
-//!     14     4    u32 package_flags (bit 0: TPKG_FLAG_LEAN)
+//!     14     4    u32 package_flags (bit 0: TPKG_FLAG_LEAN, bit 1: TPKG_FLAG_SIGNED_V2, bit 2: TPKG_FLAG_NO_INSTALL)
 //!     18     4    u32 slot_count (1..TPKG_MAX_SLOTS)
 //!     22     8    u64 slot_table_offset (absolute file offset of slot 0 record)
 //!     30   128    char runtime_ref[128] (UTF-8, NUL-padded; empty = classic bundle)
@@ -198,6 +198,12 @@ pub const TPKG_FLAG_LEAN: u32 = 0x1;
 /// Old readers pass the bit through untouched — that is what keeps v2
 /// packages readable by v1-era runtimes.
 pub const TPKG_FLAG_SIGNED_V2: u32 = 0x2;
+/// `package_flags` bit 2: the publisher froze this package — it RUNS
+/// standalone but every install attempt (`--tebako-install`,
+/// `tebako install <path>`) is refused with a named error (TODO.v2-1/12).
+/// Absence means installable-on-request, including packages written
+/// before the install verb existed — pass-through like every flag.
+pub const TPKG_FLAG_NO_INSTALL: u32 = 0x4;
 
 /// `format_id`: auto-detect from image magic.
 pub const TPKG_FORMAT_AUTO: u32 = 0;

--- a/docs/spec/00-INDEX.md
+++ b/docs/spec/00-INDEX.md
@@ -29,7 +29,7 @@ partial coverage **PARTIAL**; shipped and tested **SHIPPED**.
 orthogonal to the image format. `format_id` answers only "how do I read
 these bytes". Roles are L2, declared by manifests — never encoded in the
 format axis (the v1 `TPKG_FORMAT_RUNTIME` slot type is a legacy role wart,
-spec 02 §5).
+spec 02 §6).
 
 ## Reading order
 

--- a/docs/spec/02-tpkg-wire-format.md
+++ b/docs/spec/02-tpkg-wire-format.md
@@ -22,7 +22,7 @@ container itself stays byte-identical either way.
 |-------:|-----:|-------|
 | 0   | 10  | magic `"TEBAKOTFS\0"` |
 | 10  | 4   | u32 version = **1** (extensions ride flags, not version bumps) |
-| 14  | 4   | u32 package_flags (bit0 LEAN, bit1 SIGNED_V2) |
+| 14  | 4   | u32 package_flags (bit0 LEAN, bit1 SIGNED_V2, bit2 NO_INSTALL) |
 | 18  | 4   | u32 slot_count (1..=8) |
 | 22  | 8   | u64 slot_table_offset (absolute file offset of slot 0) |
 | 30  | 128 | char runtime_ref[128] — resolution hint (spec 05 §1); empty = classic |
@@ -57,7 +57,17 @@ trust enforcement is a reader capability, not a format barrier.
 Canonical signed bytes: `slot table ‖ digests ‖ keyid ‖ header` —
 everything except the signature and its length field.
 
-## 5. Orthogonality note (normative)
+## 5. The installability flag (bit2 `NO_INSTALL`; TODO.v2-1/12)
+
+A run is a run — a plain execution never writes payload slices into the
+local store. Installation is the EXPLICIT verb (`tebako install <path>`;
+the bootstrap's `--tebako-install` refuses or guides, spec 06 §4 exit
+76). `NO_INSTALL` marks a publisher-frozen package: it RUNS standalone
+but every install attempt is refused with a named error. Absence means
+installable-on-request, including packages pressed before the verb
+existed — pass-through like every flag.
+
+## 6. Orthogonality note (normative)
 
 `format_id` answers exactly one question: how to read the slot's bytes.
 Whether a slot is a runtime, and which payload carries the entrypoint, are

--- a/docs/spec/05-resolution-and-cache.md
+++ b/docs/spec/05-resolution-and-cache.md
@@ -61,6 +61,16 @@ keys/                                         # press-local signing keys (spec 0
 - `TEBAKO_OFFLINE=1` — cache hit or hard error.
 - `tebako cache list` / `cache prune [--all] [--older-than Nd]` manage
   the cache.
+- **A run is a run** (TODO.v2-1/12): executing a package NEVER installs
+  its payload slices. `tebako install <path>` installs a local package's
+  payload slices explicitly — trailer slot digests are the anchors for
+  signed (v2) packages, the computed digest for unsigned ones (the run's
+  own enforcement strength, never upgraded); the runtime slot is NOT
+  store-installed (it resolves into the runtime cache on first run, as
+  always). Idempotent same-sha skip; same name+version with different
+  content is never overwritten (loud warning + journal). Shims link only
+  via the explicit `--shims` (spec 07). `TPKG_FLAG_NO_INSTALL` packages
+  refuse (spec 02 §5).
 
 ## 5. Resolution chains
 

--- a/docs/spec/06-launcher-abi.md
+++ b/docs/spec/06-launcher-abi.md
@@ -36,6 +36,12 @@ republish of v1-era runtimes needed.
 
 1. Read own trailer (spec 02; absent → classic-bundle error path).
 2. Require `launcher_abi == 1` (else exit 66).
+2a. **`--tebako-install` verb (TODO.v2-1/12):** after the chain + ABI
+   gates — the package's `TPKG_FLAG_NO_INSTALL` refuses (exit 76); any
+   other package answers with the named guidance to
+   `tebako install <path>` (exit 76 — the manifest read needs the TFS
+   engine the size-capped bootstrap deliberately does not carry). A run
+   is a run: the verb is the ONLY way slices reach the store.
 3. Trust handling, by build and trailer flag:
    - **`TPKG_FLAG_SIGNED_V2`, verification ENABLED** (`openpgp-verify`
      feature): verify the OpenPGP signature against the trusted keyring
@@ -70,6 +76,7 @@ republish of v1-era runtimes needed.
 | 73 | `EX_TEBAKO_JAIL` | jail policy could not be applied (malformed `TEBAKO_JAIL`; fail-closed — spec 08) |
 | 74 | `EX_TEBAKO_IO` | filesystem/lock/install failure |
 | 75 | `EX_TEBAKO_CONTRACT` | runtime declares an unsupported `contract_version` (§6) |
+| 76 | `EX_TEBAKO_INSTALL` | `--tebako-install` refused (`TPKG_FLAG_NO_INSTALL`) or needs the CLI |
 
 stderr body: `tebako-bootstrap: <message>\n` — message bodies match the
 C++ reference bootstrap 1:1 (golden parity).

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -78,6 +78,11 @@ jobs:
   managed BEGIN/END block into the right startup file
   (`.profile`/`.bash_profile`/`.bashrc`/`.zshrc`/`.cshrc`) prepending the
   shim dir; idempotent; `uninstall-shell` removes exactly its block.
+- **Shim links are always an explicit act** (TODO.v2-1/12): registry
+  installs register the payload's `provides` (that IS the install's
+  point); a local-package install (`tebako install <path>`) links only
+  with the explicit `--shims`; a run — of any package, ever — links
+  nothing. A one-off act never claims PATH names.
 - NO eval-init hook for switching: the dispatcher reads the project file
   itself (the mise model, not the rbenv `eval "$(… init -)"` model).
 - `tebako use / disable / list / doctor` manage shims

--- a/docs/spec/15-info-command.md
+++ b/docs/spec/15-info-command.md
@@ -95,7 +95,11 @@ Rules:
   zip, tar) — never trust `format_id` alone (it is a hint; `auto` means
   detect).
 - The v1 `format_id = 4` slot is reported as `runtime (legacy role)`
-  per spec 02 §5 — role, not format.
+  per spec 02 §6 — role, not format.
+- Flags render named: the header shows `, lean` and `, no-install` after
+  the tpkg version, and the JSON `package.flags` array carries
+  `"lean" | "signed-v2" | "no-install"` (spec 02 §5 — a frozen package
+  is introspectable before you try to install it).
 - Trust section: signature state (v2 / v1-unsigned), signer keyid, and
   WITH `--verify` the actual verification outcome; without it, state is
   reported as stored, labeled `unverified`.


### PR DESCRIPTION
## Summary

A run is a run — executing a package **never** installs its payload slices (pinned by a new test: the runtime cache fills, the payloads store stays empty). Installation is the explicit verb, two surfaces, one implementation:

- **`tebako install <path>`** — reads the trailer, refuses `TPKG_FLAG_NO_INSTALL` packages with the named exit 76, then per payload slot: extract bytes, derive identity from the embedded manifest via tfs, install into the store with the trailer's v2 slot digest (signed) or the computed digest (unsigned — the run's own enforcement strength, never upgraded), provenance origin (`payload=<abspath> slot=N [signed_by=K]`), the manifest mirror, and a journal line. Idempotent same-sha skip; same name+version with DIFFERENT content never overwrites (loud warning + doctor hint); a cache Hit still reports the mirror's commands so a later `--shims` links instead of no-ops. Runtime slots are skipped with a note.
- **`<pkg> --tebako-install`** (bootstrap) — refuses frozen packages (76) or guides to the CLI (76): the manifest read needs the TFS engine the size-capped bootstrap deliberately does not carry.

Shims link ONLY via the explicit `--shims` (a one-off act never claims PATH names; registry installs keep their provides-linking).

## Press side

`tebako press --no-install` bakes `TPKG_FLAG_NO_INSTALL` (bit 2) through lean and suite stitches; `tebako-info` renders the flag (`, no-install` in the header, `"no-install"` in the JSON flags array).

## Specs

02 (the flag + new §5; orthogonality note renumbered §6 with its four refs), 05 (the install rule), 06 (exit 76 row + the verb in the loader sequence), 07 (shims stay explicit), 15 (named flag rendering).

## Tests

9 new scenarios — 6 CLI (lands+markers+mirror, skip+drift, refusal zero-writes, lean+runtime-slot note, missing-manifest named error, shims explicit-only), 2 bootstrap (verb guidance/refusal, run-never-seeds), 1 stitch flag-baking. Suites green, clippy `-D warnings` clean, fmt clean.
