### PR TITLE
rnp-rs 0.1.10 (the rnp-src era) + the musl legs return

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,8 +339,8 @@ jobs:
     name: Linux musl (${{ matrix.platform }})
     # Enabled since rnp-rs 0.1.10: the rnp-src model builds librnp+botan
     # from source (musl-capable; the container has cmake/ninja/python3).
-    # rnp-src is git-pinned (workspace [patch.crates-io]) until
-    # rnpgp/rnp-rs#63 ships a fixed crates.io release.
+    # rnp-src resolves from crates.io 0.1.2 (the rnpgp/rnp-rs#63 fix —
+    # the is_packaging() misfire that broke 0.1.1's vendored mode).
     permissions:
       contents: write
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,11 +337,10 @@ jobs:
   # ==========================================================================
   linux-musl:
     name: Linux musl (${{ matrix.platform }})
-    # DISABLED for v0.1.0: rnp-rs 0.1.7 has no musl prebuilt and its
-    # build.rs panics on musl targets. Re-enable when rnpgp's rnp-src
-    # source-built release lands (it compiles under musl). The release
-    # ships macos ×2 + linux-gnu ×2 until then; finalize needs match.
-    if: false
+    # Enabled since rnp-rs 0.1.10: the rnp-src model builds librnp+botan
+    # from source (musl-capable; the container has cmake/ninja/python3).
+    # rnp-src is git-pinned (workspace [patch.crates-io]) until
+    # rnpgp/rnp-rs#63 ships a fixed crates.io release.
     permissions:
       contents: write
     runs-on: ${{ matrix.os }}
@@ -456,7 +455,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-24.04
-    needs: [prepare, macos, linux-gnu]
+    needs: [prepare, macos, linux-gnu, linux-musl]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -505,7 +504,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag_name }}
         run: |
-          EXPECTED=$(( 4 * 4 + 2 ))   # 4 tools x 4 platforms (musl gated) + SHA256SUMS + manifest.json; becomes 4 x 6 + 2 when musl returns
+          EXPECTED=$(( 4 * 6 + 2 ))   # 4 tools x 6 platforms (macos x2, gnu x2, musl x2) + SHA256SUMS + manifest.json
           COUNT=$(gh release view "$TAG" --json assets --jq '.assets | length')
           echo "release assets: $COUNT / $EXPECTED expected"
           gh release view "$TAG" --json assets --jq '.assets[].name' | sort

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,3 @@ codegen-units = 1
 panic = "abort"
 strip = "symbols"
 
