### PR TITLE
style: rustfmt's import ordering in libtfs-preload (unblock the fmt gate)

### DIFF
--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -27,7 +27,7 @@
 
 use std::cell::Cell;
 use std::collections::HashMap;
-use std::ffi::{CStr, c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_void, CStr};
 use std::path::PathBuf;
 use std::sync::Mutex;
 

--- a/crates/libtfs-preload/src/sys/statx_abi.rs
+++ b/crates/libtfs-preload/src/sys/statx_abi.rs
@@ -16,10 +16,10 @@
 //! interpose touches, on both x86_64 and aarch64.
 
 #[cfg(all(target_os = "linux", not(target_env = "musl")))]
-pub(crate) use libc::{STATX_MODE, STATX_MTIME, STATX_NLINK, STATX_SIZE, STATX_TYPE, statx};
+pub(crate) use libc::{statx, STATX_MODE, STATX_MTIME, STATX_NLINK, STATX_SIZE, STATX_TYPE};
 
 #[cfg(all(target_os = "linux", target_env = "musl"))]
-pub(crate) use self::musl::{STATX_MODE, STATX_MTIME, STATX_NLINK, STATX_SIZE, STATX_TYPE, statx};
+pub(crate) use self::musl::{statx, STATX_MODE, STATX_MTIME, STATX_NLINK, STATX_SIZE, STATX_TYPE};
 
 #[cfg(all(target_os = "linux", target_env = "musl"))]
 mod musl {


### PR DESCRIPTION
CI's `cargo fmt --all -- --check` (stable rustfmt) rejects the mixed-case import order in `crates/libtfs-preload/src/sys/{mod,statx_abi}.rs` — committed code had `{CStr, c_char, …}`, stable rustfmt orders `{c_char, …, CStr}`. Three lines, no semantics.

The e2e test legs on this PR will stay red until the factory's manifest heals (the lean press resolves runtimes from the release's manifest.json, currently partial — the era baseline repairs it); fmt goes green here.