### PR TITLE
ci: vcpkg binary cache via GitHub Packages NuGet (x-gha is removed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,11 @@ jobs:
       - name: Configure the vcpkg binary cache (GitHub Packages NuGet)
         working-directory: tebako-rs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # First-push of a new package id CANNOT be done by GITHUB_TOKEN
+          # (GitHub quirk: 403 on creation; community#159893) — the org
+          # secret (classic PAT, write:packages) owns creation when present;
+          # GITHUB_TOKEN remains the read path and the whole fallback.
+          GH_TOKEN: ${{ secrets.TEBAKO_PACKAGES_PAT || secrets.GITHUB_TOKEN }}
         run: bash ci/vcpkg-nuget-cache.sh
 
       # Pre-install libsquashfs & co in a serialized step: sqfs-sys's
@@ -431,7 +435,11 @@ jobs:
         working-directory: tebako-rs
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # First-push of a new package id CANNOT be done by GITHUB_TOKEN
+          # (GitHub quirk: 403 on creation; community#159893) — the org
+          # secret (classic PAT, write:packages) owns creation when present;
+          # GITHUB_TOKEN remains the read path and the whole fallback.
+          GH_TOKEN: ${{ secrets.TEBAKO_PACKAGES_PAT || secrets.GITHUB_TOKEN }}
         run: bash ci/vcpkg-nuget-cache.sh
 
       - name: Cache the cargo target dir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
   test:
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      # packages:write populates the org's GitHub Packages vcpkg binary
+      # cache (ci/vcpkg-nuget-cache.sh); fork PRs are auto-downgraded to
+      # read-only, where pushes degrade to a non-fatal vcpkg note.
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -75,13 +81,15 @@ jobs:
         # libbz2-dev: rnp-rs 0.1.7 declares dylib=bz2 — give the linker a
         # REAL shared library (base-OS dep, same class as libz; macOS links
         # the system libbz2.dylib identically). Until rnp-rs ≥ 0.1.10.
+        # mono-complete: vcpkg's NuGet binary-cache provider drives
+        # nuget.exe through mono on non-Windows (macos runners ship mono).
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkg-config \
             autoconf automake autoconf-archive libtool \
             curl zip unzip tar ca-certificates \
-            libbz2-dev
+            libbz2-dev mono-complete
 
       - name: Install native build tools (macos)
         if: runner.os == 'macOS'
@@ -93,15 +101,17 @@ jobs:
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
           vcpkgDirectory: ${{ github.workspace }}/.vcpkg-root
 
-      - name: Cache vcpkg package archives
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/vcpkg
-            ~/Library/Caches/vcpkg
-          key: vcpkg-archives-${{ runner.os }}-${{ hashFiles('dwarfs-rs/dwarfs-t/vcpkg.json', 'dwarfs-rs/dwarfs-t/vcpkg_ports/**', 'dwarfs-rs/dwarfs-t/vcpkg_triplets/**', 'tebako-rs/crates/sqfs-sys/vcpkg.json', 'tebako-rs/crates/sqfs-sys/vcpkg_ports/**', 'tebako-rs/crates/sqfs-sys/vcpkg_triplets/**') }}
-          restore-keys: |
-            vcpkg-archives-${{ runner.os }}-
+      # run-vcpkg@v11 injects VCPKG_BINARY_SOURCES=clear;x-gha,readwrite,
+      # and vcpkg removed x-gha (2025.06) — that spec is zero binary cache,
+      # and it also neutered the old actions/cache over the archives dir
+      # (files provider cleared + archives path redirected). The override
+      # is the org's GitHub Packages NuGet feed; the dead cache step is
+      # gone (details in ci/vcpkg-nuget-cache.sh).
+      - name: Configure the vcpkg binary cache (GitHub Packages NuGet)
+        working-directory: tebako-rs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash ci/vcpkg-nuget-cache.sh
 
       # Pre-install libsquashfs & co in a serialized step: sqfs-sys's
       # build.rs would otherwise race dwarfs-t-sys's CMake-driven vcpkg run
@@ -361,6 +371,12 @@ jobs:
   test-windows-gnu-cli:
     name: test (windows-latest, x86_64-pc-windows-gnu, tebako-cli + tfs-cli + tebako-pkg)
     runs-on: windows-latest
+    permissions:
+      # packages:write populates the org's GitHub Packages vcpkg binary
+      # cache (ci/vcpkg-nuget-cache.sh); fork PRs are auto-downgraded to
+      # read-only, where pushes degrade to a non-fatal vcpkg note.
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -408,13 +424,15 @@ jobs:
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
           vcpkgDirectory: ${{ github.workspace }}/.vcpkg-root
 
-      - name: Cache vcpkg package archives
-        uses: actions/cache@v4
-        with:
-          path: ~/AppData/Local/vcpkg/archives
-          key: vcpkg-archives-${{ runner.os }}-mingw-${{ hashFiles('dwarfs-rs/dwarfs-t/vcpkg.json', 'dwarfs-rs/dwarfs-t/vcpkg_ports/**', 'dwarfs-rs/dwarfs-t/vcpkg_triplets/**') }}
-          restore-keys: |
-            vcpkg-archives-${{ runner.os }}-mingw-
+      # See the test job: run-vcpkg's injected x-gha spec is zero binary
+      # cache since vcpkg 2025.06 removed the provider; the org's GitHub
+      # Packages NuGet feed replaces it (ci/vcpkg-nuget-cache.sh).
+      - name: Configure the vcpkg binary cache (GitHub Packages NuGet)
+        working-directory: tebako-rs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash ci/vcpkg-nuget-cache.sh
 
       - name: Cache the cargo target dir
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,10 @@
 # upload_url) → native runners per OS → `gh release upload` per artifact
 # (the archived actions/upload-release-asset was retired 2026-08-01) —
 # plus our additions: the vendored native deps via vcpkg
-# (baseline pin + archive cache, mirrored from ci.yml), the musl legs in
+# (baseline pin + the org's GitHub Packages NuGet binary cache on the
+# native legs — the run-vcpkg x-gha injection is dead since vcpkg 2025.06;
+# the container legs keep the mounted-archives actions/cache), the musl
+# legs in
 # Alpine containers (docker run from the host; the proven native-musl
 # path — see ci/musl-build.sh; node actions cannot run on musl), the
 # bootstrap size gate (back to 3 MB: rnp/botan is feature-gated out of
@@ -77,6 +80,9 @@ jobs:
     name: macOS (${{ matrix.platform }})
     permissions:
       contents: write
+      # packages:write populates the org's GitHub Packages vcpkg binary
+      # cache (ci/vcpkg-nuget-cache.sh).
+      packages: write
     runs-on: ${{ matrix.os }}
     needs: prepare
     strategy:
@@ -125,13 +131,18 @@ jobs:
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
           vcpkgDirectory: ${{ github.workspace }}/.vcpkg-root
 
-      - name: Cache vcpkg package archives
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/Library/Caches/vcpkg
-          key: vcpkg-archives-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('dwarfs-rs/dwarfs-t/vcpkg.json', 'dwarfs-rs/dwarfs-t/vcpkg_ports/**', 'dwarfs-rs/dwarfs-t/vcpkg_triplets/**', 'tebako-rs/crates/sqfs-sys/vcpkg.json', 'tebako-rs/crates/sqfs-sys/vcpkg_ports/**', 'tebako-rs/crates/sqfs-sys/vcpkg_triplets/**') }}
-          restore-keys: |
-            vcpkg-archives-${{ runner.os }}-${{ runner.arch }}-
+      # run-vcpkg@v11 injects VCPKG_BINARY_SOURCES=clear;x-gha,readwrite,
+      # and vcpkg removed x-gha (2025.06) — that spec is zero binary cache,
+      # and it also neutered the old actions/cache over the archives dir
+      # (files provider cleared + archives path redirected). The override
+      # is the org's GitHub Packages NuGet feed; the dead cache step is
+      # gone (details in ci/vcpkg-nuget-cache.sh). macos runners ship mono
+      # (vcpkg drives nuget.exe through it off-Windows).
+      - name: Configure the vcpkg binary cache (GitHub Packages NuGet)
+        working-directory: tebako-rs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash ci/vcpkg-nuget-cache.sh
 
       - name: Pre-install squashfs-tools-ng (serialized)
         working-directory: tebako-rs
