### PR TITLE
ci(windows-gnu): static-link the mingw runtime into shipped exes + the import gate

### DIFF
--- a/ci/windows-gnu-bootstrap.sh
+++ b/ci/windows-gnu-bootstrap.sh
@@ -20,6 +20,18 @@ export PATH="/d/a/_temp/msys64/ucrt64/bin:/c/Program Files/Git/usr/bin:/c/Progra
 # One linker, resolved from the closed PATH above (ucrt64's gcc).
 export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=gcc.exe
 
+# The release-link wrapper (ci/windows-gnu-link-wrap.c): the MinGW C/C++
+# runtime chain links STATICALLY into every shipped exe — a
+# libstdc++-6.dll / libwinpthread-1.dll import is exit 127 before main on
+# stock Windows (ucrt64/bin is on THIS runner's PATH, never a user's).
+# The trailing RUSTFLAGS cannot govern build-script emissions (rustc
+# places them earlier); the wrapper rewrites them at the driver boundary
+# and the import gate (steps 2 and 5) proves the result on the real
+# binary.
+WRAP="$RUNNER_TEMP/tebako-link-wrap.exe"
+gcc -O2 -o "$WRAP" ci/windows-gnu-link-wrap.c
+export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(cygpath -w "$WRAP")"
+
 # Static-link the mingw C/C++ runtimes; the trailing -lmsvcrt restores
 # the msvcrt-after-mingwex order invariant (rustc's -nodefaultlibs tail
 # violates it; the factory probe proved libmingwex's compat _assert.o
@@ -39,18 +51,14 @@ SERIAL="--test-threads=1"
 cargo build -p tebako-bootstrap --target "$TARGET"
 cargo test -p tebako-bootstrap --target "$TARGET" --no-run
 
