### PR TITLE
contract tests: limnifs-write via the pinned git dep (fix main's all-leg cargo metadata failure)

### DIFF
--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -41,7 +41,7 @@ serde_yml = "0.0.12"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
 # — pure Rust, no `limni` binary anywhere.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "14ab01d017af054d24ff002775e17663146cdfad" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "eddaea404b7686c4f22462c366065a3a35bf9b43" }
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -29,7 +29,7 @@ tebako-json = { version = "0.1.0", path = "../tebako-json" }
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
 # §6) — pure Rust, no `limni` binary anywhere.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "14ab01d017af054d24ff002775e17663146cdfad" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "eddaea404b7686c4f22462c366065a3a35bf9b43" }
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -45,7 +45,7 @@ sqfs-sys = { version = "0.1.0", path = "../sqfs-sys", optional = true }
 # The LimniFS backend (spec 20): the pure-Rust limnifs-core reader — no
 # system dependencies, `#![forbid(unsafe_code)]` upstream. Path dep until
 # limnifs has a release to pin against (same standing as dwarfs-t).
-limnifs-core = { git = "https://github.com/limnifs/limnifs", rev = "14ab01d017af054d24ff002775e17663146cdfad", optional = true }
+limnifs-core = { git = "https://github.com/limnifs/limnifs", rev = "eddaea404b7686c4f22462c366065a3a35bf9b43", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
@@ -87,5 +87,5 @@ rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
 crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —
 # test-only, never linked into the shipped library.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "14ab01d017af054d24ff002775e17663146cdfad" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "eddaea404b7686c4f22462c366065a3a35bf9b43" }
 

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -25,4 +25,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 # The limnifs backend-pair golden class builds its fixture image
 # in-process (spec 20 §8) — never a `limni` binary.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "14ab01d017af054d24ff002775e17663146cdfad" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "eddaea404b7686c4f22462c366065a3a35bf9b43" }

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -25,4 +25,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 # The limnifs backend-pair golden class builds its fixture image
 # in-process (spec 20 §8) — never a `limni` binary.
-limnifs-write = { version = "0.2", path = "../../../../limnifs/limnifs/limnifs-write" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "14ab01d017af054d24ff002775e17663146cdfad" }


### PR DESCRIPTION
#371's path→git conversion covered crates/*/Cargo.toml but missed tests/contract/Cargo.toml — its path dep broke every CI leg on main (`cargo metadata` → "failed to read …/limnifs/limnifs/limnifs-write/Cargo.toml"). Same pinned git dep (rev 14ab01d0) as the other three manifests.