@@ -254,6 +265,12 @@ jobs:
           path: dwarfs-rs
           submodules: recursive
 
+      # Deliberately NOT the NuGet feed: vcpkg runs INSIDE the ubuntu:20.04
+      # container here (no run-vcpkg, so no dead x-gha injection — the
+      # default files provider reads/writes the mounted ~/.cache/vcpkg,
+      # and this actions/cache round-trips it). Wiring the NuGet provider
+      # into the container would need mono + feed credentials in-image for
+      # no observed 403 pain on these legs.
       - name: Cache vcpkg package archives
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -369,6 +386,11 @@ jobs:
           path: dwarfs-rs
           submodules: recursive
 
+      # Deliberately NOT the NuGet feed (same reasoning as the gnu-floor
+      # leg): vcpkg runs inside the alpine container — no run-vcpkg, no
+      # x-gha injection — and the mounted ~/.cache/vcpkg files provider
+      # round-trips through this actions/cache. Alpine has no mono package,
+      # so the NuGet provider cannot run in-leg at all.
       - name: Cache vcpkg package archives
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -501,6 +523,9 @@ jobs:
     name: Windows link-unit (ucrt64)
     permissions:
       contents: write
+      # packages:write populates the org's GitHub Packages vcpkg binary
+      # cache (ci/vcpkg-nuget-cache.sh).
+      packages: write
     runs-on: windows-latest
     needs: prepare
     env:
