### PR TITLE
docs/blocks: one page per building block — the entity view of the system

### DIFF
--- a/docs/blocks/00-INDEX.md
+++ b/docs/blocks/00-INDEX.md
@@ -1,0 +1,54 @@
+# Tebako building blocks
+
+Tebako packages an application and everything it needs into a single
+file that runs directly. This section describes the system's building
+blocks, one page each: what it is, what it is for, and how it works.
+
+## Contents
+
+| Block | Function | Page |
+|---|---|---|
+| package | the single runnable file | [package.md](package.md) |
+| bootstrap | the loader embedded in every package | [bootstrap.md](bootstrap.md) |
+| runtime slice | a downloadable, shareable interpreter | [runtime-slice.md](runtime-slice.md) |
+| executable slice | an application packaged as a mountable image | [executable-slice.md](executable-slice.md) |
+| data slice | versioned content mounted alongside an application | [data-slice.md](data-slice.md) |
+| toolkit slice | an optional capability downloaded on demand | [toolkit-slice.md](toolkit-slice.md) |
+| shim system | how packaged commands reach PATH | [shim-system.md](shim-system.md) |
+| install & local register | how slices are stored and tracked on a machine | [install-register.md](install-register.md) |
+| remote registry | how authors publish slices and users find them | [remote-registry.md](remote-registry.md) |
+
+## Terminology
+
+Seven terms are used with fixed meanings throughout the documentation.
+
+- **bootstrap** — the loader program. Not a slice.
+- **slice** — one filesystem image file (`.tfs`). Runtimes,
+  applications, data, and toolkits are all delivered as slices.
+- **slot** — a slice's numbered position inside a package.
+- **package** — the complete runnable file: bootstrap, slices in slots,
+  and a table of contents at the end of the file.
+- **stack** — physically assembling slices into a package.
+- **resolve / compose** — determining which slices a run requires and
+  combining them.
+- **mount** — making a slice's contents visible at a directory path
+  during execution.
+
+## How the parts fit together
+
+An author builds slices from source code and publishes them. A user
+downloads a package. When the package runs, its bootstrap locates or
+downloads the required runtime, mounts the slices, and starts the
+program. The program then runs against ordinary-looking files; the fact
+that those files came from images is invisible to it.
+
+```
+ author                          distribution                     user machine
+──────────────────────────────────────────────────────────────────────────────────
+ source code ──press──► slices ──publish──► registry ──download──► local store
+                 │                                   │
+                 └──stack──► package ◄────────────────┘
+                              │
+                              ▼  user runs it
+                    bootstrap → runtime → mounted slices → the program runs
+```

--- a/docs/blocks/bootstrap.md
+++ b/docs/blocks/bootstrap.md
@@ -1,0 +1,71 @@
+# The bootstrap
+
+The bootstrap is the loader embedded at the start of every tebako
+package. When a user runs a package, the operating system starts the
+bootstrap; everything after that is its job.
+
+It is a small, static Rust program with no dependencies of its own,
+kept under 3 MB so that packages stay small. That budget is enforced in
+CI.
+
+## What it does on every run
+
+The bootstrap performs the same fixed sequence:
+
+1. **Reads the trailer** at the end of its own file. If it is missing
+   or corrupt, it stops with a named error — it never guesses.
+2. **Checks the launcher ABI** the package was pressed for. A package
+   from an incompatible generation is refused with a named error.
+3. **Applies the trust policy.** If the package is signed, the
+   signature is verified (when verification support is compiled in).
+   Otherwise the package runs with a clear warning and a line in the
+   audit journal. If the user demands signed packages only
+   (`TEBAKO_REQUIRE_SIGNED=1`), an unsigned package is refused outright
+   rather than quietly accepted.
+4. **Resolves the runtime.** If the required runtime is already in the
+   machine cache, it is used directly. Otherwise the bootstrap downloads
+   it with its own built-in HTTP and TLS — never curl, git, or any
+   system tool — verifies the checksum against the release index, and
+   installs it atomically under a lock. Before accepting any checksum,
+   it checks the runtime's declared contract version: a runtime from an
+   incompatible generation is refused with a named error, so an old
+   bootstrap never silently mis-runs a new runtime.
+5. **Stages the runtime image** — the interpreter's library files —
+   into the shared cache as read-only files with their verification
+   markers.
+6. **Hands off to the runtime.** The payload slices are mounted and the
+   entrypoint is started. On Linux and macOS the bootstrap process is
+   replaced outright (`execve`), so signals and exit codes belong to
+   the runtime. On Windows there is no `execve`, so the bootstrap spawns
+   the runtime as a child, waits for it, and exits with the child's
+   exit code.
+
+## Error reporting
+
+Every failure is a named exit code with a specific message: bad
+trailer, ABI mismatch, runtime unavailable, checksum mismatch, bad
+signature, untrusted signer, jail policy error, I/O failure, contract
+mismatch, install refused. Scripts can test for each case; users get an
+explanation, not a stack trace.
+
+## Progress output
+
+Downloads report progress on an interactive terminal — a single
+updating line with transfer rate — and stay quiet in CI logs, where one
+line marks the start and one the end. A cache hit prints one line:
+`runtime ruby-3.4.2 (cached)`.
+
+## Platform coverage
+
+The same behavior is required on macOS, Linux (glibc and musl), and
+Windows. The Windows implementation uses native file locking, atomic
+rename-with-retry (for the sharing violations antivirus scanners cause),
+and the spawn-and-wait handoff described above. All of it is exercised
+by a dedicated Windows CI job.
+
+## Implementation
+
+`crates/tebako-bootstrap`, built on `crates/tebako-http` (downloads),
+`crates/tebako-term` (progress output), and `crates/tpkg` (the trailer
+format). The only unsafe code is the platform FFI, confined to one
+module.

