### PR TITLE
ci: the glibc floor gate compares numeric tails

### DIFF
--- a/ci/gnu-floor-build.sh
+++ b/ci/gnu-floor-build.sh
@@ -156,7 +156,12 @@ echo "== glibc floor gate (the artifact must need ≤ 2.31) =="
 floor="$(objdump -T "out/tebako-bootstrap-${VERSION}-${PLATFORM}" \
   | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -Vu | tail -1)"
 echo "max glibc symbol version required: ${floor:-none}"
-if [ -n "$floor" ] && [ "$(printf '%s\n2.31\n' "$floor" | sort -V | tail -1)" != "2.31" ]; then
+# Compare the NUMERIC tail: with the GLIBC_ prefix in the sort input,
+# strverscmp orders letters after digits, so every value — even a
+# compliant GLIBC_2.30 — comes out ">" 2.31 (run 30756664324: the gate
+# failed its own contract on a clean binary).
+floor_num="${floor#GLIBC_}"
+if [ -n "$floor_num" ] && [ "$(printf '%s\n2.31\n' "$floor_num" | sort -V | tail -1)" != "2.31" ]; then
   echo "::error::floor violation: the bootstrap requires $floor (> 2.31)" >&2
   exit 65
 fi


### PR DESCRIPTION
## What

Fix the glibc floor gate's comparison in `ci/gnu-floor-build.sh`: strip
the `GLIBC_` prefix before the `sort -V` max-check against 2.31.

## Why (evidence)

Release run 30756664324 (v0.1.1, both `linux-gnu` legs): the legs built
**fully green** — rnp-src/Botan with gcc-11 + `-pthread`, dwarfs-t with
cmake 3.31 + git safe.directory, staging, link unit — and then the
floor gate failed a compliant artifact:

```
max glibc symbol version required: GLIBC_2.30
##[error]floor violation: the bootstrap requires GLIBC_2.30 (> 2.31)
```

2.30 ≤ 2.31 — the binary is fine. The gate fed the `GLIBC_`-prefixed
value into `sort -V` against the bare `2.31`, and `strverscmp` orders
letters after digits, so any prefixed value sorts "newer" than 2.31.
Every earlier floor run died before the gate, so this is its first real
execution and the bug never showed.

The `sort -Vu | tail -1` max-pick on line above keeps the prefix —
every candidate carries the same one, so its ordering stays honest.
Only the cross-format comparison against `2.31` was poisoned.

## Verification

- `bash -n ci/gnu-floor-build.sh` clean.
- Semantics: `max(2.30, 2.31) = 2.31` → pass; `max(2.34, 2.31) = 2.34`
  → fail with the named `::error::` and exit 65, as designed.
- The full floor leg is the verdict: re-firing the v0.1.1 release after
  merge.