@@ -555,13 +580,18 @@ jobs:
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
           vcpkgDirectory: ${{ github.workspace }}/.vcpkg-root
 
-      - name: Cache vcpkg package archives
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/AppData/Local/vcpkg/archives
-          key: vcpkg-archives-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('dwarfs-rs/dwarfs-t/vcpkg.json', 'dwarfs-rs/dwarfs-t/vcpkg_ports/**', 'dwarfs-rs/dwarfs-t/vcpkg_triplets/**') }}
-          restore-keys: |
-            vcpkg-archives-${{ runner.os }}-${{ runner.arch }}-
+      # run-vcpkg@v11 injects VCPKG_BINARY_SOURCES=clear;x-gha,readwrite,
+      # and vcpkg removed x-gha (2025.06) — that spec is zero binary cache,
+      # and it also neutered the old actions/cache over the archives dir
+      # (files provider cleared + archives path redirected). The override
+      # is the org's GitHub Packages NuGet feed; the dead cache step is
+      # gone (details in ci/vcpkg-nuget-cache.sh).
+      - name: Configure the vcpkg binary cache (GitHub Packages NuGet)
+        working-directory: tebako-rs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash ci/vcpkg-nuget-cache.sh
 
       - name: Build the windows-gnu staticlibs (tfs, dwarfs-only)
         working-directory: tebako-rs
@@ -614,6 +644,9 @@ jobs:
     name: Windows binaries (ucrt64)
     permissions:
       contents: write
+      # packages:write populates the org's GitHub Packages vcpkg binary
+      # cache (ci/vcpkg-nuget-cache.sh).
+      packages: write
     runs-on: windows-latest
     needs: prepare
     steps:
@@ -659,13 +692,18 @@ jobs:
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
           vcpkgDirectory: ${{ github.workspace }}/.vcpkg-root
 
-      - name: Cache vcpkg package archives
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/AppData/Local/vcpkg/archives
-          key: vcpkg-archives-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('dwarfs-rs/dwarfs-t/vcpkg.json', 'dwarfs-rs/dwarfs-t/vcpkg_ports/**', 'dwarfs-rs/dwarfs-t/vcpkg_triplets/**') }}
-          restore-keys: |
-            vcpkg-archives-${{ runner.os }}-${{ runner.arch }}-
+      # run-vcpkg@v11 injects VCPKG_BINARY_SOURCES=clear;x-gha,readwrite,
+      # and vcpkg removed x-gha (2025.06) — that spec is zero binary cache,
+      # and it also neutered the old actions/cache over the archives dir
+      # (files provider cleared + archives path redirected). The override
+      # is the org's GitHub Packages NuGet feed; the dead cache step is
+      # gone (details in ci/vcpkg-nuget-cache.sh).
+      - name: Configure the vcpkg binary cache (GitHub Packages NuGet)
+        working-directory: tebako-rs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash ci/vcpkg-nuget-cache.sh
 
       - name: Build + stage the five binaries (release)
         working-directory: tebako-rs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,11 @@ jobs:
       - name: Configure the vcpkg binary cache (GitHub Packages NuGet)
         working-directory: tebako-rs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # First-push of a new package id CANNOT be done by GITHUB_TOKEN