--- a/docs/blocks/data-slice.md
+++ b/docs/blocks/data-slice.md
@@ -1,0 +1,54 @@
+# The data slice
+
+A data slice packages content rather than code: fonts, schemas,
+templates, dictionaries, model weights, datasets. It is the same
+physical form as every other slice — an image plus a manifest — but it
+offers no commands. Applications mount it; users never run it.
+
+## Purpose
+
+Applications often need large bodies of content that change on their
+own schedule, not the application's. Shipping that content inside every
+application binary duplicates it across every consumer and every
+version. A data slice makes the content a separate, versioned artifact:
+
+- one copy on disk, shared by every application that uses it;
+- its own version line, upgraded independently of any application;
+- verified with the same checksums and signatures as code.
+
+For example, a document generator can declare a dependency on a font
+collection at a specific version. The fonts download once, every
+application on the machine shares them, and a font update does not
+touch the applications.
+
+## How applications use it
+
+An application's manifest names its data dependencies along with a
+version range and a mount path — effectively "mount slice X at
+directory Y". At run time, the resolver finds (or downloads) a
+compatible version, mounts it read-only at that path next to the
+application, and the application reads the content as ordinary files.
+Inside a jail, the data slice is subject to the same read-only rules as
+the application image.
+
+Most data slices are platform-free: content does not depend on the
+CPU or operating system, so one image serves every machine.
+
+## Lifecycle
+
+1. **Press** — the content tree is packaged with a manifest giving its
+   name, version, and content hash.
+2. **Publish** — to a registry, next to the applications that consume
+   it or on its own.
+3. **Resolve** — an application's data dependency is satisfied from the
+   local store if a compatible version exists, otherwise by download.
+4. **Mount** — read-only, at the path the application declared.
+5. **Prune** — the local store tracks which applications require each
+   data slice, so cleanup removes only content nothing uses anymore.
+
+## Implementation
+
+The manifest and its content hashing: `crates/tpkg`. Resolution and
+mount composition: `crates/tebako-resolve` and `crates/tebako-shim`.
+Storage and garbage collection: the local store described in
+[install & local register](install-register.md).

