### PR TITLE
runtime install: fetch+verify+install the windows ruby DLL facet (tebako-runtime-ruby#40)

### DIFF
--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -25,7 +25,12 @@
 //!    the runtime image (`<asset>.tfs`) — downloaded and SHA256-verified
 //!    against the same release index (manifest `image` key primary,
 //!    SHA256SUMS line fallback), installed READ-ONLY with
-//!    `<image>.sha256`/`<image>.origin` trusted markers, never extracted;
+//!    `<image>.sha256`/`<image>.origin` trusted markers, never extracted.
+//!    A dll-era windows runtime (tebako-runtime-ruby#40) additionally
+//!    resolves its ruby DLL under the same flag — installed read-only next
+//!    to the exe under the manifest-declared PE name (`install_as`) with
+//!    the same marker discipline, so the PE loader resolves the exe's
+//!    imports against the exe's own directory;
 //!
 //! 6. apply the package's jail (spec 08 §2/§4): the `jail:` block of the
 //!    type-2 package manifest REQUESTS host access; the user's TEBAKO_JAIL
@@ -1014,6 +1019,35 @@ pub fn sha_from_manifest_image(text: &str, image_asset: &str) -> Result<String, 
     }
 }
 
+/// manifest.json, the dll facet (tebako-runtime-ruby#40): locate
+/// `"<dll_asset>"` (the .dll filename — it appears only inside the exe
+/// entry's additive `dll` key) and read the NEXT `"install_as"` value,
+/// bounded by the dll object's closing brace (never a later entry's
+/// key). The PE name is declared, never derived — the factory's
+/// RubyVersion#msys_dll_name is its single owner.
+#[allow(clippy::result_unit_err)] // C-style -1 error by design
+pub fn dll_install_as_from_manifest(text: &str, dll_asset: &str) -> Result<String, ()> {
+    let needle = format!("\"{dll_asset}\"");
+    let p = text.find(&needle).ok_or(())?;
+    let rest = &text[p + needle.len()..];
+    let close = rest.find('}').ok_or(())?;
+    let body = &rest[..close];
+    let k = body.find("\"install_as\"").ok_or(())?;
+    let after = &body[k + 12..];
+    let after = after.trim_start_matches([':', ' ', '\t', '\n', '\r']);
+    if !after.starts_with('"') {
+        return Err(());
+    }
+    let inner = &after[1..];
+    let endq = inner.find('"').ok_or(())?;
+    let value = &inner[..endq];
+    if value.is_empty() {
+        Err(())
+    } else {
+        Ok(value.to_string())
+    }
+}
+
 // ---------------------------------------------------------------------
 // fat package: install the runtime payload slot
 // ---------------------------------------------------------------------
@@ -1705,6 +1739,14 @@ fn resolve_runtime(
     } else {
         None
     };
+    // tebako-runtime-ruby#40: a dll-era (windows) runtime also needs its
+    // ruby DLL next to the exe — it rides the same image-era release
+    // card, resolved alongside; a no-op when the cached release index
+    // declares no dll facet (every POSIX release, pre-#40 windows
+    // releases). No handoff: the PE loader finds the DLL on its own.
+    if runtime_ref_wants_image(runtime_ref) {
+        resolve_dll(runtime_ref, rr, &layout, &mut ux)?;
+    }
     Ok((exe, image))
 }
 
@@ -2100,6 +2142,202 @@ fn resolve_image(
 }
 
 // ---------------------------------------------------------------------
+// runtime ruby DLL resolution (tebako-runtime-ruby#40, windows runtimes)
+// ---------------------------------------------------------------------
+
+/// Resolve the windows ruby DLL (`<asset_base>.dll`) into the
+/// executable's cache entry when the release declares the additive `dll`
+/// facet: download (same mirror/offline rules as the image), verify
+/// against the declared sha256, install read-only AS `install_as` — the
+/// PE name the exe and the extension .so's import, never the asset name
+/// (assets are unique per leg; two same-ABI legs share the PE name) —
+/// with `<install_as>.sha256`/`<install_as>.origin` trusted markers. The
+/// PE loader resolves the exe's imports against the exe's own directory
+/// first, so the DLL must sit next to the exe. `Ok(None)` when the
+/// release declares no dll facet (every POSIX release, pre-#40 windows
+/// releases) — the facet is declared, never derived.
+///
+/// The facet source is the entry's cached release index (the verified
+/// lean install leaves manifest.json in the entry), so a cached run
+/// never re-fetches the index — a run stays a run, offline-safe. An
+/// entry without a cached index (the fat-payload path never fetches one)
+/// declares nothing here.
+fn resolve_dll(
+    runtime_ref: &str,
+    rr: &RuntimeRef,
+    layout: &CacheLayout,
+    ux: &mut BootUx,
+) -> Result<Option<PathBuf>, BootError> {
+    let (root, entry_dir, entry) = (&layout.root, &layout.entry_dir, &layout.entry);
+    let dll_asset = format!("{}.dll", layout.asset_base);
+
+    let Ok(manifest_text) = std::fs::read_to_string(entry_dir.join("manifest.json")) else {
+        return Ok(None);
+    };
+    let Ok(install_as) = dll_install_as_from_manifest(&manifest_text, &dll_asset) else {
+        return Ok(None);
+    };
+    let dll_path = entry_dir.join(&install_as);
+    let marker = entry_dir.join(format!("{install_as}.sha256"));
+    if file_exists(&dll_path) && file_exists(&marker) {
+        return Ok(Some(dll_path));
+    }
+    let Ok(expected) = sha_from_manifest_image(&manifest_text, &dll_asset) else {
+        return Ok(None); // an incomplete facet is no facet — never guess
+    };
+    if install_as.contains('/') || install_as.contains('\\') {
+        return fail(
+            EX_TEBAKO_UNAVAILABLE,
+            format!(
+                "release manifest dll facet for {} carries an unusable install_as (\"{install_as}\") — the PE name must be a bare file name — refusing to install or execute",
+                layout.asset
+            ),
+        );
+    }
+
+    let base_raw = releases_base();
+    let base = skip_file_scheme(&base_raw).to_string();
+    let local = base_is_local(&base_raw);
+    let dll_url = format!("{base}/v{}/{dll_asset}", rr.abi);
+
+    if offline_mode() {
+        return fail(
+            EX_TEBAKO_UNAVAILABLE,
+            format!(
+                "cannot resolve runtime dll \"{runtime_ref}\": not present in the cache and TEBAKO_OFFLINE is set\n  cache entry: {}\n  would fetch: {dll_url}\n  unset TEBAKO_OFFLINE, or set TEBAKO_RUNTIME_MIRROR to a reachable mirror",
+                entry_dir.display()
+            ),
+        );
+    }
+
+    ux.resolving(runtime_ref);
+
+    // Serialize against other bootstraps installing this entry (the same
+    // lock file the executable and image installs use).
+    let locks = root.join("locks");
+    mkdir_p(&locks).map_err(|e| {
+        BootError::new(
+            EX_TEBAKO_IO,
+            format!(
+                "cannot create tebako cache directories under {}: {e}",
+                root.display()
+            ),
+        )
+    })?;
+    let lock_path = locks.join(format!("{entry}.lock"));
+    let lock = flock_acquire(&lock_path, LOCK_TIMEOUT_MS).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::TimedOut {
+            BootError::new(
+                EX_TEBAKO_UNAVAILABLE,
+                format!(
+                    "timed out after {}s waiting for another tebako bootstrap to finish installing \"{runtime_ref}\"\n  lock: {}\n  if no other tebako process is running, remove the stale lock file",
+                    LOCK_TIMEOUT_MS / 1000,
+                    lock_path.display()
+                ),
+            )
+        } else {
+            BootError::new(
+                EX_TEBAKO_IO,
+                format!("cannot acquire install lock {}: {e}", lock_path.display()),
+            )
+        }
+    })?;
+
+    // re-check under the lock
+    if file_exists(&dll_path) && file_exists(&marker) {
+        lock_release(lock);
+        return Ok(Some(dll_path));
+    }
+
+    let tmp_dir = root
+        .join("tmp")
+        .join(format!("{entry}.{}.dll", std::process::id()));
+    let tmp_dll = tmp_dir.join(&dll_asset);
+    cleanup_tmp_entry(&tmp_dir, &dll_asset);
+    if let Err(e) = std::fs::create_dir(&tmp_dir) {
+        lock_release(lock);
+        return Err(BootError::new(
+            EX_TEBAKO_IO,
+            format!("cannot create {}: {e}", tmp_dir.display()),
+        ));
+    }
+
+    let fail_dll = |lock: EntryLock, e: BootError| -> BootError {
+        cleanup_tmp_entry(&tmp_dir, &dll_asset);
+        lock_release(lock);
+        e
+    };
+
+    if fetch_asset(&dll_url, local, &tmp_dll, &dll_asset, &mut ux.prog).is_err() {
+        return Err(fail_dll(
+            lock,
+            BootError::new(
+                EX_TEBAKO_UNAVAILABLE,
+                format!(
+                    "cannot resolve runtime dll \"{runtime_ref}\": download failed\n  url: {dll_url}\n  downloads are in-process (ureq + rustls, webpki-roots) — check the network, or set\n  TEBAKO_RUNTIME_MIRROR to a reachable mirror, or TEBAKO_OFFLINE=1 for cache-only mode"
+                ),
+            ),
+        ));
+    }
+
+    ux.prog.phase("verifying sha256");
+
+    let actual = match sha256_file_hex(&tmp_dll) {
+        Ok(a) => a,
+        Err(e) => {
+            return Err(fail_dll(
+                lock,
+                BootError::new(
+                    EX_TEBAKO_IO,
+                    format!("cannot hash downloaded file {}: {e}", tmp_dll.display()),
+                ),
+            ));
+        }
+    };
+
+    let expected = expected.to_lowercase();
+    if expected != actual {
+        return Err(fail_dll(
+            lock,
+            BootError::new(
+                EX_TEBAKO_SHA,
+                format!(
+                    "SHA256 mismatch for downloaded runtime dll {dll_asset} — refusing to install or execute\n  expected: {expected} (from the cached release manifest)\n  actual:   {actual}\n  the download was deleted; the cache was not touched"
+                ),
+            ),
+        ));
+    }
+
+    // Install: the dll is immutable (0444) with trusted markers, AS
+    // install_as next to the exe.
+    ux.prog.phase("installing (locked)");
+    make_readonly(&tmp_dll);
+    if let Err(e) = os_rename(&tmp_dll, &dll_path) {
+        return Err(fail_dll(
+            lock,
+            BootError::new(
+                EX_TEBAKO_IO,
+                format!(
+                    "cannot install the runtime dll into the cache ({} -> {}): {e}",
+                    tmp_dll.display(),
+                    dll_path.display()
+                ),
+            ),
+        ));
+    }
+    let _ = write_small_file(&marker, &format!("{actual}  {install_as}\n"));
+    let _ = write_small_file(
+        &entry_dir.join(format!("{install_as}.origin")),
+        &format!("runtime_ref={runtime_ref}\nurl={dll_url}\nsha256={actual}\n"),
+    );
+    cleanup_tmp_entry(&tmp_dir, &dll_asset);
+    lock_release(lock);
+    let size = std::fs::metadata(&dll_path).map(|m| m.len()).unwrap_or(0);
+    ux.prog.line(&installed_line(&install_as, size, entry_dir));
+    Ok(Some(dll_path))
+}
+
+// ---------------------------------------------------------------------
 // exec handoff (launcher ABI v1)
 // ---------------------------------------------------------------------
 