-
-# WORKAROUND (upstream rnpgp/rnp-rs#63): rnp-src 0.1.1's is_packaging()
-# heuristic misfires for every crates.io consumer — the registry
-# extraction always contains Cargo.toml.orig, so `vendored` emits empty
-# lib/include dirs. A git checkout has no Cargo.toml.orig and builds for
-# real. Pin rnp-src to the identical git tag until a fixed 0.1.x ships,
-# then DELETE this section.
-[patch.crates-io]
-rnp-src = { git = "https://github.com/rnpgp/rnp-rs.git", tag = "rnp-src-v0.1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,13 @@ lto = "fat"
 codegen-units = 1
 panic = "abort"
 strip = "symbols"
+
+
+# WORKAROUND (upstream rnpgp/rnp-rs#63): rnp-src 0.1.1's is_packaging()
+# heuristic misfires for every crates.io consumer — the registry
+# extraction always contains Cargo.toml.orig, so `vendored` emits empty
+# lib/include dirs. A git checkout has no Cargo.toml.orig and builds for
+# real. Pin rnp-src to the identical git tag until a fixed 0.1.x ships,
+# then DELETE this section.
+[patch.crates-io]
+rnp-src = { git = "https://github.com/rnpgp/rnp-rs.git", tag = "rnp-src-v0.1.1" }

--- a/ci/musl-build.sh
+++ b/ci/musl-build.sh
@@ -18,7 +18,12 @@ echo "== apk toolchain =="
 apk --no-cache add \
   build-base cmake ninja git bash sudo \
   autoconf automake libtool make pkgconfig perl python3 \
-  curl zip unzip tar ca-certificates linux-headers
+  curl zip unzip tar ca-certificates linux-headers \
+  clang19-libclang
+
+# clang19-libclang: rnp-rs 0.1.10's build.rs runs bindgen (the rnp-src
+# source-built model) — bindgen dlopens libclang.so at runtime, which
+# only the versioned libclang package ships on alpine.
 
 # vcpkg's bootstrap downloads glibc-linked cmake/ninja by default — they
 # cannot run on musl (exit 127). Use the apk-provided tools everywhere.
@@ -74,8 +79,17 @@ echo "== pre-install squashfs-tools-ng ($TRIPLET) =="
   --overlay-triplets "$SQFS_TRIPLETS" \
   --overlay-ports "$WS/tebako-rs/crates/sqfs-sys/vcpkg_ports"
 
-# rnp-rs 0.1.7 prebuilt + botan-sys(vendored)/bzip2-sys crate deps in the
-# workspace carry all crypto statically — no provisioning anywhere.
+# Crypto comes from crates: rnp-rs 0.1.10's vendored mode builds librnp +
+# Botan + json-c + zlib + bzip2 from source via rnp-src (git-pinned at the
+# workspace root until rnpgp/rnp-rs#63 ships a fixed crates.io release).
+#
+# musl targets default to +crt-static, and a statically linked build
+# script cannot dlopen — but rnp-rs's build.rs runs bindgen, which
+# dlopens libclang. Build the musl legs with -crt-static OFF: the
+# artifacts are dynamic-musl, same shape as the runtime factory's musl
+# runtimes (musl libc is present on every musl system by definition;
+# the symbol floor is documented alongside them).
+export RUSTFLAGS="-C target-feature=-crt-static"
 echo "== cargo build (release, $TARGET) =="
 cd "$WS/tebako-rs"
 export DWARFS_RS_VCPKG_ROOT="$WS/.vcpkg-musl"

--- a/ci/musl-build.sh
+++ b/ci/musl-build.sh
@@ -80,8 +80,8 @@ echo "== pre-install squashfs-tools-ng ($TRIPLET) =="
   --overlay-ports "$WS/tebako-rs/crates/sqfs-sys/vcpkg_ports"
 
 # Crypto comes from crates: rnp-rs 0.1.10's vendored mode builds librnp +
-# Botan + json-c + zlib + bzip2 from source via rnp-src (git-pinned at the
-# workspace root until rnpgp/rnp-rs#63 ships a fixed crates.io release).
+# Botan + json-c + zlib + bzip2 from source via rnp-src (crates.io 0.1.2,
+# the rnpgp/rnp-rs#63 fix).
 #
 # musl targets default to +crt-static, and a statically linked build
 # script cannot dlopen — but rnp-rs's build.rs runs bindgen, which

--- a/crates/tebako-bootstrap/Cargo.toml
+++ b/crates/tebako-bootstrap/Cargo.toml
@@ -22,7 +22,7 @@ tebako-term = { version = "0.1.0", path = "../tebako-term" }
 # the crypto toolkit payload; until then this feature keeps the full
 # verification path available for dev builds (--features openpgp-verify).
 # With the feature off the bootstrap carries ZERO rnp/botan/json-c/bz2.
-rnp = { package = "rnp-rs", version = "=0.1.7", features = ["vendored"], optional = true }
+rnp = { package = "rnp-rs", version = "=0.1.10", features = ["vendored"], optional = true }
 libc = "0.2"
 sha2 = "0.10"
 
@@ -56,4 +56,4 @@ path = "src/lib.rs"
 # every platform (the feature above is unaffected).
 [target.'cfg(not(windows))'.dev-dependencies]
 tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
-rnp = { package = "rnp-rs", version = "=0.1.7", features = ["vendored"] }
+rnp = { package = "rnp-rs", version = "=0.1.10", features = ["vendored"] }

--- a/crates/tebako-pkg/Cargo.toml
+++ b/crates/tebako-pkg/Cargo.toml
@@ -15,7 +15,7 @@ tpkg = { version = "0.1.0", path = "../tpkg" }
 tebako-json = { version = "0.1.0", path = "../tebako-json" }
 tebako-info = { version = "0.1.0", path = "../tebako-info" }
 tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
-rnp = { package = "rnp-rs", version = "=0.1.7", features = ["vendored"] }
+rnp = { package = "rnp-rs", version = "=0.1.10", features = ["vendored"] }
 libc = "0.2"
 sha2 = "0.10"
 

--- a/crates/tebako-signer/Cargo.toml
+++ b/crates/tebako-signer/Cargo.toml
@@ -9,17 +9,10 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-rnp = { package = "rnp-rs", version = "=0.1.7", features = ["vendored"] }
-# rnp-rs 0.1.7's prebuilt ships librnp+json-c(+sexpp) statically but
-# declares botan-3 and bz2 as EXTERNAL link libs. We satisfy them as
-# crate dependencies — cargo builds both from source, static:
-#   botan-sys vendored → botan-src (Botan 3, libbotan-3.a)
-#   bzip2-sys          → bundled bzip2 source (libbz2.a)
-# json-c already ships inside the rnp-rs prebuilt; zlib stays system
-# (base-OS everywhere). Every rnp consumer depends on tebako-signer, so
-# these two live here only and their link paths propagate to all final
-# binaries. INTERIM until rnp-rs ≥ 0.1.10 (0.1.9's build.rs botan make
-# step lacks .current_dir — broken upstream).
-botan-sys = { version = "1", features = ["vendored"] }
-bzip2-sys = "0.1"
+rnp = { package = "rnp-rs", version = "=0.1.10", features = ["vendored"] }
+# rnp-rs 0.1.10's vendored mode delegates to rnp-src, which builds
+# librnp + Botan + json-c + zlib + bzip2 from source — nothing external
+# to link. (Until 0.1.7's prebuilt the two deps below were INTERIM:
+# rnp-src is currently git-pinned at the workspace root for
+# rnpgp/rnp-rs#63 — remove the patch with the fixed release.)
 sha2 = "0.10"

--- a/crates/tebako-signer/Cargo.toml
+++ b/crates/tebako-signer/Cargo.toml
@@ -13,6 +13,5 @@ rnp = { package = "rnp-rs", version = "=0.1.10", features = ["vendored"] }
 # rnp-rs 0.1.10's vendored mode delegates to rnp-src, which builds
 # librnp + Botan + json-c + zlib + bzip2 from source — nothing external
 # to link. (Until 0.1.7's prebuilt the two deps below were INTERIM:
-# rnp-src is currently git-pinned at the workspace root for
-# rnpgp/rnp-rs#63 — remove the patch with the fixed release.)
+# rnp-src resolves from crates.io 0.1.2 (the rnpgp/rnp-rs#63 fix).)
 sha2 = "0.10"

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -50,6 +50,6 @@ path = "src/lib.rs"
 tebako-contract-tests = { version = "0.1.0", path = "../../tests/contract" }
 # The --verify signature tests mint a press-local key and detached .asc.
 tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
-rnp = { package = "rnp-rs", version = "=0.1.7", features = ["vendored"] }
+rnp = { package = "rnp-rs", version = "=0.1.10", features = ["vendored"] }
 # Exec-proof image fixtures (zip backend).
 zip = { version = "2", default-features = false, features = ["deflate"] }

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -66,7 +66,7 @@ vendored-squashfs = ["dep:sqfs-sys"]
 # Tempdir scaffolding for backend tests (large-archive RSS fixtures).
 tempfile = "3"
 # ENC tests mint recipient key pairs in-memory (same pin as tebako-signer).
-rnp = { package = "rnp-rs", version = "=0.1.7", features = ["vendored"] }
+rnp = { package = "rnp-rs", version = "=0.1.10", features = ["vendored"] }
 # gzip trailer checksums in tar-backend test fixtures.
 crc32fast = "1"
 


### PR DESCRIPTION
## Summary

rnp-rs 0.1.10's `vendored` mode delegates to rnp-src (librnp + Botan + json-c + zlib + bzip2 built from source) — ending the prebuilt-archive era and its platform gaps. All six pins move `=0.1.7` → `=0.1.10`, and tebako-signer's interim `botan-sys`/`bzip2-sys` deps are dropped (rnp-src bundles them; host build + the full signer test suite green).

**Upstream bug reported**: rnp-src 0.1.1's `is_packaging()` heuristic misfires for every crates.io consumer (registry extractions always contain `Cargo.toml.orig`, so `vendored` emits empty paths — [rnpgp/rnp-rs#63](https://github.com/rnpgp/rnp-rs/issues/63)). Workaround: the workspace `[patch.crates-io]` pins rnp-src to the identical git tag (`rnp-src-v0.1.1`); the comment says to delete it with the fixed release, and a crates.io monitor is armed for it.

## The musl legs return

- `release.yml`: the musl legs ungated, `finalize` needs them, the completeness gate back to `4 × 6 + 2 = 26`.
- `ci/musl-build.sh`: `clang19-libclang` (rnp-rs's build.rs runs bindgen, which dlopens libclang) and `RUSTFLAGS="-C target-feature=-crt-static"` — musl's default static crt cannot dlopen, so the artifacts are **dynamic-musl**, the same shape as the runtime factory's musl runtimes (musl libc is present on every musl system; the symbol floor is documented).
- `install.sh` (homebrew-tap, already merged there): selects `linux-musl-<arch>` on musl hosts, with the honest 404 until the next release ships the legs.

## Verification

Host (macOS arm64): `cargo check` + the full `tebako-signer` test suite green without the interim deps.
musl: `cargo check -p tebako-signer` inside `alpine:3.21` with the CI's own toolchain (rustup 1.94.1) — rnp-src builds clean under musl (4m19s).
Windows: stays out by owner decision — the per-target OpenPGP gating stands as accepted state.