--- a/docs/blocks/executable-slice.md
+++ b/docs/blocks/executable-slice.md
@@ -1,0 +1,66 @@
+# The executable slice
+
+An executable slice is an application packaged as a single mountable
+image: the code, its dependencies, and a manifest describing what the
+image offers and what it needs. Metanorma is the flagship example;
+fontist is a smaller one; a non-interpreted tool such as Inkscape can be
+packaged the same way, with no language runtime at all.
+
+## The manifest
+
+Every slice carries a manifest file inside the image
+(`/__tpkg__/manifest.yaml`). It records:
+
+- **Identity** — the application's name and version, who produced it,
+  and a content hash of the whole tree, so the image can be verified
+  and addressed precisely.
+- **Provides** — the commands the application offers. One slice may
+  offer several; each can even request its own runtime version, so two
+  commands from one package may run on different runtimes.
+- **Requires** — what the application needs: a language runtime with a
+  version range, and any other slices it wants mounted (for example a
+  data slice at a specific path).
+- **Platform** — whether the image is universal (pure language) or tied
+  to specific platforms (anything containing compiled extensions).
+
+The manifest is the authoritative description. Registries and local
+stores only mirror it; they never override it.
+
+## Platform coverage
+
+A pure-language application produces one universal image that runs
+everywhere a compatible runtime exists. An application with compiled
+extensions produces one image per platform, and the install machinery
+selects the right variant for the user's machine declaratively — from
+the registry's platform table, not by probing.
+
+## Lifecycle
+
+1. **Press** — the application's source tree is compressed into an
+   image and the manifest is stamped in.
+2. **Publish** — the image goes to a registry, or is stacked directly
+   into a fat package.
+3. **Install** — on the user's machine the image is downloaded,
+   verified (its signature if it has one, its checksum always), and
+   stored once, shared by anything that needs it.
+4. **Run** — the image is mounted read-only and its entrypoint is
+   started under the resolved runtime. Inside a jail, the application
+   sees only the paths it was granted.
+5. **Upgrade** — a new version is a new image stored next to the old
+   one. Nothing is edited in place; rollback is keeping the old
+   version around.
+
+## Relationship to runtimes
+
+The executable slice never hard-codes a runtime version. It declares a
+range, the resolver picks the newest compatible runtime on the machine
+(or downloads it), and the application runs against that. Changing
+runtimes — for performance, or to test a newer Ruby — requires no
+rebuild of the application.
+
+## Implementation
+
+Pressing and publishing: `crates/tebako-cli`. The manifest format:
+`crates/tpkg`. Resolution and storage: `crates/tebako-resolve` and
+`crates/tebako-shim`. Mounting at run time: the `crates/tfs` engine
+inside the runtime.

--- a/docs/blocks/install-register.md
+++ b/docs/blocks/install-register.md
@@ -1,0 +1,82 @@
+# Install and the local register
+
+This page covers what lands on a user's machine when things are
+installed, where it goes, and how the machine keeps track of it.
+
+## One home per user
+
+Everything tebako stores lives under one directory:
+`~/.tebako` (`%LOCALAPPDATA%\tebako` on Windows, overridable with
+`TEBAKO_HOME`). It is split into two kinds of content:
+
+- **Things that matter** — configuration, the user's trust decisions
+  (which signers to accept), signing keys, and the audit journal.
+  Deleting these loses state that cannot be re-created.
+- **Things that can be re-derived** — downloaded runtimes, payload
+  slices, registry indexes, and the local register file itself. All of
+  it can be rebuilt by downloading again; none of it is precious.
+
+## The store
+
+Downloaded artifacts are kept in a content store, organized by what
+they are:
+
+```
+store/
+  runtimes/<language>/<version>/<tebako-abi>/<platform>/
+  toolkits/<name>/<version>/<platform>/
+  payloads/<name>/<version>/<platform or universal>/
+  data/<name>/<version>/
+```
+
+Versions of the same thing sit side by side; nothing overwrites
+anything. Each artifact keeps two small marker files next to it: its
+verified checksum (proof it was checked when it was installed) and its
+origin (where it came from). Installations are atomic — a lock, a
+temporary directory, then a rename — so a crash mid-install never
+leaves a half-written artifact visible.
+
+## The register
+
+The machine keeps a single index file — the local register — listing
+everything in the store: what it is, its version, its checksum, where
+it came from, and what depends on it.
+
+The register is a cache, not a source of truth. The truth is the store
+itself: if the register is missing, stale, or doubted, it is rebuilt by
+walking the store (`tebako cache reindex`). Tools read the register for
+speed and fall back to the store when in doubt. Because every entry
+carries its dependencies, the machine can also answer "what is still
+needed" — cleanup removes only artifacts nothing uses.
+
+## A shared store for the whole machine
+
+A second, machine-wide store can sit alongside the user's (for example
+`/usr/local/var/tebako`, or `%ProgramData%\tebako` on Windows), shared
+by every account. Lookups check the user's store first, then the shared
+one; installs go to the user's store by default and to the shared one
+only explicitly. Trust decisions always stay personal — one user's
+accepted signers are never inherited by another.
+
+## Installing is a verb
+
+Nothing lands in the store as a side effect. Running a package fills
+the runtime cache (the runtime is needed to execute at all) but never
+touches the payload store. Slices are installed by explicit commands:
+
+- `tebako install <ref | name>` — fetch from a registry, verify, store,
+  and register the application's commands.
+- `tebako install <file>` — unpack a local package's slices into the
+  store, preserving their checksums and origin. Links to PATH happen
+  only with an explicit `--shims`.
+- `tebako install ./myapp --shims` — both at once, explicitly.
+
+A package pressed with the no-install flag refuses all of these; it
+runs standalone and nothing more. Local files being developed are used
+in place and never copied into the store at all.
+
+## Implementation
+
+`crates/tebako-resolve` (the store and its locking), `crates/tebako-shim`
+(records and links), `crates/tebako-cli` (the install commands), and
+`crates/tebako-bootstrap` (the runtime cache during runs).