+          # (GitHub quirk: 403 on creation; community#159893) — the org
+          # secret (classic PAT, write:packages) owns creation when present;
+          # GITHUB_TOKEN remains the read path and the whole fallback.
+          GH_TOKEN: ${{ secrets.TEBAKO_PACKAGES_PAT || secrets.GITHUB_TOKEN }}
         run: bash ci/vcpkg-nuget-cache.sh
 
       - name: Pre-install squashfs-tools-ng (serialized)
@@ -590,7 +594,11 @@ jobs:
         working-directory: tebako-rs
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # First-push of a new package id CANNOT be done by GITHUB_TOKEN
+          # (GitHub quirk: 403 on creation; community#159893) — the org
+          # secret (classic PAT, write:packages) owns creation when present;
+          # GITHUB_TOKEN remains the read path and the whole fallback.
+          GH_TOKEN: ${{ secrets.TEBAKO_PACKAGES_PAT || secrets.GITHUB_TOKEN }}
         run: bash ci/vcpkg-nuget-cache.sh
 
       - name: Build the windows-gnu staticlibs (tfs, dwarfs-only)
@@ -702,7 +710,11 @@ jobs:
         working-directory: tebako-rs
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # First-push of a new package id CANNOT be done by GITHUB_TOKEN
+          # (GitHub quirk: 403 on creation; community#159893) — the org
+          # secret (classic PAT, write:packages) owns creation when present;
+          # GITHUB_TOKEN remains the read path and the whole fallback.
+          GH_TOKEN: ${{ secrets.TEBAKO_PACKAGES_PAT || secrets.GITHUB_TOKEN }}
         run: bash ci/vcpkg-nuget-cache.sh
 
       - name: Build + stage the five binaries (release)

