### PR TITLE
ci: the floor leg trusts the mounted git repos (safe.directory)

### DIFF
--- a/ci/gnu-floor-build.sh
+++ b/ci/gnu-floor-build.sh
@@ -23,6 +23,17 @@ apt-get install -y -qq --no-install-recommends \
   curl zip unzip tar ca-certificates git gnupg lsb-release wget \
   libbz2-dev ruby
 
+# The workspace is bind-mounted from the runner (files owned by uid
+# 1001) but the build runs as root — focal's git (2.25 with the
+# CVE-2022-24765 backport) refuses the mounted repos as "dubious
+# ownership", so dwarfs-t's cmake/version.cmake sees NO git metadata and
+# dies ("missing version files - git metadata unavailable and no
+# pre-generated version files found"; run 30750321798 — it only surfaces
+# now that cmake 3.31 lets the configure reach version.cmake). Same fix
+# as the musl leg: single-use --rm container, trust every repo under the
+# mount.
+git config --global --add safe.directory '*'
+
 # rnp-rs's build.rs runs bindgen, which dlopens libclang. Focal's stock
 # libclang (v10) is too old for the current bindgen; llvm.org publishes
 # clang-19 for focal (the same version the musl leg uses).


### PR DESCRIPTION
## What

One-line class of fix: the gnu-floor release leg now runs
`git config --global --add safe.directory '*'` inside its single-use
ubuntu:20.04 container — the same fix the musl leg already carries
(06582b8), for the same root cause.

## Why (evidence chain)

Release run 30750321798 (v0.1.1, both `linux-gnu` legs): dwarfs-t-sys's
cmake configure died at `cmake/version.cmake:61` —

```
-- GIT_TOPLEVEL:  ()
-- PRJ_GIT_REV:
CMake Error at cmake/version.cmake:61 (message):
  missing version files - git metadata unavailable and no pre-generated
  version files found
```

The container builds as root on a workspace owned by uid 1001; focal's
git (2.25 + the CVE-2022-24765 backport) refuses the mounted repos as
"dubious ownership", emptying every git probe `version.cmake` makes.

It only surfaces now: run 30742821370 predates the dwarfs-t guard, run
30745532174 died earlier at `cmake_minimum_required` (cmake 3.16 <
3.28), run 30748661257 died earlier at the librnp examples link. With
the toolchain fixes from those waves in place (cmake 3.31.8, gcc-11,
-pthread), the configure finally reaches `version.cmake`.

## Verification

- `bash -n ci/gnu-floor-build.sh` clean.
- The musl legs (same bind-mount shape, same fix) went green end-to-end
  in run 30750321798 — the mechanism is proven, this is the symmetric
  application.
- The full floor leg is the verdict: re-firing the v0.1.1 release after
  merge.