--- a/docs/blocks/package.md
+++ b/docs/blocks/package.md
@@ -1,0 +1,68 @@
+# The package
+
+A tebako package is the system's deliverable: one file that runs on a
+matching machine with no installer, no extraction step, and no external
+dependencies.
+
+## Structure
+
+A package has three parts, in order:
+
+1. **The bootstrap** — the loader executable. Every package starts with
+   it, so every package is directly runnable. See
+   [bootstrap](bootstrap.md).
+2. **The slots** — numbered slices: the application, its data, and
+   optionally a runtime. A package with no runtime slot is called
+   *lean*; one that carries its runtime is called *fat*.
+3. **The trailer** — a small block at the end of the file containing
+   the table of contents: how many slots there are, where each one
+   starts and ends, which runtime the package wants, and a checksum.
+
+Because the table of contents sits at the end, a package can be
+inspected or reassembled without parsing the payload bytes. It also
+means appending data to a package does not disturb anything an
+operating-system code signature has already signed.
+
+## Flags
+
+Three independent properties are recorded in the trailer:
+
+- **lean** — the runtime resolves at run time (downloaded once per
+  machine, then shared by all packages).
+- **signed** — the package carries a publisher's signature; loaders
+  verify it before trusting the contents.
+- **no-install** — the publisher froze the package. It runs normally,
+  but `tebako install` refuses to unpack it into the local store. This
+  is for vendors who want a strictly run-only artifact.
+
+## Operations
+
+- **Press** (`tebako press`) — build slices from source and stack them
+  into a package. One press can bundle several commands into a single
+  package.
+- **Surgery** (`tebako-pkg`) — modify an existing package: insert or
+  remove slices, replace the runtime, reassemble from parts.
+- **Inspect** (`tebako-pkg info`, `tfs info`) — show the trailer, the
+  slots, the trust state, and the manifests, as text or JSON.
+- **Run** — execute it. The [bootstrap](bootstrap.md) does the rest.
+- **Install** (`tebako install <file>`) — unpack the slices into the
+  local store so they can be upgraded or recombined later. Always an
+  explicit command, never a side effect of running; see
+  [install & local register](install-register.md).
+
+## Distribution forms
+
+A package is distributed two ways:
+
+- **Standalone** — the complete file, for users who have nothing else
+  installed. Built per platform.
+- **Registry payload** — a bare slice published to a registry, for
+  users who run the dispatcher. Pure-language applications ship one
+  universal file; applications with native extensions ship one file per
+  platform.
+
+## Implementation
+
+The format lives in `crates/tpkg`; surgery in `crates/tebako-pkg`;
+pressing in `crates/tebako-cli`; inspection in `crates/tebako-info`;
+execution in `crates/tebako-bootstrap`.