@@ -2395,5 +2633,217 @@ mod store_layout_tests {
         let err = store_layout_check_once(&home).unwrap_err();
         assert!(err.contains("banana"), "{err}");
         let _ = std::fs::remove_dir_all(&home);
+    }
+}
+
+#[cfg(test)]
+mod dll_tests {
+    use super::*;
+
+    const EXE: &str = "tebako-runtime-0.16.3-3.3.12-windows-ucrt64.exe";
+    const DLL: &str = "tebako-runtime-0.16.3-3.3.12-windows-ucrt64.dll";
+    const INSTALL_AS: &str = "x64-ucrt-ruby330.dll";
+    const RUNTIME_REF: &str = "ruby@3.3.12;tebako=0.16.3;image";
+
+    fn dir(tag: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("tebako-boot-dll-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    /// The era-2 factory manifest shape with the given `dll` key body
+    /// appended to the exe entry ("" = no facet, the POSIX shape).
+    fn manifest(dll_key: &str) -> String {
+        format!(
+            "[{{\"contract_era\": 2, \"contract_version\": 2, \"mount_root\": \"/__tfs__\", \"filename\": \"{EXE}\", \"sha256\": \"{}\", \"image\": {{\"filename\": \"tebako-runtime-0.16.3-3.3.12-windows-ucrt64.tfs\", \"sha256\": \"{}\"}}{dll_key}}}]\n",
+            "a".repeat(64),
+            "b".repeat(64),
+        )
+    }
+
+    fn dll_key(install_as: &str, sha256: &str) -> String {
+        format!(
+            ", \"dll\": {{\"filename\": \"{DLL}\", \"install_as\": \"{install_as}\", \"sha256\": \"{sha256}\", \"size_bytes\": 14}}"
+        )
+    }
+
+    /// A cache entry (exe + optional cached release index) in the shape
+    /// the lean install leaves behind (its tmp/ dir included — the exe
+    /// install creates it before the dll resolution runs).
+    fn dll_layout(home: &Path, manifest_text: Option<&str>) -> (CacheLayout, RuntimeRef) {
+        let entry = "ruby-3.3.12-0.16.3-windows-ucrt64";
+        let asset_base = "tebako-runtime-0.16.3-3.3.12-windows-ucrt64";
+        let asset = format!("{asset_base}.exe");
+        let entry_dir = home.join("runtimes").join(entry);
+        std::fs::create_dir_all(&entry_dir).unwrap();
+        std::fs::create_dir_all(home.join("tmp")).unwrap();
+        std::fs::write(entry_dir.join(&asset), b"fake runtime exe\n").unwrap();
+        if let Some(text) = manifest_text {
+            std::fs::write(entry_dir.join("manifest.json"), text).unwrap();
+        }
+        (
+            CacheLayout {
+                root: home.to_path_buf(),
+                entry_dir: entry_dir.clone(),
+                exe_path: entry_dir.join(&asset),
+                asset,
+                asset_base: asset_base.to_string(),
+                entry: entry.to_string(),
+            },
+            RuntimeRef {
+                r#type: "ruby".to_string(),
+                version: "3.3.12".to_string(),
+                abi: "0.16.3".to_string(),
+            },
+        )
+    }
+
+    #[test]
+    fn dll_install_as_parses_from_the_dll_facet() {
+        let text = manifest(&dll_key(INSTALL_AS, &"c".repeat(64)));
+        assert_eq!(
+            dll_install_as_from_manifest(&text, DLL),
+            Ok(INSTALL_AS.to_string())
+        );
+        // the facet's sha rides the same next-sha256 reader the image uses
+        assert_eq!(sha_from_manifest_image(&text, DLL), Ok("c".repeat(64)));
+    }
+
+    #[test]
+    fn dll_facet_absent_or_incomplete_is_no_answer() {
+        // no dll key at all (every POSIX release, pre-#40 windows)
+        assert_eq!(dll_install_as_from_manifest(&manifest(""), DLL), Err(()));
+        // the dll key without install_as — never guess the PE name
+        let text = manifest(&format!(
+            ", \"dll\": {{\"filename\": \"{DLL}\", \"sha256\": \"{}\"}}",
+            "c".repeat(64)
+        ));
+        assert_eq!(dll_install_as_from_manifest(&text, DLL), Err(()));
+        // an empty install_as is no name
+        let text = manifest(&dll_key("", &"c".repeat(64)));
+        assert_eq!(dll_install_as_from_manifest(&text, DLL), Err(()));
+    }
+
+    #[test]
+    fn dll_install_as_is_bounded_to_its_own_entry() {
+        // the first entry's dll object has no install_as; the second
+        // entry's must not leak across the object boundary
+        let text = format!(
+            "[{{\"filename\": \"{EXE}\", \"sha256\": \"{a}\", \"dll\": {{\"filename\": \"{DLL}\", \"sha256\": \"{b}\"}}}}, {{\"filename\": \"other.exe\", \"sha256\": \"{a}\", \"dll\": {{\"filename\": \"other.dll\", \"install_as\": \"x64-ucrt-ruby340.dll\", \"sha256\": \"{b}\"}}}}]",
+            a = "a".repeat(64),
+            b = "b".repeat(64),
+        );
+        assert_eq!(dll_install_as_from_manifest(&text, DLL), Err(()));
+    }
+
+    /// The env-using flow (TEBAKO_RUNTIME_MIRROR / TEBAKO_OFFLINE) lives
+    /// in ONE test so the process-wide variables never race a sibling.
+    #[test]
+    fn resolve_dll_flow() {
+        let home = dir("flow");
+        let mirror = home.join("mirror").join("v0.16.3");
+        std::fs::create_dir_all(&mirror).unwrap();
+        std::fs::write(mirror.join(DLL), b"fake ruby dll\n").unwrap();
+        let dll_sha = sha256_file_hex(&mirror.join(DLL)).unwrap();
+        let text = manifest(&dll_key(INSTALL_AS, &dll_sha));
+        let (layout, rr) = dll_layout(&home, Some(&text));
+        std::env::set_var(
+            "TEBAKO_RUNTIME_MIRROR",
+            format!("file://{}", home.join("mirror").display()),
+        );
+
+        // fresh install: the dll lands AS install_as with trusted markers
+        let mut ux = BootUx::new();
+        let got = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux).unwrap();
+        let dll_path = layout.entry_dir.join(INSTALL_AS);
+        assert_eq!(got, Some(dll_path.clone()));
+        assert!(dll_path.is_file());
+        assert!(
+            !layout.entry_dir.join(DLL).exists(),
+            "the asset name is not the install name"
+        );
+        let marker =
+            std::fs::read_to_string(layout.entry_dir.join(format!("{INSTALL_AS}.sha256"))).unwrap();
+        assert_eq!(marker, format!("{dll_sha}  {INSTALL_AS}\n"));
+        let origin =
+            std::fs::read_to_string(layout.entry_dir.join(format!("{INSTALL_AS}.origin"))).unwrap();
+        assert!(origin.contains(&format!("/v0.16.3/{DLL}")), "{origin}");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                dll_path.metadata().unwrap().permissions().mode() & 0o777,
+                0o444
+            );
+        }
+
+        // a cached run needs no mirror at all (offline-safe re-resolution)
+        std::fs::remove_dir_all(home.join("mirror")).unwrap();
+        let mut ux = BootUx::new();
+        let got = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux).unwrap();
+        assert_eq!(got, Some(dll_path.clone()));
+
+        // a declared-but-missing dll under TEBAKO_OFFLINE is the named error
+        std::fs::remove_file(&dll_path).unwrap();
+        std::fs::remove_file(layout.entry_dir.join(format!("{INSTALL_AS}.sha256"))).unwrap();
+        std::env::set_var("TEBAKO_OFFLINE", "1");
+        let mut ux = BootUx::new();
+        let err = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_UNAVAILABLE);
+        assert!(err.message.contains("TEBAKO_OFFLINE"), "{}", err.message);
+        std::env::remove_var("TEBAKO_OFFLINE");
+
+        // a wrong declared sha is exit 70; the download is deleted
+        std::fs::create_dir_all(&mirror).unwrap();
+        std::fs::write(mirror.join(DLL), b"fake ruby dll\n").unwrap();
+        std::fs::write(
+            layout.entry_dir.join("manifest.json"),
+            manifest(&dll_key(INSTALL_AS, &"f".repeat(64))),
+        )
+        .unwrap();
+        let mut ux = BootUx::new();
+        let err = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_SHA);
+        assert!(!dll_path.exists());
+        assert!(
+            !layout
+                .entry_dir
+                .join(format!("{INSTALL_AS}.sha256"))
+                .exists(),
+            "a failed install leaves no trust marker"
+        );
+
+        // an install_as with a path separator is refused by name
+        std::fs::write(
+            layout.entry_dir.join("manifest.json"),
+            manifest(&dll_key("../evil.dll", &dll_sha)),
+        )
+        .unwrap();
+        let mut ux = BootUx::new();
+        let err = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_UNAVAILABLE);
+        assert!(err.message.contains("bare file name"), "{}", err.message);
+        assert!(!home.join("runtimes").join("evil.dll").exists());
+
+        // no dll key declared (every POSIX release): a quiet no-op
+        let home2 = dir("nofacet");
+        let (layout2, rr2) = dll_layout(&home2, Some(&manifest("")));
+        let mut ux = BootUx::new();
+        assert!(resolve_dll(RUNTIME_REF, &rr2, &layout2, &mut ux)
+            .unwrap()
+            .is_none());
+        // no cached release index at all (the fat-payload path): a no-op
+        let home3 = dir("nomanifest");
+        let (layout3, rr3) = dll_layout(&home3, None);
+        let mut ux = BootUx::new();
+        assert!(resolve_dll(RUNTIME_REF, &rr3, &layout3, &mut ux)
+            .unwrap()
+            .is_none());
+
+        std::env::remove_var("TEBAKO_RUNTIME_MIRROR");
+        let _ = std::fs::remove_dir_all(&home);
+        let _ = std::fs::remove_dir_all(&home2);
+        let _ = std::fs::remove_dir_all(&home3);
     }
 }

