### PR TITLE
feat: the limnifs TFS backend (spec 20)

### DIFF
--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -41,7 +41,7 @@ serde_yml = "0.0.12"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
 # — pure Rust, no `limni` binary anywhere.
-limnifs-write = { version = "0.2", path = "../../../../limnifs/limnifs/limnifs-write" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "14ab01d017af054d24ff002775e17663146cdfad" }
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -39,6 +39,9 @@ serde_yml = "0.0.12"
 # The in-process DwarFS writer (dwarfs-t-rs): the application and deploy
 # driver images are built without any mkdwarfs binary.
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
+# The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
+# — pure Rust, no `limni` binary anywhere.
+limnifs-write = { version = "0.2", path = "../../../../limnifs/limnifs/limnifs-write" }
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tebako-cli/src/deploy.rs
+++ b/crates/tebako-cli/src/deploy.rs
@@ -90,7 +90,18 @@ impl RuntimeDeployer {
             )));
         }
         self.write_driver(seed_dir, ops);
-        crate::image::build_image(&self.driver_image(), seed_dir)?;
+        // The deploy driver image is PRESS-INTERNAL machinery: the
+        // resolved runtime mounts it to run the deploy ops, and released
+        // runtimes predate the limnifs backend — it stays dwarfs
+        // regardless of --format (which governs the shipped app payload
+        // only). A limnifs-less runtime therefore presses a
+        // `--format limnifs` package fine; running that package needs a
+        // limnifs-capable runtime (spec 20 §5's fail-closed rule).
+        crate::image::build_image(
+            &self.driver_image(),
+            seed_dir,
+            crate::options::PressImageFormat::Dwarfs,
+        )?;
         self.stitch_driver_package()?;
         if self.shim_supported() {
             self.write_bundle_exec_script()?;

--- a/crates/tebako-cli/src/image.rs
+++ b/crates/tebako-cli/src/image.rs
@@ -1,30 +1,40 @@
-//! In-process DwarFS image creation via the dwarfs-t `Writer` (the safe
-//! binding of dwarfs-t-rs). No mkdwarfs binary, no PATH lookup, no
-//! provisioning — the same stable C ABI the reader uses produces the
-//! image.
+//! In-process image creation (spec 20 §6): DwarFS via the dwarfs-t
+//! `Writer` (the safe binding of dwarfs-t-rs), LimniFS via
+//! `limnifs-write` (pure Rust). No mkdwarfs/limni binary, no PATH
+//! lookup, no provisioning — in-process writers only.
 //!
-//! Images produced here carry dwarfs-t-native (FlatBuffers) metadata —
-//! upstream DwarFS cannot read them — so they are named `.tfs` (the
-//! `.dwarfs` extension stays for upstream-compatible images).
+//! DwarFS images produced here carry dwarfs-t-native (FlatBuffers)
+//! metadata — upstream DwarFS cannot read them — so they are named
+//! `.tfs` (the `.dwarfs` extension stays for upstream-compatible
+//! images). LimniFS images are the tebako single-file layout (spec 20
+//! §4): the writer's manifest bytes verbatim plus every slab appended
+//! in slab-ordinal order; they are `.tfs`-named too (the store's rule:
+//! payload artifacts keep one extension regardless of format).
 
 use std::path::Path;
 
 use dwarfs_t::{Writer, WriterOptions};
 
 use crate::error::{plain_error, TebakoError};
+use crate::options::PressImageFormat;
 
-/// Build a DwarFS image of `src_dir` at `out` (the mkdwarfs
-/// `-o <out> -i <src_dir>` equivalent, in-process). The Writer never
-/// overwrites; the packaging environment is recreated per press, so
-/// `out` never exists at this point.
+/// Build the application image of `src_dir` at `out` in the chosen
+/// format (spec 20 §6: the flag routes the packager's image build and
+/// nothing else). An existing output is replaced (the mkdwarfs
+/// `--force` parity).
 ///
 /// When the assembled tree carries `__tpkg__/manifest.yaml`, its
 /// `identity.digest.tree_hash` is filled with the payload tree hash
 /// (spec 03 §7 fixed-point rule: the hash excludes `/__tpkg__/`, so the
 /// stamp is a fixed point) via a hardlink staging mirror — the assembled
-/// tree itself is never mutated.
-pub fn build_image(out: &Path, src_dir: &Path) -> Result<(), TebakoError> {
-    println!("-- Building DwarFS image {}", out.display());
+/// tree itself is never mutated. The stamp is format-neutral: it rides
+/// ahead of writer selection.
+pub fn build_image(
+    out: &Path,
+    src_dir: &Path,
+    format: PressImageFormat,
+) -> Result<(), TebakoError> {
+    println!("-- Building {} image {}", format.name(), out.display());
     let staged = stamp_tree_hash(src_dir)?;
     let staged_tree;
     let source = match &staged {
@@ -35,6 +45,16 @@ pub fn build_image(out: &Path, src_dir: &Path) -> Result<(), TebakoError> {
         }
         None => src_dir,
     };
+    match format {
+        PressImageFormat::Dwarfs => write_dwarfs_image(out, source),
+        PressImageFormat::Limnifs => write_limnifs_image(out, source),
+    }
+}
+
+/// The DwarFS writer (the mkdwarfs `-o <out> -i <src_dir>` equivalent,
+/// in-process). The Writer never overwrites; the packaging environment
+/// is recreated per press, so `out` never exists at this point.
+fn write_dwarfs_image(out: &Path, source: &Path) -> Result<(), TebakoError> {
     let mut writer = Writer::new(WriterOptions::default())
         .map_err(|e| plain_error(format!("dwarfs writer: {e}")))?;
     writer
@@ -43,6 +63,36 @@ pub fn build_image(out: &Path, src_dir: &Path) -> Result<(), TebakoError> {
     writer
         .write(out)
         .map_err(|e| plain_error(format!("dwarfs writer: {}: {e}", out.display())))
+}
+
+/// The LimniFS writer (spec 20 §6): manifest bytes verbatim + every
+/// slab appended in slab-ordinal order (the mount-open walk relies on
+/// exactly this shape). Dictionaries are disabled: a dictionary section
+/// would sit between the history section and the slab region (and tag
+/// drops with dictionary ids), neither of which the v1 backend
+/// resolves.
+fn write_limnifs_image(out: &Path, source: &Path) -> Result<(), TebakoError> {
+    let mut config = limnifs_write::WriteConfig::default_v0_1();
+    config.dictionaries.enabled = false;
+    let artifact = limnifs_write::write_directory_with_config(source, &config).map_err(|e| {
+        plain_error(format!(
+            "limnifs writer: scanning {}: {e}",
+            source.display()
+        ))
+    })?;
+    if let Some(sidecar) = &artifact.metadata_sidecar {
+        return Err(plain_error(format!(
+            "limnifs writer: the tree's metadata externalized ({} bytes to '{}') — a self-contained tebako image inlines the metadata; the tree is too large for this format today",
+            sidecar.bytes.len(),
+            sidecar.locator
+        )));
+    }
+    let mut image = artifact.bytes;
+    for slab in &artifact.slabs {
+        image.extend_from_slice(&slab.bytes);
+    }
+    std::fs::write(out, &image)
+        .map_err(|e| plain_error(format!("limnifs writer: {}: {e}", out.display())))
 }
 
 /// Fill the payload manifest's tree hash and stage the stamped tree
@@ -74,19 +124,58 @@ fn stamp_tree_hash(src_dir: &Path) -> Result<Option<(tempfile::TempDir, String)>
 mod tests {
     use super::*;
 
-    #[test]
-    fn image_roundtrip_through_the_reader() {
-        let dir = std::env::temp_dir().join(format!("tebako-cli-image-{}", std::process::id()));
+    fn fixture_tree(tag: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+        // Unique per test: the tests run concurrently in one process.
+        let dir =
+            std::env::temp_dir().join(format!("tebako-cli-image-{tag}-{}", std::process::id()));
         let src = dir.join("src");
         std::fs::create_dir_all(src.join("local")).unwrap();
         std::fs::write(src.join("local").join("hello.txt"), b"hi").unwrap();
+        (dir, src)
+    }
+
+    #[test]
+    fn dwarfs_image_roundtrip_through_the_reader() {
+        let (dir, src) = fixture_tree("dwarfs");
         let out = dir.join("fs.tfs");
-        build_image(&out, &src).unwrap();
+        build_image(&out, &src, PressImageFormat::Dwarfs).unwrap();
         let fs = dwarfs_t::Filesystem::open(&out).unwrap();
         let meta = fs.stat("local/hello.txt").unwrap();
         let mut buf = vec![0u8; meta.size as usize];
         let n = fs.pread("local/hello.txt", &mut buf, 0).unwrap();
         assert_eq!(&buf[..n], b"hi");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The limnifs press path (spec 20 §6): the image detects as
+    /// limnifs and mounts through the tfs backend.
+    #[test]
+    #[cfg(not(windows))] // windows ships a dwarfs-only tfs (TODO.v2-1/02)
+    fn limnifs_image_roundtrip_through_the_backend() {
+        let (dir, src) = fixture_tree("limnifs");
+        let out = dir.join("fs.tfs");
+        build_image(&out, &src, PressImageFormat::Limnifs).unwrap();
+        let mount = tfs::mount::build_from_file(&out.to_string_lossy(), "/mnt")
+            .expect("the pressed image mounts");
+        assert_eq!(mount.backend.name().to_str().unwrap(), "LimniFS");
+        let st = mount.backend.stat("local/hello.txt").unwrap();
+        assert_eq!(st.size, 2);
+        let mut buf = [0u8; 2];
+        let n = mount.backend.pread("local/hello.txt", &mut buf, 0).unwrap();
+        assert_eq!(&buf[..n], b"hi");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn press_image_format_ids_match_the_trailer_vocabulary() {
+        assert_eq!(
+            PressImageFormat::Dwarfs.tpkg_format_id(),
+            tpkg::TPKG_FORMAT_DWARFS
+        );
+        assert_eq!(
+            PressImageFormat::Limnifs.tpkg_format_id(),
+            tpkg::TPKG_FORMAT_LIMNIFS
+        );
+        assert!(PressImageFormat::parse("zip").is_err());
     }
 }

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -232,7 +232,7 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     let mut images: Vec<(PathBuf, String, u32)> = vec![(
         app_image,
         scenario.fs_mount_point.clone(),
-        tpkg::TPKG_FORMAT_DWARFS,
+        opts.format.tpkg_format_id(),
     )];
     for (path, mount) in opts.images()? {
         images.push((PathBuf::from(path), mount, tpkg::TPKG_FORMAT_DWARFS));

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -13,6 +13,7 @@ const USAGE: &str = "Usage:
                [-R <ruby>] [-m lean|fat] [-l error|warn|debug|trace]
                [--image <path>:<mount>]... [--bootstrap <path>]
                [--tebako-version <v>] [--prefer-local] [--jail <spec>]
+               [--format dwarfs|limnifs]
   tebako press --suite <suite.yaml> [-o <output>] [-p <prefix>] [-R <ruby>]
                one package, N commands (spec 03 §6: per-entry slots + type-2 manifest)
   tebako run <pkg> [--jail <spec>] [--mount <host:mount:ro|rw>]... [--no-host]
@@ -609,6 +610,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
     let mut suite: Option<PathBuf> = None;
     let mut jail: Option<String> = None;
     let mut no_install = false;
+    let mut format = tebako_cli::options::PressImageFormat::Dwarfs;
 
     let mut i = 0;
     while i < args.len() {
@@ -645,6 +647,11 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
             "--suite" => suite = Some(PathBuf::from(take_value(&mut i)?)),
             "--jail" => jail = Some(take_value(&mut i)?),
             "--no-install" => no_install = true,
+            "--format" => {
+                let v = take_value(&mut i)?;
+                format =
+                    tebako_cli::options::PressImageFormat::parse(&v).map_err(CliExit::Usage)?;
+            }
             "-D" | "--devmode" => devmode = true,
             "-t" | "--tebafile" => {
                 let _ = take_value(&mut i)?;
@@ -710,5 +717,6 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
         suite,
         jail,
         no_install,
+        format,
     })
 }

--- a/crates/tebako-cli/src/options.rs
+++ b/crates/tebako-cli/src/options.rs
@@ -37,6 +37,44 @@ impl PressMode {
     }
 }
 
+/// The application image format (spec 20 §6, the PLANNED `--format`
+/// press flag): which writer the packager's image build runs and which
+/// `format_id` hint the app-image slots are stamped with. `dwarfs` is
+/// the default; the flag never changes anything else about press.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PressImageFormat {
+    Dwarfs,
+    Limnifs,
+}
+
+impl PressImageFormat {
+    pub fn parse(s: &str) -> Result<PressImageFormat, String> {
+        match s {
+            "dwarfs" => Ok(PressImageFormat::Dwarfs),
+            "limnifs" => Ok(PressImageFormat::Limnifs),
+            _ => Err(format!(
+                "unsupported image format '{s}' (supported: dwarfs, limnifs)"
+            )),
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            PressImageFormat::Dwarfs => "dwarfs",
+            PressImageFormat::Limnifs => "limnifs",
+        }
+    }
+
+    /// The slot-record `format_id` hint (spec 02 §6; detection stays
+    /// authoritative — the hint never overrides magic).
+    pub fn tpkg_format_id(&self) -> u32 {
+        match self {
+            PressImageFormat::Dwarfs => tpkg::TPKG_FORMAT_DWARFS,
+            PressImageFormat::Limnifs => tpkg::TPKG_FORMAT_LIMNIFS,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PressOptions {
     /// Root folder as given on the command line, made absolute
@@ -82,6 +120,9 @@ pub struct PressOptions {
     /// `tebako install <path>`) is refused with a named error. Off by
     /// default (installable on explicit request).
     pub no_install: bool,
+    /// --format <dwarfs|limnifs> (spec 20 §6): the application image
+    /// format. Dwarfs by default.
+    pub format: PressImageFormat,
 }
 
 impl PressOptions {

--- a/crates/tebako-cli/src/packager.rs
+++ b/crates/tebako-cli/src/packager.rs
@@ -57,7 +57,7 @@ pub fn build_app_image(
         align_layout_to_runtime(&opts.data_src_dir(), layout_dir, ruby_ver);
     }
     write_entry_dispatcher(&opts.data_src_dir(), scenario, opts.cwd.as_deref());
-    build_image(&opts.data_bundle_file(), &opts.data_src_dir())?;
+    build_image(&opts.data_bundle_file(), &opts.data_src_dir(), opts.format)?;
     Ok(opts.data_bundle_file())
 }
 
@@ -783,6 +783,7 @@ mod tests {
             suite: None,
             jail: None,
             no_install: false,
+            format: crate::options::PressImageFormat::Dwarfs,
         }
     }
 

--- a/crates/tebako-cli/src/suite.rs
+++ b/crates/tebako-cli/src/suite.rs
@@ -389,7 +389,7 @@ pub fn press_suite(
         images.push((
             staged,
             scenario_mgr.fs_mount_point.clone(),
-            tpkg::TPKG_FORMAT_DWARFS,
+            entry_opts.format.tpkg_format_id(),
         ));
         runtime_refs.push(entry_runtime_ref(entry, &ruby_ver, opts, resolved));
     }

--- a/crates/tebako-cli/tests/suite.rs
+++ b/crates/tebako-cli/tests/suite.rs
@@ -32,6 +32,7 @@ fn opts() -> PressOptions {
         suite: None,
         jail: None,
         no_install: false,
+        format: tebako_cli::options::PressImageFormat::Dwarfs,
     }
 }
 

--- a/crates/tebako-info/src/format.rs
+++ b/crates/tebako-info/src/format.rs
@@ -13,8 +13,8 @@
 //! so the flavor is read off the schema-section size.
 
 use tpkg::{
-    TPKG_FORMAT_AUTO, TPKG_FORMAT_DWARFS, TPKG_FORMAT_RUNTIME, TPKG_FORMAT_SQUASHFS,
-    TPKG_FORMAT_ZIP,
+    TPKG_FORMAT_AUTO, TPKG_FORMAT_DWARFS, TPKG_FORMAT_LIMNIFS, TPKG_FORMAT_RUNTIME,
+    TPKG_FORMAT_SQUASHFS, TPKG_FORMAT_ZIP,
 };
 
 /// The schema-section marker size emitted for FlatBuffers images.
@@ -51,6 +51,7 @@ impl FormatInfo {
                 )
             }
             "SquashFS" => ("squashfs".to_string(), "squashfs".to_string()),
+            "LimniFS" => ("limnifs".to_string(), "limnifs".to_string()),
             "ZIP" => ("zip".to_string(), "zip".to_string()),
             "TAR" => ("tar".to_string(), "tar".to_string()),
             "TAR.GZ" => ("tar.gz".to_string(), "tar.gz".to_string()),
@@ -104,7 +105,8 @@ fn dwarfs_flavor(backend_json: Option<&str>) -> DwarfsFlavor {
 }
 
 /// The `format_id` hint rendered for humans (spec 02 §6: 4 is a legacy
-/// ROLE riding in the format field, reported as such).
+/// ROLE riding in the format field, reported as such; 5 is limnifs —
+/// spec 20).
 pub fn hint_name(format_id: u32) -> &'static str {
     match format_id {
         TPKG_FORMAT_AUTO => "auto",
@@ -112,6 +114,7 @@ pub fn hint_name(format_id: u32) -> &'static str {
         TPKG_FORMAT_SQUASHFS => "squashfs",
         TPKG_FORMAT_ZIP => "zip",
         TPKG_FORMAT_RUNTIME => "runtime (legacy role)",
+        TPKG_FORMAT_LIMNIFS => "limnifs",
         _ => "unknown",
     }
 }
@@ -166,6 +169,8 @@ mod tests {
     fn backend_labels() {
         assert_eq!(FormatInfo::detect("ZIP", None).short, "zip");
         assert_eq!(FormatInfo::detect("SquashFS", None).short, "squashfs");
+        assert_eq!(FormatInfo::detect("LimniFS", None).short, "limnifs");
+        assert_eq!(FormatInfo::detect("LimniFS", None).label, "limnifs");
         assert_eq!(FormatInfo::detect("TAR", None).label, "tar");
         assert_eq!(FormatInfo::detect("TAR.GZ", None).label, "tar.gz");
         assert_eq!(FormatInfo::detect("TAR.ZST", None).label, "tar.zst");
@@ -178,6 +183,7 @@ mod tests {
         assert_eq!(hint_name(TPKG_FORMAT_SQUASHFS), "squashfs");
         assert_eq!(hint_name(TPKG_FORMAT_ZIP), "zip");
         assert_eq!(hint_name(TPKG_FORMAT_RUNTIME), "runtime (legacy role)");
+        assert_eq!(hint_name(TPKG_FORMAT_LIMNIFS), "limnifs");
         assert_eq!(hint_name(9), "unknown");
     }
 }

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -27,6 +27,9 @@ tebako-info = { version = "0.1.0", path = "../tebako-info" }
 tebako-json = { version = "0.1.0", path = "../tebako-json" }
 # The in-process DwarFS writer for mkimage (dwarfs-t-rs).
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
+# The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
+# §6) — pure Rust, no `limni` binary anywhere.
+limnifs-write = { version = "0.2", path = "../../../../limnifs/limnifs/limnifs-write" }
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -29,7 +29,7 @@ tebako-json = { version = "0.1.0", path = "../tebako-json" }
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
 # §6) — pure Rust, no `limni` binary anywhere.
-limnifs-write = { version = "0.2", path = "../../../../limnifs/limnifs/limnifs-write" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "14ab01d017af054d24ff002775e17663146cdfad" }
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is

--- a/crates/tfs-cli/src/lib.rs
+++ b/crates/tfs-cli/src/lib.rs
@@ -103,6 +103,21 @@ fn full_path(path: &str) -> String {
     }
 }
 
+/// The mounted image's backend name (`"DwarFS"`, `"LimniFS"`, …), or
+/// `None` when the ABI reports none. Read after `MountGuard::mount`.
+fn mount_backend_name() -> Option<String> {
+    let name = unsafe { tebako_get_backend_name() };
+    if name.is_null() {
+        None
+    } else {
+        Some(
+            unsafe { std::ffi::CStr::from_ptr(name) }
+                .to_string_lossy()
+                .into_owned(),
+        )
+    }
+}
+
 /// stat helper (errno-valued). TebakoStat is the platform's `struct stat`
 /// on unix and the pinned `__stat64`-layout struct on windows (the C ABI
 /// authority — c_api.rs).
@@ -466,8 +481,14 @@ pub fn cmd_info(image: &Path) -> Result<String, (String, i32)> {
     let ty = match ext.as_str() {
         "zip" => "ZIP",
         "sqfs" | "squashfs" => "SquashFS",
-        // .tfs is the dwarfs-t-native (FlatBuffers metadata) extension
-        "dwarfs" | "tfs" => "DwarFS",
+        // .tfs is the dwarfs-t-native (FlatBuffers metadata) extension,
+        // but the bytes are authoritative: a limnifs image under .tfs
+        // reports its own backend (spec 20 §2 — the detection-derived
+        // label), never "DwarFS".
+        "dwarfs" | "tfs" => match mount_backend_name().as_deref() {
+            Some("LimniFS") => "LimniFS",
+            _ => "DwarFS",
+        },
         _ => "Unknown",
     };
 
@@ -950,20 +971,21 @@ fn name_matches(pattern: &str, name: &str) -> bool {
 }
 
 // ---------------------------------------------------------------------
-// mkimage (in-process dwarfs-t Writer — no mkdwarfs binary anywhere)
+// mkimage (in-process writers: dwarfs-t / limnifs — no binaries anywhere)
 // ---------------------------------------------------------------------
 
-/// `tfs mkimage --format dwarfs <srcdir> -o <img>` — builds the image
-/// in-process via the dwarfs-t Writer (the same C ABI the reader uses;
-/// no mkdwarfs binary, no PATH lookup). An existing output is replaced
-/// (the mkdwarfs --force parity). Images carry dwarfs-t-native
-/// (FlatBuffers) metadata — name them `.tfs` (the `.dwarfs` extension
-/// stays for upstream-compatible images).
+/// `tfs mkimage --format <fmt> <srcdir> -o <img>` — builds the image
+/// in-process (dwarfs: the dwarfs-t Writer, the same C ABI the reader
+/// uses; limnifs: `limnifs-write`, spec 20 §6). No mkdwarfs/limni binary,
+/// no PATH lookup. An existing output is replaced (the mkdwarfs --force
+/// parity). Dwarfs images carry dwarfs-t-native (FlatBuffers) metadata —
+/// name them `.tfs` (the `.dwarfs` extension stays for
+/// upstream-compatible images).
 pub fn cmd_mkimage(format: &str, source_dir: &Path, output: &Path) -> Result<(), (String, i32)> {
     let fmt = format.to_lowercase();
     if fmt == "zip" {
         return Err((
-            "mkimage --format zip is not supported: the zip backend is read-only (only 'dwarfs' can be written)"
+            "mkimage --format zip is not supported: the zip backend is read-only (only 'dwarfs' and 'limnifs' can be written)"
                 .to_string(),
             1,
         ));
@@ -975,9 +997,9 @@ pub fn cmd_mkimage(format: &str, source_dir: &Path, output: &Path) -> Result<(),
             1,
         ));
     }
-    if fmt != "dwarfs" {
+    if fmt != "dwarfs" && fmt != "limnifs" {
         return Err((
-            format!("unsupported image format '{format}' (supported: dwarfs)"),
+            format!("unsupported image format '{format}' (supported: dwarfs, limnifs)"),
             1,
         ));
     }
@@ -989,8 +1011,9 @@ pub fn cmd_mkimage(format: &str, source_dir: &Path, output: &Path) -> Result<(),
     }
     // Stamp the payload manifest's `tree_hash` when the source carries a
     // manifest (spec 03 §7 fixed-point rule: the hash excludes
-    // `/__tpkg__/`, so the stamp is a fixed point). The stamped tree is
-    // a hardlink staging mirror — the author's source is never mutated.
+    // `/__tpkg__/`, so the stamp is a fixed point). The stamp is
+    // format-neutral (spec 20 §6: the staged hardlink mirror rides ahead
+    // of writer selection) — the author's source is never mutated.
     let staged = stamp_tree_hash(source_dir)?;
     let staged_tree;
     let source = match &staged {
@@ -1006,17 +1029,57 @@ pub fn cmd_mkimage(format: &str, source_dir: &Path, output: &Path) -> Result<(),
         std::fs::remove_file(output)
             .map_err(|e| (format!("cannot replace {}: {e}", output.display()), 1))?;
     }
-    let mut writer = dwarfs_t::Writer::new(dwarfs_t::WriterOptions::default())
-        .map_err(|e| (format!("dwarfs writer: {e}"), 1))?;
-    writer.add_tree(source, "/").map_err(|e| {
+    match fmt.as_str() {
+        "dwarfs" => {
+            let mut writer = dwarfs_t::Writer::new(dwarfs_t::WriterOptions::default())
+                .map_err(|e| (format!("dwarfs writer: {e}"), 1))?;
+            writer.add_tree(source, "/").map_err(|e| {
+                (
+                    format!("dwarfs writer: scanning {}: {e}", source.display()),
+                    1,
+                )
+            })?;
+            writer
+                .write(output)
+                .map_err(|e| (format!("dwarfs writer: {}: {e}", output.display()), 1))?;
+        }
+        "limnifs" => write_limnifs_image(source, output)?,
+        _ => unreachable!("the format gate above admits only dwarfs/limnifs"),
+    }
+    Ok(())
+}
+
+/// `mkimage --format limnifs`: the tebako single-file layout (spec 20
+/// §4) — the writer's manifest bytes verbatim, then every slab appended
+/// in slab-ordinal order. Dictionaries are disabled: a dictionary
+/// section would sit between the history section and the slab region
+/// (and reference per-drop dictionary ids), neither of which the v1
+/// backend resolves.
+fn write_limnifs_image(source: &Path, output: &Path) -> Result<(), (String, i32)> {
+    let mut config = limnifs_write::WriteConfig::default_v0_1();
+    config.dictionaries.enabled = false;
+    let artifact = limnifs_write::write_directory_with_config(source, &config).map_err(|e| {
         (
-            format!("dwarfs writer: scanning {}: {e}", source.display()),
+            format!("limnifs writer: scanning {}: {e}", source.display()),
             1,
         )
     })?;
-    writer
-        .write(output)
-        .map_err(|e| (format!("dwarfs writer: {}: {e}", output.display()), 1))?;
+    if let Some(sidecar) = &artifact.metadata_sidecar {
+        return Err((
+            format!(
+                "limnifs writer: the tree's metadata externalized ({} bytes to '{}') — a self-contained tebako image inlines the metadata; the tree is too large for this format today",
+                sidecar.bytes.len(),
+                sidecar.locator
+            ),
+            1,
+        ));
+    }
+    let mut image = artifact.bytes;
+    for slab in &artifact.slabs {
+        image.extend_from_slice(&slab.bytes);
+    }
+    std::fs::write(output, &image)
+        .map_err(|e| (format!("limnifs writer: {}: {e}", output.display()), 1))?;
     Ok(())
 }
 
@@ -1418,5 +1481,37 @@ mod tests {
         // (No unterminated-'[' case: the libcs diverge there — BSD
         // refuses the match, glibc and the windows matcher treat '[' as
         // a literal — so the shared oracle cannot pin it.)
+    }
+
+    /// `mkimage --format limnifs` (spec 20 §6): the image detects as
+    /// limnifs and the backend serves the tree back. Windows ships a
+    /// dwarfs-only tfs, so the mount half of the check is POSIX-only —
+    /// the unsupported-format named error is platform-independent.
+    #[test]
+    fn mkimage_limnifs_writes_a_mountable_image() {
+        let dir = std::env::temp_dir().join(format!("tfs-cli-mkimage-{}", std::process::id()));
+        let src = dir.join("src");
+        std::fs::create_dir_all(src.join("sub")).unwrap();
+        std::fs::write(src.join("hello.txt"), b"hello from mkimage").unwrap();
+        std::fs::write(src.join("sub").join("big.bin"), vec![0xABu8; 120_000]).unwrap();
+        let out = dir.join("fs.tfs");
+        cmd_mkimage("limnifs", &src, &out).expect("mkimage limnifs");
+
+        #[cfg(not(windows))]
+        {
+            let mount = tfs::mount::build_from_file(&out.to_string_lossy(), "/mnt")
+                .expect("the written image mounts");
+            assert_eq!(mount.backend.name().to_str().unwrap(), "LimniFS");
+            assert_eq!(mount.backend.stat("hello.txt").unwrap().size, 18);
+            let mut buf = vec![0u8; 120_000];
+            let n = mount.backend.pread("sub/big.bin", &mut buf, 0).unwrap();
+            assert_eq!(n, 120_000);
+            assert!(buf.iter().all(|&b| b == 0xAB));
+        }
+
+        // The unsupported-format named error lists the new supported set.
+        let (msg, _) = cmd_mkimage("ext4", &src, &out).unwrap_err();
+        assert!(msg.contains("supported: dwarfs, limnifs"), "{msg}");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/tfs-cli/src/main.rs
+++ b/crates/tfs-cli/src/main.rs
@@ -10,7 +10,7 @@
 //! tfs stat [-v] <image> <path>
 //! tfs extract [-v] [-q|--quiet] [-d|--dest <dir>] <image> [files...]
 //! tfs find [-v] <image> <pattern>
-//! tfs mkimage --format dwarfs <srcdir> -o <img> [-v]
+//! tfs mkimage --format dwarfs|limnifs <srcdir> -o <img> [-v]
 //! tfs exec <image>[:mount] [--image <image:mount>]... [--jail <spec>] -- <cmd> [args...]
 //! tfs encrypt <image> -o <img> --recipient <pubkey>... [--subtree <path>=<pubkey>]...
 //! tfs encrypt <image> -o <img> --rewrap --key <secret> --recipient <pubkey>...
@@ -398,8 +398,11 @@ fn cmd_mkimage_main(rest: &[String]) -> ExitCode {
         Ok(a) => a,
         Err(e) => return fail(&format!("Error: {e}")),
     };
-    if let Err(e) = a.positional_count(1, 1, "tfs mkimage --format dwarfs <srcdir> --output <img>")
-    {
+    if let Err(e) = a.positional_count(
+        1,
+        1,
+        "tfs mkimage --format dwarfs|limnifs <srcdir> --output <img>",
+    ) {
         return fail(&format!("Error: {e}"));
     }
     let Some(format) = a.format else {
@@ -626,7 +629,9 @@ fn print_help() {
     println!("  stat     Show file/directory metadata");
     println!("  extract  Extract archive contents (-d dest, default .)");
     println!("  find     Search for files by name glob");
-    println!("  mkimage  Create a dwarfs (.tfs) image from a directory (in-process writer)");
+    println!(
+        "  mkimage  Create a dwarfs or limnifs (.tfs) image from a directory (in-process writer)"
+    );
     println!("  exec     Run a dynamic native command with the VFS injected (preload shim)");
     println!("  encrypt  Encrypt an image to recipients (-o, --recipient, --subtree;");
     println!("           --rewrap --key rotates grants without touching the bulk)");

--- a/crates/tfs-cli/tests/mkimage.rs
+++ b/crates/tfs-cli/tests/mkimage.rs
@@ -89,6 +89,60 @@ fn mkimage_roundtrip_ls_cat_stat_extract() {
     assert_eq!(std::fs::read(dest.join("sub/two.txt")).unwrap(), b"two");
 }
 
+/// The limnifs writer path (spec 20 §6): same tree in, same CLI
+/// answers out — `Type: LimniFS` comes off the mounted backend, never
+/// the extension.
+#[test]
+#[cfg(not(windows))] // windows ships a dwarfs-only tfs (TODO.v2-1/02)
+fn mkimage_limnifs_roundtrip_ls_cat_stat_extract() {
+    let w = TempDir::new("mkimglim");
+    let src = make_source(&w);
+    let img = w.0.join("app.tfs");
+
+    let (rc, _, err) = run(
+        &[
+            "mkimage",
+            "--format",
+            "limnifs",
+            src.to_str().unwrap(),
+            "-o",
+            img.to_str().unwrap(),
+        ],
+        &w.0,
+    );
+    assert_eq!((rc, err.as_str()), (0, ""), "mkimage must succeed");
+    assert!(img.is_file());
+
+    let (rc, out, _) = run(&["info", img.to_str().unwrap()], &w.0);
+    assert_eq!(rc, 0);
+    assert!(out.contains("Type: LimniFS"), "{out}");
+    assert!(out.contains("Files: 3"), "{out}");
+    assert!(out.contains("Directories: 1"), "{out}");
+
+    let (rc, out, _) = run(&["tree", img.to_str().unwrap()], &w.0);
+    assert_eq!(rc, 0);
+    assert!(out.contains("one.txt"), "{out}");
+    assert!(out.contains("two.txt"), "{out}");
+
+    let (rc, out, _) = run(&["cat", img.to_str().unwrap(), "sub/three.txt"], &w.0);
+    assert_eq!((rc, out.as_str()), (0, "three"));
+
+    let dest = w.0.join("extracted");
+    std::fs::create_dir_all(&dest).unwrap();
+    let (rc, _, _) = run(
+        &[
+            "extract",
+            "-d",
+            dest.to_str().unwrap(),
+            img.to_str().unwrap(),
+        ],
+        &w.0,
+    );
+    assert_eq!(rc, 0);
+    assert_eq!(std::fs::read(dest.join("one.txt")).unwrap(), b"one");
+    assert_eq!(std::fs::read(dest.join("sub/two.txt")).unwrap(), b"two");
+}
+
 #[test]
 fn mkimage_overwrites_existing_output() {
     let w = TempDir::new("mkimg3");
@@ -118,7 +172,7 @@ fn mkimage_error_surfaces() {
     for (args, expect) in [
         (
             vec!["mkimage", "--format", "zip", src.to_str().unwrap(), "-o", "x.zip"],
-            "Error: mkimage failed: mkimage --format zip is not supported: the zip backend is read-only (only 'dwarfs' can be written)\n",
+            "Error: mkimage failed: mkimage --format zip is not supported: the zip backend is read-only (only 'dwarfs' and 'limnifs' can be written)\n",
         ),
         (
             vec!["mkimage", "--format", "squashfs", src.to_str().unwrap(), "-o", "x.sqfs"],
@@ -126,7 +180,7 @@ fn mkimage_error_surfaces() {
         ),
         (
             vec!["mkimage", "--format", "foo", src.to_str().unwrap(), "-o", "x"],
-            "Error: mkimage failed: unsupported image format 'foo' (supported: dwarfs)\n",
+            "Error: mkimage failed: unsupported image format 'foo' (supported: dwarfs, limnifs)\n",
         ),
         (
             vec!["mkimage", "--format", "dwarfs", "nosuchdir", "-o", "x.tfs"],

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -42,6 +42,10 @@ ruzstd = "0.7"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs", optional = true }
 # libsquashfs (squashfs-tools-ng) via vcpkg for the SquashFS backend.
 sqfs-sys = { version = "0.1.0", path = "../sqfs-sys", optional = true }
+# The LimniFS backend (spec 20): the pure-Rust limnifs-core reader — no
+# system dependencies, `#![forbid(unsafe_code)]` upstream. Path dep until
+# limnifs has a release to pin against (same standing as dwarfs-t).
+limnifs-core = { version = "0.2", path = "../../../../limnifs/limnifs/limnifs-core", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
@@ -65,10 +69,14 @@ getrandom = "0.2"
 # unproven (TODO.v2-1/08), so windows consumers take
 # default-features = false, features = ["vendored-dwarfs"] and an ENC
 # mount fails with named ENOTSUP.
-default = ["vendored-dwarfs", "vendored-squashfs", "enc"]
+# `backend-limnifs` (default): the LimniFS backend (spec 20) via the
+# pure-Rust limnifs-core — the first of the `backend-*` feature family;
+# the `vendored-*` features migrate to it as aliases per spec 20 §5.
+default = ["vendored-dwarfs", "vendored-squashfs", "enc", "backend-limnifs"]
 vendored-dwarfs = ["dep:dwarfs-t"]
 vendored-squashfs = ["dep:sqfs-sys"]
 enc = ["dep:tebako-signer"]
+backend-limnifs = ["dep:limnifs-core"]
 
 [dev-dependencies]
 # Tempdir scaffolding for backend tests (large-archive RSS fixtures).
@@ -77,4 +85,7 @@ tempfile = "3"
 rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
 # gzip trailer checksums in tar-backend test fixtures.
 crc32fast = "1"
+# LimniFS golden fixtures are written in-process (never a limni binary) —
+# test-only, never linked into the shipped library.
+limnifs-write = { version = "0.2", path = "../../../../limnifs/limnifs/limnifs-write" }
 

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -45,7 +45,7 @@ sqfs-sys = { version = "0.1.0", path = "../sqfs-sys", optional = true }
 # The LimniFS backend (spec 20): the pure-Rust limnifs-core reader — no
 # system dependencies, `#![forbid(unsafe_code)]` upstream. Path dep until
 # limnifs has a release to pin against (same standing as dwarfs-t).
-limnifs-core = { version = "0.2", path = "../../../../limnifs/limnifs/limnifs-core", optional = true }
+limnifs-core = { git = "https://github.com/limnifs/limnifs", rev = "14ab01d017af054d24ff002775e17663146cdfad", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
@@ -87,5 +87,5 @@ rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
 crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —
 # test-only, never linked into the shipped library.
-limnifs-write = { version = "0.2", path = "../../../../limnifs/limnifs/limnifs-write" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "14ab01d017af054d24ff002775e17663146cdfad" }
 

--- a/crates/tfs/src/backend.rs
+++ b/crates/tfs/src/backend.rs
@@ -132,6 +132,8 @@ pub enum ImageFormat {
     Dwarfs,
     /// SquashFS image ("hsqs").
     Squashfs,
+    /// LimniFS image ("LMFS" manifest magic — spec 20).
+    Limnifs,
     /// tar stream (no strong magic — header-checksum heuristic, LAST).
     Tar,
     /// gzip-wrapped tar ("\x1f\x8b" + deflate method byte).
@@ -143,8 +145,10 @@ pub enum ImageFormat {
 }
 
 /// Sniff the archive format from its first bytes (spec 11 §3: strong magic
-/// first, the weak tar heuristic LAST). `magic` should carry at least one
-/// 512-byte tar block for the tar heuristic to fire.
+/// first, the weak tar heuristic LAST; spec 20 §3 locks the probe order:
+/// zip, dwarfs, squashfs, limnifs, tar envelopes, then the heuristic).
+/// `magic` should carry at least one 512-byte tar block for the tar
+/// heuristic to fire.
 pub fn detect_format(magic: &[u8]) -> ImageFormat {
     if magic.starts_with(b"PK\x03\x04") || magic.starts_with(b"PK\x05\x06") {
         ImageFormat::Zip
@@ -152,6 +156,11 @@ pub fn detect_format(magic: &[u8]) -> ImageFormat {
         ImageFormat::Dwarfs
     } else if magic.starts_with(b"hsqs") {
         ImageFormat::Squashfs
+    } else if magic.starts_with(b"LMFS") {
+        // Disjoint 4-byte prefix against every arm above; `LIM1` (the
+        // slab magic) is a section magic inside the image, never an
+        // offset-0 image magic.
+        ImageFormat::Limnifs
     } else if magic.len() >= 3 && magic[0] == 0x1f && magic[1] == 0x8b && magic[2] == 8 {
         // gzip envelope; the only gzip payload TFS mounts is tar.
         ImageFormat::TarGz

--- a/crates/tfs/src/backends_limnifs.rs
+++ b/crates/tfs/src/backends_limnifs.rs
@@ -1,0 +1,1015 @@
+//! LimniFS backend (spec 20, image format 5) over `limnifs-core` — pure
+//! safe Rust (no FFI, so the `unsafe`-at-FFI-boundary rule never
+//! triggers), read-only forever (the transforms law: COW/ENC stack
+//! above it unchanged).
+//!
+//! ## The self-contained image layout
+//!
+//! A stock LimniFS artifact is a manifest plus `file:`-located sidecar
+//! slabs. A tebako payload is ONE file, so the tebako writer path
+//! (`tfs mkimage --format limnifs`, `tebako press --format limnifs`)
+//! emits the writer's manifest bytes verbatim followed by every slab in
+//! slab-ordinal order:
+//!
+//! ```text
+//! [manifest header][feature flags][metadata_reference][slab_index]
+//! [history][slab 0 (LIM1…)][slab 1 (LIM1…)]…
+//! ```
+//!
+//! Mount-open therefore parses, from the image byte slice (spec 20 §4):
+//! `ManifestCursor` → `parse_manifest_header` → `parse_metadata_reference`
+//! → `parse_metadata_blob` (inline metadata is REQUIRED — a `file:`
+//! metadata sidecar would be a second artifact) → `parse_slab_index` →
+//! `parse_history` → `parse_slab` per appended slab (index only — no
+//! upfront decompression; drops materialize per read window).
+//!
+//! `LIM1` is a SECTION magic inside the image, never an offset-0 image
+//! magic — detection keys on `LMFS` only (spec 20 §3).
+//!
+//! ## Error mapping (spec 20 §4, errno-valued, named, never silent)
+//!
+//! `TooShort`/`BadMagic`/`Corrupt` → `EINVAL` at mount-open (not a
+//! limnifs image / broken structural invariant / metadata checksum);
+//! `UnsupportedFeature` → `ENOTSUP` naming the feature (on the
+//! `TEBAKO_DEBUG` log — the errno channel carries the code); while
+//! serving, `Corrupt` → `EIO`, `UnsupportedFeature` → `ENOTSUP`, path
+//! misses → `ENOENT`.
+
+use std::collections::HashMap;
+
+use limnifs_core::{
+    parse_feature_flags_section, parse_history, parse_manifest_header, parse_metadata_blob,
+    parse_metadata_reference, parse_slab, parse_slab_header, parse_slab_index, ContentHandle,
+    CoreError, DropRecord, Inode, ManifestCursor, ManifestHeader, MetadataBlob, SLAB_HEADER_LEN,
+};
+
+use crate::backend::{Backend, EntryType, RawDirEntry, RawStat};
+
+/// The slab section magic (`LIM1`) — a section marker inside the
+/// image, checked at the slab-region boundary (spec 20 §3).
+const SLAB_MAGIC: &[u8; 4] = b"LIM1";
+
+/// Nanoseconds per second, for the `mtime_ns` → `RawStat` seconds
+/// truncation (spec 20 §8).
+const NANOS_PER_SEC: u64 = 1_000_000_000;
+
+/// A mounted LimniFS image.
+#[derive(Debug)]
+pub struct LimnifsBackend {
+    /// The whole image (manifest + appended slabs), owned.
+    image: Vec<u8>,
+    /// Parsed manifest header (versions for the info surface).
+    header: ManifestHeader,
+    /// The parsed metadata blob (inodes + directory nodes).
+    blob: MetadataBlob,
+    /// Path → inode number (keys relative, no leading slash; `""` is
+    /// the root), built once at open (O(N)) for O(1) lookups.
+    paths: HashMap<String, u64>,
+    /// The root directory's inode number.
+    root: u64,
+    /// One entry per appended slab: the absolute offset of its solid
+    /// window inside `image`.
+    slab_windows: Vec<usize>,
+    /// Drop id → (slab ordinal, drop record), built once at open.
+    drops: HashMap<[u8; 32], (usize, DropRecord)>,
+    /// Section spans for `image_info_json` (`tfs info --backend-json`).
+    sections: Vec<(&'static str, usize)>,
+    /// Per-slab drop counts (the info surface).
+    slab_drop_counts: Vec<usize>,
+}
+
+/// Mount-open mapping (spec 20 §4): `TooShort`/`BadMagic`/`Corrupt` →
+/// `EINVAL`, `UnsupportedFeature` → `ENOTSUP`. The named reason rides
+/// the debug log — the errno channel carries the code.
+fn open_error(e: CoreError) -> i32 {
+    let errno = match &e {
+        CoreError::UnsupportedFeature { .. } => libc::ENOTSUP,
+        CoreError::TooShort { .. } | CoreError::BadMagic { .. } | CoreError::Corrupt { .. } => {
+            libc::EINVAL
+        }
+    };
+    tebako_log::log!(
+        tebako_log::Level::Trace,
+        "tfs",
+        "limnifs mount-open failed: {e} (errno {errno})"
+    );
+    errno
+}
+
+/// A feature the adapter does not implement is refused by NAME on the
+/// debug log and by `ENOTSUP` on the errno channel (spec 20 §5's
+/// compiled-out/unsupported rule: never a silent re-route).
+fn unsupported(what: String) -> i32 {
+    tebako_log::log!(
+        tebako_log::Level::Warn,
+        "tfs",
+        "limnifs: unsupported feature: {what} (ENOTSUP)"
+    );
+    libc::ENOTSUP
+}
+
+/// Serving-side mapping (spec 20 §4): `Corrupt` → `EIO`,
+/// `UnsupportedFeature` → `ENOTSUP`.
+fn serve_error(e: CoreError) -> i32 {
+    match &e {
+        CoreError::UnsupportedFeature { .. } => libc::ENOTSUP,
+        CoreError::TooShort { .. } | CoreError::BadMagic { .. } | CoreError::Corrupt { .. } => {
+            libc::EIO
+        }
+    }
+}
+
+/// Normalize an in-image path: no leading or trailing `/`, `""` for root.
+fn normalize(path: &str) -> &str {
+    path.trim_start_matches('/').trim_end_matches('/')
+}
+
+impl LimnifsBackend {
+    /// Open a self-contained limnifs image (module doc layout) held in
+    /// memory. Every mount source (whole file, file region, memory) is
+    /// read into one owned byte slice and funnels here — spec 11 §5's
+    /// four mount-source kinds all serve one `&[u8]` core.
+    pub fn from_image(data: Vec<u8>) -> Result<LimnifsBackend, i32> {
+        let mut cursor = ManifestCursor::new(&data);
+
+        let header = parse_manifest_header(&mut cursor).map_err(open_error)?;
+        let header_end = cursor.position();
+
+        let flags = parse_feature_flags_section(&mut cursor).map_err(open_error)?;
+        for entry in &flags.entries {
+            if entry.required {
+                return Err(unsupported(format!(
+                    "required feature flag 0x{:04X}",
+                    entry.flag_id
+                )));
+            }
+            // Optional flags are silently ignored (limnifs spec §18's
+            // unknown-flag policy).
+        }
+        let flags_end = cursor.position();
+
+        let meta_ref = parse_metadata_reference(&mut cursor).map_err(open_error)?;
+        let meta_ref_end = cursor.position();
+        let Some(blob_bytes) = meta_ref.inline_metadata.as_deref() else {
+            return Err(unsupported(
+                "external metadata locator (a self-contained tebako image inlines the metadata blob)"
+                    .to_string(),
+            ));
+        };
+        // The reference's hash commits to the uncompressed blob: a
+        // checksum failure is Corrupt at mount-open → EINVAL (spec 20 §4).
+        if limnifs_core::hash_section(blob_bytes) != meta_ref.metadata_hash {
+            return Err(open_error(CoreError::Corrupt {
+                reason: "metadata blob does not match the metadata_reference hash".to_string(),
+            }));
+        }
+        let blob = parse_metadata_blob(&mut ManifestCursor::new(blob_bytes)).map_err(open_error)?;
+        let root = blob.root_inode_number().ok_or_else(|| {
+            open_error(CoreError::Corrupt {
+                reason: "no unique root directory inode".to_string(),
+            })
+        })?;
+
+        let mut paths: HashMap<String, u64> =
+            HashMap::with_capacity(blob.inodes.len().saturating_add(1));
+        paths.insert(String::new(), root);
+        for (path, number) in blob.build_path_index() {
+            // The limnifs index is absolute (`/a/b`); the Backend trait
+            // speaks relative paths (`a/b`, `""` for root).
+            paths.insert(normalize(&path).to_string(), number);
+        }
+
+        let slab_index = parse_slab_index(&mut cursor).map_err(open_error)?;
+        let slab_index_end = cursor.position();
+
+        // The writer always emits a history section after the slab
+        // index; parsing it lands the cursor exactly on the slab region.
+        let _history = parse_history(&mut cursor).map_err(open_error)?;
+        let history_end = cursor.position();
+
+        let sections: Vec<(&'static str, usize)> = vec![
+            ("MANIFEST_HEADER", header_end),
+            ("FEATURE_FLAGS", flags_end - header_end),
+            ("METADATA_REFERENCE", meta_ref_end - flags_end),
+            ("SLAB_INDEX", slab_index_end - meta_ref_end),
+            ("HISTORY", history_end - slab_index_end),
+        ];
+
+        let mut slab_windows: Vec<usize> = Vec::with_capacity(slab_index.len());
+        let mut slab_drop_counts: Vec<usize> = Vec::with_capacity(slab_index.len());
+        let mut drops: HashMap<[u8; 32], (usize, DropRecord)> = HashMap::new();
+        let mut pos = history_end;
+        if slab_index.is_empty() {
+            if pos != data.len() {
+                return Err(open_error(CoreError::Corrupt {
+                    reason: format!(
+                        "{} trailing bytes after the manifest of a slab-less image",
+                        data.len() - pos
+                    ),
+                }));
+            }
+        } else {
+            for entry in &slab_index.entries {
+                if data.len() < pos.saturating_add(SLAB_HEADER_LEN)
+                    || &data[pos..pos.saturating_add(4)] != SLAB_MAGIC
+                {
+                    // Slab bytes are missing (external `file:` locators —
+                    // a second artifact) or a trailing manifest section
+                    // this adapter does not know (profile descriptor,
+                    // dictionary, …) sits before the slab region.
+                    return Err(unsupported(format!(
+                        "slab ordinal {} is not appended to the image (external locator or unknown trailing section)",
+                        entry.slab_id.ordinal
+                    )));
+                }
+                let mut slab_cursor = ManifestCursor::at_start(&data, pos).map_err(open_error)?;
+                let slab_header = parse_slab_header(&mut slab_cursor).map_err(open_error)?;
+                if slab_header.is_sealed() {
+                    return Err(unsupported(
+                        "AEAD-sealed slab (spec 20 §7: tebako-side encryption stays the spec-10 transform)"
+                            .to_string(),
+                    ));
+                }
+                if slab_header.slab_id != entry.slab_id {
+                    return Err(open_error(CoreError::Corrupt {
+                        reason: format!(
+                            "appended slab id (ordinal {}) does not match the slab_index entry (ordinal {})",
+                            slab_header.slab_id.ordinal, entry.slab_id.ordinal
+                        ),
+                    }));
+                }
+                let total = usize::try_from(slab_header.total_length).map_err(|_| {
+                    open_error(CoreError::Corrupt {
+                        reason: "slab total_length exceeds usize".to_string(),
+                    })
+                })?;
+                let Some(end) = pos.checked_add(total) else {
+                    return Err(libc::EINVAL);
+                };
+                if end > data.len() {
+                    return Err(open_error(CoreError::TooShort {
+                        have: data.len() - pos,
+                        need: total,
+                    }));
+                }
+                let view = parse_slab(&data[pos..end]).map_err(open_error)?;
+                slab_drop_counts.push(view.drop_records().len());
+                for record in view.drop_records() {
+                    drops.insert(*record.drop_id.as_bytes(), (slab_windows.len(), *record));
+                }
+                slab_windows.push(pos + view.solid_window_offset());
+                pos = end;
+            }
+            if pos != data.len() {
+                return Err(open_error(CoreError::Corrupt {
+                    reason: format!(
+                        "{} trailing bytes after the last appended slab",
+                        data.len() - pos
+                    ),
+                }));
+            }
+        }
+
+        Ok(LimnifsBackend {
+            image: data,
+            header,
+            blob,
+            paths,
+            root,
+            slab_windows,
+            drops,
+            sections,
+            slab_drop_counts,
+        })
+    }
+
+    /// The inode for a Backend-convention path, `ENOENT` when missing.
+    fn inode_for(&self, path: &str) -> Result<&Inode, i32> {
+        let number = if path.is_empty() {
+            self.root
+        } else {
+            *self.paths.get(path).ok_or(libc::ENOENT)?
+        };
+        self.blob.inode_by_number(number).ok_or_else(|| {
+            tebako_log::log!(
+                tebako_log::Level::Trace,
+                "tfs",
+                "limnifs: dangling inode number {number} (EIO)"
+            );
+            libc::EIO
+        })
+    }
+
+    /// The materialized plaintext of one drop (on-demand, per-class
+    /// decompression — spec 20 §4; no slab access for inline drops ever
+    /// reaches here).
+    fn drop_plaintext(&self, drop_id: &[u8; 32]) -> Result<Vec<u8>, i32> {
+        let Some((slab, record)) = self.drops.get(drop_id) else {
+            // A slice references a drop no slab carries: a broken
+            // cross-reference, i.e. corruption while serving.
+            return Err(libc::EIO);
+        };
+        if record.representation.aead != 0x00 {
+            return Err(unsupported(format!(
+                "drop AEAD 0x{:02X} (only plaintext drops are mounted)",
+                record.representation.aead
+            )));
+        }
+        if record.solid_window_index != 0 {
+            return Err(unsupported(format!(
+                "solid_window_index {} (single-window slabs only)",
+                record.solid_window_index
+            )));
+        }
+        if record.dict_id != limnifs_core::drop_record::NO_DICT {
+            return Err(unsupported(
+                "dictionary-compressed drop (the tebako writer path emits no dictionaries)"
+                    .to_string(),
+            ));
+        }
+        let start = self.slab_windows[*slab]
+            .saturating_add(usize::try_from(record.offset_in_window).map_err(|_| libc::EIO)?);
+        let end =
+            start.saturating_add(usize::try_from(record.len_in_window).map_err(|_| libc::EIO)?);
+        if end > self.image.len() {
+            return Err(libc::EIO);
+        }
+        limnifs_core::codec::decompress(
+            record.representation.codec,
+            &self.image[start..end],
+            record.plaintext_len,
+        )
+        .map_err(serve_error)
+    }
+
+    /// The byte length a stat reports for a regular file's content
+    /// handle: inline length for `InlineData` (`SharedInline` resolves
+    /// to `InlineData` at parse), summed `SliceRef` spans for
+    /// `SliceMap` (spec 20 §4).
+    fn content_size(inode: &Inode) -> i64 {
+        match &inode.content_handle {
+            ContentHandle::InlineData(data) => data.len() as i64,
+            ContentHandle::SliceMap(slices) => slices
+                .iter()
+                .map(|s| (s.file_byte_end - s.file_byte_start) as i64)
+                .sum(),
+            ContentHandle::Symlink(target) => target.len() as i64,
+            ContentHandle::SharedInline(_) => 0, // unreachable post-parse (EIO on read)
+            ContentHandle::Directory(_) | ContentHandle::Device(_) | ContentHandle::Pipe(_) => 0,
+        }
+    }
+}
+
+impl Backend for LimnifsBackend {
+    fn name(&self) -> &'static std::ffi::CStr {
+        c"LimniFS"
+    }
+
+    fn stat(&self, path: &str) -> Result<RawStat, i32> {
+        let inode = self.inode_for(normalize(path))?;
+        let entry_type = match inode.file_type() {
+            limnifs_core::S_IFREG => EntryType::File,
+            limnifs_core::S_IFDIR => EntryType::Directory,
+            limnifs_core::S_IFLNK => EntryType::Symlink,
+            _ => EntryType::Other,
+        };
+        Ok(RawStat {
+            entry_type,
+            perms: inode.mode & 0o7777,
+            size: Self::content_size(inode),
+            mtime: (inode.mtime_ns / NANOS_PER_SEC) as i64,
+        })
+    }
+
+    fn pread(&self, path: &str, buf: &mut [u8], offset: u64) -> Result<usize, i32> {
+        let inode = self.inode_for(normalize(path))?;
+        match &inode.content_handle {
+            // Inline drops: served straight from the metadata blob — no
+            // slab access, no decompression (spec 20 §4).
+            ContentHandle::InlineData(data) => {
+                let size = data.len() as u64;
+                if offset >= size || buf.is_empty() {
+                    return Ok(0);
+                }
+                let want = std::cmp::min(buf.len() as u64, size - offset) as usize;
+                buf[..want].copy_from_slice(&data[offset as usize..offset as usize + want]);
+                Ok(want)
+            }
+            // Slab drops: only the drops intersecting the requested
+            // window are materialized (spec 20 §4). Callers clamp to
+            // EOF; short reads allowed.
+            ContentHandle::SliceMap(slices) => {
+                let size: u64 = slices
+                    .iter()
+                    .map(|s| s.file_byte_end - s.file_byte_start)
+                    .sum();
+                if offset >= size || buf.is_empty() {
+                    return Ok(0);
+                }
+                let win_start = offset;
+                let win_end = offset + std::cmp::min(buf.len() as u64, size - offset);
+                let mut pos = win_start; // expected contiguous coverage start
+                let mut done = 0usize;
+                for slice in slices {
+                    if slice.file_byte_end <= win_start {
+                        continue;
+                    }
+                    if slice.file_byte_start >= win_end {
+                        break;
+                    }
+                    let span = slice.file_byte_end - slice.file_byte_start;
+                    if u64::from(slice.drop_byte_len) != span {
+                        return Err(libc::EIO); // a partial-drop mapping we cannot serve
+                    }
+                    if slice.file_byte_start > pos {
+                        return Err(libc::EIO); // a hole in the file's coverage
+                    }
+                    let lo = std::cmp::max(pos, slice.file_byte_start);
+                    let hi = std::cmp::min(win_end, slice.file_byte_end);
+                    if lo >= hi {
+                        continue;
+                    }
+                    let plain = self.drop_plaintext(slice.drop_id.as_bytes())?;
+                    let ds =
+                        (u64::from(slice.drop_byte_start) + (lo - slice.file_byte_start)) as usize;
+                    let de =
+                        (u64::from(slice.drop_byte_start) + (hi - slice.file_byte_start)) as usize;
+                    if de > plain.len() {
+                        return Err(libc::EIO);
+                    }
+                    let at = (lo - win_start) as usize;
+                    buf[at..at + (hi - lo) as usize].copy_from_slice(&plain[ds..de]);
+                    done += (hi - lo) as usize;
+                    pos = hi;
+                }
+                Ok(done)
+            }
+            ContentHandle::SharedInline(_) => Err(libc::EIO), // unresolved shared table
+            ContentHandle::Directory(_) => Err(libc::EISDIR),
+            ContentHandle::Symlink(_) | ContentHandle::Device(_) | ContentHandle::Pipe(_) => {
+                Err(libc::EINVAL)
+            }
+        }
+    }
+
+    fn read_dir(&self, path: &str) -> Result<Vec<RawDirEntry>, i32> {
+        let inode = self.inode_for(normalize(path))?;
+        let ContentHandle::Directory(hash) = &inode.content_handle else {
+            return Err(libc::ENOTDIR);
+        };
+        let node = self.blob.dir_node_by_hash(hash).ok_or(libc::EIO)?;
+        Ok(node
+            .entries
+            .iter()
+            .map(|e| RawDirEntry {
+                name: e.name.clone(),
+                is_dir: e.entry_type == limnifs_core::directory_node::entry_type::DIRECTORY,
+            })
+            .collect())
+    }
+
+    fn read_link(&self, path: &str) -> Result<String, i32> {
+        let inode = self.inode_for(normalize(path))?;
+        match &inode.content_handle {
+            ContentHandle::Symlink(target) => Ok(target.clone()),
+            _ => Err(libc::EINVAL),
+        }
+    }
+
+    fn image_info_json(&self) -> Option<String> {
+        let mut json = format!(
+            "{{\"format\":\"limnifs\",\"versions\":{{\"drop_store\":{},\"metadata\":{},\"manifest\":{}}},\"inode_count\":{},\"directory_count\":{},\"slab_count\":{},\"drop_count\":{},\"image_bytes\":{},\"sections\":[",
+            self.header.drop_store_version,
+            self.header.metadata_version,
+            self.header.manifest_version,
+            self.blob.inodes.len(),
+            self.blob.dir_nodes.len(),
+            self.slab_windows.len(),
+            self.drops.len(),
+            self.image.len(),
+        );
+        let mut first = true;
+        for (name, size) in &self.sections {
+            if !first {
+                json.push(',');
+            }
+            first = false;
+            json.push_str(&format!("{{\"type\":\"{name}\",\"size\":{size}}}"));
+        }
+        for (ordinal, drops) in self.slab_drop_counts.iter().enumerate() {
+            json.push_str(&format!(
+                ",{{\"type\":\"SLAB\",\"ordinal\":{ordinal},\"drops\":{drops}}}"
+            ));
+        }
+        json.push_str("]}");
+        Some(json)
+    }
+}
+
+// ---------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------
+
+/// Golden fixtures are built IN-PROCESS with limnifs-write (never a
+/// `limni` binary — invariant 1) in a tempdir, then mounted through the
+/// backend and the mount constructors. The dwarfs backend is the parity
+/// oracle (spec 20 §8): same tree in → same logical VFS answers out.
+#[cfg(all(test, feature = "backend-limnifs"))]
+mod tests {
+    use super::*;
+    use crate::backend::detect_format;
+    use crate::backend::ImageFormat;
+
+    /// Build the tebako single-file layout (module doc): the writer's
+    /// manifest bytes verbatim + every slab appended in ordinal order.
+    /// Dictionaries are disabled so the manifest section order is the
+    /// fixed writer sequence the mount-open walk relies on.
+    fn build_image(dir: &std::path::Path) -> Vec<u8> {
+        let mut config = limnifs_write::WriteConfig::default_v0_1();
+        config.dictionaries.enabled = false;
+        let artifact =
+            limnifs_write::write_directory_with_config(dir, &config).expect("write succeeds");
+        assert!(
+            artifact.metadata_sidecar.is_none(),
+            "the fixture tree must keep its metadata inline"
+        );
+        let mut image = artifact.bytes;
+        for slab in &artifact.slabs {
+            image.extend_from_slice(&slab.bytes);
+        }
+        image
+    }
+
+    /// Deterministic 200_000-byte payload (multi-drop slab coverage).
+    fn big_payload() -> Vec<u8> {
+        (0..200_000u32)
+            .map(|i| ((i.wrapping_mul(2654435761) >> 13) & 0xFF) as u8)
+            .collect()
+    }
+
+    /// The fixture tree: an inline file, a nested inline file, and a
+    /// slab-backed file (> 4096-byte inline threshold).
+    fn fixture_tree() -> (tempfile::TempDir, Vec<u8>) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        std::fs::write(root.join("hello.txt"), b"hello, limnifs\n").unwrap();
+        std::fs::write(root.join("sub").join("nested.txt"), b"nested content here").unwrap();
+        std::fs::write(root.join("big.bin"), big_payload()).unwrap();
+        let image = build_image(root);
+        (tmp, image)
+    }
+
+    #[test]
+    fn lmfs_magic_detects_limnifs() {
+        let mut magic = [0u8; 512];
+        magic[..4].copy_from_slice(b"LMFS");
+        assert_eq!(detect_format(&magic), ImageFormat::Limnifs);
+        // The other strong magics keep their answers (probe order
+        // unchanged above limnifs).
+        magic[..4].copy_from_slice(b"PK\x03\x04");
+        assert_eq!(detect_format(&magic), ImageFormat::Zip);
+        magic[..6].copy_from_slice(b"DWARFS");
+        assert_eq!(detect_format(&magic), ImageFormat::Dwarfs);
+        magic[..4].copy_from_slice(b"hsqs");
+        assert_eq!(detect_format(&magic), ImageFormat::Squashfs);
+        magic[..4].copy_from_slice(b"LMFS");
+        // A slot STAMPED limnifs whose bytes are not limnifs mounts by
+        // what the magic says — here the gzip tar envelope.
+        magic[..4].copy_from_slice(&[0x1f, 0x8b, 8, 0]);
+        assert_eq!(detect_format(&magic), ImageFormat::TarGz);
+        magic[..4].copy_from_slice(b"\x28\xb5\x2f\xfd");
+        assert_eq!(detect_format(&magic), ImageFormat::TarZst);
+    }
+
+    #[test]
+    fn lim1_slab_magic_is_not_an_image_magic() {
+        // `LIM1` is a section magic inside the image (spec 20 §3) —
+        // detection must NOT claim it.
+        let mut magic = [0u8; 512];
+        magic[..4].copy_from_slice(b"LIM1");
+        assert_eq!(detect_format(&magic), ImageFormat::Unknown);
+    }
+
+    #[test]
+    fn stat_reports_types_perms_sizes_and_truncated_mtime() {
+        let (tmp, image) = fixture_tree();
+        let backend = LimnifsBackend::from_image(image).expect("mounts");
+        assert_eq!(backend.name().to_str().unwrap(), "LimniFS");
+
+        let root = backend.stat("").expect("root stats");
+        assert_eq!(root.entry_type, EntryType::Directory);
+        assert_eq!(root.perms, 0o755);
+
+        let hello = backend.stat("hello.txt").expect("file stats");
+        assert_eq!(hello.entry_type, EntryType::File);
+        assert_eq!(hello.perms, 0o644);
+        assert_eq!(hello.size, 15);
+        // mtime truncation: limnifs mtime_ns → RawStat seconds (the
+        // writer takes the host file's real mtime).
+        let host_secs = std::fs::metadata(tmp.path().join("hello.txt"))
+            .unwrap()
+            .modified()
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert_eq!(hello.mtime, host_secs as i64);
+
+        let big = backend.stat("big.bin").expect("big stats");
+        assert_eq!(big.entry_type, EntryType::File);
+        assert_eq!(big.size, 200_000);
+
+        let sub = backend.stat("sub").expect("dir stats");
+        assert_eq!(sub.entry_type, EntryType::Directory);
+
+        assert_eq!(backend.stat("nope").unwrap_err(), libc::ENOENT);
+        assert_eq!(backend.stat("sub/nope").unwrap_err(), libc::ENOENT);
+    }
+
+    #[test]
+    fn has_entry_or_children_is_the_stat_answer() {
+        let (_tmp, image) = fixture_tree();
+        let backend = LimnifsBackend::from_image(image).expect("mounts");
+        assert!(backend.has_entry_or_children(""));
+        assert!(backend.has_entry_or_children("sub"));
+        assert!(backend.has_entry_or_children("hello.txt"));
+        assert!(!backend.has_entry_or_children("nope"));
+        assert!(!backend.has_entry_or_children("sub/nope"));
+    }
+
+    #[test]
+    fn inline_only_tree_has_no_slab_at_all() {
+        // A tree of small files produces NO slab: every read is served
+        // straight from the metadata blob (spec 20 §4's zero-copy path).
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), b"alpha").unwrap();
+        std::fs::write(tmp.path().join("b.txt"), b"beta").unwrap();
+        let backend = LimnifsBackend::from_image(build_image(tmp.path())).expect("mounts");
+        assert!(backend.drops.is_empty());
+        assert!(backend.slab_windows.is_empty());
+        let mut buf = [0u8; 8];
+        assert_eq!(backend.pread("a.txt", &mut buf, 0).unwrap(), 5);
+        assert_eq!(&buf[..5], b"alpha");
+        assert_eq!(backend.pread("b.txt", &mut buf, 1).unwrap(), 3);
+        assert_eq!(&buf[..3], b"eta");
+    }
+
+    #[test]
+    fn pread_inline_drop_never_touches_the_slab() {
+        let (_tmp, image) = fixture_tree();
+        let backend = LimnifsBackend::from_image(image).expect("mounts");
+        // Full read.
+        let mut buf = [0u8; 64];
+        let n = backend.pread("hello.txt", &mut buf, 0).unwrap();
+        assert_eq!(&buf[..n], b"hello, limnifs\n");
+        // Windowed read.
+        let n = backend.pread("hello.txt", &mut buf, 7).unwrap();
+        assert_eq!(&buf[..n], b"limnifs\n");
+        // EOF clamping: offset at/past end reads 0.
+        assert_eq!(backend.pread("hello.txt", &mut buf, 15).unwrap(), 0);
+        assert_eq!(backend.pread("hello.txt", &mut buf, 4096).unwrap(), 0);
+        // Short read at the tail.
+        let n = backend.pread("hello.txt", &mut buf, 13).unwrap();
+        assert_eq!(&buf[..n], b"s\n");
+        // Errors: missing file, directory, empty buffer.
+        assert_eq!(
+            backend.pread("nope", &mut buf, 0).unwrap_err(),
+            libc::ENOENT
+        );
+        assert_eq!(backend.pread("sub", &mut buf, 0).unwrap_err(), libc::EISDIR);
+        assert_eq!(backend.pread("hello.txt", &mut [], 0).unwrap(), 0);
+    }
+
+    #[test]
+    fn pread_slab_drop_materializes_per_window() {
+        let (_tmp, image) = fixture_tree();
+        let backend = LimnifsBackend::from_image(image).expect("mounts");
+        assert!(!backend.drops.is_empty(), "big.bin must be slab-backed");
+        let want = big_payload();
+
+        // Whole-file read in one buffer.
+        let mut buf = vec![0u8; want.len()];
+        let n = backend.pread("big.bin", &mut buf, 0).unwrap();
+        assert_eq!(n, want.len());
+        assert_eq!(buf, want);
+
+        // A middle window crossing chunk (drop) boundaries.
+        let mut win = [0u8; 30_000];
+        let n = backend.pread("big.bin", &mut win, 77_777).unwrap();
+        assert_eq!(n, 30_000);
+        assert_eq!(&win[..], &want[77_777..107_777]);
+
+        // A tiny window inside one drop.
+        let mut small = [0u8; 17];
+        let n = backend.pread("big.bin", &mut small, 3).unwrap();
+        assert_eq!(&small[..n], &want[3..20]);
+
+        // Tail short read + EOF clamp.
+        let mut tail = [0u8; 128];
+        let n = backend.pread("big.bin", &mut tail, 199_950).unwrap();
+        assert_eq!(n, 50);
+        assert_eq!(&tail[..n], &want[199_950..]);
+        assert_eq!(backend.pread("big.bin", &mut tail, 200_000).unwrap(), 0);
+    }
+
+    #[test]
+    fn read_dir_lists_direct_children_only() {
+        let (_tmp, image) = fixture_tree();
+        let backend = LimnifsBackend::from_image(image).expect("mounts");
+
+        let mut root = backend.read_dir("").expect("root lists");
+        root.sort_by(|a, b| a.name.cmp(&b.name));
+        let names: Vec<(&str, bool)> = root.iter().map(|e| (e.name.as_str(), e.is_dir)).collect();
+        assert_eq!(
+            names,
+            vec![("big.bin", false), ("hello.txt", false), ("sub", true)]
+        );
+        // No `.`/`..`, and the nested file is not a direct child.
+        assert!(!root.iter().any(|e| e.name == "." || e.name == ".."));
+        assert!(!root.iter().any(|e| e.name == "nested.txt"));
+
+        let sub = backend.read_dir("sub").expect("sub lists");
+        assert_eq!(sub.len(), 1);
+        assert_eq!(sub[0].name, "nested.txt");
+        assert!(!sub[0].is_dir);
+
+        assert_eq!(backend.read_dir("hello.txt").unwrap_err(), libc::ENOTDIR);
+        assert_eq!(backend.read_dir("nope").unwrap_err(), libc::ENOENT);
+    }
+
+    #[test]
+    fn nested_paths_resolve_through_the_tree() {
+        let (_tmp, image) = fixture_tree();
+        let backend = LimnifsBackend::from_image(image).expect("mounts");
+        let st = backend.stat("sub/nested.txt").expect("nested stats");
+        assert_eq!(st.entry_type, EntryType::File);
+        assert_eq!(st.size, 19);
+        let mut buf = [0u8; 32];
+        let n = backend.pread("sub/nested.txt", &mut buf, 0).unwrap();
+        assert_eq!(&buf[..n], b"nested content here");
+        // Leading-slash tolerance (the mount layer strips, the backend
+        // normalizes regardless).
+        let n = backend.pread("/sub/nested.txt", &mut buf, 7).unwrap();
+        assert_eq!(&buf[..n], b"content here");
+    }
+
+    #[test]
+    fn symlink_inodes_read_link() {
+        let image = symlink_image();
+        let backend = LimnifsBackend::from_image(image).expect("mounts");
+
+        let st = backend.stat("link").expect("symlink stats");
+        assert_eq!(st.entry_type, EntryType::Symlink);
+        assert_eq!(backend.read_link("link").unwrap(), "a.txt");
+        assert_eq!(backend.read_link("a.txt").unwrap_err(), libc::EINVAL);
+        assert_eq!(backend.read_link("nope").unwrap_err(), libc::ENOENT);
+        let mut buf = [0u8; 8];
+        assert_eq!(
+            backend.pread("link", &mut buf, 0).unwrap_err(),
+            libc::EINVAL
+        );
+    }
+
+    #[test]
+    fn corrupt_metadata_checksum_is_einvl_at_open() {
+        let (_tmp, mut image) = fixture_tree();
+        // Flip the inline metadata blob's last wire byte (a hash
+        // mismatch when the blob is stored, a decode failure when it
+        // is compressed — Corrupt at mount-open either way → EINVAL).
+        let at = metadata_blob_wire_end(&image) - 1;
+        image[at] ^= 0xFF;
+        assert_eq!(LimnifsBackend::from_image(image).unwrap_err(), libc::EINVAL);
+    }
+
+    #[test]
+    fn truncated_image_is_einvl_at_open() {
+        let (_tmp, image) = fixture_tree();
+        let short = image[..image.len() / 2].to_vec();
+        assert_eq!(LimnifsBackend::from_image(short).unwrap_err(), libc::EINVAL);
+        let empty: Vec<u8> = Vec::new();
+        assert_eq!(LimnifsBackend::from_image(empty).unwrap_err(), libc::EINVAL);
+    }
+
+    #[test]
+    fn trailing_garbage_is_einvl_at_open() {
+        let (_tmp, mut image) = fixture_tree();
+        image.extend_from_slice(b"garbage");
+        assert_eq!(LimnifsBackend::from_image(image).unwrap_err(), libc::EINVAL);
+    }
+
+    #[test]
+    fn required_feature_flag_is_enotsup_at_open() {
+        let (_tmp, mut image) = fixture_tree();
+        // The feature-flags section follows the 16-byte header:
+        // version(1) + count(4). Declare one required flag.
+        image[16] = 1; // section version
+        image[17..21].copy_from_slice(&1u32.to_le_bytes());
+        let flag = [0x20, 0x00, 0x01]; // id 0x0020, required
+        image.splice(21..21, flag);
+        assert_eq!(
+            LimnifsBackend::from_image(image).unwrap_err(),
+            libc::ENOTSUP
+        );
+    }
+
+    #[test]
+    fn external_metadata_locator_is_enotsup_at_open() {
+        // A stock limnifs manifest whose metadata is a `file:` sidecar
+        // cannot be a tebako payload (one file, byte-identical) — the
+        // mount refuses by name, never a silent re-route.
+        let image = external_metadata_image();
+        assert_eq!(
+            LimnifsBackend::from_image(image).unwrap_err(),
+            libc::ENOTSUP
+        );
+    }
+
+    #[test]
+    fn image_info_json_reports_sections_and_counts() {
+        let (_tmp, image) = fixture_tree();
+        let image_len = image.len();
+        let backend = LimnifsBackend::from_image(image).expect("mounts");
+        let json = backend.image_info_json().expect("limnifs has a surface");
+        assert!(json.contains("\"format\":\"limnifs\""), "{json}");
+        assert!(json.contains("\"inode_count\":5"), "{json}");
+        assert!(json.contains("\"slab_count\":1"), "{json}");
+        assert!(
+            json.contains(&format!("\"image_bytes\":{image_len}")),
+            "{json}"
+        );
+        assert!(json.contains("METADATA_REFERENCE"), "{json}");
+        assert!(json.contains("\"type\":\"SLAB\""), "{json}");
+    }
+
+    #[test]
+    fn mounts_through_the_three_mount_constructors() {
+        let (_tmp, image) = fixture_tree();
+
+        // Memory.
+        let mount = crate::mount::build_from_memory(&image, "/mnt").expect("memory mount");
+        let st = mount.backend.stat("hello.txt").expect("stats");
+        assert_eq!(st.size, 15);
+
+        // Whole file.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("fs.tfs");
+        std::fs::write(&path, &image).unwrap();
+        let mount =
+            crate::mount::build_from_file(&path.to_string_lossy(), "/mnt").expect("file mount");
+        assert_eq!(mount.backend.name().to_str().unwrap(), "LimniFS");
+
+        // File region (the image embedded after a 4 KiB prefix — the
+        // tpkg slot shape).
+        let mut packaged = vec![0x5Au8; 4096];
+        packaged.extend_from_slice(&image);
+        let pkg_path = tmp.path().join("pkg.bin");
+        std::fs::write(&pkg_path, &packaged).unwrap();
+        let mount = crate::mount::build_from_file_at(
+            &pkg_path.to_string_lossy(),
+            4096,
+            image.len() as u64,
+            "/mnt",
+        )
+        .expect("region mount");
+        let mut buf = [0u8; 16];
+        let n = mount.backend.pread("hello.txt", &mut buf, 0).unwrap();
+        assert_eq!(&buf[..n], b"hello, limnifs\n");
+    }
+
+    // ---------------------------------------------------------------
+    // fixture encoders (mirroring limnifs-core's own test encoders)
+    // ---------------------------------------------------------------
+
+    /// The inline metadata blob's wire end (one past its last byte),
+    /// walked with the real parsers. The blob is the reference section's
+    /// trailing field, so this is inside it for any non-empty blob.
+    fn metadata_blob_wire_end(image: &[u8]) -> usize {
+        let mut cursor = ManifestCursor::new(image);
+        let _ = parse_manifest_header(&mut cursor).unwrap();
+        let _ = parse_feature_flags_section(&mut cursor).unwrap();
+        let reference = parse_metadata_reference(&mut cursor).unwrap();
+        assert!(reference.is_inlined());
+        cursor.position()
+    }
+
+    fn encode_inode(number: u64, mode: u32, mtime_ns: u64, flags: u8, body: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&number.to_le_bytes());
+        bytes.extend_from_slice(&mode.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // uid
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // gid
+        bytes.extend_from_slice(&mtime_ns.to_le_bytes());
+        bytes.extend_from_slice(&mtime_ns.to_le_bytes()); // ctime
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // nlink
+        bytes.push(flags);
+        bytes.extend_from_slice(body);
+        bytes
+    }
+
+    fn encode_dir_node(entries: &[(&str, u64, u8)]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.push(1u8); // DIRECTORY_NODE_VERSION
+        bytes.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+        for (name, number, ty) in entries {
+            bytes.extend_from_slice(&(name.len() as u32).to_le_bytes());
+            bytes.extend_from_slice(name.as_bytes());
+            bytes.extend_from_slice(&number.to_le_bytes());
+            bytes.push(*ty);
+        }
+        bytes
+    }
+
+    /// Assemble a minimal manifest (header + empty flags + inline
+    /// metadata reference v1 + empty slab index + the mandatory single
+    /// build history entry) around a hand-built metadata blob.
+    fn assemble_manifest(blob: &[u8]) -> Vec<u8> {
+        let mut image = Vec::new();
+        image.extend_from_slice(&ManifestHeader::current().to_bytes());
+        image.push(1u8); // feature flags section version
+        image.extend_from_slice(&0u32.to_le_bytes());
+        image.push(1u8); // metadata_reference section version 1
+        image.extend_from_slice(&limnifs_core::hash_section(blob));
+        image.extend_from_slice(&0u32.to_le_bytes()); // no locators
+        image.extend_from_slice(&(blob.len() as u32).to_le_bytes());
+        image.extend_from_slice(blob);
+        image.push(1u8); // slab_index section version
+        image.extend_from_slice(&0u32.to_le_bytes());
+        append_build_history(&mut image);
+        image
+    }
+
+    /// The writer's mandatory history section: version 1, one build
+    /// entry (op 0x01, zero epoch, no inputs, no params) — an empty
+    /// history is Corrupt ("every image has a build entry").
+    fn append_build_history(image: &mut Vec<u8>) {
+        image.push(1u8); // history section version
+        image.extend_from_slice(&1u32.to_le_bytes());
+        image.push(0x01); // build op
+        image.extend_from_slice(&0u64.to_le_bytes());
+        image.extend_from_slice(&0u32.to_le_bytes());
+        image.extend_from_slice(&0u32.to_le_bytes());
+    }
+
+    /// An image with one inline file and one symlink at the root —
+    /// hand-encoded because limnifs-write v0.2 does not walk symlinks.
+    fn symlink_image() -> Vec<u8> {
+        const S_IFREG: u32 = 0o100_000;
+        const S_IFDIR: u32 = 0o040_000;
+        const S_IFLNK: u32 = 0o120_000;
+        const INLINE: u8 = 0x04; // INODE_FLAG_INLINE_DATA
+
+        let file_body: Vec<u8> = {
+            let mut b = (5u32).to_le_bytes().to_vec();
+            b.extend_from_slice(b"data!");
+            b
+        };
+        let link_body: Vec<u8> = {
+            let mut b = (5u32).to_le_bytes().to_vec();
+            b.extend_from_slice(b"a.txt");
+            b
+        };
+        let node = encode_dir_node(&[("a.txt", 2, 0x01), ("link", 3, 0x03)]);
+        let node_hash = limnifs_core::metadata::dir_node_hash(&[
+            limnifs_core::DirEntry {
+                name: "a.txt".to_string(),
+                inode_number: 2,
+                entry_type: 0x01,
+            },
+            limnifs_core::DirEntry {
+                name: "link".to_string(),
+                inode_number: 3,
+                entry_type: 0x03,
+            },
+        ]);
+
+        let mut blob = Vec::new();
+        blob.extend_from_slice(&3u32.to_le_bytes());
+        blob.extend_from_slice(&encode_inode(1, S_IFDIR | 0o755, 0, 0, &node_hash));
+        blob.extend_from_slice(&encode_inode(2, S_IFREG | 0o644, 0, INLINE, &file_body));
+        blob.extend_from_slice(&encode_inode(3, S_IFLNK | 0o777, 0, 0, &link_body));
+        blob.extend_from_slice(&1u32.to_le_bytes());
+        blob.extend_from_slice(&node);
+        assemble_manifest(&blob)
+    }
+
+    /// A manifest whose metadata lives behind a `file:` locator.
+    fn external_metadata_image() -> Vec<u8> {
+        let blob: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0]; // empty blob (unused)
+        let mut image = Vec::new();
+        image.extend_from_slice(&ManifestHeader::current().to_bytes());
+        image.push(1u8);
+        image.extend_from_slice(&0u32.to_le_bytes());
+        image.push(1u8); // metadata_reference v1
+        image.extend_from_slice(&limnifs_core::hash_section(&blob));
+        image.extend_from_slice(&1u32.to_le_bytes()); // one locator
+        let uri = b"file:metadata.bin";
+        image.extend_from_slice(&(uri.len() as u32).to_le_bytes());
+        image.extend_from_slice(uri);
+        image.extend_from_slice(&0u32.to_le_bytes()); // no inline data
+        image.push(1u8); // slab_index
+        image.extend_from_slice(&0u32.to_le_bytes());
+        append_build_history(&mut image);
+        image
+    }
+}

--- a/crates/tfs/src/lib.rs
+++ b/crates/tfs/src/lib.rs
@@ -20,6 +20,7 @@
 //!                   │         composite write seam — spec 11 §4)
 //!                   ├── backends_zip.rs  (ZIP via the pure-Rust `zip` crate)
 //!                   ├── backends_tar.rs  (tar/tar.gz/tar.zst, offset index)
+//!                   ├── backends_limnifs.rs (LimniFS via limnifs-core, spec 20)
 //!                   ├── backends_cow.rs  (COW composite + whiteout journal)
 //!                   ├── backends_hostdir.rs (host directory, the COW overlay)
 //!                   ├── dwarfs           (external dwarfs-rs crate)
@@ -46,9 +47,11 @@
 //! journal) or `_RW` (2, ENOTSUP — no in-tree backend writes in place).
 //! Backends: ZIP (pure-Rust `zip` crate), tar/tar.gz/tar.zst (pure-Rust
 //! offset index — `backends_tar`), COW composite over any image
-//! (`backends_cow` + `backends_hostdir`), and DwarFS (external `dwarfs-rs`
-//! crate, feature `vendored-dwarfs`, default on); SquashFS via
-//! `crates/sqfs-sys` (feature `vendored-squashfs`, default on). Writes on
+//! (`backends_cow` + `backends_hostdir`), DwarFS (external `dwarfs-rs`
+//! crate, feature `vendored-dwarfs`, default on), SquashFS via
+//! `crates/sqfs-sys` (feature `vendored-squashfs`, default on), and
+//! LimniFS (spec 20 — `limnifs-core`, pure Rust, feature
+//! `backend-limnifs`, default on). Writes on
 //! RO mounts fail EROFS; path-level writes on COW mounts route through
 //! the context (`pwrite_path`/`truncate_path`/`mkdir_path`/`remove_path`);
 //! the fd-based write family (spec 11 §7) is a later additive milestone.
@@ -72,6 +75,8 @@ pub mod backends_dwarfs;
 #[cfg(feature = "enc")]
 pub mod backends_enc;
 pub mod backends_hostdir;
+#[cfg(feature = "backend-limnifs")]
+pub mod backends_limnifs;
 #[cfg(feature = "vendored-squashfs")]
 pub mod backends_squashfs;
 pub mod backends_tar;

--- a/crates/tfs/src/mount.rs
+++ b/crates/tfs/src/mount.rs
@@ -1,7 +1,8 @@
 //! Mount construction: open an image (file / file region / memory), sniff
 //! its format, build the backend. Mirrors the C++ BackendFactory dispatch:
-//! DwarFS (vendored-dwarfs) and SquashFS (vendored-squashfs) are real with
-//! their default features on, ENOTSUP stubs without.
+//! DwarFS (vendored-dwarfs), SquashFS (vendored-squashfs) and LimniFS
+//! (backend-limnifs, spec 20) are real with their default features on,
+//! ENOTSUP stubs without.
 //!
 //! Mounts carry a mode (spec 11 §3): RO (default), COW (a HostDir overlay
 //! stacked over the image backend — spec 11 §4), RW (in-place; no in-tree
@@ -22,6 +23,8 @@ use crate::context::Mount;
 
 #[cfg(feature = "vendored-dwarfs")]
 use crate::backends_dwarfs::DwarfsBackend;
+#[cfg(feature = "backend-limnifs")]
+use crate::backends_limnifs::LimnifsBackend;
 #[cfg(feature = "vendored-squashfs")]
 use crate::backends_squashfs::SquashfsBackend;
 
@@ -142,6 +145,12 @@ pub fn build_from_file_with_mode(
         ImageFormat::Squashfs => Box::new(SquashfsBackend::from_file(archive_path)?),
         #[cfg(not(feature = "vendored-squashfs"))]
         ImageFormat::Squashfs => return Err(libc::ENOTSUP),
+        #[cfg(feature = "backend-limnifs")]
+        ImageFormat::Limnifs => Box::new(LimnifsBackend::from_image(
+            std::fs::read(archive_path).map_err(open_error)?,
+        )?),
+        #[cfg(not(feature = "backend-limnifs"))]
+        ImageFormat::Limnifs => return Err(libc::ENOTSUP),
         ImageFormat::Unknown => return Err(libc::EINVAL),
     };
     let backend = apply_mode(backend, mode, overlay_dir)?;
@@ -229,6 +238,12 @@ pub fn build_from_file_at_with_mode(
         )?)?),
         #[cfg(not(feature = "vendored-squashfs"))]
         ImageFormat::Squashfs => return Err(libc::ENOTSUP),
+        #[cfg(feature = "backend-limnifs")]
+        ImageFormat::Limnifs => Box::new(LimnifsBackend::from_image(read_region(
+            &mut file, offset, length,
+        )?)?),
+        #[cfg(not(feature = "backend-limnifs"))]
+        ImageFormat::Limnifs => return Err(libc::ENOTSUP),
         ImageFormat::Unknown => return Err(libc::EINVAL),
     };
     let backend = apply_mode(backend, mode, overlay_dir)?;
@@ -275,6 +290,10 @@ pub fn build_from_memory_with_mode(
         ImageFormat::Squashfs => Box::new(SquashfsBackend::from_memory(data.to_vec())?),
         #[cfg(not(feature = "vendored-squashfs"))]
         ImageFormat::Squashfs => return Err(libc::ENOTSUP),
+        #[cfg(feature = "backend-limnifs")]
+        ImageFormat::Limnifs => Box::new(LimnifsBackend::from_image(data.to_vec())?),
+        #[cfg(not(feature = "backend-limnifs"))]
+        ImageFormat::Limnifs => return Err(libc::ENOTSUP),
         ImageFormat::Unknown => return Err(libc::EINVAL),
     };
     let backend = apply_mode(backend, mode, overlay_dir)?;
@@ -302,6 +321,30 @@ mod tests {
         magic.resize(SNIFF_LEN, 0);
         let path = std::env::temp_dir().join(format!(
             "tfs-enotsup-{}-{}.sqfs",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, &magic).unwrap();
+        let result = build_from_file(&path.to_string_lossy(), "/x");
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(result.err(), Some(libc::ENOTSUP));
+    }
+
+    /// The compiled-out rule (spec 20 §5): a mount of `LMFS` bytes on a
+    /// build without the limnifs backend fails with the NAMED ENOTSUP —
+    /// never a silent re-route. Runs in the `--no-default-features` CI
+    /// job (the limnifs feature is off there).
+    #[cfg(not(feature = "backend-limnifs"))]
+    #[test]
+    fn limnifs_without_the_backend_is_a_named_enotsup() {
+        let mut magic = Vec::with_capacity(SNIFF_LEN);
+        magic.extend_from_slice(b"LMFS");
+        magic.resize(SNIFF_LEN, 0);
+        let path = std::env::temp_dir().join(format!(
+            "tfs-enotsup-{}-{}.lim",
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -26,7 +26,7 @@
 //!   offset  size  field
 //!      0     8    u64 offset (image start, absolute file offset)
 //!      8     8    u64 size   (image length in bytes)
-//!     16     4    u32 format_id (0=auto, 1=dwarfs, 2=squashfs, 3=zip, 4=runtime)
+//!     16     4    u32 format_id (0=auto, 1=dwarfs, 2=squashfs, 3=zip, 4=runtime, 5=limnifs)
 //!     20     4    u32 flags
 //!     24   256    char mount_point[256] (UTF-8, NUL-padded)
 //! ```
@@ -225,6 +225,12 @@ pub const TPKG_FORMAT_SQUASHFS: u32 = 2;
 pub const TPKG_FORMAT_ZIP: u32 = 3;
 /// `format_id`: runtime payload slot (fat packages).
 pub const TPKG_FORMAT_RUNTIME: u32 = 4;
+/// `format_id`: LimniFS image (spec 20). The reference C99 `tpkg.h`
+/// keeps its validation bound at 4 and rejects a format-5 slot with its
+/// NAMED invalid error — fail-closed and correct (a v1-era reader
+/// cannot read limnifs bytes, so it refuses by name). Parity ends
+/// exactly at the new id; ids ≥ 6 stay unallocated.
+pub const TPKG_FORMAT_LIMNIFS: u32 = 5;
 
 // ---------------------------------------------------------------------
 // Typed extension blocks (spec 02 §5b; all block numerics BIG-ENDIAN,

--- a/crates/tpkg/src/model.rs
+++ b/crates/tpkg/src/model.rs
@@ -3,7 +3,7 @@
 use crate::error::TpkgError;
 use crate::ext::ExtBlock;
 use crate::{
-    TPKG_EXT_TYPE_V2_SIGNING, TPKG_FLAG_SIGNED_V2, TPKG_FORMAT_RUNTIME, TPKG_KEYID_LEN,
+    TPKG_EXT_TYPE_V2_SIGNING, TPKG_FLAG_SIGNED_V2, TPKG_FORMAT_LIMNIFS, TPKG_KEYID_LEN,
     TPKG_MAX_SLOTS, TPKG_MOUNT_POINT_LEN, TPKG_RUNTIME_REF_LEN, TPKG_SHA256_LEN, TPKG_SIG_MAX,
     TPKG_VERSION,
 };
@@ -173,8 +173,11 @@ impl Manifest {
 
     /// Magic-independent structural checks, mirroring the C `tpkg_validate()`:
     /// version supported, `1..=TPKG_MAX_SLOTS` slots, `offset+size`
-    /// non-overflowing, `format_id <= TPKG_FORMAT_RUNTIME`, `runtime_ref` and
-    /// mount points NUL-terminated within their fixed fields. Extension
+    /// non-overflowing, `format_id <= TPKG_FORMAT_LIMNIFS` (spec 20 raised
+    /// the bound from the C reference's `TPKG_FORMAT_RUNTIME` — the
+    /// documented parity end: the C99 header keeps rejecting format 5 by
+    /// name), `runtime_ref` and mount points NUL-terminated within their
+    /// fixed fields. Extension
     /// blocks (spec 02 §5b) must not use the reserved type 1 and must fit
     /// the u32 length field; unknown types PASS here (readers skip them —
     /// [`Manifest::validate_strict`] is the fail-closed gate). The v2
@@ -195,7 +198,7 @@ impl Manifest {
             if slot.size > u64::MAX - slot.offset {
                 return Err(TpkgError::Invalid);
             }
-            if slot.format_id > TPKG_FORMAT_RUNTIME {
+            if slot.format_id > TPKG_FORMAT_LIMNIFS {
                 return Err(TpkgError::Invalid);
             }
             if strnlen(&slot.mount_point) == TPKG_MOUNT_POINT_LEN {

--- a/crates/tpkg/tests/behavior.rs
+++ b/crates/tpkg/tests/behavior.rs
@@ -102,9 +102,10 @@ fn validate_rejects_bad_manifests() {
     m.version = 99;
     assert_eq!(m.validate(), Err(TpkgError::Version));
 
-    // format_id out of range
+    // format_id out of range (spec 20: 5 = limnifs is admitted; ids ≥ 6
+    // stay unallocated and fail closed)
     let mut m = one_slot_manifest();
-    m.slots[0].format_id = TPKG_FORMAT_RUNTIME + 1;
+    m.slots[0].format_id = TPKG_FORMAT_LIMNIFS + 1;
     assert_eq!(m.validate(), Err(TpkgError::Invalid));
 
     // offset+size overflow

--- a/crates/tpkg/tests/golden.rs
+++ b/crates/tpkg/tests/golden.rs
@@ -160,6 +160,53 @@ fn crc32_vectors_match_c() {
     assert_eq!(crc32(b"tebako"), 0xF39D_4673);
 }
 
+// ---------------------------------------------------------------------
+// spec 20 §2: format_id 5 = limnifs. The golden vectors above stay
+// byte-identical (the C parity); the limnifs allocation EXTENDS them —
+// the Rust validation bound admits 5 while the C99 reference keeps
+// rejecting it with its named invalid error (fail-closed, correct).
+// ---------------------------------------------------------------------
+
+#[test]
+fn limnifs_slot_encodes_validates_and_round_trips() {
+    let mut m = Manifest {
+        version: TPKG_VERSION,
+        package_flags: TPKG_FLAG_LEAN,
+        launcher_abi: 3,
+        ..Default::default()
+    };
+    m.set_runtime_ref(b"tebako-runtime-0.16.2-linux-arm64");
+    m.slots
+        .push(Slot::new(0, 4096, TPKG_FORMAT_LIMNIFS, "/__tebako__"));
+
+    // The raised bound admits format 5 (structural validation + the
+    // encode gate).
+    m.validate().expect("format 5 validates");
+    let encoded = encode_trailer(&m, TABLE_OFFSET).expect("encode format 5");
+
+    // The format_id field sits at record offset 16 (little-endian).
+    assert_eq!(&encoded[16..20], &TPKG_FORMAT_LIMNIFS.to_le_bytes());
+
+    let mut image = vec![0x5Au8; TABLE_OFFSET as usize];
+    image.extend_from_slice(&encoded);
+    let parsed = parse_trailer(&image).expect("parse format-5 trailer");
+    assert_eq!(parsed, m);
+    assert_eq!(parsed.slots[0].format_id, TPKG_FORMAT_LIMNIFS);
+}
+
+#[test]
+fn format_ids_above_limnifs_stay_unallocated() {
+    let mut m = Manifest::default();
+    m.slots
+        .push(Slot::new(0, 100, TPKG_FORMAT_LIMNIFS + 1, "/m"));
+    assert_eq!(m.validate(), Err(TpkgError::Invalid));
+    assert_eq!(
+        encode_trailer(&m, TABLE_OFFSET),
+        Err(TpkgError::Invalid),
+        "the encode gate shares the validation bound"
+    );
+}
+
 #[test]
 fn write_to_appends_at_eof_and_read_from_reads_it() {
     use std::io::Cursor;

--- a/docs/spec/02-tpkg-wire-format.md
+++ b/docs/spec/02-tpkg-wire-format.md
@@ -119,7 +119,10 @@ multi-runtime packages live in the type-2 manifest (no size cap).
 - Prefix ok, magic bad → `Magic`. Magic ok, crc bad → `Crc`.
 - Version ≠ 1 → `Version`. Slot count outside 1..=8 → `Slots`.
 - Structural validation mirrors the reference C `tpkg_validate()`:
-  `offset+size` non-overflowing, `format_id` ≤ 4, `runtime_ref` and mount
+  `offset+size` non-overflowing, `format_id` ≤ 5 (spec 20 raised the
+  bound from the C reference's ≤ 4 — the documented parity end: the C99
+  reader keeps rejecting format 5 with its named invalid error; ids ≥ 6
+  stay unallocated), `runtime_ref` and mount
   points NUL-terminated within their fixed fields; table fits entirely
   before the header.
 - v2: flag/extension co-presence; zeroed digest tail; signature non-empty

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -23,3 +23,6 @@ libc = "0.2"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
+# The limnifs backend-pair golden class builds its fixture image
+# in-process (spec 20 §8) — never a `limni` binary.
+limnifs-write = { version = "0.2", path = "../../../../limnifs/limnifs/limnifs-write" }

--- a/tests/contract/tests/limnifs_backend.rs
+++ b/tests/contract/tests/limnifs_backend.rs
@@ -1,0 +1,276 @@
+//! LimniFS backend contract cases (spec 20 §8): the backend-pair golden
+//! class — the SAME logical tree the dwarfs fixture holds is imaged with
+//! limnifs-write IN-PROCESS (no `limni` binary) and mounted through the
+//! `tebako_fs_*` ABI, and the two mounts must answer identically
+//! (readdir sets, stat types/sizes, file contents) — byte-identity is
+//! per-backend, semantics are shared. Plus the region/memory mount
+//! constructors and the named-error surfaces.
+//!
+//! Windows ships a dwarfs-only tfs (TODO.v2-1/02): the limnifs cases are
+//! POSIX-only.
+#![cfg(not(windows))]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+use tebako_contract_tests::TempDir;
+
+static LOCK: Mutex<()> = Mutex::new(());
+
+const JUNK_SIZE: u64 = 1000;
+
+fn fixture_image() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/simple.dwarfs")
+        .canonicalize()
+        .expect("simple.dwarfs fixture must exist")
+}
+
+fn c(s: &str) -> std::ffi::CString {
+    std::ffi::CString::new(s).unwrap()
+}
+
+unsafe fn errno() -> i32 {
+    unsafe { tfs::c_api::tebako_get_errno() }
+}
+
+struct F {
+    _guard: MutexGuard<'static, ()>,
+    _tmp: TempDir,
+    /// The limnifs single-file image (manifest + appended slabs).
+    image: Vec<u8>,
+    image_path: PathBuf,
+    combined_path: PathBuf,
+    mount_point: String,
+}
+
+/// Snapshot of one mount's logical answers: path → (is_dir, size,
+/// content for regular files). THE parity surface (spec 20 §8).
+type Tree = BTreeMap<String, (bool, i64, Vec<u8>)>;
+
+/// Mount `path` at `mp` through the C ABI and snapshot every answer the
+/// VFS gives for the whole tree, then unmount.
+unsafe fn snapshot(path: &std::ffi::CStr, mp: &str) -> Tree {
+    let rc = unsafe { tfs::c_api::tebako_fs_init_from_file(path.as_ptr(), c(mp).as_ptr()) };
+    assert_eq!(rc, 0, "mount of {} must succeed", path.to_string_lossy());
+    let mut tree = Tree::new();
+    unsafe { walk_into(mp, &mut tree) };
+    unsafe { tfs::c_api::tebako_fs_unmount() };
+    tree
+}
+
+unsafe fn walk_into(dir: &str, tree: &mut Tree) {
+    let d = unsafe { tfs::c_api::tebako_fs_opendir(c(dir).as_ptr()) };
+    assert!(!d.is_null(), "opendir {dir}");
+    loop {
+        let entry = unsafe { tfs::c_api::tebako_fs_readdir(d) };
+        if entry.is_null() {
+            break;
+        }
+        let name = unsafe { std::ffi::CStr::from_ptr((*entry).d_name.as_ptr()) }
+            .to_string_lossy()
+            .into_owned();
+        if name == "." || name == ".." {
+            continue;
+        }
+        let path = format!("{dir}/{name}");
+        let mut st: libc::stat = unsafe { std::mem::zeroed() };
+        assert_eq!(
+            unsafe { tfs::c_api::tebako_fs_stat(c(&path).as_ptr(), &mut st) },
+            0
+        );
+        let is_dir = (st.st_mode & libc::S_IFMT) == libc::S_IFDIR as _;
+        if is_dir {
+            tree.insert(path.clone(), (true, 0, Vec::new()));
+            unsafe { walk_into(&path, tree) };
+        } else {
+            let mut content = vec![0u8; st.st_size as usize];
+            let fd = unsafe { tfs::c_api::tebako_fs_open(c(&path).as_ptr(), libc::O_RDONLY) };
+            assert!(fd > 0, "open {path}");
+            let n = unsafe {
+                tfs::c_api::tebako_fs_read(fd, content.as_mut_ptr().cast(), content.len())
+            };
+            assert_eq!(n as i64, st.st_size, "short read on {path}");
+            assert_eq!(unsafe { tfs::c_api::tebako_fs_close(fd) }, 0);
+            tree.insert(path, (false, st.st_size, content));
+        }
+    }
+    assert_eq!(unsafe { tfs::c_api::tebako_fs_closedir(d) }, 0);
+}
+
+/// Materialize a snapshot onto the host (the limnifs writer's input).
+fn materialize(tree: &Tree, mp: &str, dest: &Path) {
+    for (path, (is_dir, _, content)) in tree {
+        let rel = path
+            .strip_prefix(&format!("{mp}/"))
+            .expect("snapshot paths are mount-relative");
+        let host = dest.join(rel);
+        if *is_dir {
+            std::fs::create_dir_all(&host).unwrap();
+        } else {
+            std::fs::write(&host, content).unwrap();
+        }
+    }
+}
+
+/// The tebako single-file limnifs layout (spec 20 §4): the writer's
+/// manifest bytes verbatim + every slab appended in slab-ordinal order.
+/// Dictionaries off — the v1 backend resolves the fixed section order.
+fn build_limnifs_image(src: &Path) -> Vec<u8> {
+    let mut config = limnifs_write::WriteConfig::default_v0_1();
+    config.dictionaries.enabled = false;
+    let artifact = limnifs_write::write_directory_with_config(src, &config).expect("limnifs write");
+    assert!(artifact.metadata_sidecar.is_none());
+    let mut image = artifact.bytes;
+    for slab in &artifact.slabs {
+        image.extend_from_slice(&slab.bytes);
+    }
+    image
+}
+
+fn setup() -> (F, Tree) {
+    let guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    unsafe { tfs::c_api::tebako_fs_unmount() };
+
+    let tmp = TempDir::new("limnifs");
+    let mp = "/__limnifs_contract__";
+
+    // The parity oracle: snapshot the dwarfs fixture's tree, materialize
+    // it, and image it with limnifs-write — same tree in.
+    let dwarfs_tree = unsafe { snapshot(&c(&fixture_image().to_string_lossy()), mp) };
+    assert!(!dwarfs_tree.is_empty(), "the dwarfs fixture is non-empty");
+    let src = tmp.0.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    materialize(&dwarfs_tree, mp, &src);
+
+    let image = build_limnifs_image(&src);
+    let image_path = tmp.0.join("fs.tfs");
+    std::fs::write(&image_path, &image).unwrap();
+
+    // junk prefix (deliberately not a valid archive magic) + image.
+    let combined_path = tmp.0.join("combined.bin");
+    let mut combined = Vec::new();
+    for i in 0..JUNK_SIZE {
+        combined.push(b'A' + ((i * 7) % 26) as u8);
+    }
+    combined.extend_from_slice(&image);
+    std::fs::write(&combined_path, &combined).unwrap();
+
+    (
+        F {
+            _guard: guard,
+            _tmp: tmp,
+            image,
+            image_path,
+            combined_path,
+            mount_point: mp.to_string(),
+        },
+        dwarfs_tree,
+    )
+}
+
+// ===================================================================
+
+/// The backend-pair golden class (spec 20 §8): same tree in → same
+/// logical VFS answers out.
+#[test]
+fn backend_pair_golden_parity_vs_dwarfs() {
+    let (f, dwarfs_tree) = setup();
+    let limnifs_tree = unsafe { snapshot(&c(&f.image_path.to_string_lossy()), &f.mount_point) };
+    assert_eq!(
+        limnifs_tree, dwarfs_tree,
+        "the limnifs mount must answer identically to the dwarfs mount"
+    );
+
+    // The backend names itself for the detection-derived label (spec 15).
+    let rc = unsafe {
+        tfs::c_api::tebako_fs_init_from_file(
+            c(f.image_path.to_str().unwrap()).as_ptr(),
+            c(&f.mount_point).as_ptr(),
+        )
+    };
+    assert_eq!(rc, 0);
+    let bn = unsafe { tfs::c_api::tebako_get_backend_name() };
+    assert!(!bn.is_null());
+    assert_eq!(
+        unsafe { std::ffi::CStr::from_ptr(bn) }.to_bytes(),
+        b"LimniFS"
+    );
+    unsafe { tfs::c_api::tebako_fs_unmount() };
+}
+
+/// Region and memory mounts (spec 11 §5's mount-source kinds — one
+/// `&[u8]` core serves them all).
+#[test]
+fn offset_and_memory_mounts() {
+    let (f, dwarfs_tree) = setup();
+
+    // Region: explicit offset+length into the combined file.
+    let rc = unsafe {
+        tfs::c_api::tebako_fs_init_from_file_at(
+            c(f.combined_path.to_str().unwrap()).as_ptr(),
+            JUNK_SIZE,
+            f.image.len() as u64,
+            c(&f.mount_point).as_ptr(),
+        )
+    };
+    assert_eq!(rc, 0);
+    let bn = unsafe { tfs::c_api::tebako_get_backend_name() };
+    assert_eq!(
+        unsafe { std::ffi::CStr::from_ptr(bn) }.to_bytes(),
+        b"LimniFS"
+    );
+    let mut tree = Tree::new();
+    unsafe { walk_into(&f.mount_point, &mut tree) };
+    unsafe { tfs::c_api::tebako_fs_unmount() };
+    assert_eq!(tree, dwarfs_tree);
+
+    // Memory.
+    let rc = unsafe {
+        tfs::c_api::tebako_fs_init(
+            f.image.as_ptr().cast(),
+            f.image.len(),
+            c(&f.mount_point).as_ptr(),
+        )
+    };
+    assert_eq!(rc, 0);
+    assert!(unsafe { tfs::c_api::tebako_get_archive_path() }.is_null());
+    let mut tree = Tree::new();
+    unsafe { walk_into(&f.mount_point, &mut tree) };
+    unsafe { tfs::c_api::tebako_fs_unmount() };
+    assert_eq!(tree, dwarfs_tree);
+}
+
+/// A truncated limnifs image fails the mount with the NAMED EINVAL —
+/// never a silent re-route (spec 20 §3/§5).
+#[test]
+fn corrupt_image_mount_fails_named() {
+    let (f, _) = setup();
+    let truncated = f.image[..f.image.len() / 2].to_vec();
+    let rc = unsafe {
+        tfs::c_api::tebako_fs_init(
+            truncated.as_ptr().cast(),
+            truncated.len(),
+            c(&f.mount_point).as_ptr(),
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(unsafe { errno() }, libc::EINVAL);
+    assert_eq!(unsafe { tfs::c_api::tebako_is_initialized() }, 0);
+
+    // Garbage with the LMFS magic but a zeroed section behind it: the
+    // feature-flags section version is unsupported → the NAMED ENOTSUP
+    // (spec 20 §4's UnsupportedFeature row), never a crash.
+    let mut garbage = b"LMFS".to_vec();
+    garbage.resize(512, 0);
+    let rc = unsafe {
+        tfs::c_api::tebako_fs_init(
+            garbage.as_ptr().cast(),
+            garbage.len(),
+            c(&f.mount_point).as_ptr(),
+        )
+    };
+    assert_eq!(rc, -1);
+    assert_eq!(unsafe { errno() }, libc::ENOTSUP);
+}


### PR DESCRIPTION
## What

Implements spec 20 (the LimniFS backend, image format 5) end to end in the owning crates: the `format_id` allocation, the `LMFS` detection arm, the TFS backend over `limnifs-core`, the `backend-limnifs` cargo feature, both writer paths, and the info surface. Spec text: PR #369 (`docs/spec/20-limnifs-backend.md`, PLANNED).

LimniFS is pure Rust (`#![forbid(unsafe_code)]`, no system dependencies) — this is the first backend that compiles everywhere Rust compiles, the spec 20 §5 exit from per-target C++ cross-compilation.

## The self-contained image layout

A stock LimniFS artifact is a manifest plus `file:`-located sidecar slabs — two artifacts, which a tebako payload can never be (one `.tfs`, byte-identical with the registry). The tebako writer path therefore emits the **writer's manifest bytes verbatim followed by every slab in slab-ordinal order**:

```
[manifest header][feature flags][metadata_reference][slab_index][history][slab 0 (LIM1…)][slab 1 (LIM1…)]…
```

Mount-open parses exactly the spec 20 §4 sequence — `ManifestCursor` → `parse_manifest_header` → `parse_metadata_reference` → `parse_metadata_blob` (inline metadata required, its BLAKE3 verified against the reference hash) → `parse_slab_index` → `parse_history` (lands the cursor on the slab region) → `parse_slab` per appended slab (index only, no upfront decompression; each slab's embedded `SlabId` cross-checked against the slab-index entry). Dictionaries are disabled in the writer path, so the section order above is fixed and drops are never dict-tagged.

## By crate

- **`tpkg`**: `TPKG_FORMAT_LIMNIFS = 5`; the structural-validation bound raised from `TPKG_FORMAT_RUNTIME` to admit 5 (ids ≥ 6 stay unallocated, fail closed); golden vectors **extended, not altered** (format-5 encode/validate/round-trip + the ≥ 6 rejection). The C99-reference deviation is documented at the constant: the v1 header keeps rejecting format 5 with its named invalid error — fail-closed, correct. `docs/spec/02` §6's bound text updated in the same PR (doc-sync rule; PR #369 deliberately left it to the implementation).
- **`tfs`**: `backends_limnifs.rs` behind `backend-limnifs` (default ON like the others; the first `backend-*` feature). Backend trait: `stat` (mode/type from the inode, `mtime_ns` → seconds truncation, size = inline length / summed `SliceRef` spans), `has_entry_or_children` (the trait default — explicit directory entries like dwarfs), `pread` (**inline drops served from the metadata blob with no slab access; SliceMap drops materialized per requested window via the slab**), `read_dir` (direct children, `ENOTDIR`), `read_link` (symlink inodes), `image_info_json`, `writable() = None` forever. `CoreError` mapping per spec 20 §4: `TooShort`/`BadMagic`/`Corrupt` → `EINVAL` at mount-open, `UnsupportedFeature` → `ENOTSUP` (named on the `TEBAKO_DEBUG` log), serving-side `Corrupt` → `EIO`, misses → `ENOENT`. Detection: `LMFS` arm inserted 4th in the strong-magic group (`LIM1` is a section magic, never an image magic; the weak tar heuristic stays last). All three mount constructors wired; compiled-out format → named `ENOTSUP` (tested both ways).
- **`tfs-cli`**: `tfs mkimage --format limnifs` via `limnifs-write::write_directory_with_config` — in-process, no `limni` binary. `tree_hash` stamping stays format-neutral; output replacement keeps the `--force` parity; `dwarfs` stays the default; the unsupported-format named error lists the new set. The legacy `tfs info` summary's `.tfs → DwarFS` extension label now disambiguates by the mounted backend (a limnifs `.tfs` reports `Type: LimniFS`; every pre-existing case is byte-identical).
- **`tebako-cli`**: `tebako press --format dwarfs|limnifs` (default `dwarfs`) — `PressImageFormat` routes the app-image build and stamps the app-image slot `format_id = 5` at the single-press and suite-press stitch sites. **The deploy-time driver image deliberately stays dwarfs**: it is press-internal machinery mounted at press time by the *resolved runtime*, and every released runtime predates the limnifs backend — a limnifs driver would make `press --format limnifs` fail mid-press against today's runtimes. The shipped app payload carries the chosen format; running it needs a limnifs-capable runtime (spec 20 §5's fail-closed rule).
- **`tebako-info`**: `hint_name(5)` → `limnifs`; the `LimniFS` backend name maps to the `limnifs` short/label.

## Tests (all green locally)

- `crates/tfs` — 86 lib tests (17 new limnifs): golden fixtures written **in-process** with limnifs-write (never a binary): stat/pread/readdir/read_link semantics, nested paths, an inline-drop case (inline-only tree ⇒ no slab at all), a SliceMap slab case (windowed reads across drop boundaries, EOF clamping), symlink inodes (hand-encoded — see deviations), detection order (LMFS → limnifs; other magics unchanged; LIM1 → Unknown), corrupt/truncated/trailing-garbage → EINVAL, required-flag → ENOTSUP, external metadata locator → ENOTSUP, all three mount constructors.
- `tests/contract` — the **backend-pair golden class** (spec 20 §8): the dwarfs fixture's tree is snapshotted through the C ABI, re-imaged with limnifs-write, and both mounts must answer identically (readdir sets, stat types/sizes, file contents); region + memory mounts; corrupt-image EINVAL through the ABI.
- `crates/tpkg` — golden vectors extended (above); `crates/tfs-cli` — `mkimage --format limnifs` round-trip through the backend + a CLI-level integration case (mkimage → info/tree/cat/extract) + the named-error set; `crates/tebako-cli` — dwarfs/limnifs image round-trips + format-id mapping; `crates/tebako-info` — hint/label assertions.
- Feature-off: `cargo check -p tfs --no-default-features` clean; `cargo test -p tfs --no-default-features --lib mount::tests` — an `LMFS` mount on a limnifs-less build fails with the named `ENOTSUP` (and the squashfs precedent still passes).

## Deviations from spec 20 (with reasons)

1. **Deploy-time driver image stays dwarfs** (see above). Spec 20 §6 lists "deploy" among the stitch sites for `format_id = 5`; stamping it 5 would only matter if the driver image were also built limnifs, which breaks press against every released runtime today. The stamp is a hint (detection is authoritative); the driver slot keeps `TPKG_FORMAT_DWARFS`.
2. **limnifs-write v0.2.35 rejects symlinks at walk time** (`unsupported file type`). The backend *reads* symlink inodes fine (hand-encoded fixture proves it), but trees containing symlinks cannot be imaged yet — the writer error surfaces by name at mkimage/press. Dwarfs handles them; tracked as limnifs-writer work.
3. **Externalized metadata unsupported**: trees whose compressed metadata blob exceeds the writer's 768 KiB inline threshold produce a `file:` sidecar — a second artifact, never a tebako payload. mkimage/press refuse by name; a mount of such an image fails `ENOTSUP` naming the locator. (Tens of thousands of inodes fit under the threshold.)
4. **The `backend-*` feature-family migration (§5) is not done**: `backend-limnifs` is added as the first `backend-*` feature; renaming `vendored-dwarfs`/`vendored-squashfs` to aliases is left out to keep this PR's touch points minimal against PR #366.
5. **limnifs deps are path deps** (`limnifs-core`, `limnifs-write` → `/Users/mulgogi/src/limnifs/limnifs`) until limnifs has a release to pin against — same standing as the `dwarfs-t` path dep. CI needs the same sibling-checkout convention (or a crates.io release) before this can merge.

## Verification (env per AGENTS.md §13)

- `cargo test -p tfs -p tpkg` — **253 tests green** (86 tfs lib incl. 17 new, all tpkg suites incl. extended golden).
- `cargo test -p tebako-cli --lib` — **53 green**; `cargo test -p tfs-cli` — 18 green; `cargo test -p tebako-info` — 4 green.
- `cargo test -p tebako-contract-tests` — green incl. the limnifs backend-pair class (see checks).
- `cargo clippy -p tpkg -p tfs -p tfs-cli -p tebako-cli -p tebako-info --tests -- -D warnings` — clean; `cargo fmt` — clean.
- **Known pre-existing failure (not this PR):** `cli_e2e::press_gemfile_fontist_modern_resolution_and_platform_gems` fails identically on pristine `origin/main` (verified in a detached baseline worktree — rubygems resolution drift in the e2e environment; the other 8 cli_e2e failures in a full run are its mutex-poison cascades).

## What remains for the e2e press-and-run proof (spec 20 §8 item 5)

- A limnifs-capable **runtime** must exist: today's released runtimes (0.16.x) link tfs without the limnifs backend, so a `--format limnifs` package correctly fails closed (`ENOTSUP`, backend named) at boot. The boot-smoke + `tebako inspect` (format `limnifs`, hint `5`) proof needs a runtime release built from a tebako-driver that includes this backend.
- Multi-slab images (> 60 MiB payloads) are supported by the walk but exercised only by construction (unit fixtures stay single-slab).
- The pure-Rust runtime line (§5's strategic goal) is a separate distribution item.
