### PR TITLE
chore: runtime pin 0.16.1 -> 0.16.2 + rustfmt import ordering (subsumes #363)

### DIFF
--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -27,7 +27,7 @@
 
 use std::cell::Cell;
 use std::collections::HashMap;
-use std::ffi::{CStr, c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_void, CStr};
 use std::path::PathBuf;
 use std::sync::Mutex;
 

--- a/crates/libtfs-preload/src/sys/statx_abi.rs
+++ b/crates/libtfs-preload/src/sys/statx_abi.rs
@@ -16,10 +16,10 @@
 //! interpose touches, on both x86_64 and aarch64.
 
 #[cfg(all(target_os = "linux", not(target_env = "musl")))]
-pub(crate) use libc::{STATX_MODE, STATX_MTIME, STATX_NLINK, STATX_SIZE, STATX_TYPE, statx};
+pub(crate) use libc::{statx, STATX_MODE, STATX_MTIME, STATX_NLINK, STATX_SIZE, STATX_TYPE};
 
 #[cfg(all(target_os = "linux", target_env = "musl"))]
-pub(crate) use self::musl::{STATX_MODE, STATX_MTIME, STATX_NLINK, STATX_SIZE, STATX_TYPE, statx};
+pub(crate) use self::musl::{statx, STATX_MODE, STATX_MTIME, STATX_NLINK, STATX_SIZE, STATX_TYPE};
 
 #[cfg(all(target_os = "linux", target_env = "musl"))]
 mod musl {

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -90,7 +90,7 @@ pub const LAUNCHER_ABI: u32 = 1;
 /// 0.16.1 the runtimes bake the renamed mount root (`/__tfs__`, `A:/t`);
 /// older releases carry the legacy `__tebako_memfs__` layout and are NOT
 /// served (no old contract, no compat readers).
-pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.1";
+pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.2";
 
 pub const VERSION_BANNER: &str = "Tebako executable packager version 0.15.9";
 


### PR DESCRIPTION
v0.16.1's metadata names are durably poisoned on the release backend (a name that went through one delete cycle 422s re-uploads for hours — proven tonight). The factory republishes the identical-content runtime set as v0.16.2, a fresh release object where every upload is a CREATE.

**Hold until the v0.16.2 era baseline + audit are green** — the e2e press legs then resolve v0.16.2 runtimes.