--- a/crates/tebako-cli/src/resolve.rs
+++ b/crates/tebako-cli/src/resolve.rs
@@ -85,12 +85,27 @@ pub struct IndexEntry {
     /// The runtime image sibling (item 30b): `<asset>.tfs` from the
     /// manifest's additive `image` key or the SHA256SUMS line.
     pub image: Option<ImageRef>,
+    /// The windows ruby DLL sibling (tebako-runtime-ruby#40): `<asset>.dll`
+    /// from the manifest's additive `dll` key or the SHA256SUMS line.
+    pub dll: Option<DllRef>,
 }
 
 /// A resolved runtime image reference (filename + expected sha256).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImageRef {
     pub filename: String,
+    pub sha256: String,
+}
+
+/// A resolved ruby DLL reference (tebako-runtime-ruby#40): the release
+/// asset (`filename` — unique per leg), the PE name it installs under
+/// (`install_as` — two same-ABI legs share it; the SHA256SUMS index form
+/// carries no PE name, so a sums-derived ref cannot be installed), and the
+/// expected sha256.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DllRef {
+    pub filename: String,
+    pub install_as: Option<String>,
     pub sha256: String,
 }
 
@@ -175,7 +190,12 @@ impl Resolver {
     /// bootstrap consumes at first run. On a cache hit the image metadata
     /// comes from the entry's trusted marker; an entry whose marker is
     /// missing (installed before the image era, or partially wiped) has
-    /// its image backfilled from the release index.
+    /// its image backfilled from the release index. A windows release
+    /// (tebako-runtime-ruby#40) additionally carries the ruby DLL facet:
+    /// it installs next to the executable under its PE name (`install_as`)
+    /// whenever the index is in hand (the fresh install and the backfill
+    /// alike); a contract-complete entry with no `dll` key installs the
+    /// executable alone (every POSIX release).
     pub fn resolve_runtime(
         &self,
         ruby_version: &str,
@@ -201,6 +221,9 @@ impl Resolver {
                     if let Some(image) = entry.image.clone() {
                         self.install_image(&dir, &image, tebako_version)?;
                     }
+                    if let Some(dll) = entry.dll.clone() {
+                        self.install_dll(&dir, &dll, tebako_version)?;
+                    }
                     return Ok(());
                 }
                 // The exe is cached but its image marker is missing (an
@@ -217,6 +240,9 @@ impl Resolver {
                     }
                     if let Some(image) = entry.image.clone() {
                         self.install_image(&dir, &image, tebako_version)?;
+                    }
+                    if let Some(dll) = entry.dll.clone() {
+                        self.install_dll(&dir, &dll, tebako_version)?;
                     }
                 }
                 Ok(())
@@ -319,6 +345,86 @@ impl Resolver {
             format!("{url}\n"),
         )
         .map_err(err)?;
+        Ok(())
+    }
+
+    /// Download + verify + install the windows ruby DLL
+    /// (tebako-runtime-ruby#40) next to the executable AS `install_as` —
+    /// the PE name the exe and the extension .so's import (never the asset
+    /// name: assets are unique per leg, two same-ABI legs share the PE
+    /// name) — read-only with `<install_as>.sha256`/`<install_as>.origin`
+    /// trusted markers, the image's exact discipline. A ref without an
+    /// `install_as` (the SHA256SUMS index form carries no PE name) is not
+    /// installable: the dll facet is manifest-keyed. Called with the entry
+    /// lock already held.
+    fn install_dll(
+        &self,
+        dir: &Path,
+        dll: &DllRef,
+        tebako_version: &str,
+    ) -> Result<(), TebakoError> {
+        let Some(install_as) = dll.install_as.as_deref() else {
+            return Ok(());
+        };
+        // The PE name writes a file into the cache entry — a separator
+        // would escape it; refuse by name, never install.
+        if install_as.contains('/') || install_as.contains('\\') {
+            return Err(packaging_error(
+                122,
+                Some(&format!(
+                    "release index dll facet for {} carries an unusable install_as (\"{install_as}\") — the PE name must be a bare file name",
+                    dll.filename
+                )),
+            ));
+        }
+        let dll_path = dir.join(install_as);
+        let marker = dir.join(format!("{install_as}.sha256"));
+        if dll_path.is_file() && marker.is_file() {
+            return Ok(());
+        }
+        let url = self.package_url(&dll.filename, tebako_version);
+        let tmp_dir = self.cache_root.join(TMP_DIR);
+        let tmp = tmp_dir.join(format!("{}.{}.part", dll.filename, std::process::id()));
+        match fetch_bytes(&url) {
+            Ok(bytes) => {
+                if let Err(e) = crate::fetch::write_tmp(&tmp, &bytes) {
+                    let _ = fs::remove_file(&tmp);
+                    return Err(packaging_error(122, Some(&format!("{e} writing {url}"))));
+                }
+            }
+            Err(FetchError::IndexUnavailable(_)) => {
+                let _ = fs::remove_file(&tmp);
+                return Err(packaging_error(122, Some(&format!("{url}: not found"))));
+            }
+            Err(e @ FetchError::Throttled { .. }) => {
+                let _ = fs::remove_file(&tmp);
+                return Err(packaging_error(122, Some(&e.to_string())));
+            }
+            Err(FetchError::DownloadFailed(msg)) => {
+                let _ = fs::remove_file(&tmp);
+                return Err(packaging_error(122, Some(&msg)));
+            }
+        }
+        let actual = sha256_file_hex(&tmp)
+            .ok_or_else(|| packaging_error(121, Some(&format!("cannot hash {}", tmp.display()))))?;
+        let expected = dll.sha256.to_ascii_lowercase();
+        if actual != expected {
+            let _ = fs::remove_file(&tmp);
+            return Err(packaging_error(
+                121,
+                Some(&format!(
+                    "{}: expected {expected}, got {actual}; download deleted",
+                    dll.filename
+                )),
+            ));
+        }
+        let err = |e: std::io::Error| {
+            crate::error::plain_error(format!("{e} installing {}", dll_path.display()))
+        };
+        make_readonly(&tmp).map_err(err)?;
+        fs::rename(&tmp, &dll_path).map_err(err)?;
+        fs::write(&marker, format!("{expected}  {install_as}\n")).map_err(err)?;
+        fs::write(dir.join(format!("{install_as}.origin")), format!("{url}\n")).map_err(err)?;
         Ok(())
     }
 