--- a/docs/blocks/remote-registry.md
+++ b/docs/blocks/remote-registry.md
@@ -1,0 +1,77 @@
+# The remote registry
+
+The remote registry is how slices are published by authors and found by
+users. It is deliberately lightweight: there is no central server to
+operate. A registry is a small YAML index hosted anywhere a file can be
+served — a GitHub repository's releases, a GitLab or Bitbucket project,
+any git repository, any plain HTTPS location, or a local directory.
+
+## What a registry is
+
+A registry is one index file, `tpkg-registry.yaml`, plus the slice
+files it references. The index declares the publisher's signing key and
+lists its payloads: for each one, the available versions, the platforms
+each version covers (or a universal marker), and for each artifact its
+URL, size, checksum, and optional signature. The format is versioned so
+older readers keep working.
+
+An author publishes by building slices in CI and uploading them with
+the updated index — the publish step signs every artifact and writes
+the index's signing block automatically. A project with its own GitHub
+organization needs no other infrastructure.
+
+## How users reference things
+
+References are exact and spell out their transport, never implied from
+a default:
+
+- `tfs:github:<org>/<repo>:<version>` — a GitHub release
+- `tfs:gitlab:<org>/<repo>:<version>` — a GitLab release
+- `tfs:bitbucket:<org>/<repo>:<version>` — a Bitbucket release
+- `tfs+git://<host>/<path>.git[@<ref>][#<path-in-repo>]` — a git
+  repository, with an optional branch/tag and a path inside it
+- `tfs:https://<host>/<file>` — a plain HTTPS artifact (a checksum can
+  be pinned in the URL)
+- a local path or `file://` — used in place, nothing downloaded
+
+There is no default registry and no shorthand that assumes one: every
+reference says exactly where to go.
+
+## How resolution works
+
+The user registers a registry once:
+
+```
+tebako add-registry tfs:github:metanorma/metanorma
+```
+
+The index is fetched, its signing key is shown for confirmation, and
+the key is pinned to that registry. After that:
+
+- `tebako install metanorma` resolves the name against the registered
+  registries, picks the newest version (or a pinned one), verifies the
+  signature against the pinned key, and installs.
+- Registry indexes are cached locally with a time-to-live and refreshed
+  on demand; offline mode uses the cache or fails with a named error.
+
+Trust is anchored by confirmation, not by infrastructure: the first
+fetch shows the publisher's fingerprint, the user confirms it, and
+every later artifact from that identity must verify against the pinned
+key. A key that changes unexpectedly is a hard failure naming both
+fingerprints; legitimate rotation carries a signed successor statement
+that forward-verifies.
+
+## Relationship to everything else
+
+The registry is only a finding mechanism. Verification, storage, and
+execution all happen locally, described in
+[install & local register](install-register.md). A registry can be
+deleted and recreated from the published slices; the slices are the
+product, the index is a convenience over them.
+
+## Implementation
+
+Reference parsing and transport (HTTPS, git, file — all in-process, no
+CLI tools): `crates/tebako-resolve`. Registry management and install:
+`crates/tebako-cli`. Trust pinning and verification:
+`crates/tebako-signer`.