-# --- 2. DLL-import forensics ------------------------------------------------
-# STATUS_ENTRYPOINT_NOT_FOUND fails the process BEFORE main, so the
-# failure's own stderr never names the missing entry — enumerate every
-# import up front instead. Unprefixed binutils: MSYS2's ucrt64 package
-# ships objdump.exe/strip.exe WITHOUT the x86_64-w64-mingw32- alias
-# (run 30697405256 proved the prefixed names do not resolve); the closed
-# PATH makes the one toolchain's tools unambiguous.
-for exe in target/"$TARGET"/debug/deps/*.exe; do
-  echo "=== imports: $exe ==="
-  objdump -p "$exe" \
-    | grep -E "DLL Name|^\s+[0-9a-f]+\s+\S+\s*$" | head -60 || true
-done
+# --- 2. DLL-import gate -----------------------------------------------------
+# The informational forensics dump became a GATE (the 0.1.1 windows-ucrt64
+# exe class: an off-list import dies before main on stock Windows).
+# Unprefixed binutils: MSYS2's ucrt64 package ships objdump.exe/strip.exe
+# WITHOUT the x86_64-w64-mingw32- alias (run 30697405256 proved the
+# prefixed names do not resolve); the closed PATH makes the one
+# toolchain's tools unambiguous.
+bash ci/windows-gnu-import-gate.sh target/"$TARGET"/debug/tebako-bootstrap.exe
 
 # --- 3. test (serialized) ---------------------------------------------------
 cargo test -p tebako-bootstrap --target "$TARGET" -- "$SERIAL" --nocapture
@@ -59,6 +67,7 @@ cargo test -p tebako-bootstrap --target "$TARGET" -- "$SERIAL" --nocapture
 cargo build --release -p tebako-bootstrap --target "$TARGET"
 EXE="target/$TARGET/release/tebako-bootstrap.exe"
 strip "$EXE"
+bash ci/windows-gnu-import-gate.sh "$EXE"
 size=$(stat -c %s "$EXE")
 echo "tebako-bootstrap.exe (stripped, release): $size bytes (budget $BUDGET)"
 if [ "$size" -ge "$BUDGET" ]; then

--- a/ci/windows-gnu-cli.sh
+++ b/ci/windows-gnu-cli.sh
@@ -31,8 +31,19 @@ mkdir -p "$TOOLSHIM"
 cp "/d/a/_temp/msys64/ucrt64/bin/mingw32-make.exe" "$TOOLSHIM/make.exe"
 export PATH="$TOOLSHIM:$PATH"
 
-# One linker, resolved from the closed PATH above (ucrt64's gcc).
-export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=gcc.exe
+# One linker, resolved from the closed PATH above (ucrt64's gcc) — behind
+# the release-link wrapper (ci/windows-gnu-link-wrap.c): the MinGW C/C++
+# runtime chain links STATICALLY into every shipped exe. A libstdc++-6.dll /
+# libwinpthread-1.dll import is exit 127 before main on any stock Windows
+# (the 0.1.1 windows-ucrt64 failure class; ucrt64/bin sits on THIS runner's
+# PATH, never on a user's). The trailing RUSTFLAGS below cannot do it —
+# rustc emits a build script's `-lstdc++`/`-lpthread` (rnp-rs's is an
+# explicit `dylib=stdc++`) at its own position, BEFORE the `-C link-arg`
+# tail — so the wrapper rewrites those references at the driver boundary,
+# and the import gate (step 2) proves the result on the real binaries.
+WRAP="$RUNNER_TEMP/tebako-link-wrap.exe"
+gcc -O2 -o "$WRAP" ci/windows-gnu-link-wrap.c
+export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(cygpath -w "$WRAP")"
 
 # Static-link the mingw C/C++ runtimes; the trailing -lmsvcrt restores
 # the msvcrt-after-mingwex order invariant (rustc's -nodefaultlibs tail
@@ -77,18 +88,19 @@ SERIAL="--test-threads=1"
 cargo build -p tebako-cli -p tfs-cli -p tebako-pkg --target "$TARGET"
 cargo test -p tebako-cli -p tfs-cli -p tebako-pkg --target "$TARGET" --no-run
 
-# --- 2. DLL-import forensics ------------------------------------------------
-# STATUS_ENTRYPOINT_NOT_FOUND fails the process BEFORE main, so the
-# failure's own stderr never names the missing entry — enumerate every
-# import up front instead. Unprefixed binutils: MSYS2's ucrt64 package
-# ships objdump.exe/strip.exe WITHOUT the x86_64-w64-mingw32- alias
+# --- 2. DLL-import gate -----------------------------------------------------
+# The informational forensics dump became a GATE (the 0.1.1 windows-ucrt64
+# exes imported libstdc++-6.dll/libwinpthread-1.dll and nobody failed the
+# build — they die before main on stock Windows). The gate audits the
+# shipped-shape exes against the inbox-DLL allowlist; the link wrapper
+# above is the mechanism it verifies. Unprefixed binutils: MSYS2's ucrt64
+# package ships objdump.exe/strip.exe WITHOUT the x86_64-w64-mingw32- alias
 # (run 30697405256 proved the prefixed names do not resolve); the closed
 # PATH makes the one toolchain's tools unambiguous.
-for exe in target/"$TARGET"/debug/deps/*.exe; do
-  echo "=== imports: $exe ==="
-  objdump -p "$exe" \
-    | grep -E "DLL Name|^\s+[0-9a-f]+\s+\S+\s*$" | head -60 || true
-done
+bash ci/windows-gnu-import-gate.sh \
+  target/"$TARGET"/debug/tebako.exe \
+  target/"$TARGET"/debug/tfs.exe \
+  target/"$TARGET"/debug/tebako-pkg.exe
 
 # --- 3. test (serialized) ---------------------------------------------------
 cargo test -p tebako-cli -p tfs-cli -p tebako-pkg --target "$TARGET" -- "$SERIAL" --nocapture

--- a/ci/windows-gnu-import-gate.sh
+++ b/ci/windows-gnu-import-gate.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# ci/windows-gnu-import-gate.sh — audit PE import tables of the shipped
+# windows-gnu binaries and FAIL on any non-inbox DLL.
+#
+#   windows-gnu-import-gate.sh <exe> [<exe> ...]
+#
+# Why: a windows-gnu exe that imports a MinGW runtime DLL
+# (libstdc++-6.dll, libwinpthread-1.dll, libgcc_s_seh-1.dll, …) dies
+# before main() on stock Windows — STATUS_DLL_NOT_FOUND, surfaced as
+# exit 127 — because nothing outside a toolchain installs those DLLs.
+# Audience law: a tebako user downloads and runs, full stop. The 0.1.1
+# windows-ucrt64 assets shipped exactly this break; the informational
+# "DLL-import forensics" step saw it and did not fail. This gate is the
+# enforcement: the allowlist is the Windows-inbox surface (the UCRT
+# api-ms-win-crt-*/api-ms-win-core-* set — inbox since Windows 10 — plus
+# the classic system DLLs); anything else needs a conscious edit of this
+# file with the reason recorded.
+#
+# The mechanism that makes the link clean lives in
+# ci/windows-gnu-link-wrap.c; this gate is what PROVES it on the real
+# binaries, in the same leg, so a wrapper miss can never ship silently.
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <exe> [<exe> ...]" >&2
+  exit 64
+fi
+
+# Inbox DLL allowlist (lowercase, basename). api-ms-win-* is a family, not
+# a fixed list — matched by prefix below.
+ALLOWED_EXACT="
+kernel32.dll
+advapi32.dll
+user32.dll
+ws2_32.dll
+wsock32.dll
+mswsock.dll
+ntdll.dll
+msvcrt.dll
+bcrypt.dll
+bcryptprimitives.dll
+crypt32.dll
+shell32.dll
+shlwapi.dll
+psapi.dll
+userenv.dll
+ole32.dll
+oleaut32.dll
+uuid.dll
+secur32.dll
+sspicli.dll
+iphlpapi.dll
+rpcrt4.dll
+dbghelp.dll
+version.dll
+gdi32.dll
+comctl32.dll
+setupapi.dll
+netapi32.dll
+pdh.dll
+powrprof.dll
+propsys.dll
+shcore.dll
+winmm.dll
+wldap32.dll
+imm32.dll
+dwmapi.dll
+uxtheme.dll
+winspool.drv
+cfgmgr32.dll
+kernel.appcore.dll
+authz.dll
+credui.dll
+cryptnet.dll
+normaliz.dll
+timezoneapi.dll
+winhttp.dll
+wininet.dll
+comdlg32.dll
+msimg32.dll
+"
+
+offenders=0
+for exe in "$@"; do
+  [ -f "$exe" ] || { echo "import-gate: no such file: $exe" >&2; exit 66; }
+  echo "=== imports: $exe ==="
+  dlls=$(objdump -p "$exe" | grep "DLL Name:" | sed 's/.*DLL Name: //' | sort -u)
+  echo "$dlls"
+  while IFS= read -r dll; do
+    [ -n "$dll" ] || continue
+    low=$(printf '%s' "$dll" | tr 'A-Z' 'a-z')
+    case "$low" in
+      api-ms-win-*) continue ;;
+    esac
+    if ! printf '%s\n' "$ALLOWED_EXACT" | grep -qxF "$low"; then
+      echo "import-gate: OFF-LIST DLL import in $exe: $dll" >&2
+      offenders=$((offenders + 1))
+    fi
+  done <<< "$dlls"
+done
+
+if [ "$offenders" -gt 0 ]; then
+  echo "import-gate: FAIL — $offenders off-list DLL import(s). A shipped exe must run on stock Windows (ucrt64 bin is NOT on a user's PATH). See ci/windows-gnu-link-wrap.c for the link policy." >&2
+  exit 1
+fi
+echo "import-gate: PASS ($# exe(s), inbox-only imports)"