@@ -713,6 +819,19 @@ impl Resolver {
                                     .to_ascii_lowercase(),
                             })
                         }),
+                        // tebako-runtime-ruby#40: the additive `dll` key
+                        // (windows packages only) — absent on every POSIX
+                        // entry, ignored by consumers that predate it.
+                        dll: e.find("dll").and_then(|d| {
+                            Some(DllRef {
+                                filename: d.find("filename").and_then(|v| v.as_string())?,
+                                install_as: d.find("install_as").and_then(|v| v.as_string()),
+                                sha256: d
+                                    .find("sha256")
+                                    .and_then(|v| v.as_string())?
+                                    .to_ascii_lowercase(),
+                            })
+                        }),
                     })
                     .collect())
             }
@@ -742,6 +861,7 @@ impl Resolver {
                             .unwrap_or_default()
                             .to_ascii_lowercase(),
                         image: None,
+                        dll: None,
                     })
                     .collect())
             }
@@ -750,10 +870,15 @@ impl Resolver {
 
     /// `<sha256>  <filename>` lines; filenames may carry a `*` prefix.
     /// Runtime lines may name the image sibling (`<asset>.tfs`, item
-    /// 30b): they attach to the matching runtime entry as its `image`.
+    /// 30b) or the windows ruby DLL sibling (`<asset>.dll`,
+    /// tebako-runtime-ruby#40): they attach to the matching runtime entry
+    /// as its `image` / `dll`. The sums form carries no PE name, so a
+    /// sums-derived dll ref has no `install_as` (not installable — the
+    /// dll facet is manifest-keyed).
     fn parse_sha256sums(&self, body: &str, tebako_version: &str) -> Vec<IndexEntry> {
         let mut out: Vec<IndexEntry> = Vec::new();
         let mut images: Vec<(String, String, String)> = Vec::new(); // (rv, platform, ImageRef parts)
+        let mut dlls: Vec<(String, String, String)> = Vec::new(); // (rv, platform, DllRef parts)
         for line in body.lines() {
             let mut parts = line.trim().splitn(2, char::is_whitespace);
             let (Some(sha256), Some(file)) = (parts.next(), parts.next()) else {
@@ -774,6 +899,14 @@ impl Resolver {
                         }
                         continue;
                     }
+                    // The ruby DLL sibling (tebako-runtime-ruby#40): the
+                    // same treatment.
+                    if let Some(rest) = rest.strip_suffix(".dll") {
+                        if let Some((ruby_version, platform)) = split_ruby_platform(rest) {
+                            dlls.push((ruby_version, platform, format!("{file}|{sha256}")));
+                        }
+                        continue;
+                    }
                     let rest = rest.strip_suffix(".exe").unwrap_or(rest);
                     let Some((ruby_version, platform)) = split_ruby_platform(rest) else {
                         continue;
@@ -784,6 +917,7 @@ impl Resolver {
                         filename: file.to_string(),
                         sha256: sha256.to_ascii_lowercase(),
                         image: None,
+                        dll: None,
                     });
                 }
                 Flavor::Bootstrap => {
@@ -801,6 +935,7 @@ impl Resolver {
                         filename: file.to_string(),
                         sha256: sha256.to_ascii_lowercase(),
                         image: None,
+                        dll: None,
                     });
                 }
             }