--- a/docs/blocks/runtime-slice.md
+++ b/docs/blocks/runtime-slice.md
@@ -1,0 +1,68 @@
+# The runtime slice
+
+A runtime slice supplies the interpreter a packaged application runs
+on. Today that interpreter is Ruby, built with tebako support compiled
+in; other languages follow the same model.
+
+The runtime slice exists so that packages do not each carry their own
+interpreter. One runtime is downloaded once per machine and shared by
+every package that needs it. Packages stay small, and upgrading Ruby
+does not require rebuilding any application.
+
+## Two files, one unit
+
+A runtime slice is published as two files with one name:
+
+1. **The runtime executable** — the interpreter itself, patched so it
+   can mount slices and run from them.
+2. **The runtime image** (`.tfs`) — the interpreter's library tree:
+   the standard library, bundled gems, and support files, mounted
+   read-only when the interpreter starts.
+
+Both are versioned together and published per platform: macOS (Apple
+silicon and Intel), Linux (glibc and musl, x86_64 and arm64), and
+Windows. The musl builds are dynamically linked against musl by design
+and document a minimum musl version (musl ≥ 1.2.3, e.g. Alpine ≥ 3.17).
+
+## How a package gets its runtime
+
+Each package records a runtime reference: the language and version it
+wants, and the tebako generation. On first run the bootstrap looks for
+a compatible runtime in the machine cache. If none is present, it
+downloads the newest compatible one from the runtime release, verifies
+its checksum against the release's published index, and installs it
+under a lock so two packages installing at once cannot corrupt the
+cache. Later runs start instantly from the cache.
+
+A package built fat skips all of this: its runtime is one of its slots,
+verified and used in place.
+
+## Versioning and compatibility
+
+Applications declare a range, not an exact runtime. A pure-Ruby
+application typically accepts any recent line (for example
+`>= 3.3, < 5.0`); an application with native extensions locks to the
+Ruby ABI line it was built against. This means a runtime upgrade almost
+never requires an application rebuild — and when an application is run
+against an incompatible runtime, the result is a clear compatibility
+error, not a crash.
+
+The loader and runtime also carry a small contract version. If a future
+runtime changes how it expects to be launched, an old bootstrap refuses
+it with a named error instead of mis-launching it; older runtimes
+without the field are treated as the first contract generation and run
+normally.
+
+## How runtimes are made
+
+Runtimes are built by a dedicated factory repository. For each Ruby
+version and platform, patched Ruby sources are compiled, packaged with
+their image, and smoke-tested by actually booting them and exercising
+the filesystem, gems, and locking behavior. Only after that passes are
+they published as a release with a machine-readable index.
+
+## Implementation
+
+The factory is `tebako-runtime-ruby`; the per-version patches live in
+`tamatebako/ruby`; the download and cache logic lives in
+`crates/tebako-bootstrap`.