--- a/ci/vcpkg-nuget-cache.sh
+++ b/ci/vcpkg-nuget-cache.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# vcpkg-nuget-cache.sh — point vcpkg's binary cache at the tamatebako org's
+# GitHub Packages NuGet feed.
+#
+# Mirrored per repo (tebako, dwarfs-t-rs, tebako-runtime-ruby): CI glue is
+# a per-repo copy by convention here (same keep-in-step rule as the
+# VCPKG_COMMIT pins) so no repo's CI depends on another repo's main.
+#
+# Why this exists: lukka/run-vcpkg@v11 injects
+# VCPKG_BINARY_SOURCES=clear;x-gha,readwrite into every later step's
+# environment. vcpkg removed the x-gha provider in the 2025.06.13 release
+# (the GitHub Actions cache service API it rode on was retired), so the
+# injected spec degrades to a warning plus NO binary cache at all — and the
+# old actions/cache step over the vcpkg archives dir was dead twice over
+# (the `clear` drops the default files provider, and
+# VCPKG_DEFAULT_BINARY_CACHE is redirected to run-vcpkg's scratch dir).
+# Every baseline miss became a full from-source port build, and when a
+# github.com tarball fetch 403'd mid-build the leg went red (tebako run
+# 30982378190: boost-mp11:x64-mingw-static).
+#
+# The surviving native GitHub integration is vcpkg's NuGet binary-cache
+# provider backed by the org's GitHub Packages feed. This script fetches a
+# pinned nuget.exe, registers the feed + the job token in the user-level
+# nuget.config (shared with whatever nuget.exe vcpkg drives), shadows PATH
+# with it, then overrides VCPKG_BINARY_SOURCES for the remaining steps via
+# GITHUB_ENV.
+#
+# Why a self-fetched nuget.exe instead of `vcpkg fetch nuget`: the ARM64
+# runner images set VCPKG_FORCE_SYSTEM_BINARIES=1, which forbids vcpkg's
+# own tool downloads — its nuget lookup then falls back to PATH and finds
+# Mono.framework's `nuget` WRAPPER SCRIPT (not an assembly: "File does not
+# contain a valid CIL image" under mono). A real nuget.exe earlier on PATH
+# satisfies that lookup; where FORCE_SYSTEM_BINARIES is unset vcpkg simply
+# downloads its own copy and only the shared nuget.config matters.
+#
+# Usage: ci/vcpkg-nuget-cache.sh   (GH_TOKEN must be set)
+#
+# Contract:
+# - Run AFTER lukka/run-vcpkg (it is the env writer this overrides) and
+#   BEFORE anything that invokes vcpkg (the sqfs pre-install, cargo builds
+#   — dwarfs-t-sys's CMake toolchain invocation inherits the step env).
+# - Non-Windows runners need mono on PATH (vcpkg drives nuget.exe through
+#   mono; macos runners ship it, the ubuntu legs apt-install mono-complete).
+# - The job needs packages:write for the push side; fork PRs get a
+#   read-only token, where pushes degrade to a non-fatal vcpkg note while
+#   restores keep working — and a cold feed just builds from source,
+#   exactly the pre-fix behavior. Any failure here is a warning, never a
+#   red leg: cache setup must not take the build down with it.
+set -euo pipefail
+
+: "${GH_TOKEN:?set GH_TOKEN to secrets.GITHUB_TOKEN}"
+FEED="https://nuget.pkg.github.com/tamatebako/index.json"
+# nuget.exe 7.0.1, the release vcpkg 2025.06+ fetches (same pin + sha256 as
+# dwarfs-t's _build.yml).
+NUGET_URL="https://dist.nuget.org/win-x86-commandline/v7.0.1/nuget.exe"
+NUGET_SHA256="8ddc8cc04298fa08277efdca35373eb158f0c95f5bb1b15efcab2b62952028f6"
+
+NUGET_DIR="${RUNNER_TEMP:-/tmp}/tebako-nuget-bin"
+mkdir -p "$NUGET_DIR"
+NUGET="$NUGET_DIR/nuget.exe"
+if ! curl -fsSL -o "$NUGET" "$NUGET_URL" ||
+   ! { echo "$NUGET_SHA256  $NUGET" | { sha256sum -c 2>/dev/null || shasum -a 256 -c; }; }; then
+  echo "::warning::nuget.exe download/verify failed — this leg runs without the binary cache (ports build from source)."
+  exit 0
+fi
+chmod +x "$NUGET"
+
+# vcpkg runs nuget.exe natively on Windows and through mono elsewhere.
+# The FORCE_SYSTEM_BINARIES PATH lookup searches the bare stem `nuget` —
+# on Windows nuget.exe itself already matches (and a bare-name copy would
+# be the same file on the case-insensitive FS).
+MONO="mono"
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) MONO="" ;;
+  *) cp "$NUGET" "$NUGET_DIR/nuget" ;;
+esac
+echo "$NUGET_DIR" >> "$GITHUB_PATH"
+
+if ! $MONO "$NUGET" sources add -source "$FEED" -name GitHub \
+       -username tebako-ci -password "$GH_TOKEN" -storepasswordincleartext > /dev/null 2>&1 ||
+   ! $MONO "$NUGET" setapikey "$GH_TOKEN" -source "$FEED" > /dev/null 2>&1; then
+  # vcpkg's nuget push passes no -ApiKey; the stored key authenticates it.
+  echo "::warning::nuget feed registration failed — this leg runs without the binary cache (ports build from source)."
+  exit 0
+fi
+
+echo "VCPKG_BINARY_SOURCES=clear;nuget,GitHub,readwrite" >> "$GITHUB_ENV"
+echo "vcpkg binary cache: nuget feed $FEED (readwrite)"

--- a/ci/vcpkg-nuget-cache.sh
+++ b/ci/vcpkg-nuget-cache.sh
@@ -46,6 +46,12 @@
 #   restores keep working — and a cold feed just builds from source,
 #   exactly the pre-fix behavior. Any failure here is a warning, never a
 #   red leg: cache setup must not take the build down with it.
+# - GitHub Packages quirk (community discussion #159893): the FIRST push
+#   of a new package id cannot be done by GITHUB_TOKEN (403 Forbidden on
+#   creation — proven on tebako run 30989981488's ubuntu leg). Set the
+#   org secret TEBAKO_PACKAGES_PAT (classic PAT, write:packages) and the
+#   workflow's GH_TOKEN prefers it; GITHUB_TOKEN remains the read path
+#   and the fallback while the secret is absent.
 set -euo pipefail
 
 : "${GH_TOKEN:?set GH_TOKEN to secrets.GITHUB_TOKEN}"


### PR DESCRIPTION
## Problem