@@ -815,6 +950,21 @@ impl Resolver {
             }) {
                 entry.image = Some(ImageRef {
                     filename: filename.to_string(),
+                    sha256: sha256.to_ascii_lowercase(),
+                });
+            }
+        }
+        for (ruby_version, platform, parts) in dlls {
+            let Some((filename, sha256)) = parts.split_once('|') else {
+                continue;
+            };
+            if let Some(entry) = out.iter_mut().find(|e| {
+                e.ruby_version.as_deref() == Some(ruby_version.as_str())
+                    && e.platform.as_deref() == Some(platform.as_str())
+            }) {
+                entry.dll = Some(DllRef {
+                    filename: filename.to_string(),
+                    install_as: None,
                     sha256: sha256.to_ascii_lowercase(),
                 });
             }
@@ -1216,5 +1366,219 @@ mod tests {
         let err = contract_gate("ruby@3.4.2", Some(&card(full)), "nope").unwrap_err();
         assert_eq!(err.code, 75);
         assert!(err.message.contains("pre-era"), "{}", err.message);
+    }
+
+    // ---- tebako-runtime-ruby#40: the windows ruby DLL facet -------------
+
+    #[test]
+    fn sha256sums_dll_lines_attach_to_the_runtime_entry() {
+        let r = Resolver::new(Flavor::Runtime);
+        let body = "aaa111  tebako-runtime-0.16.3-3.3.12-windows-ucrt64.exe\n\
+                    bbb222  tebako-runtime-0.16.3-3.3.12-windows-ucrt64.tfs\n\
+                    ccc333  tebako-runtime-0.16.3-3.3.12-windows-ucrt64.dll\n\
+                    ddd444  tebako-runtime-0.16.3-3.4.2-macos-arm64\n";
+        let entries = r.parse_sha256sums(body, "0.16.3");
+        assert_eq!(entries.len(), 2);
+        let win = &entries[0];
+        assert_eq!(win.platform.as_deref(), Some("windows-ucrt64"));
+        assert_eq!(
+            win.image.as_ref().map(|i| i.filename.as_str()),
+            Some("tebako-runtime-0.16.3-3.3.12-windows-ucrt64.tfs")
+        );
+        let dll = win.dll.as_ref().expect("the dll line attaches");
+        assert_eq!(
+            dll.filename,
+            "tebako-runtime-0.16.3-3.3.12-windows-ucrt64.dll"
+        );
+        assert_eq!(dll.sha256, "ccc333");
+        // the sums form carries no PE name — not installable from here
+        assert_eq!(dll.install_as, None);
+        // a POSIX entry carries no facet
+        assert_eq!(entries[1].image, None);
+        assert_eq!(entries[1].dll, None);
+    }
+
+    #[test]
+    fn manifest_runtime_dll_facet() {
+        let r = Resolver::new(Flavor::Runtime);
+        let body = r#"[
+          {"tebako_version":"0.16.3","ruby_version":"3.3.12","platform":"windows-ucrt64",
+           "filename":"tebako-runtime-0.16.3-3.3.12-windows-ucrt64.exe","sha256":"AAA",
+           "image":{"filename":"tebako-runtime-0.16.3-3.3.12-windows-ucrt64.tfs","sha256":"BBB","size_bytes":5},
+           "dll":{"filename":"tebako-runtime-0.16.3-3.3.12-windows-ucrt64.dll",
+                  "install_as":"x64-ucrt-ruby330.dll","sha256":"CCC","size_bytes":7}},
+          {"tebako_version":"0.16.3","ruby_version":"3.3.12","platform":"macos-arm64",
+           "filename":"tebako-runtime-0.16.3-3.3.12-macos-arm64","sha256":"DDD",
+           "image":{"filename":"tebako-runtime-0.16.3-3.3.12-macos-arm64.tfs","sha256":"EEE","size_bytes":5}}
+        ]"#;
+        let entries = r.parse_manifest(body, "0.16.3").unwrap();
+        assert_eq!(entries.len(), 2);
+        let dll = entries[0].dll.as_ref().expect("the dll key parses");
+        assert_eq!(
+            dll.filename,
+            "tebako-runtime-0.16.3-3.3.12-windows-ucrt64.dll"
+        );
+        assert_eq!(dll.install_as.as_deref(), Some("x64-ucrt-ruby330.dll"));
+        assert_eq!(dll.sha256, "ccc");
+        // the POSIX entry carries no dll facet (the additive-key compat rule)
+        assert_eq!(entries[1].dll, None);
+    }
+
+    /// A scratch (cache root, release mirror) pair in the factory's
+    /// era-2 shape: exe + image (+ optional dll, `tamper_dll` poisons
+    /// its declared sha) and a manifest.json declaring the contract set.
+    fn dll_mirror(tag: &str, with_dll: bool, tamper_dll: bool) -> (PathBuf, PathBuf) {
+        let dir =
+            std::env::temp_dir().join(format!("tebako-resolve-dll-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let cache = dir.join("home");
+        let release = dir.join("mirror").join("v0.16.3");
+        fs::create_dir_all(&release).unwrap();
+        let exe = "tebako-runtime-0.16.3-3.3.12-windows-ucrt64.exe";
+        let image = "tebako-runtime-0.16.3-3.3.12-windows-ucrt64.tfs";
+        let dll = "tebako-runtime-0.16.3-3.3.12-windows-ucrt64.dll";
+        fs::write(release.join(exe), b"fake runtime exe\n").unwrap();
+        fs::write(release.join(image), b"fake env image\n").unwrap();
+        let mut manifest = format!(
+            "[{{\"tebako_version\":\"0.16.3\",\"contract_era\":2,\"contract_version\":2,\"mount_root\":\"/__tfs__\",\"ruby_version\":\"3.3.12\",\"platform\":\"windows-ucrt64\",\"filename\":\"{exe}\",\"sha256\":\"{}\",\"image\":{{\"filename\":\"{image}\",\"sha256\":\"{}\"}}",
+            sha256_file_hex(&release.join(exe)).unwrap(),
+            sha256_file_hex(&release.join(image)).unwrap(),
+        );
+        if with_dll {
+            fs::write(release.join(dll), b"fake ruby dll\n").unwrap();
+            let declared = if tamper_dll {
+                "f".repeat(64)
+            } else {
+                sha256_file_hex(&release.join(dll)).unwrap()
+            };
+            manifest.push_str(&format!(
+                ",\"dll\":{{\"filename\":\"{dll}\",\"install_as\":\"x64-ucrt-ruby330.dll\",\"sha256\":\"{declared}\",\"size_bytes\":14}}"
+            ));
+        }
+        manifest.push_str("}]\n");
+        fs::write(release.join("manifest.json"), manifest).unwrap();
+        (cache, dir.join("mirror"))
+    }
+
+    fn dll_resolver(cache: &Path, mirror: &Path) -> Resolver {
+        Resolver {
+            flavor: Flavor::Runtime,
+            cache_root: cache.to_path_buf(),
+            mirror: format!("file://{}", mirror.display()),
+            lock_timeout: LOCK_TIMEOUT,
+        }
+    }
+
+    fn dll_entry_dir(cache: &Path) -> PathBuf {
+        cache
+            .join("runtimes")
+            .join("ruby-3.3.12-0.16.3-windows-ucrt64")
+    }
+
+    #[test]
+    fn resolve_runtime_installs_the_dll_as_install_as_with_markers() {
+        let (cache, mirror) = dll_mirror("install", true, false);
+        let r = dll_resolver(&cache, &mirror);
+        let resolved = r
+            .resolve_runtime("3.3.12", "windows-ucrt64", "0.16.3")
+            .unwrap();
+        assert!(resolved.executable.is_file());
+        let dir = dll_entry_dir(&cache);
+        // the env image landed too
+        assert!(dir
+            .join("tebako-runtime-0.16.3-3.3.12-windows-ucrt64.tfs")
+            .is_file());
+        // the dll materializes under its PE name — never the asset name
+        let dll = dir.join("x64-ucrt-ruby330.dll");
+        assert!(dll.is_file(), "{}", dll.display());
+        assert!(
+            !dir.join("tebako-runtime-0.16.3-3.3.12-windows-ucrt64.dll")
+                .exists(),
+            "the asset name is not the install name"
+        );
+        let marker = fs::read_to_string(dir.join("x64-ucrt-ruby330.dll.sha256")).unwrap();
+        assert_eq!(
+            marker,
+            format!("{}  x64-ucrt-ruby330.dll\n", sha256_file_hex(&dll).unwrap())
+        );
+        let origin = fs::read_to_string(dir.join("x64-ucrt-ruby330.dll.origin")).unwrap();
+        assert_eq!(
+            origin,
+            format!(
+                "file://{}/v0.16.3/tebako-runtime-0.16.3-3.3.12-windows-ucrt64.dll\n",
+                mirror.display()
+            )
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(dll.metadata().unwrap().permissions().mode() & 0o777, 0o444);
+        }
+        // a cache hit needs no mirror at all (a run is a run, offline-safe)
+        fs::remove_dir_all(&mirror).unwrap();
+        r.resolve_runtime("3.3.12", "windows-ucrt64", "0.16.3")
+            .unwrap();
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn resolve_runtime_without_the_dll_key_installs_the_exe_alone() {
+        let (cache, mirror) = dll_mirror("nodll", false, false);
+        let r = dll_resolver(&cache, &mirror);
+        r.resolve_runtime("3.3.12", "windows-ucrt64", "0.16.3")
+            .unwrap();
+        let dir = dll_entry_dir(&cache);
+        assert!(dir
+            .join("tebako-runtime-0.16.3-3.3.12-windows-ucrt64.exe")
+            .is_file());
+        assert!(!dir.join("x64-ucrt-ruby330.dll").exists());
+        assert!(
+            !fs::read_dir(&dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .any(|e| e.file_name().to_string_lossy().ends_with(".dll")),
+            "no dll facet declared, no dll installed"
+        );
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn resolve_runtime_wrong_dll_sha_is_a_named_error() {
+        let (cache, mirror) = dll_mirror("badsha", true, true);
+        let r = dll_resolver(&cache, &mirror);
+        let err = r
+            .resolve_runtime("3.3.12", "windows-ucrt64", "0.16.3")
+            .unwrap_err();
+        assert_eq!(err.code, 121);
+        assert!(err.message.contains("download deleted"), "{}", err.message);
+        let dir = dll_entry_dir(&cache);
+        assert!(!dir.join("x64-ucrt-ruby330.dll").exists());
+        assert!(
+            !fs::read_dir(cache.join(TMP_DIR))
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .any(|e| e.file_name().to_string_lossy().contains(".dll")),
+            "the failed download was deleted"
+        );
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn resolve_runtime_dll_traversal_install_as_is_a_named_error() {
+        let (cache, mirror) = dll_mirror("traversal", true, false);
+        // poison the facet's PE name: a separator would escape the entry
+        let manifest_path = mirror.join("v0.16.3").join("manifest.json");
+        let text = fs::read_to_string(&manifest_path)
+            .unwrap()
+            .replace("x64-ucrt-ruby330.dll", "../evil.dll");
+        fs::write(&manifest_path, text).unwrap();
+        let r = dll_resolver(&cache, &mirror);
+        let err = r
+            .resolve_runtime("3.3.12", "windows-ucrt64", "0.16.3")
+            .unwrap_err();
+        assert_eq!(err.code, 122);
+        assert!(err.message.contains("bare file name"), "{}", err.message);
+        assert!(!cache.join("runtimes").join("evil.dll").exists());
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
     }
 }

--- a/crates/tebako-shim/src/runtime.rs
+++ b/crates/tebako-shim/src/runtime.rs
@@ -614,6 +614,35 @@ fn sha_from_manifest(text: &str, asset: &str) -> Result<String, ()> {
     Err(())
 }
 
+/// The release manifest's ruby DLL facet for the exe entry `asset`
+/// (tebako-runtime-ruby#40 — the additive `dll` key, windows packages
+/// only): `(dll asset filename, install_as, sha256)`. `None` when the
+/// entry carries no `dll` key (every POSIX entry) or the key is
+/// incomplete — the facet is manifest-keyed: the PE name (`install_as`)
+/// exists only there, never derived (the factory's
+/// RubyVersion#msys_dll_name is its single owner).
+fn dll_from_manifest(text: &str, asset: &str) -> Option<(String, String, String)> {
+    let parsed = tebako_json::parse(text).ok()?;
+    let tebako_json::Value::Array(entries) = &parsed else {
+        return None;
+    };
+    entries.iter().find_map(|entry| {
+        if entry
+            .find("filename")
+            .and_then(|f| f.as_string())
+            .as_deref()
+            != Some(asset)
+        {
+            return None;
+        }
+        let dll = entry.find("dll")?;
+        let filename = dll.find("filename").and_then(|v| v.as_string())?;
+        let install_as = dll.find("install_as").and_then(|v| v.as_string())?;
+        let sha256 = dll.find("sha256").and_then(|v| v.as_string())?;
+        Some((filename, install_as, sha256))
+    })
+}
+
 /// SHA256SUMS.txt fallback: "<64hex><spaces>[*]<filename>" per line.
 #[allow(clippy::result_unit_err)]
 fn sha_from_sums(text: &str, asset: &str) -> Result<String, ()> {
@@ -958,6 +987,37 @@ fn download_runtime(
         } else {
             false
         };
+        // windows dll-era runtimes (tebako-runtime-ruby#40): the exe
+        // imports the ruby core DLL — the release manifest's additive
+        // `dll` key names the asset and the PE name (`install_as`) it
+        // installs under next to the exe (never the asset name: assets
+        // are unique per leg, two same-ABI legs share the PE name). Same
+        // mirror/offline/verify rules as the image, the same contract
+        // gate (the exe entry governs its additive facets); a
+        // contract-complete entry with no `dll` key installs the exe
+        // alone (every POSIX release).
+        if let Some((dll_asset, install_as, dll_expected)) = dll_from_manifest(&manifest_text, &asset)
+        {
+            if install_as.contains('/') || install_as.contains('\\') {
+                return fail(
+                    EX_TEBAKO_UNAVAILABLE,
+                    format!(
+                        "release manifest dll facet for {asset} carries an unusable install_as (\"{install_as}\") — the PE name must be a bare file name — refusing to install or execute"
+                    ),
+                );
+            }
+            let dll_url = format!("{base}/v{}/{dll_asset}", pref.tebako);
+            let dll_actual = install_asset(&dll_url, local, &install_as, &tmp_dir, &dll_expected)?;
+            make_readonly(&tmp_dir.join(&install_as));
+            let _ = std::fs::write(
+                tmp_dir.join(format!("{install_as}.sha256")),
+                format!("{dll_actual}  {install_as}\n"),
+            );
+            let _ = std::fs::write(
+                tmp_dir.join(format!("{install_as}.origin")),
+                format!("runtime_ref={runtime_ref}\nurl={dll_url}\nsha256={dll_actual}\n"),
+            );
+        }
         let _ = std::fs::write(tmp_dir.join("sha256"), format!("{actual}  {asset}\n"));
         let _ = std::fs::write(
             tmp_dir.join("origin"),

--- a/crates/tebako-shim/tests/common/mod.rs
+++ b/crates/tebako-shim/tests/common/mod.rs
@@ -203,6 +203,45 @@ pub fn write_mirror(root: &Path, lv: &str, ver: &str, tamper: bool) -> PathBuf {
     root.to_path_buf()
 }
 
+/// `write_mirror` plus the windows ruby DLL facet
+/// (tebako-runtime-ruby#40): the release also carries `<asset_base>.dll`
+/// and the manifest entry declares the additive `dll` key with the PE
+/// name (`install_as`) the exe imports. `tamper` poisons the DLL's
+/// declared sha256. Returns (mirror root, install_as).
+pub fn write_mirror_dll(root: &Path, lv: &str, ver: &str, tamper: bool) -> (PathBuf, String) {
+    let platform = platform();
+    let dir = root.join(format!("v{ver}"));
+    std::fs::create_dir_all(&dir).expect("mirror dir");
+    let asset_base = format!("tebako-runtime-{ver}-{lv}-{platform}");
+    let exe_name = format!("{asset_base}{}", tebako_shim::runtime::exe_suffix());
+    let image_name = format!("{asset_base}.tfs");
+    let dll_name = format!("{asset_base}.dll");
+    let install_as = "x64-ucrt-ruby330.dll";
+    let exe_bytes = b"mirrored runtime exe\n";
+    let image_bytes = b"mirrored runtime image\n";
+    let dll_bytes = b"mirrored ruby dll\n";
+    std::fs::write(dir.join(&exe_name), exe_bytes).expect("exe");
+    std::fs::write(dir.join(&image_name), image_bytes).expect("image");
+    std::fs::write(dir.join(&dll_name), dll_bytes).expect("dll");
+    let exe_sha = sha256_hex(exe_bytes);
+    let image_sha = sha256_hex(image_bytes);
+    let dll_sha = if tamper {
+        "f".repeat(64)
+    } else {
+        sha256_hex(dll_bytes)
+    };
+    std::fs::write(
+        dir.join("manifest.json"),
+        // The era-2 factory shape with the additive `dll` key
+        // (tebako-runtime-ruby#40) alongside the `image` key.
+        format!(
+            "[{{\"contract_era\": 2, \"contract_version\": 2, \"mount_root\": \"/__tfs__\", \"filename\": \"{exe_name}\", \"sha256\": \"{exe_sha}\", \"image\": {{\"filename\": \"{image_name}\", \"sha256\": \"{image_sha}\"}}, \"dll\": {{\"filename\": \"{dll_name}\", \"install_as\": \"{install_as}\", \"sha256\": \"{dll_sha}\"}}}}]\n"
+        ),
+    )
+    .expect("manifest.json");
+    (root.to_path_buf(), install_as.to_string())
+}
+
 pub fn write_config(home: &Path, yaml: &str) {
     std::fs::create_dir_all(home).expect("home");
     std::fs::write(home.join("config.yaml"), yaml).expect("config");

--- a/crates/tebako-shim/tests/runtime.rs
+++ b/crates/tebako-shim/tests/runtime.rs
@@ -186,6 +186,153 @@ fn sha_mismatch_is_exit_70_and_nothing_enters_the_cache() {
 }
 
 #[test]
+fn download_installs_the_dll_as_install_as_with_markers() {
+    // tebako-runtime-ruby#40: a windows release declares the ruby DLL in
+    // the additive `dll` key — it installs next to the exe under its PE
+    // name (`install_as`), verified and marked like the image.
+    let tmp = TempDir::new("download-dll");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    let (_, install_as) = write_mirror_dll(&mirror, "3.3.12", "0.16.3", false);
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 3.3.12\n    tebako: 0.16.3\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+
+    let rt = ready(runtime::resolve_runtime(Some(&req("~> 3.3.0")), true, &ctx).unwrap());
+    assert_eq!(rt.lang_version, "3.3.12");
+    assert!(rt.exe.is_file());
+    // the dll materializes under its PE name — never the asset name
+    let dll = rt.dir.join(&install_as);
+    assert!(dll.is_file(), "{}", dll.display());
+    let asset_name = rt
+        .dir
+        .join(format!("tebako-runtime-0.16.3-3.3.12-{}.dll", platform()));
+    assert!(
+        !asset_name.exists(),
+        "the asset name is not the install name"
+    );
+    // trust markers installed
+    let marker = rt.dir.join(format!("{install_as}.sha256"));
+    assert!(marker.is_file(), "marker {}", marker.display());
+    let text = std::fs::read_to_string(&marker).unwrap();
+    assert_eq!(
+        text,
+        format!("{}  {install_as}\n", sha256_hex(b"mirrored ruby dll\n"))
+    );
+    let origin = std::fs::read_to_string(rt.dir.join(format!("{install_as}.origin"))).unwrap();
+    assert!(
+        origin.contains(&format!("tebako-runtime-0.16.3-3.3.12-{}.dll", platform())),
+        "{origin}"
+    );
+    // the dll is read-only (0444)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        assert_eq!(dll.metadata().unwrap().permissions().mode() & 0o777, 0o444);
+    }
+
+    // second resolution is a cache hit: the mirror is gone, still Ready
+    std::fs::remove_dir_all(&mirror).unwrap();
+    let rt2 = ready(runtime::resolve_runtime(Some(&req("~> 3.3.0")), true, &ctx).unwrap());
+    assert_eq!(rt2.lang_version, "3.3.12");
+}
+
+#[test]
+fn dll_sha_mismatch_is_exit_70_and_nothing_enters_the_cache() {
+    let tmp = TempDir::new("dll-sha-mismatch");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    write_mirror_dll(&mirror, "3.3.12", "0.16.3", true);
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 3.3.12\n    tebako: 0.16.3\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    let err = runtime::resolve_runtime(Some(&req("~> 3.3.0")), true, &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_SHA);
+    assert!(
+        !home
+            .join("runtimes")
+            .join(format!("ruby-3.3.12-0.16.3-{}", platform()))
+            .exists(),
+        "a failed install must be invisible"
+    );
+}
+
+#[test]
+fn a_release_without_the_dll_key_installs_the_exe_alone() {
+    // the additive-key compat rule: a contract-complete release with no
+    // `dll` key (every POSIX release) installs the exe alone.
+    let tmp = TempDir::new("download-nodll");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    write_mirror(&mirror, "4.0.6", "0.16.0", false);
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    let rt = ready(runtime::resolve_runtime(Some(&req(">= 3.3, < 5.0")), true, &ctx).unwrap());
+    assert!(rt.exe.is_file());
+    assert!(
+        !std::fs::read_dir(&rt.dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().ends_with(".dll")),
+        "no dll facet declared, no dll installed"
+    );
+}
+
+#[test]
+fn a_dll_install_as_with_a_path_separator_is_a_named_error() {
+    // the PE name installs a file into the cache entry — a name with a
+    // separator would escape it; refuse by name, never install.
+    let tmp = TempDir::new("dll-traversal");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    write_mirror_dll(&mirror, "3.3.12", "0.16.3", false);
+    let manifest = mirror.join("v0.16.3").join("manifest.json");
+    let text = std::fs::read_to_string(&manifest)
+        .unwrap()
+        .replace("x64-ucrt-ruby330.dll", "../evil.dll");
+    std::fs::write(&manifest, text).unwrap();
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 3.3.12\n    tebako: 0.16.3\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    let err = runtime::resolve_runtime(Some(&req("~> 3.3.0")), true, &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_UNAVAILABLE);
+    assert!(err.message.contains("bare file name"), "{}", err.message);
+    assert!(!home.join("tmp").join("evil.dll").exists());
+    assert!(
+        !home
+            .join("runtimes")
+            .join(format!("ruby-3.3.12-0.16.3-{}", platform()))
+            .exists(),
+        "a refused install must be invisible"
+    );
+}
+
+#[test]
 fn pre_era_release_is_refused_before_download() {
     // spec 18 S11: a release whose manifest declares no contract set
     // (the pre-18 factory shape — contract fields absent) is refused by


### PR DESCRIPTION
## What

tebako-runtime-ruby#40 made the windows runtime `--enable-shared`: the ruby core + tebako driver + libtfs closure live in `x64-ucrt-ruby<ABI>.dll`, which the runtime exe imports. The factory therefore ships THREE artifacts per windows runtime package (exe, env `.tfs` image, ruby DLL), and the release manifest carries the additive `dll` key alongside `image`:

```json
{ ..., "filename": "tebako-runtime-0.16.3-3.3.12-windows-ucrt64.exe", ...,
  "image": {"filename": "tebako-runtime-0.16.3-3.3.12-windows-ucrt64.tfs", "sha256": "...", "size_bytes": N},
  "dll":   {"filename": "tebako-runtime-0.16.3-3.3.12-windows-ucrt64.dll",
            "install_as": "x64-ucrt-ruby330.dll",
            "sha256": "...", "size_bytes": N} }
```

(SHA256SUMS.txt carries the dll line after the image line.) The PE loader resolves the exe's DLL imports against the exe's own directory first, so the DLL must sit NEXT TO THE EXE in the store entry (`~/.tebako/runtimes/<lang>-<lv>-<ver>-<triplet>/`) — materialized under its PE name (`install_as`), never the asset name: assets are unique per leg, two same-ABI legs share the PE name. The PE name is declared, never derived — the factory's `RubyVersion#msys_dll_name` is its single owner (spec 00 SSOT).

This PR teaches the three runtime install paths to fetch + verify + install the dll facet, mirroring the image facet exactly. Consumers predating the `dll` key keep working unchanged (the same additive-key compat rule as `image`): a contract-complete entry with no `dll` key — every POSIX release today — installs the exe alone.

## The three install paths

- **`crates/tebako-cli/src/resolve.rs`** (press-time resolver): `IndexEntry` gains `dll: Option<DllRef>` (filename + install_as + sha256), parsed from manifest.json's `dll` key; `.dll` lines attach to the runtime entry in `parse_sha256sums` with the same treatment as `.tfs` lines (the sums form carries no PE name, so a sums-derived ref has `install_as: None` and is not installable — the facet is manifest-keyed; sums-only Runtime installs are refused by the spec 18 contract gate anyway). `resolve_runtime` installs the dll whenever the index is in hand — the fresh install AND the image-backfill path: download to `tmp/`, sha256-verify against the manifest value, atomic rename into the entry dir AS `install_as`, read-only (0444 / readonly attribute, like the image), plus `<install_as>.sha256` and `<install_as>.origin` trusted markers.
- **`crates/tebako-shim/src/runtime.rs`** (dispatch-time install): `dll_from_manifest` reads the exe entry's `dll` key; after the image install, the dll downloads and stages into the tmp dir AS `install_as` (same mirror/offline/verify discipline, read-only, both markers) and rides the same atomic tmp-dir rename into the cache entry — exe + image + dll enter the cache together or not at all.
- **`crates/tebako-bootstrap/src/lib.rs`** (standalone first-run install): `resolve_dll` runs alongside `resolve_image` under the same `;image` condition (the dll facet rides the image-era release card). The facet source is the entry's cached `manifest.json` — the verified lean install leaves it in the entry — so a cached run never re-fetches the index (a run is a run; offline-safe). A declared-but-missing dll is downloaded + installed (this also heals entries cached by pre-dll bootstraps once a dll-era release exists); an offline miss is the named `TEBAKO_OFFLINE` error; a sha mismatch is exit 70 with the download deleted. No handoff change: the PE loader finds the DLL on its own.

All three installers refuse an `install_as` containing a path separator by name — the PE name writes a file into the cache entry, and a separator would escape it.

## Tests (same conventions as each crate's image-facet tests)

- tebako-cli (inline): SHA256SUMS `.dll`-line attach (install_as `None`), manifest `dll`-key parse, absent-key `None`; `file://`-mirror install tests: the dll lands AS `install_as` with markers + 0444 (asset name absent), a cache hit needs no mirror, no `dll` key → exe alone, wrong declared sha → exit 121 "download deleted" with no dll and no leftover `.part`.
- tebako-shim (`tests/runtime.rs` + `common`): `write_mirror_dll` fixture; install-as-`install_as` with markers + 0444 + cache-hit-after-mirror-removal; dll sha mismatch → exit 70 and nothing enters the cache; no `dll` key → no dll in the entry; traversal `install_as` → named error, nothing written.
- tebako-bootstrap (inline): facet parse, absent/incomplete facet, cross-entry bounding of the hand-rolled reader; one env-using flow test (so `TEBAKO_RUNTIME_MIRROR`/`TEBAKO_OFFLINE` never race a sibling): install AS `install_as` + markers + 0444, offline-safe cached re-resolution with the mirror deleted, declared-but-missing under `TEBAKO_OFFLINE` → exit 69 named, wrong sha → exit 70, traversal refusal, no-facet and no-cached-index no-ops.

## Validation

Run on macOS (arm64) with the workspace's local-build env (`DWARFS_RS_VCPKG_ROOT`/`VCPKG_ROOT`/`SQFS_SYS_VCPKG_ROOT` set, `CARGO_NET_GIT_FETCH_WITH_CLI=true`; no `--release`):

- `cargo fmt -p tebako-cli -p tebako-shim -p tebako-bootstrap -- --check` — clean.
- `cargo clippy -p tebako-resolve -p tebako-shim -p tebako-cli -p tebako-bootstrap --all-targets` — Finished, no warnings.
- `cargo test --no-fail-fast -p tebako-resolve -p tebako-shim -p tebako-bootstrap` — 24 test targets ok, 0 failed; the new `dll_tests::*` (bootstrap) and the four new `tests/runtime.rs` dll tests (shim) pass.
- `TEBAKO_CLI_SKIP_E2E=1 cargo test -p tebako-cli` — 12 test targets ok, 0 failed (the lib's 60 unit tests include the six new dll tests; the network/mkdwarfs e2e presses self-skip via the suite's own gate).

## Follow-ups (not this PR)

- e2e against a real 0.16.3 windows runtime release — that release does not exist yet; the install paths are covered here by `file://` mirrors in the factory's exact manifest shape.
- Fat windows packages of dll-era runtimes: the runtime exe rides a payload slot; the dll does not (the bootstrap's fat path carries no release index to declare it). Press-side stitching of the dll slot is a separate feature.
- tebako-cli's cache-hit fast path (exe + image marker present) does not heal a torn dll-era entry cached by a pre-dll tebako-cli; the shim's cache-hit path likewise reports what is cached. Both heal on the next fresh install (or a cache prune) — the same shape the image era had before the backfill path.
