### PR TITLE
ci: the release ship gate — clean-env smoke + dependency whitelist per leg

### DIFF
--- a/.github/workflows/lib/ship-gate.sh
+++ b/.github/workflows/lib/ship-gate.sh
@@ -1,0 +1,234 @@
+#!/bin/sh
+# ship-gate.sh — the release ship gate. A binary must FAIL ITS OWN
+# RELEASE PIPELINE, never ship broken (the 0.1.1 lesson: the windows
+# exes imported libstdc++-6.dll/libwinpthread-1.dll, the musl exes
+# NEEDED libstdc++.so.6 — both exit 127 before main on a vanilla box,
+# and build-success was the only gate).
+#
+#   ship-gate.sh <platform> <binary> [<binary> ...]
+#
+# Runs on the STAGED out/ artifacts (the exact shipped bytes), before
+# any upload step of the leg. Two phases per binary:
+#
+#   SMOKE — a bare no-op launch (--version / --help; tebako-bootstrap
+#   has no flags and must answer with its named bare-trailer error,
+#   exit 65) in the CLEANEST environment the leg allows:
+#     windows : PATH scrubbed to System32+Windows — no msys2/ucrt64/Git
+#               bin dirs, because no user machine has them
+#     linux   : the workflow runs this script inside a PRISTINE
+#               ubuntu:20.04 (gnu) / alpine:3.21 (musl) container — the
+#               exact floor the leg claims to target, with none of the
+#               build container's apt/apk additions
+#     macos   : plain launch on the runner
+#   A process that dies before main (missing DLL/dylib: exit 127,
+#   STATUS_DLL_NOT_FOUND, ld.so "not found") never produces the expected
+#   no-op result, so the expected exit code is the whole assertion.
+#
+#   AUDIT — the dynamic-dependency whitelist, pinned from the actual
+#   dumps of the shipped artifacts (0.1.0/0.1.1) and the audience law
+#   (a user box has the OS base, never a toolchain):
+#     windows-*    PE imports must be Windows-inbox — delegated to
+#                  ci/windows-gnu-import-gate.sh (the same gate the
+#                  windows-gnu build legs run; libstdc++-6.dll,
+#                  libwinpthread-1.dll, libgcc_s* = FAIL)
+#     linux-gnu-*  ldd may list ONLY the glibc surface:
+#                  linux-vdso.so.1, ld-linux-{x86-64,aarch64}.so.2,
+#                  libc.so.6, libm.so.6, libpthread.so.0, libdl.so.2,
+#                  librt.so.1 — anything else (libstdc++.so.6,
+#                  libgcc_s.so.1 included) = FAIL. The C++ runtime chain
+#                  is absorbed statically by ci/linux-link-wrap.sh.
+#     linux-musl-* ldd may list ONLY the musl libc:
+#                  ld-musl-{x86_64,aarch64}.so.1,
+#                  libc.musl-{x86_64,aarch64}.so.1 — anything else =
+#                  FAIL. Dynamic-musl is the deliberate shape (see
+#                  ci/musl-build.sh: musl libc is present on every musl
+#                  system by definition); the toolchain runtimes are NOT
+#                  part of a vanilla alpine and must be absorbed.
+#     macos-*      otool -L entries must live under /usr/lib/ or
+#                  /System/ (libSystem, libc++.1, libiconv, the
+#                  Security/CoreFoundation frameworks — the actual
+#                  0.1.1 set); @rpath/@executable_path/absolute
+#                  toolchain paths = FAIL.
+#
+# POSIX sh: runs under bash (ubuntu/macos/windows legs) and busybox sh
+# (the pristine alpine gate container).
+set -eu
+set -f
+
+if [ "$#" -lt 2 ]; then
+  echo "usage: $0 <platform> <binary> [<binary> ...]" >&2
+  exit 64
+fi
+PLATFORM=$1
+shift
+
+case $PLATFORM in
+  windows-*|linux-gnu-*|linux-musl-*|macos-*) ;;
+  *)
+    echo "ship-gate: unknown platform family: $PLATFORM" >&2
+    exit 64 ;;
+esac
+
+REPO_ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/../../.." && pwd)
+failures=0
+
+note() { echo "ship-gate: $*"; }
+bad() {
+  echo "ship-gate: FAIL — $*" >&2
+  failures=$((failures + 1))
+}
+
+# ---------------------------------------------------------------------
+# smoke: one bare launch, expected exit code per tool
+# ---------------------------------------------------------------------
+# Returns the expected exit code for the tool named by the binary
+# basename; the actual launch happens in smoke_one.
+expected_rc() {
+  case $1 in
+    tebako-bootstrap*) echo 65 ;;  # named bare-trailer error (EX_TEBAKO_MANIFEST)
+    tebako-shim*)      echo 0 ;;   # --help
+    tebako-pkg*)       echo 0 ;;   # --help
+    tebako-*)          echo 0 ;;   # --version
+    tfs*)              echo 0 ;;   # --help
+    *)
+      echo "ship-gate: unknown tool name: $1" >&2
+      return 64 ;;
+  esac
+}
+
+smoke_args() {
+  case $1 in
+    tebako-bootstrap*) echo "" ;;
+    tebako-shim*)      echo "--help" ;;
+    tebako-pkg*)       echo "--help" ;;
+    tebako-*)          echo "--version" ;;
+    tfs*)              echo "--help" ;;
+    *)                 echo "--help" ;;
+  esac
+}
+
+smoke_one() {
+  bin=$1
+  base=$(basename "$bin")
+  base=${base%.exe}
+  want=$(expected_rc "$base") || exit 64
+  args=$(smoke_args "$base")
+
+  # tebako-shim dispatches on argv[0]'s basename: invoked under its
+  # staged name (tebako-shim-<ver>-<platform>) it would try to dispatch
+  # that "command" instead of entering management mode. Run the smoke
+  # through a scratch copy carrying the real dispatcher name. (A copy,
+  # not a symlink: Git-bash "symlinks" are text files to CreateProcess.)
+  case $base in
+    tebako-shim*)
+      shimdir=$(mktemp -d "${TMPDIR:-/tmp}/tebako-ship-gate.XXXXXX")
+      case $PLATFORM in
+        windows-*) shimbin="$shimdir/tebako-shim.exe" ;;
+        *)         shimbin="$shimdir/tebako-shim" ;;
+      esac
+      cp "$bin" "$shimbin"
+      bin=$shimbin ;;
+  esac
+
+  note "smoke: $base ${args:-<no args>} (expect exit $want)"
+  set +e
+  if [ "${PLATFORM#windows-}" != "$PLATFORM" ]; then
+    # A user machine has System32 and Windows on PATH — and nothing
+    # else of ours: no msys2, no ucrt64, no Git bin dir. The msys2
+    # runtime re-encodes PATH to windows form for the native child.
+    # $args is a single flag word (or empty): deliberate word splitting.
+    # shellcheck disable=SC2086
+    out=$( PATH="/c/Windows/System32:/c/Windows"
+           export PATH
+           "$bin" $args </dev/null 2>&1 )
+    rc=$?
+  else
+    # shellcheck disable=SC2086
+    out=$("$bin" $args </dev/null 2>&1)
+    rc=$?
+  fi
+  set -e
+  printf '%s\n' "$out" | sed 's/^/    /' | head -5
+  if [ "$rc" -ne "$want" ]; then
+    bad "$base launched with exit $rc, expected $want — the process did not reach its own no-op path (missing runtime library?)"
+  fi
+}
+
+# ---------------------------------------------------------------------
+# audit: the per-family dependency whitelist
+# ---------------------------------------------------------------------
+gnu_whitelist() {
+  case $1 in
+    linux-vdso.so.1|ld-linux-x86-64.so.2|ld-linux-aarch64.so.1|\
+    libc.so.6|libm.so.6|libpthread.so.0|libdl.so.2|librt.so.1) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+musl_whitelist() {
+  case $1 in
+    ld-musl-x86_64.so.1|ld-musl-aarch64.so.1|\
+    libc.musl-x86_64.so.1|libc.musl-aarch64.so.1) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+audit_ldd() {
+  bin=$1
+  family=$2
+  deps=$(ldd "$bin" 2>&1) || true
+  if printf '%s\n' "$deps" | grep -qi 'not a dynamic executable\|not a valid dynamic program'; then
+    note "audit: $(basename "$bin") is fully static — no dynamic deps to audit"
+    return 0
+  fi
+  printf '%s\n' "$deps" | sed 's/^/    /'
+  if printf '%s\n' "$deps" | grep -qi 'not found\|error loading\|error relocating'; then
+    bad "$(basename "$bin"): ldd reports an unresolvable dependency"
+    return 0
+  fi
+  # First field of each line is the soname (or the interpreter path).
+  for dep in $(printf '%s\n' "$deps" | awk '{print $1}'); do
+    soname=$(basename "$dep")
+    if ! "${family}"_whitelist "$soname"; then
+      bad "$(basename "$bin"): off-whitelist dependency: $soname"
+    fi
+  done
+}
+
+audit_macos() {
+  bin=$1
+  deps=$(otool -L "$bin" | tail -n +2 | awk '{print $1}')
+  printf '%s\n' "$deps" | sed 's/^/    /'
+  for dep in $deps; do
+    case $dep in
+      /usr/lib/*|/System/*) ;;
+      *) bad "$(basename "$bin"): off-whitelist dylib: $dep" ;;
+    esac
+  done
+}
+
+note "platform $PLATFORM — gating $# binar$( [ "$#" -eq 1 ] && echo y || echo ies)"
+
+for bin in "$@"; do
+  [ -f "$bin" ] || { echo "ship-gate: no such file: $bin" >&2; exit 66; }
+  note "=== $bin ==="
+  smoke_one "$bin"
+  case $PLATFORM in
+    windows-*)
+      # objdump-based PE import audit (the windows-gnu legs' own gate);
+      # needs the leg's toolchain PATH, so it runs here, not in the
+      # scrubbed smoke environment.
+      if ! bash "$REPO_ROOT/ci/windows-gnu-import-gate.sh" "$bin"; then
+        failures=$((failures + 1))
+      fi ;;
+    linux-gnu-*)  audit_ldd "$bin" gnu ;;
+    linux-musl-*) audit_ldd "$bin" musl ;;
+    macos-*)      audit_macos "$bin" ;;
+  esac
+done
+
+if [ "$failures" -gt 0 ]; then
+  echo "ship-gate: FAIL — $failures violation(s); a broken binary fails its own release pipeline, it never ships" >&2
+  exit 1
+fi
+note "PASS ($# gated: clean-env smoke + dependency whitelist)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,17 @@
 # completeness gate (the finalize job fails unless every expected asset
 # landed).
 #
+# The ship gate (.github/workflows/lib/ship-gate.sh): every leg proves
+# its staged binaries BEFORE any upload — a bare no-op launch in the
+# cleanest environment the leg allows (windows: PATH scrubbed of every
+# msys2/ucrt64/Git bin dir; linux-gnu: a PRISTINE ubuntu:20.04
+# container, the floor the leg claims; linux-musl: a pristine
+# alpine:3.21; macos: plain launch) plus a hard dynamic-dependency
+# whitelist audit (PE imports / ldd / otool -L). A broken binary fails
+# its own leg and blocks finalize — it never ships (the 0.1.1 windows
+# exes imported ucrt64 DLLs and died before main on stock Windows with
+# build-success as the only gate).
+#
 # Unsigned-first: SHA256SUMS + manifest.json ship from day one; detached
 # signatures slot in later (item 29 phase 2) by signing SHA256SUMS and
 # uploading .asc files — no restructuring.
@@ -64,6 +75,11 @@ jobs:
       - name: Get release
         id: get_release
         uses: bruceadams/get-release@v1.3.2
+        # workflow_dispatch has no release to get: tolerate the miss so a
+        # dispatch is a build+gate dry run (every upload/publish step is
+        # already gated on upload_url != ''). Real release events stay
+        # strict — a get-release failure there must fail the pipeline.
+        continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Resolve tag and version
@@ -71,7 +87,11 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name || github.ref_name }}"
           echo "tag_name=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          VERSION="${TAG#v}"
+          # A workflow_dispatch carries the BRANCH name (ci/foo), and the
+          # version lands in the staged artifact filenames — slashes
+          # would make them paths. Real tags never contain one.
+          echo "version=${VERSION//\//-}" >> "$GITHUB_OUTPUT"
 
   # ==========================================================================
   # macOS (native runners, both arches — parsanol shape)
@@ -181,6 +201,15 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
           PLATFORM: ${{ matrix.platform }}
         run: bash .github/workflows/lib/stage.sh
+
+      # The ship gate BEFORE any upload: bare-launch smoke (plain run on
+      # the runner) + the otool -L whitelist (/usr/lib + /System only).
+      - name: Ship gate (bare-launch smoke + dylib audit)
+        working-directory: tebako-rs
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: bash .github/workflows/lib/ship-gate.sh "$PLATFORM" out/*-"$VERSION-$PLATFORM"
 
       - name: Stage the link unit (tebako-driver + tfs, scoped, + closure)
         working-directory: tebako-rs
@@ -308,6 +337,22 @@ jobs:
             -e GITHUB_STEP_SUMMARY -e GITHUB_WORKSPACE \
             ubuntu:20.04 bash "$GITHUB_WORKSPACE/tebako-rs/ci/gnu-floor-build.sh"
 
+      # The ship gate BEFORE any upload, in a PRISTINE ubuntu:20.04
+      # container — the exact floor the leg claims, with none of the
+      # build container's apt additions (a dependency that only the
+      # build container provides fails HERE, not on a user box):
+      # bare-launch smoke + the ldd glibc-surface whitelist.
+      - name: Ship gate (pristine ubuntu:20.04 — smoke + ldd audit)
+        working-directory: tebako-rs
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+            -w "$GITHUB_WORKSPACE/tebako-rs" \
+            ubuntu:20.04 bash .github/workflows/lib/ship-gate.sh "$PLATFORM" out/*-"$VERSION-$PLATFORM"
+
       - name: Upload link-unit
         if: needs.prepare.outputs.upload_url != ''
         run: gh release upload "${{ needs.prepare.outputs.tag_name }}" "tebako-rs/out/link-unit-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}.tar.gz" --clobber
@@ -421,6 +466,22 @@ jobs:
             -e RUST_VERSION -e VCPKG_COMMIT -e BOOTSTRAP_SIZE_BUDGET \
             -e GITHUB_STEP_SUMMARY -e GITHUB_WORKSPACE \
             alpine:3.21 sh "$GITHUB_WORKSPACE/tebako-rs/ci/musl-build.sh"
+
+      # The ship gate BEFORE any upload, in a PRISTINE alpine:3.21
+      # container — a vanilla musl box (busybox sh, no toolchain
+      # libraries): bare-launch smoke + the ldd whitelist (libc.musl
+      # only; libstdc++/libgcc_s = FAIL — the 0.1.1 musl assets exit 127
+      # here).
+      - name: Ship gate (pristine alpine:3.21 — smoke + ldd audit)
+        working-directory: tebako-rs
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+            -w "$GITHUB_WORKSPACE/tebako-rs" \
+            alpine:3.21 sh .github/workflows/lib/ship-gate.sh "$PLATFORM" out/*-"$VERSION-$PLATFORM"
 
       - name: Upload fragment artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -726,6 +787,22 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
           PLATFORM: windows-ucrt64
         run: bash ci/windows-gnu-release.sh
+
+      # The ship gate BEFORE any upload: the PE import audit (the
+      # windows-gnu-import-gate delegation — inbox DLLs only;
+      # libstdc++-6.dll/libwinpthread-1.dll = FAIL) and the bare-launch
+      # smoke with PATH scrubbed to System32+Windows — what a user
+      # machine actually looks like (no msys2/ucrt64/Git bin dirs; the
+      # 0.1.1 exes only survived because ucrt64/bin sat on the runner's
+      # PATH).
+      - name: Ship gate (clean-PATH smoke + PE import audit)
+        working-directory: tebako-rs
+        shell: bash
+        run: |
+          # objdump for the import audit comes from the ucrt64 toolchain
+          # (the same closed-PATH root windows-gnu-release.sh uses).
+          export PATH="/d/a/_temp/msys64/ucrt64/bin:$PATH"
+          bash .github/workflows/lib/ship-gate.sh windows-ucrt64 out/*.exe
 
       - name: Dump vcpkg build logs on failure
         if: failure()

--- a/ci/gnu-floor-build.sh
+++ b/ci/gnu-floor-build.sh
@@ -145,6 +145,24 @@ export DWARFS_RS_VCPKG_TRIPLET="$TRIPLET"
 export SQFS_SYS_VCPKG_TRIPLET="$TRIPLET"
 export SQFS_SYS_VCPKG_INSTALLED_DIR="$WS/.sqfs-floor/$TRIPLET"
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
+# Absorb the C/C++ runtime chain (libstdc++, libgcc_s) STATICALLY into
+# the shipped binaries. The floor promise is "runs on a vanilla 20.04+
+# box", and a NEEDED libstdc++.so.6 built against the ppa gcc imports
+# GLIBCXX symbol versions above focal's stock 3.4.28 — the same
+# dies-before-main class as the 0.1.1 windows exes. Trailing link-arg
+# flags cannot do it: rustc emits a build script's -lstdc++/-lgcc_s
+# wrapped in -Wl,-Bdynamic at its own position, BEFORE the -C link-arg
+# tail, and gcc's -static-libstdc++ rewrites only the driver's own
+# implicit -l (proven on this container's gcc). ci/linux-link-wrap.sh
+# rewrites the tokens at the driver boundary (the linux twin of the
+# windows-gnu legs' ci/windows-gnu-link-wrap.c). Engaged via -C linker
+# in RUSTFLAGS: with --target passed, RUSTFLAGS reaches the target
+# units (the shipped exes) while build scripts keep the default linker
+# (CARGO_TARGET_<triple>_LINKER would work here too, but -C linker is
+# the one form that ALSO covers the musl leg's no---target build —
+# one mechanism for both). The release leg's ship gate (the ldd
+# whitelist in .github/workflows/lib/ship-gate.sh) is the enforcement.
+export RUSTFLAGS="-C linker=$WS/tebako-rs/ci/linux-link-wrap.sh"
 cargo build --release --target "$TARGET" \
   -p tebako-bootstrap -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim
 

--- a/ci/linux-link-wrap.sh
+++ b/ci/linux-link-wrap.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# linux-link-wrap.sh — the release-link policy for the shipped LINUX
+# binaries (the gnu floor legs and the musl legs): the C/C++ runtime
+# chain is ALWAYS absorbed statically, no matter which crate in the
+# dependency tree emitted the link directive.
+#
+# Why (the exit-127 class, linux edition): a shipped exe that NEEDs
+# libstdc++.so.6 / libgcc_s.so.1 dies before main on a vanilla target
+# box — alpine:3.21 has neither (the 0.1.1 musl assets exit 127 there),
+# and a gnu build against the ppa gcc's libstdc++ imports GLIBCXX symbol
+# versions above the claimed glibc-2.31 floor. RUSTFLAGS tail flags
+# (-C link-arg=-static-libstdc++ -C link-arg=-static-libgcc) look like
+# the fix but are not: rustc passes a build script's
+# cargo:rustc-link-lib=dylib=stdc++ (rnp-rs emits exactly that) as an
+# explicit -lstdc++ wrapped in -Wl,-Bdynamic at its OWN position, BEFORE
+# the trailing -C link-args — and gcc's -static-libstdc++ only rewrites
+# the driver's own implicit -lstdc++, never an explicit one (proven on
+# ubuntu:20.04 gcc-9: `gcc t.o -Wl,-Bdynamic -lstdc++ -static-libstdc++`
+# keeps the NEEDED libstdc++.so.6). Same conclusion the windows-gnu legs
+# reached (ci/windows-gnu-link-wrap.c).
+#
+# What it does: every reference is rewritten to a form that is immune to
+# position and to the surrounding -Bstatic/-Bdynamic mode:
+#
+#   -lstdc++   ->  -l:libstdc++.a            (exact-archive form)
+#   -lgcc_s    ->  -l:libgcc.a -l:libgcc_eh.a
+#
+# in all three rustc emission shapes: bare argv entries, members of
+# -Wl,<a>,<b>,... comma lists, and tokens inside @response files (rustc
+# moves long link lines into one). Everything else passes through
+# untouched: the glibc surface (-lc -lm -lpthread -ldl -lrt -lutil)
+# stays dynamic by design, and the musl legs keep libc.musl dynamic —
+# the same shape as the runtime factory's musl runtimes (musl libc is
+# present on every musl system by definition).
+#
+# Engaged from ci/gnu-floor-build.sh / ci/musl-build.sh via
+#   CARGO_TARGET_<TRIPLE>_LINKER=<this script>
+# (cargo spawns the linker directly — the shebang makes a script a valid
+# linker; the windows-gnu wrapper must be a compiled exe only because
+# CreateProcess has no shebang). The real driver is $TEBAKO_LINK_WRAP_CC,
+# default cc — resolved from the leg's PATH at exec time.
+#
+# The ship gate (.github/workflows/lib/ship-gate.sh) audits the result
+# on the staged bytes; this wrapper is the mechanism it verifies.
+set -eu
+# No globbing anywhere below (the IFS=, member split must not expand).
+set -f
+
+REAL="${TEBAKO_LINK_WRAP_CC:-cc}"
+
+TMPD=$(mktemp -d "${TMPDIR:-/tmp}/tebako-link-wrap.XXXXXX")
+trap 'rm -rf "$TMPD"' EXIT HUP INT TERM
+
+# rewrite_respfile <path> <scratch-name> -> prints the rewritten copy's
+# path. The rewrite targets are exact flag spellings that can never
+# appear inside a quoted path member, so a byte-level global rewrite of
+# the response file is token-safe (sed BRE: '+' is literal).
+rewrite_respfile() {
+  nf="$TMPD/$2"
+  sed -e 's/-lstdc++/-l:libstdc++.a/g' \
+      -e 's/-lgcc_s/-l:libgcc.a -l:libgcc_eh.a/g' "$1" > "$nf"
+  printf '%s' "$nf"
+}
+
+# rewrite_wl <-Wl,a,b,...> -> prints the rewritten list, newline-ended
+# (members never contain spaces; a -lgcc_s member becomes two
+# comma-joined members).
+rewrite_wl() {
+  rest=${1#-Wl,}
+  out="-Wl,"
+  first=1
+  oldifs=$IFS
+  IFS=,
+  for m in $rest; do
+    IFS=$oldifs
+    case $m in
+      -lstdc++) r='-l:libstdc++.a' ;;
+      -lgcc_s)  r='-l:libgcc.a,-l:libgcc_eh.a' ;;
+      *)        r=$m ;;
+    esac
+    if [ "$first" -eq 1 ]; then
+      out="$out$r"
+      first=0
+    else
+      out="$out,$r"
+    fi
+    IFS=,
+  done
+  IFS=$oldifs
+  printf '%s\n' "$out"
+}
+
+# Rebuild the positional parameters with every rewrite applied. The
+# rewritten argv is collected one token per line in a scratch file (a
+# passthrough token may legitimately contain spaces; newline framing
+# keeps it intact).
+LIST="$TMPD/argv"
+: > "$LIST"
+i=0
+for a in "$@"; do
+  case $a in
+    -lstdc++)
+      printf '%s\n' '-l:libstdc++.a' >> "$LIST" ;;
+    -lgcc_s)
+      printf '%s\n%s\n' '-l:libgcc.a' '-l:libgcc_eh.a' >> "$LIST" ;;
+    -Wl,*)
+      rewrite_wl "$a" >> "$LIST" ;;
+    @*)
+      f=${a#@}
+      if [ -f "$f" ]; then
+        i=$((i + 1))
+        nf=$(rewrite_respfile "$f" "resp.$i")
+        printf '@%s\n' "$nf" >> "$LIST"
+      else
+        printf '%s\n' "$a" >> "$LIST"
+      fi ;;
+    *)
+      printf '%s\n' "$a" >> "$LIST" ;;
+  esac
+done
+
+set --
+while IFS= read -r line; do
+  set -- "$@" "$line"
+done < "$LIST"
+
+exec "$REAL" "$@"

--- a/ci/linux-link-wrap.sh
+++ b/ci/linux-link-wrap.sh
@@ -23,7 +23,16 @@
 # position and to the surrounding -Bstatic/-Bdynamic mode:
 #
 #   -lstdc++   ->  -l:libstdc++.a            (exact-archive form)
-#   -lgcc_s    ->  -l:libgcc.a -l:libgcc_eh.a
+#   -lgcc_s    ->  -l:libgcc.a -l:libgcc_eh.a -l:libgcc.a
+#
+# The libgcc BOOKEND mirrors gcc's own static spec (libgcc, libgcc_eh,
+# libgcc): libgcc_eh's frame-registry objects back-reference the
+# compiler support routines — on aarch64 the LSE outline atomics
+# (__aarch64_cas8_acq_rel & co. from unwind-dw2-btree.h, live in
+# libgcc.a) — and a single leading -l:libgcc.a has already been passed
+# by then (alpine:3.21 gcc-14 musl-arm64 link of any rust build script:
+# "undefined reference to __aarch64_cas8_acq_rel"; green run
+# 30986954656's musl-arm64 leg).
 #
 # in all three rustc emission shapes: bare argv entries, members of
 # -Wl,<a>,<b>,... comma lists, and tokens inside @response files (rustc
@@ -58,7 +67,7 @@ trap 'rm -rf "$TMPD"' EXIT HUP INT TERM
 rewrite_respfile() {
   nf="$TMPD/$2"
   sed -e 's/-lstdc++/-l:libstdc++.a/g' \
-      -e 's/-lgcc_s/-l:libgcc.a -l:libgcc_eh.a/g' "$1" > "$nf"
+      -e 's/-lgcc_s/-l:libgcc.a -l:libgcc_eh.a -l:libgcc.a/g' "$1" > "$nf"
   printf '%s' "$nf"
 }
 
@@ -75,7 +84,7 @@ rewrite_wl() {
     IFS=$oldifs
     case $m in
       -lstdc++) r='-l:libstdc++.a' ;;
-      -lgcc_s)  r='-l:libgcc.a,-l:libgcc_eh.a' ;;
+      -lgcc_s)  r='-l:libgcc.a,-l:libgcc_eh.a,-l:libgcc.a' ;;
       *)        r=$m ;;
     esac
     if [ "$first" -eq 1 ]; then
@@ -102,7 +111,7 @@ for a in "$@"; do
     -lstdc++)
       printf '%s\n' '-l:libstdc++.a' >> "$LIST" ;;
     -lgcc_s)
-      printf '%s\n%s\n' '-l:libgcc.a' '-l:libgcc_eh.a' >> "$LIST" ;;
+      printf '%s\n%s\n%s\n' '-l:libgcc.a' '-l:libgcc_eh.a' '-l:libgcc.a' >> "$LIST" ;;
     -Wl,*)
       rewrite_wl "$a" >> "$LIST" ;;
     @*)

--- a/ci/musl-build.sh
+++ b/ci/musl-build.sh
@@ -109,7 +109,20 @@ echo "== pre-install squashfs-tools-ng ($TRIPLET) =="
 # RUSTFLAGS then covers host units, and the artifacts land in the
 # default-target layout target/release (stage.sh and link-unit-stage.sh
 # resolve both layouts).
-export RUSTFLAGS="-C target-feature=-crt-static"
+# ...but the toolchain runtimes are NOT part of that contract: a NEEDED
+# libstdc++.so.6/libgcc_s.so.1 is exit 127 on a vanilla alpine (proven by
+# the 0.1.1 musl assets). Absorb them STATICALLY: the trailing-flags
+# trick cannot (rustc emits a build script's -lstdc++/-lgcc_s before the
+# -C link-arg tail — see ci/linux-link-wrap.sh), so the driver-boundary
+# wrapper rewrites those tokens. Engaged via -C linker INSIDE RUSTFLAGS:
+# this leg builds without --target, and cargo honors neither
+# CARGO_TARGET_<host-triple>_LINKER nor target-unit-only flags for the
+# shipped exes in that mode (proven on alpine:3.21 cargo) — RUSTFLAGS is
+# the one channel that covers every unit here. The wrapper's rewrites
+# are harmless to build-script links. The release leg's ship gate (the
+# musl ldd whitelist in .github/workflows/lib/ship-gate.sh) is the
+# enforcement: libc.musl ONLY.
+export RUSTFLAGS="-C target-feature=-crt-static -C linker=$WS/tebako-rs/ci/linux-link-wrap.sh"
 echo "== cargo build (release, $TARGET — native, no --target) =="
 cd "$WS/tebako-rs"
 export DWARFS_RS_VCPKG_ROOT="$WS/.vcpkg-musl"

--- a/crates/tebako-arscope/src/main.rs
+++ b/crates/tebako-arscope/src/main.rs
@@ -562,12 +562,28 @@ fn scope_object(
             _ => object::write::SymbolSection::Undefined,
         };
         let flags = map_symbol_flags(symbol.flags(), &section_ids, &symbol_ids)?;
+        // object 0.37's ELF reader maps STB_GNU_UNIQUE (glibc-target
+        // g++'s vague-linkage binding — template/inline statics;
+        // libstdc++.a alone carries 154) to SymbolScope::Unknown, and its
+        // writer asserts a defined symbol is scoped (write/mod.rs:434).
+        // Re-scope to Linkage for the write: the passthrough st_info
+        // flags keep the UNIQUE binding in the emitted symbol, so the
+        // output is byte-equivalent to what the pre-assert writer
+        // produced — the v0.1.0 gnu link unit shipped exactly this shape
+        // and the factory consumed it. Only the gnu legs carry such
+        // members (musl and Mach-O have no GNU_UNIQUE), which is why the
+        // floor leg's scoper panic (run 30988106906) was the first time
+        // a gnu release build reached this code.
+        let scope = match symbol.scope() {
+            SymbolScope::Unknown if !symbol.is_undefined() => SymbolScope::Linkage,
+            scope => scope,
+        };
         let id = out.add_symbol(object::write::Symbol {
             name: renamed.into_bytes(),
             value: symbol.address(),
             size: symbol.size(),
             kind: symbol.kind(),
-            scope: symbol.scope(),
+            scope,
             weak: symbol.is_weak(),
             section,
             flags,
@@ -771,6 +787,77 @@ mod tests {
         );
         assert_eq!(report.kept, 1);
         assert_eq!(report.scoped, 1);
+    }
+
+    /// A defined STB_GNU_UNIQUE symbol (glibc-target g++'s vague-linkage
+    /// binding — every C++ object with template/inline statics carries
+    /// them on the gnu legs) reads back as SymbolScope::Unknown; the
+    /// rewrite must re-scope it for the writer instead of panicking on
+    /// its defined-symbol assert (the floor leg's scoper panic, release
+    /// run 30988106906). ELF-only: Mach-O has no such binding.
+    fn fixture_object_gnu_unique() -> Vec<u8> {
+        let arch = if cfg!(target_arch = "aarch64") {
+            object::Architecture::Aarch64
+        } else {
+            object::Architecture::X86_64
+        };
+        let mut out = object::write::Object::new(
+            object::BinaryFormat::Elf,
+            arch,
+            object::Endianness::Little,
+        );
+        let text = out.add_section(
+            b".text".to_vec(),
+            b".text".to_vec(),
+            object::SectionKind::Text,
+        );
+        out.section_mut(text).set_data(b"\x90\x90\xc3", 1);
+        out.add_symbol(object::write::Symbol {
+            name: b"_ZN1HIiE1vE".to_vec(),
+            value: 0,
+            size: 4,
+            kind: object::SymbolKind::Data,
+            scope: object::SymbolScope::Linkage,
+            weak: false,
+            section: object::write::SymbolSection::Section(text),
+            // st_info = STB_GNU_UNIQUE (10) << 4 | STT_OBJECT (1)
+            flags: object::SymbolFlags::Elf {
+                st_info: (10 << 4) | 1,
+                st_other: 0,
+            },
+        });
+        out.write().expect("fixture object")
+    }
+
+    #[test]
+    fn gnu_unique_symbols_survive_the_rewrite() {
+        let fixture = fixture_object_gnu_unique();
+        let obj = File::parse(&fixture[..]).expect("parse the fixture");
+        let sym = obj
+            .symbols()
+            .find(|s| s.name().ok() == Some("_ZN1HIiE1vE"))
+            .expect("the fixture carries the unique symbol");
+        assert_eq!(
+            sym.scope(),
+            SymbolScope::Unknown,
+            "the fixture must read back the way glibc-target objects do"
+        );
+
+        let mut report = Report::default();
+        let (bytes, _exported) = scope_object(
+            &fixture,
+            KEEP_PREFIX,
+            SCOPE_PREFIX,
+            &std::collections::HashSet::new(),
+            &mut report,
+        )
+        .expect("scope the fixture");
+        let obj = File::parse(&bytes[..]).expect("parse the rewritten object");
+        let sym = obj
+            .symbols()
+            .find(|s| s.name().ok() == Some("_ZN1HIiE1vE"))
+            .expect("the unique symbol survives the rewrite");
+        assert!(!sym.is_undefined());
     }
 
     /// A fixture object with one defined global and two undefined

--- a/crates/tebako-arscope/src/main.rs
+++ b/crates/tebako-arscope/src/main.rs
@@ -801,11 +801,8 @@ mod tests {
         } else {
             object::Architecture::X86_64
         };
-        let mut out = object::write::Object::new(
-            object::BinaryFormat::Elf,
-            arch,
-            object::Endianness::Little,
-        );
+        let mut out =
+            object::write::Object::new(object::BinaryFormat::Elf, arch, object::Endianness::Little);
         let text = out.add_section(
             b".text".to_vec(),
             b".text".to_vec(),


### PR DESCRIPTION
Owner directive: a broken binary must FAIL ITS OWN RELEASE PIPELINE, never ship — proven necessary by the v0.1.1 windows exes (exit 127 on a vanilla box, shipped green).

This PR is the three unique commits from the release-ship-gate work, cherry-picked onto post-#367/#368 main (the static-link and link-wrap-rewrite halves already merged as #367):

1. **The ship gate**: after build, before any upload, each of the five binaries runs a no-op in a clean environment — on windows with msys2/ucrt64 REMOVED from PATH (what a user's machine looks like) — plus a hard dependency whitelist per platform (PE imports / ldd / otool; `libstdc++-6.dll`/`libwinpthread-1.dll` off-list = FAIL). A gate failure fails the leg and blocks publish.
2. **link-wrap — the libgcc bookend** (aarch64 outline atomics back-reference).
3. **arscope: re-scope STB_GNU_UNIQUE definitions** for the object writer (exposed by the first gate attempts; regression test added).

Proofs already on record from the original branch: the deliberately-broken windows build (0.1.1 reproduction) was caught — exit 127 on the scrubbed PATH, audit flagged both DLLs, uploads skipped, finalize blocked — with zero false positives on the clean binaries (run 30988263282); the fixed-shape build runs green (run 30992103241).