"cache miss ⇒ source build ⇒ network 403 ⇒ red CI" on the vcpkg legs. Evidence: run [30982378190](https://github.com/tamatebako/tebako/actions/runs/30982378190) (feat/union-mount-model), `test (windows-latest, x86_64-pc-windows-gnu, tebako-cli + tfs-cli + tebako-pkg)`:

```
Installing 102/194 boost-uninstall:x64-mingw-static@1.90.0#1...
error: https://github.com/boostorg/mp11/archive/boost-1.90.0.tar.gz: failed: status code 403
error: building boost-mp11:x64-mingw-static failed with: BUILD_FAILED
```

## Root cause (two dead caches, not one)

1. `lukka/run-vcpkg@v11` injects `VCPKG_BINARY_SOURCES=clear;x-gha,readwrite` (plus `VCPKG_DEFAULT_BINARY_CACHE=<its scratch dir>`) into every later step's environment — visible in any vcpkg leg's env dump.
2. **vcpkg removed the `x-gha` provider in the 2025.06.13 release** (the GitHub Actions cache service API it rode on was retired; [vcpkg binary caching reference](https://github.com/MicrosoftDocs/vcpkg-docs/blob/main/vcpkg/reference/binarycaching.md): "`x-gha` — Removed: This feature has been removed from vcpkg"). On the pinned `VCPKG_COMMIT` (f14401ca, 2026-01-25) the spec degrades to a *warning* ("The 'x-gha' binary caching backend has been removed…") and — because of the leading `clear` — **zero binary cache remains**.
3. The hand-rolled `actions/cache` over the archives dir was therefore dead twice over: the `clear` drops the default files provider, and `VCPKG_DEFAULT_BINARY_CACHE` no longer points at the cached directory. The "Cache not found" miss in that run was cosmetic — even a hit would have been ignored.

So every baseline-restore miss / abi drift became a full from-source build of ~194 ports, one github.com tarball 403 away from a red leg.

## Fix

The surviving native GitHub integration is vcpkg's **NuGet binary-cache provider backed by the org's GitHub Packages feed** (`https://nuget.pkg.github.com/tamatebako/index.json`):

- **`ci/vcpkg-nuget-cache.sh`** (new, the single owner) registers the feed + the job token for the `nuget.exe` vcpkg drives (`vcpkg fetch nuget`), stores the push apikey, then overrides `VCPKG_BINARY_SOURCES=clear;nuget,GitHub,readwrite` via `GITHUB_ENV`. Placed after `Set up vcpkg` (run-vcpkg is the env writer being overridden) and before anything that invokes vcpkg — the sqfs pre-install and the cargo-driven dwarfs-t-sys/sqfs-sys CMake toolchain invocations all inherit the step env.
- The dead `actions/cache` steps on the native legs are removed. No read-only transition fallback is kept: the old archives cache was provably unreadable (above), so there was nothing to fall back to. Cold-feed behavior is the pre-fix behavior (ports build from source), and each built port is pushed as it finishes, so a retried run resumes where the last one died.
- **mono**: vcpkg drives `nuget.exe` through mono off-Windows. `mono-complete` is apt-installed on the ubuntu legs (noble/universe); the macos-14 runner image ships Mono 6.12; Windows runs nuget.exe natively.
- **`packages: write`** on the vcpkg jobs. Fork PRs are auto-downgraded to a read-only token: pushes degrade to a non-fatal vcpkg note, restores keep working, and worst case the leg builds from source — never a hard failure.

### Deliberate exception

The release.yml container legs (`linux-gnu` floor in `ubuntu:20.04`, `linux-musl` in `alpine:3.21`) keep the mounted-`~/.cache/vcpkg` `actions/cache`: vcpkg runs *inside* the container there, where run-vcpkg never injects anything, so the default files provider round-trips through the mount today. Alpine has no mono package at all, and plumbing feed credentials into the floor container buys nothing these legs have suffered from.

## Verification

- [ ] First (cold-feed) CI run on this branch green — check the run below
- [ ] Re-run of the same jobs: vcpkg logs show `Restored N package(s) from NuGet` and no `Building boost-*` / github.com tarball downloads

(run links and evidence lines to be pasted once CI completes)

## Notes

- One PR per repo; the same pattern propagates to tebako-runtime-ruby (`_build-platform.yml` windows link-unit leg) and dwarfs-t-rs (ci.yml) after this one proves out in CI.
- The NuGet feed is org-scoped, so dwarfs-t-rs / tebako-runtime-ruby legs read the same per-(port, triplet, abi) entries this repo's legs write.
- Not merging is intentional — left for the orchestrator.

---

## Status update (2026-08-05, ~17:15 UTC)

**Mechanism proven in CI** (run [30989981488](https://github.com/tamatebako/tebako/actions/runs/30989981488), sha b77a71c3 — same script as HEAD plus the windows `cp` fix at 964a4553):

- Configure step takes the real path on ubuntu-24.04 + macos-14: `vcpkg binary cache: nuget feed https://nuget.pkg.github.com/tamatebako/index.json (readwrite)`; subsequent steps show `VCPKG_BINARY_SOURCES: clear;nuget,GitHub,readwrite` (run-vcpkg's x-gha injection overridden).
- Cold feed behaves exactly as designed: `Restored 0 package(s) from NuGet in 7 s` — per-package `Restoring NuGet package <id>` → `NotFound` (**read auth with GITHUB_TOKEN works**, pull_request event included).
- Ports build from source, then `Uploading binaries for zstd:x64-linux-static@1.5.7 to NuGet …` ×7 per leg — the push pipeline engages; no leg ever fails on cache errors (warn-degrade works).
- Two ubuntu pushes got `Forbidden https://nuget.pkg.github.com/tamatebako/` (`vcpkg-cmake-config_x64-linux`, `vcpkg-cmake_x64-linux`). The restore log shows those exact ids were **not in the feed** (`NotFound`), so this is package-**creation** being denied, not an ownership conflict. Two candidate causes — mono's `setapikey` persistence vs pull_request-event token restrictions on `packages:write`. Discriminator runs are staged: this run's windows leg (native nuget.exe) and the `feat/nuget-push-probe` branch (push event, same sha).
- Windows leg of that run verified the download+sha256 of the pinned nuget.exe (`nuget.exe: OK`) and exposed a same-file `cp` bug — fixed in 964a4553.

**CI red on the vcpkg legs is pre-existing, not from this PR**: `main` at the same base (2f46901c) fails identically — run [30923767408](https://github.com/tamatebako/tebako/actions/runs/30923767408) shows `invalid option --tebako-extract` in the tebako-cli e2e on macos-14 and ubuntu-24.04 (the 0.16.2 runtime pin vs the released runtime; #366 carries the e2e heal).

**Blocked on GitHub, not on the code**: since ~08:50 UTC 2026-08-05, GitHub has not dispatched a single job for any newly created run in the tamatebako org (0 in-progress across all 25 org repos for hours; 20+ runs queued). Runs awaiting dispatch: this PR's [31006408061](https://github.com/tamatebako/tebako/actions/runs/31006408061) and the push-event probe [31015504848](https://github.com/tamatebako/tebako/actions/runs/31015504848). When scheduling resumes: this run proves the windows-leg configure fix + per-id push outcomes (Created vs Forbidden), and a re-run (`gh run rerun <id> --failed`) produces the warm evidence — `Restored N package(s) from NuGet` with N>0 and zero `Building boost-*` / github.com tarball downloads.

**Update 2 (same day, later): push-403 root cause found + PAT wiring added.** The two `Forbidden` pushes were GitHub's **first-push creation quirk** ([community#159893](https://github.com/orgs/community/discussions/159893)): a brand-new package id cannot be created by `GITHUB_TOKEN` at all — 403 regardless of `packages:write` — until it exists (created by a PAT). Ruled out by a local `ubuntu:24.04`+mono-6.8 container repro: `setapikey` persists and decrypts the apikey correctly (`~/.config/NuGet/NuGet.Config` carries source, cleartext basic creds, and the encrypted apikey), and a push attaches it properly — the client flow is exact; the server rejects creation. **Action for the org admin:** create a classic PAT with `write:packages` and add it as the org Actions secret `TEBAKO_PACKAGES_PAT` (visible to tebako, dwarfs-t-rs, tebako-runtime-ruby). The configure steps now prefer `${{ secrets.TEBAKO_PACKAGES_PAT || secrets.GITHUB_TOKEN }}` (6d7bf336): restores work with either token today; pushes light up the moment the secret lands; fork PRs never see the secret and stay read-only + source builds.