--- a/docs/blocks/shim-system.md
+++ b/docs/blocks/shim-system.md
@@ -1,0 +1,68 @@
+# The shim system
+
+The shim system is how a packaged command becomes an ordinary command
+on the user's PATH. After installing an application with tebako, the
+user types its name — `metanorma`, for example — and it runs, with the
+right version and the right runtime chosen automatically.
+
+## How it works
+
+There is one directory on PATH: `~/.tebako/shims`. Every installed
+command is a small file in it:
+
+- on Linux and macOS, a symlink;
+- on Windows, a copy named `<command>.exe` (symlinks need elevation
+  there, a copy does not).
+
+Both point at one compiled dispatcher binary, `tebako-shim`. When the
+command runs, the dispatcher reads its own invocation name, looks the
+command up, and launches it. This is the same arrangement busybox and
+rustup use, and it is chosen over shell scripts for concrete reasons:
+arguments pass through without quoting problems in four different shell
+dialects, there is no extra process layer swallowing signals, and the
+command's own flags can never be confused with tebako's.
+
+## What the dispatcher does on each invocation
+
+1. Reads the command name from how it was invoked.
+2. Picks a version: an environment override first, then a pin file in
+   the current project, then the user's default, then the registry's
+   default. Two projects can pin different versions of the same tool
+   and both just work.
+3. Resolves the runtime the command needs — newest compatible one
+   already cached, or a download.
+4. Mounts the payload and its declared dependencies, applies the jail
+   policy, and starts the command. On Linux and macOS the dispatcher
+   replaces itself with the runtime process; on Windows it spawns,
+   waits, and passes the exit code back.
+
+## PATH setup
+
+`tebako-shim install-shell` performs the one-time setup:
+
+- On Linux and macOS it adds a small managed block to the shell's
+  startup file (`.bashrc`, `.zshrc`, fish's config, `.cshrc`), marked
+  so `uninstall-shell` can remove exactly that block later.
+- On Windows it prepends the shim directory to the user's PATH in the
+  registry and broadcasts the change so new terminals see it. The
+  current terminal needs to be reopened; the tool says so.
+
+After that, installing or removing applications only adds or removes
+files in the shim directory — PATH itself is never edited again. The
+`doctor` command checks the whole arrangement (PATH entry, links,
+payload integrity) and names any problem it finds.
+
+## Explicitness
+
+Installing an application from a registry registers its commands
+because that is what installing means. Everything else is explicit
+only: running a package creates no links, and installing a local
+package links only with an explicit `--shims`. A casual run never
+silently claims a name on the user's PATH.
+
+## Implementation
+
+`crates/tebako-shim` — the dispatcher, the version manager
+(list/enable/disable/which/doctor), and the shell integration. The
+full setup walkthrough, including per-shell instructions, is in
+[docs/shell-setup.md](../shell-setup.md).

--- a/docs/blocks/toolkit-slice.md
+++ b/docs/blocks/toolkit-slice.md
@@ -1,0 +1,58 @@
+# The toolkit slice
+
+A toolkit slice packages an optional capability as a downloadable
+image: cryptography is the first example, UI toolkits are the expected
+next. It is neither an interpreter nor an end-user application — it is
+machinery other parts of the system call on when they need it.
+
+## Why it exists
+
+Some capabilities are too large or too specialized to build into every
+binary. Cryptography is the case in point: a full OpenPGP library with
+post-quantum algorithms adds megabytes and a long dependency chain. The
+tebako bootstrap stays under 3 MB precisely by *not* containing it.
+
+The toolkit slice moves that cost out of the core. The bootstrap ships
+without cryptographic verification built in and says so plainly when a
+signature cannot be checked. When verification is actually required,
+the crypto toolkit is downloaded once, verified itself by the
+bootstrap's small built-in check, and used from then on. The core stays
+small; the capability is available exactly when needed; and when it is
+absent, the error says so by name instead of pretending otherwise.
+
+## The first toolkit: tebako-crypto
+
+The crypto toolkit is built in exactly one place — its own feedstock
+repository — from source, with the complete algorithm suite including
+the post-quantum families, and published as a signed slice per
+platform. Nothing else in the ecosystem compiles that library; everyone
+else consumes the slice. One build to audit, one place to fix.
+
+## How capabilities are declared
+
+A toolkit slice's manifest names what it provides — a capability
+identifier and its ABI version — and the platforms it covers. Consumers
+declare the capability, not a file path: a package or a policy says it
+requires cryptography, and the resolver finds a suitable toolkit slice,
+fetches it if missing, and mounts it. If none can be found, the failure
+names the missing capability.
+
+## Lifecycle
+
+1. **Build** — the feedstock compiles and tests the toolkit per
+   platform, then releases it.
+2. **Declare** — packages and policies reference the capability by
+   name.
+3. **Resolve** — the local store is consulted first; a miss downloads
+   and verifies the slice.
+4. **Mount** — the toolkit is available to the runtime for the duration
+   of the run.
+5. **Upgrade** — a new toolkit version ships independently of every
+   consumer, with its own version and ABI markers.
+
+## Implementation
+
+The crypto toolkit lives in `tebako-packages/tebako-crypto`. Capability
+resolution follows the same store and registry machinery as every other
+slice; see [install & local register](install-register.md) and
+[remote registry](remote-registry.md).


### PR DESCRIPTION
## Summary

Public-facing documentation organized by **building block** rather than by engineering domain. Until now the normative specs covered the content (by domain: wire format, manifest, refs, cache, ABI...) but no page answered "what is the bootstrap" or "what is a data slice" in one place. This adds the entity layer:

- **index** — the locked vocabulary (bootstrap / slice / slot / package / stack / resolve-compose / mount) and the lifecycle picture (author → press → publish → store → dispatch → mount → exec)
- **package** — the three-part executable: bootstrap + slots + trailer
- **bootstrap** — the loader: trailer, trust, resolution, contract negotiation, exec/spawn handoff
- **runtime slice** — the interpreter as two published files (exe + image), contract-versioned, shared per machine
- **executable slice** — the application: manifest (identity/provides/requires/capabilities), press → publish → install → run → upgrade
- **data slice** — versioned content mounted as a dependency; pruned by refcount
- **toolkit slice** — optional capabilities (crypto first); why the core stays under 3 MB
- **shim system** — one directory on PATH, one dispatcher binary, argv[0] dispatch; why binary links not shell scripts
- **install & local register** — the explicit install verb (now shipped, #358), the store layout, the regenerable index, the global chain
- **remote registry** — registries as YAML indexes anywhere a file lives; the MECE reference forms; trust pinning

## Style rules (owner-reviewed)

- **No internal tracking references anywhere** — no spec numbers, no TODO/roadmap IDs, no item numbers. These pages stand alone as public documentation (grep-verified).
- **Editorial register** — every term defined at first use, the problem stated before the mechanism, no slogan-stacking. One framing line per section, then exposition.