--- a/ci/windows-gnu-link-wrap.c
+++ b/ci/windows-gnu-link-wrap.c
@@ -1,0 +1,276 @@
+/*
+ * ci/windows-gnu-link-wrap.c — the release-link policy for the shipped
+ * windows-gnu binaries: the MinGW C/C++ runtime chain is ALWAYS linked
+ * statically, no matter which crate in the dependency tree emits the
+ * link directive.
+ *
+ * Why this exists (the exit-127 class): a windows-gnu exe that imports
+ * libstdc++-6.dll / libwinpthread-1.dll dies before main() on any stock
+ * Windows (STATUS_DLL_NOT_FOUND — surfaces as exit 127) unless the
+ * ucrt64 toolchain's bin dir happens to sit on PATH. Audience law: a
+ * user running tebako packages needs NO toolchain libraries. The tebako
+ * 0.1.1 windows-ucrt64 exes shipped exactly that failure:
+ * RUSTFLAGS="-C link-arg=-static-libstdc++ ..." looks like the fix but
+ * is not — rustc emits a build script's (dylib) `stdc++` / `pthread`
+ * as `-Wl,-Bdynamic` + `-lstdc++` / `-lpthread` at its own position,
+ * BEFORE the trailing `-C link-arg`s, so the driver-level static flags
+ * never govern them (and rnp-rs — external — emits an explicit
+ * `dylib=stdc++`, which no flag of ours can rewrite).
+ *
+ * What it does: every reference to the mingw runtime libs is rewritten
+ * to the `-l:<file>` exact-archive form, which is IMMUNE to the
+ * surrounding -Bstatic / -Bdynamic mode:
+ *
+ *   -lstdc++      -> -l:libstdc++.a
+ *   -lpthread     -> -l:libwinpthread.a
+ *   -lwinpthread  -> -l:libwinpthread.a
+ *
+ * in three shapes: standalone argv entries, members of -Wl,<a>,<b>,...
+ * comma lists, and tokens inside @response files (rustc moves long link
+ * lines into one — the rewritten file rides next to the original as
+ * <name>.wrapped). The gcc driver's own library search dirs resolve the
+ * archives; system import libraries (kernel32 & co.) are untouched.
+ *
+ * The enforcement half lives in ci/windows-gnu-import-gate.sh: every
+ * shipped exe's import table is audited against the inbox-DLL allowlist
+ * in the same CI leg, so a future emission shape this wrapper misses
+ * fails the build loudly instead of shipping a broken exe.
+ *
+ * Compiled once per CI leg by the windows-gnu scripts:
+ *   gcc -O2 -o "$RUNNER_TEMP/tebako-link-wrap.exe" ci/windows-gnu-link-wrap.c
+ * and engaged via
+ *   CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=<that exe>
+ * (cargo spawns the linker with CreateProcess — the wrapper must be a
+ * real exe, not a shell script).
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#if defined(_WIN32)
+#include <process.h> /* execvp lives here on MinGW; unistd.h elsewhere */
+#endif
+
+static const char *rewrite_lib(const char *name)
+{
+  if (strcmp(name, "stdc++") == 0)
+    return "-l:libstdc++.a";
+  if (strcmp(name, "pthread") == 0 || strcmp(name, "winpthread") == 0)
+    return "-l:libwinpthread.a";
+  return NULL;
+}
+
+/* If arg is exactly -l<name> with a static rewrite, return the
+ * replacement; otherwise NULL. */
+static const char *rewrite_arg(const char *arg)
+{
+  if (strncmp(arg, "-l", 2) != 0 || strncmp(arg, "-l:", 3) == 0)
+    return NULL;
+  return rewrite_lib(arg + 2);
+}
+
+/* ---------------- @response files ---------------- */
+/* gcc response file grammar: whitespace-separated tokens, single- or
+ * double-quoted groups, backslash escapes the next character. The
+ * rewrite is token-exact, so re-emitting tokens bare (quoting only when
+ * a token genuinely needs it) preserves the file's semantics. */
+
+typedef struct {
+  char *data;
+  size_t len, cap;
+} buf;
+
+static void buf_putc(buf *b, char c)
+{
+  if (b->len + 1 >= b->cap) {
+    b->cap = b->cap ? b->cap * 2 : 1 << 16;
+    b->data = realloc(b->data, b->cap);
+    if (!b->data) {
+      fprintf(stderr, "tebako-link-wrap: out of memory\n");
+      exit(70);
+    }
+  }
+  b->data[b->len++] = c;
+}
+
+static void buf_puts(buf *b, const char *s)
+{
+  while (*s)
+    buf_putc(b, *s++);
+}
+
+/* Append `tok` to `out`, applying the lib rewrite; quote on emit only
+ * when the token carries response-file specials. */
+static void emit_token(buf *out, const char *tok)
+{
+  const char *r = rewrite_arg(tok);
+  if (r) {
+    buf_puts(out, r);
+    return;
+  }
+  int need_quote = (tok[0] == '\0');
+  for (const char *p = tok; *p && !need_quote; p++)
+    if (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r' || *p == '"' || *p == '\'' || *p == '\\')
+      need_quote = 1;
+  if (!need_quote) {
+    buf_puts(out, tok);
+    return;
+  }
+  buf_putc(out, '"');
+  for (const char *p = tok; *p; p++) {
+    if (*p == '"' || *p == '\\')
+      buf_putc(out, '\\');
+    buf_putc(out, *p);
+  }
+  buf_putc(out, '"');
+}
+
+/* Rewrite the response file at `path` (token-exact) into
+ * "<path>.wrapped" and return the new @-argument. Falls through to the
+ * original argument untouched when the file cannot be read (the link
+ * will then succeed or fail exactly as unwrapped). */
+static char *rewrite_response_file(const char *arg)
+{
+  const char *path = arg + 1;
+  FILE *f = fopen(path, "rb");
+  if (!f)
+    return (char *)arg;
+  buf in = {0}, out = {0};
+  int c;
+  while ((c = fgetc(f)) != EOF)
+    buf_putc(&in, (char)c);
+  fclose(f);
+  buf_putc(&in, '\0');
+
+  /* tokenize */
+  size_t i = 0;
+  int first = 1;
+  while (i < in.len - 1) {
+    while (i < in.len - 1 && (in.data[i] == ' ' || in.data[i] == '\t' || in.data[i] == '\n' || in.data[i] == '\r'))
+      i++;
+    if (i >= in.len - 1)
+      break;
+    buf tok = {0};
+    while (i < in.len - 1 && in.data[i] != ' ' && in.data[i] != '\t' && in.data[i] != '\n' && in.data[i] != '\r') {
+      if (in.data[i] == '\\' && i + 1 < in.len - 1) {
+        /* Conservative backslash rule: it escapes only a recognized
+         * special (quote, backslash, whitespace); before anything else
+         * it is kept verbatim — Windows paths with single backslashes
+         * survive the round trip either way. */
+        char nxt = in.data[i + 1];
+        if (nxt == '"' || nxt == '\'' || nxt == '\\' || nxt == ' ' || nxt == '\t' || nxt == '\n' || nxt == '\r') {
+          buf_putc(&tok, nxt);
+          i += 2;
+          continue;
+        }
+        buf_putc(&tok, in.data[i++]);
+        continue;
+      }
+      if (in.data[i] == '"' || in.data[i] == '\'') {
+        char q = in.data[i++];
+        while (i < in.len - 1 && in.data[i] != q) {
+          if (q == '"' && in.data[i] == '\\' && i + 1 < in.len - 1) {
+            char nxt = in.data[i + 1];
+            if (nxt == '"' || nxt == '\\') {
+              buf_putc(&tok, nxt);
+              i += 2;
+              continue;
+            }
+            /* keep a non-escape backslash verbatim */
+            buf_putc(&tok, in.data[i++]);
+            continue;
+          }
+          buf_putc(&tok, in.data[i++]);
+        }
+        if (i < in.len - 1)
+          i++; /* closing quote */
+        continue;
+      }
+      buf_putc(&tok, in.data[i++]);
+    }
+    buf_putc(&tok, '\0');
+    if (!first)
+      buf_putc(&out, ' ');
+    first = 0;
+    emit_token(&out, tok.data ? tok.data : "");
+    free(tok.data);
+  }
+  buf_putc(&out, '\0');
+
+  static char wrapped[4096];
+  snprintf(wrapped, sizeof(wrapped), "%s.wrapped", path);
+  FILE *wf = fopen(wrapped, "wb");
+  if (!wf) {
+    free(in.data);
+    free(out.data);
+    return (char *)arg;
+  }
+  fwrite(out.data, 1, out.len - 1, wf);
+  fclose(wf);
+  free(in.data);
+  free(out.data);
+
+  static char newarg[4160];
+  snprintf(newarg, sizeof(newarg), "@%s", wrapped);
+  return newarg;
+}
+
+int main(int argc, char **argv)
+{
+  static char *out[8192];
+  static char wlbuf[8192][512]; /* rewritten -Wl, list members */
+  int n = 0;
+  out[n++] = (char *)"gcc";
+
+  for (int i = 1; i < argc; i++) {
+    const char *a = argv[i];
+
+    if (a[0] == '@' && a[1] != '\0') {
+      out[n++] = rewrite_response_file(a);
+      continue;
+    }
+
+    const char *r = rewrite_arg(a);
+    if (r) {
+      out[n++] = (char *)r;
+      continue;
+    }
+
+    if (strncmp(a, "-Wl,", 4) == 0) {
+      /* Rewrite any -l<name> members of a -Wl,<a>,<b>,... list,
+       * preserving the member order and the -Wl, framing. */
+      const char *p = a + 4;
+      char *dst = wlbuf[i % 8192];
+      char *d = dst;
+      size_t cap = sizeof(wlbuf[0]);
+      d += snprintf(d, cap, "-Wl,");
+      int first = 1;
+      while (1) {
+        const char *comma = strchr(p, ',');
+        size_t len = comma ? (size_t)(comma - p) : strlen(p);
+        char member[480];
+        if (len >= sizeof(member))
+          len = sizeof(member) - 1;
+        memcpy(member, p, len);
+        member[len] = '\0';
+        const char *mr = rewrite_arg(member);
+        d += snprintf(d, cap - (size_t)(d - dst), "%s%s", first ? "" : ",",
+                      mr ? mr : member);
+        first = 0;
+        if (!comma)
+          break;
+        p = comma + 1;
+      }
+      out[n++] = dst;
+      continue;
+    }
+
+    out[n++] = argv[i];
+  }
+  out[n] = NULL;
+
+  execvp("gcc", out);
+  /* execvp only returns on failure; make the failure diagnosable. */
+  perror("tebako-link-wrap: cannot exec gcc");
+  return 127;
+}

--- a/ci/windows-gnu-link-wrap.c
+++ b/ci/windows-gnu-link-wrap.c
@@ -69,11 +69,7 @@ static const char *rewrite_arg(const char *arg)
   return rewrite_lib(arg + 2);
 }
 
