### PR TITLE
driver: the uniform VFS namespace — declared mounts qualify onto the windows VFS drive (fixes #365)

### DIFF
--- a/crates/tebako-cli/src/deploy.rs
+++ b/crates/tebako-cli/src/deploy.rs
@@ -147,7 +147,7 @@ impl RuntimeDeployer {
         format!(
             "{}:0:{}",
             self.driver_package().display(),
-            self.fs_mount_point
+            crate::declared_mount(&self.fs_mount_point)
         )
     }
 
@@ -167,21 +167,58 @@ impl RuntimeDeployer {
 
     /// The runtime reads the slot region referenced by the file's tpkg
     /// trailer; the base bytes are irrelevant to the mount, so the package
-    /// is stitched onto an empty base.
+    /// is stitched onto an empty base. The slot's mount point is the
+    /// DECLARED root (the driver qualifies it onto the VFS drive at boot,
+    /// spec 17 §1) and the L2 `mounts:` row declares the union over the
+    /// env image — the deploy driver image lands at the runtime root the
+    /// env image already owns.
     fn stitch_driver_package(&self) -> Result<(), TebakoError> {
         let empty_base = self.staging_bin_dir.join(EMPTY_BASE);
         fs::write(&empty_base, b"").map_err(|e| {
             crate::error::plain_error(format!("{e} writing {}", empty_base.display()))
         })?;
+        let declared = crate::declared_mount(&self.fs_mount_point);
         let images = [tebako_pkg::PackageImage {
             path: self.driver_image(),
-            mount_point: self.fs_mount_point.clone(),
+            mount_point: declared.to_string(),
             format_id: tpkg::TPKG_FORMAT_DWARFS,
         }];
+        let runtime_ref = format!("ruby@{};tebako={}", self.ruby_version, self.tebako_version);
         let options = tebako_pkg::PackageOptions {
-            runtime_ref: format!("ruby@{};tebako={}", self.ruby_version, self.tebako_version),
+            runtime_ref: runtime_ref.clone(),
             package_flags: tpkg::TPKG_FLAG_LEAN,
             launcher_abi: crate::LAUNCHER_ABI,
+            package_manifest: Some(tpkg::PackageManifest {
+                schema_version: tpkg::PACKAGE_SCHEMA_VERSION,
+                package: tpkg::PackageIdentity {
+                    name: "tebako-deploy-driver".to_string(),
+                    version: self.tebako_version.clone(),
+                    producer: tpkg::Producer {
+                        tool: "tebako-cli".to_string(),
+                        tool_version: self.tebako_version.clone(),
+                    },
+                    created: crate::install::rfc3339_utc(
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs())
+                            .unwrap_or(0),
+                    ),
+                },
+                entries: vec![tpkg::PackageEntry {
+                    name: "tebako-deploy-driver".to_string(),
+                    slot: 0,
+                    entrypoint: "/local/stub.rb".to_string(),
+                    runtime_ref,
+                }],
+                jail: None,
+                env: Default::default(),
+                mounts: vec![tpkg::PackageMount {
+                    slot: 0,
+                    point: declared.to_string(),
+                    mode: tpkg::MountMode::Union,
+                    precedence: Some(tpkg::Precedence::AfterEnv),
+                }],
+            }),
             ..Default::default()
         };
         tebako_pkg::bundle_exact(&empty_base, &images, &self.driver_package(), &options)

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -87,8 +87,9 @@ pub const LAUNCHER_ABI: u32 = 1;
 /// and the tebako=<...> component of the trailer's runtime_ref. Matches
 /// the reference gem's Tebako::VERSION at port time.
 /// The tebako release line the CLI presses against. New-era only: from
-/// 0.16.1 the runtimes bake the renamed mount root (`/__tfs__`, `A:/t`);
-/// older releases carry the legacy `__tebako_memfs__` layout and are NOT
+/// 0.16.1 the runtimes bake the renamed mount root (`/__tfs__`,
+/// `A:/__tfs__` on windows — the one name on every platform); older
+/// releases carry the legacy `__tebako_memfs__` layout and are NOT
 /// served (no old contract, no compat readers).
 pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.2";
 
@@ -231,7 +232,7 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
 
     let mut images: Vec<(PathBuf, String, u32)> = vec![(
         app_image,
-        scenario.fs_mount_point.clone(),
+        declared_mount(&scenario.fs_mount_point).to_string(),
         opts.format.tpkg_format_id(),
     )];
     for (path, mount) in opts.images()? {
@@ -272,7 +273,7 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
         &package,
         &runtime_ref,
         &opts.tebako_version,
-        &scenario.fs_mount_point,
+        declared_mount(&scenario.fs_mount_point),
         jail,
     );
     stitch(
@@ -475,6 +476,21 @@ pub(crate) fn stitch(
     Ok(())
 }
 
+/// The declared (POSIX) form of a mount point: the uniform VFS
+/// namespace name the trailer slots and L2 `mounts:` rows carry on
+/// every platform — the physical root minus any windows drive
+/// (`A:/__tfs__` → `/__tfs__`; POSIX roots are unchanged). The driver
+/// re-qualifies declared mounts onto the VFS drive at boot (spec 17
+/// §1), so the argv grammar never has to carry a drive colon.
+pub(crate) fn declared_mount(mount_point: &str) -> &str {
+    let b = mount_point.as_bytes();
+    if b.len() >= 2 && b[0].is_ascii_alphabetic() && b[1] == b':' {
+        &mount_point[2..]
+    } else {
+        mount_point
+    }
+}
+
 /// The L2 package manifest every runnable press writes (spec 03 §6 /
 /// spec 02 §5b): minimal identity (press has no package-version input —
 /// a --package-version flag is a later milestone), one entry naming the
@@ -482,10 +498,11 @@ pub(crate) fn stitch(
 /// — mount-relative; the driver joins mount+entry, spec 17 §1),
 /// `runtime_ref` mirroring the trailer field, and the `mounts:` row
 /// declaring the app slot's union over the env image at the runtime
-/// root (`mount_point` — the trailer's own mount point, `/__tfs__` or
-/// `A:/t` on windows, so the two stay consistent by construction). A
-/// --jail press composes the policy into the same block — the package's
-/// host-access REQUEST the bootstrap tightens at handoff (spec 08 §2).
+/// root (`mount_point` — the trailer's own mount point, the declared
+/// `/__tfs__` on every platform, so the two stay consistent by
+/// construction). A --jail press composes the policy into the same
+/// block — the package's host-access REQUEST the bootstrap tightens at
+/// handoff (spec 08 §2).
 fn press_package_manifest(
     package: &str,
     runtime_ref: &str,

--- a/crates/tebako-cli/src/scenario.rs
+++ b/crates/tebako-cli/src/scenario.rs
@@ -390,7 +390,7 @@ impl ScenarioManager {
             fs_entrance: ent.clone(),
             fs_entry_point: format!("/bin/{ent}"),
             fs_mount_point: if msys {
-                "A:/t".to_string()
+                "A:/__tfs__".to_string()
             } else {
                 "/__tfs__".to_string()
             },

--- a/crates/tebako-cli/src/suite.rs
+++ b/crates/tebako-cli/src/suite.rs
@@ -393,7 +393,7 @@ pub fn press_suite(
         })?;
         images.push((
             staged,
-            scenario_mgr.fs_mount_point.clone(),
+            crate::declared_mount(&scenario_mgr.fs_mount_point).to_string(),
             entry_opts.format.tpkg_format_id(),
         ));
         runtime_refs.push(entry_runtime_ref(entry, &ruby_ver, opts, resolved));

--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -496,6 +496,35 @@ fn join_mount(mount_point: &str, entry: &str) -> String {
     )
 }
 
+/// The VFS drive of a runtime root: `A:/__tfs__` → `Some("A:")`;
+/// `/__tfs__` → `None` (POSIX — no drive qualification).
+fn vfs_drive(runtime_root: &str) -> Option<&str> {
+    let b = runtime_root.as_bytes();
+    if b.len() >= 2 && b[0].is_ascii_alphabetic() && b[1] == b':' {
+        Some(&runtime_root[..2])
+    } else {
+        None
+    }
+}
+
+/// Windows (spec 17 §1): a declared mount is a POSIX absolute path in
+/// the VFS namespace (`/`, `/__tfs__`, `/opt/x`); on windows the
+/// namespace presents on its own drive — the drive of the runtime root
+/// (`A:/__tfs__` — the uniform root: the same name on every platform).
+/// The driver therefore mounts every declared point at
+/// `<drive><mount>`. Ruby's C-level path expansion re-roots
+/// drive-relative paths (`/...`) onto the process cwd drive; only
+/// drive-qualified paths are stable across expansion, so qualifying is
+/// what keeps payload paths inside the VFS. POSIX roots carry no
+/// drive: the mount is used as declared. A relative mount (the grammar
+/// admits it) is never qualified.
+fn qualify_mount(mount: &str, runtime_root: &str) -> String {
+    match vfs_drive(runtime_root) {
+        Some(drive) if mount.starts_with('/') => format!("{drive}{mount}"),
+        _ => mount.to_string(),
+    }
+}
+
 /// Resolve the entry against the first image's mount (the app payload —
 /// spec 17 §1) and verify it exists in the mounted tree — but only
 /// against mounts THIS boot established (an entry outside them belongs
@@ -535,7 +564,8 @@ fn resolve_entry(
 /// semantics preserved: the parser scans from index 0 (callers pass the
 /// full argv; non-loader leading args end the scan — the plain-boot
 /// case). `runtime_root` is the mount point the interpreter was compiled
-/// against (ruby: `/__tfs__`, `A:/t` on windows).
+/// against (ruby: `/__tfs__`, `A:/__tfs__` on windows — the one name on
+/// every platform; spec 17 §1).
 pub fn boot(
     argv: &[String],
     runtime_root: &str,
@@ -554,7 +584,13 @@ pub fn boot_with_mount_modes(
     env: &dyn Env,
     modes: &dyn MountModes,
 ) -> Result<BootOutcome, DriverError> {
-    let h = Handoff::parse(argv)?;
+    let mut h = Handoff::parse(argv)?;
+    // Windows: qualify the declared mounts onto the VFS drive (spec 17
+    // §1) before any mount/entry use — the mount table, the union-mode
+    // rows, and the entry resolution all see the physical points.
+    for spec in &mut h.images {
+        spec.mount = qualify_mount(&spec.mount, runtime_root);
+    }
 
     // Plain boot: no loader args at all. The interpreter runs its own
     // argv; the env image still mounts when handed (image-era standalone
@@ -632,4 +668,43 @@ pub fn boot_with_mount_modes(
         context().write().unwrap().unmount();
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vfs_drive_reads_the_root_drive() {
+        assert_eq!(vfs_drive("A:/__tfs__"), Some("A:"));
+        assert_eq!(vfs_drive("a:/t"), Some("a:"));
+        assert_eq!(vfs_drive("A:"), Some("A:"));
+        assert_eq!(vfs_drive("/__tfs__"), None);
+        assert_eq!(vfs_drive("//share/x"), None);
+        assert_eq!(vfs_drive("1:/x"), None);
+        assert_eq!(vfs_drive(""), None);
+    }
+
+    #[test]
+    fn declared_mounts_qualify_onto_the_vfs_drive() {
+        // The uniform namespace (spec 17 §1): the POSIX absolute
+        // namespace presents on the runtime root's drive, so the
+        // runtime root is the same NAME on every platform.
+        assert_eq!(qualify_mount("/", "A:/__tfs__"), "A:/");
+        assert_eq!(qualify_mount("/__tfs__", "A:/__tfs__"), "A:/__tfs__");
+        assert_eq!(qualify_mount("/opt/x", "A:/__tfs__"), "A:/opt/x");
+    }
+
+    #[test]
+    fn posix_roots_never_qualify() {
+        assert_eq!(qualify_mount("/", "/__tfs__"), "/");
+        assert_eq!(qualify_mount("/__tfs__", "/__tfs__"), "/__tfs__");
+        assert_eq!(qualify_mount("/opt/x", "/__tfs__"), "/opt/x");
+    }
+
+    #[test]
+    fn relative_mounts_are_never_qualified() {
+        assert_eq!(qualify_mount("rel", "A:/__tfs__"), "rel");
+        assert_eq!(qualify_mount("rel", "/__tfs__"), "rel");
+    }
 }

--- a/crates/tebako-driver/src/ffi.rs
+++ b/crates/tebako-driver/src/ffi.rs
@@ -31,15 +31,16 @@ use crate::{EX_TEBAKO_IO, EX_TEBAKO_MANIFEST};
 /// source tarball's tebako-mount-root manifest → the exe's generated fs
 /// TU → tebako_main forwards it here); this default is only for
 /// driver-only consumers and tests and follows the factory convention:
-/// `A:/t` on windows, where the memfs presents as its own drive, and
-/// `/__tfs__` elsewhere.
+/// `A:/__tfs__` on windows, where the memfs presents as its own drive —
+/// the one root name on every platform (spec 17 §1) — and `/__tfs__`
+/// elsewhere.
 #[cfg(windows)]
-const RUBY_RUNTIME_ROOT: &str = "A:/t";
+const RUBY_RUNTIME_ROOT: &str = "A:/__tfs__";
 #[cfg(not(windows))]
 const RUBY_RUNTIME_ROOT: &str = "/__tfs__";
 
 #[cfg(windows)]
-static DEFAULT_ROOT: &[u8] = b"A:/t\0";
+static DEFAULT_ROOT: &[u8] = b"A:/__tfs__\0";
 #[cfg(not(windows))]
 static DEFAULT_ROOT: &[u8] = b"/__tfs__\0";
 static EMPTY: &[u8] = b"\0";

--- a/crates/tebako-driver/src/layout.rs
+++ b/crates/tebako-driver/src/layout.rs
@@ -152,8 +152,8 @@ mod tests {
         let with_future = format!("{GOOD}future_field: {{anything: goes}}\n");
         ImageLayout::check(&with_future, "/__tfs__", "/rt/ruby.tfs").unwrap();
         // the windows root spelling pairs the same way
-        let win = GOOD.replace("/__tfs__", "A:/t");
-        ImageLayout::check(&win, "A:/t", "C:/rt/ruby.tfs").unwrap();
+        let win = GOOD.replace("/__tfs__", "A:/__tfs__");
+        ImageLayout::check(&win, "A:/__tfs__", "C:/rt/ruby.tfs").unwrap();
     }
 
     #[test]

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -864,6 +864,88 @@ fn union_row_merges_the_trees_at_the_runtime_root() {
     assert_eq!(seen, vec!["ruby", "tebako"]);
 }
 
+// ---------------------------------------------------------------------
+// The uniform VFS namespace on windows roots (spec 17 §1): declared
+// mounts qualify onto the runtime root's drive before any mount/entry
+// computation.
+// ---------------------------------------------------------------------
+
+/// The env fixture's layout declaration with the windows root spelling.
+fn write_env_image_windows_root(dir: &Path) -> PathBuf {
+    write_env_image_with_layout(
+        dir,
+        Some(&GOOD_LAYOUT.replace("/__tfs__", "A:/__tfs__")),
+    )
+}
+
+#[test]
+fn windows_root_qualifies_declared_mounts_onto_the_vfs_drive() {
+    let g = guard("win-qualify");
+    let env_image = write_env_image_windows_root(g.path());
+    let payload = write_payload_image(g.path());
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    let out = boot(
+        &argv(&[
+            "ruby.exe",
+            "--tebako-image",
+            &format!("{}:0:/", payload.display()),
+            "--tebako-entry",
+            "/bin/app",
+            "--version",
+        ]),
+        "A:/__tfs__",
+        &env,
+    )
+    .unwrap();
+    // The declared `/` mount qualified onto the VFS drive; the entry
+    // resolves drive-qualified, so ruby's C-level expansion can never
+    // re-root it onto the cwd drive.
+    assert_eq!(out.argv, argv(&["ruby.exe", "A:/bin/app", "--version"]));
+    // Both mounts live in the physical namespace: the env image at the
+    // qualified root, the payload at the drive root.
+    assert_eq!(
+        read_file("A:/__tfs__/lib/ruby/rubygems.rb"),
+        b"# rubygems core\n"
+    );
+    assert_eq!(read_file("A:/bin/app"), b"#!/usr/bin/env ruby\nputs 'hi'\n");
+}
+
+#[test]
+fn windows_root_union_merges_at_the_qualified_root() {
+    let g = guard("win-union");
+    let env_image = write_env_image_windows_root(g.path());
+    let payload = write_shadowing_payload(g.path());
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    let out = tebako_driver::boot_with_mount_modes(
+        &argv(&[
+            "ruby.exe",
+            "--tebako-image",
+            &format!("{}:0:/__tfs__", payload.display()),
+            "--tebako-entry",
+            "/local/stub.rb",
+        ]),
+        "A:/__tfs__",
+        &env,
+        &StubModes(Some(union_row())),
+    )
+    .unwrap();
+    // The declared union target is the SAME NAME the root carries, so
+    // the qualified points coincide and the union row governs.
+    assert_eq!(out.argv, argv(&["ruby.exe", "A:/__tfs__/local/stub.rb"]));
+    assert_eq!(
+        read_file("A:/__tfs__/local/stub.rb"),
+        b"load \"/__tfs__/bin/app\"\n"
+    );
+    assert_eq!(
+        read_file("A:/__tfs__/lib/ruby/rubygems.rb"),
+        b"# app-shadowed rubygems\n"
+    );
+}
+
 #[test]
 fn a_named_mode_source_error_surfaces_and_rolls_back() {
     let g = guard("modes-err");

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -872,10 +872,7 @@ fn union_row_merges_the_trees_at_the_runtime_root() {
 
 /// The env fixture's layout declaration with the windows root spelling.
 fn write_env_image_windows_root(dir: &Path) -> PathBuf {
-    write_env_image_with_layout(
-        dir,
-        Some(&GOOD_LAYOUT.replace("/__tfs__", "A:/__tfs__")),
-    )
+    write_env_image_with_layout(dir, Some(&GOOD_LAYOUT.replace("/__tfs__", "A:/__tfs__")))
 }
 
 #[test]

--- a/crates/tebako-driver/tests/ffi.rs
+++ b/crates/tebako-driver/tests/ffi.rs
@@ -165,7 +165,7 @@ fn tebako_main_boots_with_the_ruby_root_and_exports_the_contract() {
     #[cfg(not(windows))]
     assert_eq!(mp, "/__tfs__");
     #[cfg(windows)]
-    assert_eq!(mp, "A:/t");
+    assert_eq!(mp, "A:/__tfs__");
     let pwd =
         unsafe { CStr::from_ptr(tebako_driver::ffi::tebako_original_pwd()) }.to_string_lossy();
     assert!(!pwd.is_empty(), "the original cwd is recorded");

--- a/docs/spec/17-runtime-driver-contract.md
+++ b/docs/spec/17-runtime-driver-contract.md
@@ -24,6 +24,19 @@ exact contract (roadmap 22's "add a language" playbook).
 - **Mount order:** the env image first, then payload triples in argv
   order; the table is longest-prefix and nested mounts are legal; any
   failure unmounts everything — never a partial mount.
+- **The uniform VFS namespace (locked 2026-08-06):** declared mount
+  points are POSIX absolute paths on every platform — in manifests, in
+  trailer slot records, and on this wire. On windows the namespace
+  presents on its own drive: the driver qualifies every declared mount
+  `<mount>` onto the runtime root's drive (`<drive><mount>`) before any
+  mount, union, or entry computation, and the runtime root is the one
+  name on every platform (ruby: `/__tfs__`, presented `A:/__tfs__` on
+  windows). An interpreter's C-level path expansion re-roots
+  drive-relative paths (`/...`) onto the process cwd drive; only
+  drive-qualified paths are stable across expansion, so qualifying is
+  what keeps payload paths inside the VFS. The wire grammar therefore
+  never carries a drive letter: `<mount>` is always the declared form,
+  and a declared mount naming a drive is malformed.
 - **Mount modes (locked 2026-08-04):** every mount is `exclusive`
   (default) or `union`, declared per slot in the package manifest's
   `mounts:` block (spec 03 §6). An exclusive mount onto an occupied

--- a/docs/spec/schemas/layout.yaml
+++ b/docs/spec/schemas/layout.yaml
@@ -79,7 +79,8 @@ grammar:
     notes: >-
       The mount root the image was built for — must equal the exe's
       compiled-in value (the one tebako_main forwards to the driver;
-      ruby: /__tfs__, A:/t on windows). Mismatch → exit 78, both values
+      ruby: /__tfs__, A:/__tfs__ on windows — the one name on every
+      platform). Mismatch → exit 78, both values
       printed (S19). The value FLOWS from tamatebako/ruby's patch
       literals (the single owner); nothing re-authors it.
   interpreter_api_version:

--- a/docs/spec/schemas/runtime-manifest.yaml
+++ b/docs/spec/schemas/runtime-manifest.yaml
@@ -80,8 +80,9 @@ grammar:
     type: string
     required: true
     notes: >-
-      The exe's compiled-in runtime root (ruby: /__tfs__, A:/t on
-      windows). FLOWS from tamatebako/ruby's patch literals — the single
+      The exe's compiled-in runtime root (ruby: /__tfs__, A:/__tfs__ on
+      windows — the one name on every platform). FLOWS from
+      tamatebako/ruby's patch literals — the single
       owner — through the source tarball's tebako-mount-root manifest;
       nothing downstream re-authors it.
   image_layout:


### PR DESCRIPTION
## What

Fixes #365 — the last windows-exec blocker for ruby payloads.

- **Driver qualification (spec 17 §1, locked 2026-08-06):** declared mount points are POSIX absolute paths on every platform — manifests, trailer slots, and the `--tebako-image` wire. On windows the driver qualifies every declared mount onto the runtime root's drive (`<drive><mount>`) before any mount/union/entry computation. Ruby's C-level path expansion re-roots drive-relative paths onto the cwd drive; only drive-qualified paths stay inside the VFS. The wire grammar never carries a drive letter.
- **Uniform root:** `A:/t` → `A:/__tfs__` — the one root name on every platform, so a declared union at `/__tfs__` lands on the windows env root exactly like POSIX. The value flows from tamatebako/ruby's patch literals (owner); the driver default, CLI scenario, layout/ffi tests, and spec schemas follow here.
- **Press writes declared mounts:** trailer slots and L2 `mounts:` rows carry `/__tfs__` on every platform (`declared_mount()` — the physical root minus any drive). Previously the windows press baked the physical root into the trailer, which the colon grammar could not even parse at handoff.
- **Deploy driver package gains its union row** — it mounts at the runtime root the env image owns; exclusive was EEXIST whenever the env image rode along.

## Proof

- `cargo test -p tebako-driver` — 31 boot + 6 ffi + 4 new unit tests green, including two new windows-root boot tests: payload at declared `/` mounts at `A:/` with the entry rewritten `A:/bin/app`; a declared union at `/__tfs__` merges over the env at `A:/__tfs__`.
- `cargo test -p tebako-cli --lib` — 59 green (press manifest assertions included).
- `cargo build --workspace` clean.

## Cross-repo chain (separate PRs)

- tamatebako/ruby: the 5 `mkconfig_memfs_prefix_msys.patch` literals `A:/t` → `A:/__tfs__` + source tarball re-roll (v0.2.16).
- tamatebako/tebako-runtime-ruby: convention copies (platform.rb, CMakeLists, boot probe, specs) + source pin bump.

The 0.16.3 era rebuild must carry all three — do not fire it before the ruby/factory legs land.