-/* ---------------- @response files ---------------- */
-/* gcc response file grammar: whitespace-separated tokens, single- or
- * double-quoted groups, backslash escapes the next character. The
- * rewrite is token-exact, so re-emitting tokens bare (quoting only when
- * a token genuinely needs it) preserves the file's semantics. */
+/* ---------------- token rewriting ---------------- */
 
 typedef struct {
   char *data;
@@ -99,30 +95,86 @@ static void buf_puts(buf *b, const char *s)
     buf_putc(b, *s++);
 }
 
-/* Append `tok` to `out`, applying the lib rewrite; quote on emit only
- * when the token carries response-file specials. */
-static void emit_token(buf *out, const char *tok)
+static void *xstrndup(const char *s, size_t len)
+{
+  char *m = malloc(len + 1);
+  if (!m) {
+    fprintf(stderr, "tebako-link-wrap: out of memory\n");
+    exit(70);
+  }
+  memcpy(m, s, len);
+  m[len] = '\0';
+  return m;
+}
+
+/* The full token rewrite, shared by the argv path and the @response-file
+ * path: an exact -l<name>, or any -l<name> member of a -Wl,<a>,<b>,...
+ * comma list (member order and framing preserved). Returns a malloc'd
+ * replacement, or NULL when the token needs none. */
+static char *rewrite_token_dup(const char *tok)
 {
   const char *r = rewrite_arg(tok);
-  if (r) {
-    buf_puts(out, r);
-    return;
+  if (r)
+    return xstrndup(r, strlen(r));
+  if (strncmp(tok, "-Wl,", 4) != 0)
+    return NULL;
+  buf out = {0};
+  buf_puts(&out, "-Wl,");
+  const char *p = tok + 4;
+  int first = 1, changed = 0;
+  while (1) {
+    const char *comma = strchr(p, ',');
+    size_t len = comma ? (size_t)(comma - p) : strlen(p);
+    char *member = xstrndup(p, len);
+    const char *mr = rewrite_arg(member);
+    if (mr)
+      changed = 1;
+    if (!first)
+      buf_putc(&out, ',');
+    buf_puts(&out, mr ? mr : member);
+    free(member);
+    first = 0;
+    if (!comma)
+      break;
+    p = comma + 1;
   }
-  int need_quote = (tok[0] == '\0');
-  for (const char *p = tok; *p && !need_quote; p++)
+  buf_putc(&out, '\0');
+  if (!changed) {
+    free(out.data);
+    return NULL;
+  }
+  return out.data;
+}
+
+/* ---------------- @response files ---------------- */
+/* gcc response file grammar: whitespace-separated tokens, single- or
+ * double-quoted groups, backslash escapes the next character. The
+ * rewrite is token-exact, so re-emitting tokens bare (quoting only when
+ * a token genuinely needs it) preserves the file's semantics. */
+
+/* Append `tok` to `out`, applying the rewrite; quote on emit only when
+ * the (possibly rewritten) token carries response-file specials. */
+static void emit_token(buf *out, const char *tok)
+{
+  char *rt = rewrite_token_dup(tok);
+  const char *s = rt ? rt : tok;
+  int need_quote = (s[0] == '\0');
+  for (const char *p = s; *p && !need_quote; p++)
     if (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r' || *p == '"' || *p == '\'' || *p == '\\')
       need_quote = 1;
   if (!need_quote) {
-    buf_puts(out, tok);
+    buf_puts(out, s);
+    free(rt);
     return;
   }
   buf_putc(out, '"');
-  for (const char *p = tok; *p; p++) {
+  for (const char *p = s; *p; p++) {
     if (*p == '"' || *p == '\\')
       buf_putc(out, '\\');
     buf_putc(out, *p);
   }
   buf_putc(out, '"');
+  free(rt);
 }
 
 /* Rewrite the response file at `path` (token-exact) into
@@ -218,7 +270,6 @@ static char *rewrite_response_file(const char *arg)
 int main(int argc, char **argv)
 {
   static char *out[8192];
-  static char wlbuf[8192][512]; /* rewritten -Wl, list members */
   int n = 0;
   out[n++] = (char *)"gcc";
 
@@ -230,38 +281,9 @@ int main(int argc, char **argv)
       continue;
     }
 
-    const char *r = rewrite_arg(a);
-    if (r) {
-      out[n++] = (char *)r;
-      continue;
-    }
-
-    if (strncmp(a, "-Wl,", 4) == 0) {
-      /* Rewrite any -l<name> members of a -Wl,<a>,<b>,... list,
-       * preserving the member order and the -Wl, framing. */
-      const char *p = a + 4;
-      char *dst = wlbuf[i % 8192];
-      char *d = dst;
-      size_t cap = sizeof(wlbuf[0]);
-      d += snprintf(d, cap, "-Wl,");
-      int first = 1;
-      while (1) {
-        const char *comma = strchr(p, ',');
-        size_t len = comma ? (size_t)(comma - p) : strlen(p);
-        char member[480];
-        if (len >= sizeof(member))
-          len = sizeof(member) - 1;
-        memcpy(member, p, len);
-        member[len] = '\0';
-        const char *mr = rewrite_arg(member);
-        d += snprintf(d, cap - (size_t)(d - dst), "%s%s", first ? "" : ",",
-                      mr ? mr : member);
-        first = 0;
-        if (!comma)
-          break;
-        p = comma + 1;
-      }
-      out[n++] = dst;
+    char *rt = rewrite_token_dup(a);
+    if (rt) {
+      out[n++] = rt;
       continue;
     }
 

--- a/ci/windows-gnu-release.sh
+++ b/ci/windows-gnu-release.sh
@@ -32,8 +32,19 @@ mkdir -p "$TOOLSHIM"
 cp "/d/a/_temp/msys64/ucrt64/bin/mingw32-make.exe" "$TOOLSHIM/make.exe"
 export PATH="$TOOLSHIM:$PATH"
 
-# One linker, resolved from the closed PATH above (ucrt64's gcc).
-export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=gcc.exe
+# One linker, resolved from the closed PATH above (ucrt64's gcc) — behind
+# the release-link wrapper (ci/windows-gnu-link-wrap.c): the MinGW C/C++
+# runtime chain links STATICALLY into every shipped exe. A libstdc++-6.dll /
+# libwinpthread-1.dll import is exit 127 before main on any stock Windows
+# (the 0.1.1 windows-ucrt64 failure class; ucrt64/bin sits on THIS runner's
+# PATH, never on a user's). The trailing RUSTFLAGS below cannot do it —
+# rustc emits a build script's `-lstdc++`/`-lpthread` (rnp-rs's is an
+# explicit `dylib=stdc++`) at its own position, BEFORE the `-C link-arg`
+# tail — so the wrapper rewrites those references at the driver boundary,
+# and the import gate (step 3) proves the result on the staged exes.
+WRAP="$RUNNER_TEMP/tebako-link-wrap.exe"
+gcc -O2 -o "$WRAP" ci/windows-gnu-link-wrap.c
+export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(cygpath -w "$WRAP")"
 
 # Static-link the mingw C/C++ runtimes; the trailing -lmsvcrt restores
 # the msvcrt-after-mingwex order invariant (rustc's -nodefaultlibs tail
@@ -75,15 +86,12 @@ cargo build --release --target "$TARGET" \
 # manifest.json. The windows binaries carry .exe.
 TARGET="$TARGET" EXE_SUFFIX=.exe bash .github/workflows/lib/stage.sh
 
-# --- 3. DLL-import forensics ------------------------------------------------
-# STATUS_ENTRYPOINT_NOT_FOUND fails the process BEFORE main, so a bad
-# import never names itself — enumerate every import of the SHIPPED exes
-# up front instead. Unprefixed binutils: MSYS2's ucrt64 ships objdump.exe
-# without the x86_64-w64-mingw32- alias; the closed PATH makes the one
-# toolchain's tools unambiguous. Informational (the static-libgcc /
-# static-libstdc++ RUSTFLAGS above are the invariant this audits).
-for exe in out/*.exe; do
-  echo "=== imports: $exe ==="
-  objdump -p "$exe" \
-    | grep -E "DLL Name" | sort -u || true
-done
+# --- 3. DLL-import gate -----------------------------------------------------
+# The SHIPPED exes run on machines with no toolchain on PATH: an off-list
+# import is exit 127 before main (the 0.1.1 windows-ucrt64 failure class —
+# this step was informational then and shipped the break). The gate audits
+# every staged exe against the inbox-DLL allowlist; the link wrapper above
+# is the mechanism it verifies. Unprefixed binutils: MSYS2's ucrt64 ships
+# objdump.exe without the x86_64-w64-mingw32- alias; the closed PATH makes
+# the one toolchain's tools unambiguous.
+bash ci/windows-gnu-import-gate.sh out/*.exe

--- a/ci/windows-gnu-shim.sh
+++ b/ci/windows-gnu-shim.sh
@@ -23,6 +23,17 @@ export PATH="/d/a/_temp/msys64/ucrt64/bin:/c/Program Files/Git/usr/bin:/c/Progra
 # One linker, resolved from the closed PATH above (ucrt64's gcc).
 export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=gcc.exe
 
+# The release-link wrapper (ci/windows-gnu-link-wrap.c): the MinGW C/C++
+# runtime chain links STATICALLY into every shipped exe — a
+# libstdc++-6.dll / libwinpthread-1.dll import is exit 127 before main on
+# stock Windows (ucrt64/bin is on THIS runner's PATH, never a user's).
+# The trailing RUSTFLAGS cannot govern build-script emissions (rustc
+# places them earlier); the wrapper rewrites them at the driver boundary
+# and the import gate (step 2) proves the result on the real binary.
+WRAP="$RUNNER_TEMP/tebako-link-wrap.exe"
+gcc -O2 -o "$WRAP" ci/windows-gnu-link-wrap.c
+export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(cygpath -w "$WRAP")"
+
 # Static-link the mingw C/C++ runtimes; the trailing -lmsvcrt restores
 # the msvcrt-after-mingwex order invariant (rustc's -nodefaultlibs tail
 # violates it; the factory probe proved libmingwex's compat _assert.o
@@ -39,18 +50,14 @@ SERIAL="--test-threads=1"
 cargo build -p tebako-shim -p tebako-resolve --target "$TARGET"
 cargo test -p tebako-shim -p tebako-resolve --target "$TARGET" --no-run
 
-# --- 2. DLL-import forensics ------------------------------------------------
-# STATUS_ENTRYPOINT_NOT_FOUND fails the process BEFORE main, so the
-# failure's own stderr never names the missing entry — enumerate every
-# import up front instead. Unprefixed binutils: MSYS2's ucrt64 package
-# ships objdump.exe/strip.exe WITHOUT the x86_64-w64-mingw32- alias
-# (run 30697405256 proved the prefixed names do not resolve); the closed
-# PATH makes the one toolchain's tools unambiguous.
-for exe in target/"$TARGET"/debug/deps/*.exe; do
-  echo "=== imports: $exe ==="
-  objdump -p "$exe" \
-    | grep -E "DLL Name|^\s+[0-9a-f]+\s+\S+\s*$" | head -60 || true
-done
+# --- 2. DLL-import gate -----------------------------------------------------
+# The informational forensics dump became a GATE (the 0.1.1 windows-ucrt64
+# exe class: an off-list import dies before main on stock Windows).
+# Unprefixed binutils: MSYS2's ucrt64 package ships objdump.exe/strip.exe
+# WITHOUT the x86_64-w64-mingw32- alias (run 30697405256 proved the
+# prefixed names do not resolve); the closed PATH makes the one
+# toolchain's tools unambiguous.
+bash ci/windows-gnu-import-gate.sh target/"$TARGET"/debug/tebako-shim.exe
 
 # --- 3. test (serialized) ---------------------------------------------------
 cargo test -p tebako-shim -p tebako-resolve --target "$TARGET" -- "$SERIAL" --nocapture


### PR DESCRIPTION
## What

Fixes the shipped windows-ucrt64 binaries dying before `main()` on stock Windows (exit 127), and turns the informational DLL-import forensics into a hard gate so it cannot regress silently.

## The failure (the exact chain, proven end-to-end)

The tebako-packages/hello windows dogfood (new permanent workflow there) failed at the very first CLI invocation: `tebako add-registry …` → **exit 127, no output**. Root cause, at byte level: the published v0.1.1 windows-ucrt64 assets import MinGW runtime DLLs that do not exist outside a toolchain —

- `tebako-0.1.1-windows-ucrt64.exe`: imports `libstdc++-6.dll` + `libwinpthread-1.dll` (objdump import table; symbols are dwarfs-t's `std::filesystem`/`std::locale` and winpthread's `pthread_rwlock_*`)
- `tfs-…exe`, `tebako-pkg-…exe`: same two
- `tebako-shim-…exe`, `tebako-bootstrap-…exe`: clean (inbox DLLs only)

On a stock machine the loader can't resolve them → `STATUS_DLL_NOT_FOUND` → the process never starts; shells report 127. It passed all CI because every CI leg runs with ucrt64's `bin` on PATH, where those DLLs live. Audience law violated: a user running tebako packages needs no toolchain libraries.

## Why the existing RUSTFLAGS didn't prevent it

`-C link-arg=-static-libgcc -C link-arg=-static-libstdc++` looks like the fix and isn't. rustc emits a build script's `cargo:rustc-link-lib=stdc++` (dylib kind, and rnp-rs 0.1.11's vendored mode emits an *explicit* `dylib=stdc++`) as `-Wl,-Bdynamic` + `-lstdc++` at its own position in the link line — **before** the trailing `-C link-arg`s, which therefore never govern them. Proven empirically on a windows runner (tebako-packages/hello scratch workflows, runs 30976501418 and 30977573807): current flags → DLL imports + exit 127 on a stock PATH; trailing `-static` → same failure; only rewriting the `-l` references themselves produces an inbox-only import table.

## The fix — mechanism + enforcement

- **`ci/windows-gnu-link-wrap.c`** (new): the four windows-gnu scripts engage it as `CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER`. It rewrites `-lstdc++` / `-lpthread` / `-lwinpthread` to the `-l:<archive>` exact-file form — immune to the surrounding `-Bstatic`/`-Bdynamic` mode — in all three shapes they can arrive: bare argv entries, `-Wl,<a>,<b>` comma-list members, and tokens inside `@response` files (rustc moves long link lines into one). Everything else passes through byte-identically; the wrapper execs the same ucrt64 `gcc` from the closed PATH. The response-file tokenizer round-trips quoting and windows paths (local harness-verified).
- **`ci/windows-gnu-import-gate.sh`** (new): audits the PE import table of every shipped-shape exe against the Windows-inbox DLL allowlist (`api-ms-win-*` family + the classic system DLLs) and **fails the leg** on anything else. The 0.1.1 break was visible in the old informational forensics dump and shipped anyway — now the audit is the gate.

Gate coverage: cli leg (`tebako.exe`, `tfs.exe`, `tebako-pkg.exe`, debug), shim leg (`tebako-shim.exe`), bootstrap leg (debug + the stripped release exe), release leg (`out/*.exe` — the actual shipped bytes).

## Notes / follow-ups (not in this PR)

- The same static closure could instead be declared per `-sys` crate (`static=stdc++` from dwarfs-t-sys; needs the gcc lib dirs on the search path because rustc resolves `static=` eagerly — proven in the same experiment runs). That fixes our crate but relies on rustc's same-name dedup to neutralize rnp-rs's `dylib=stdc++` (external crate, rnpgp/rnp-rs). The wrapper covers every crate, present and future, and the gate verifies the outcome on the real binaries either way.
- No source changes; no overlap with #366 (that PR touches `crates/`, this touches `ci/` only).
- The already-published v0.1.1 windows assets stay broken by construction; the next release cut from a tree containing this PR ships static exes (the release leg gates itself green before upload).

## Verification

- Wrapper C: `clang -Wall -Wextra -fsyntax-only` clean; tokenizer harness (quoting/backslash round-trip + exact rewrites) passes locally.
- Scripts: `bash -n` clean on all four + the gate.
- Mechanism: proven on-runner by the scratch experiments cited above (the exact rewrite the wrapper performs produced inbox-only imports and ran with a stock PATH).
- This PR's own `test (windows-latest, x86_64-pc-windows-gnu, …)` legs are the evidence on the real build: the gate step runs there and must be green.
- End-to-end: the hello windows dogfood (tebako-packages/hello, `dogfood-windows.yml`) run with `tebako_ref=fix/windows-exec-chain` — linked in a comment once completed.
