### PR TITLE
arscope: scope mach-o symbol names verbatim — fix the blake3 dual-spelling collapse (0.16.3 macos x86_64)

### DIFF
--- a/crates/tebako-arscope/src/macho.rs
+++ b/crates/tebako-arscope/src/macho.rs
@@ -60,6 +60,13 @@ fn symtab(bytes: &[u8]) -> Result<(usize, usize, usize, usize, usize), String> {
     Ok((lc, symoff, nsyms, stroff, strsize))
 }
 
+/// Test-only view of the private symtab walker (the dual-spelling
+/// regression test parses the scoped object back).
+#[cfg(test)]
+pub fn symtab_for_test(bytes: &[u8]) -> Result<(usize, usize, usize, usize, usize), String> {
+    symtab(bytes)
+}
+
 /// One nlist entry, decoded.
 struct Sym {
     at: usize,
@@ -124,6 +131,20 @@ fn renames_def(name: &[u8], keep: &str) -> bool {
     !logical.trim_start_matches('_').starts_with(keep)
 }
 
+/// The scoped spelling of a raw nlist name. The raw name rides the
+/// prefix VERBATIM — the Mach-O leading underscore is NOT stripped.
+/// blake3's x86-64 assembly legitimately defines every entry point
+/// twice in one object (`_blake3_hash_many_sse2` AND
+/// `blake3_hash_many_sse2`, the Mach-O and ELF spellings, same
+/// address); stripping the underscore would collapse the pair into one
+/// scoped name and ld64 errors "duplicate symbol" on the synthetic
+/// collision (the 0.16.3-era macos-x86_64 miniruby link, 11 symbols).
+/// Keeping the underscore keeps the spellings distinct:
+/// `__tebako_internal__blake3_*` vs `__tebako_internal_blake3_*`.
+fn scoped_name(name: &[u8], prefix: &str) -> String {
+    format!("{prefix}{}", String::from_utf8_lossy(name))
+}
+
 /// Pass A: the raw strtab names of every definition this tool will
 /// rename anywhere in the archive. References compare against these
 /// raw names (Mach-O leading underscore included).
@@ -171,10 +192,7 @@ pub fn scope(
                 continue;
             }
             if renames_def(name, keep) {
-                exported.push(format!(
-                    "{prefix}{}",
-                    String::from_utf8_lossy(name.strip_prefix(b"_").unwrap_or(name))
-                ));
+                exported.push(scoped_name(name, prefix));
                 true
             } else {
                 exported.push(String::from_utf8_lossy(name).into_owned());
@@ -192,8 +210,7 @@ pub fn scope(
             continue;
         }
         renamed += 1;
-        let logical = name.strip_prefix(b"_").unwrap_or(name);
-        let new_name = format!("{prefix}{}", String::from_utf8_lossy(logical));
+        let new_name = scoped_name(name, prefix);
         let new_strx = new_strtab.len() as u32;
         new_strtab.extend_from_slice(new_name.as_bytes());
         new_strtab.push(0);

--- a/crates/tebako-arscope/src/main.rs
+++ b/crates/tebako-arscope/src/main.rs
@@ -769,12 +769,21 @@ mod tests {
                 .iter()
                 .any(|n: &String| n.trim_start_matches('_') == want.trim_start_matches('_'))
         };
+        // macho.rs scopes the raw nlist name VERBATIM (leading
+        // underscore kept — blake3's dual `_sym`/`sym` spellings must
+        // not collapse), so the Mach-O expectation carries the doubled
+        // underscore; the ELF path has no mangling prefix to keep.
+        let internal = if cfg!(target_os = "macos") {
+            "__tebako_internal__rust_eh_personality"
+        } else {
+            "__tebako_internal_rust_eh_personality"
+        };
         assert!(
             has("tebako_probe"),
             "the public surface survives: {names:?}"
         );
         assert!(
-            has("__tebako_internal_rust_eh_personality"),
+            names.iter().any(|n| n == internal),
             "the internal symbol is renamed: {names:?}"
         );
         assert!(
@@ -931,15 +940,114 @@ mod tests {
                 .any(|n: &String| n.trim_start_matches('_') == want.trim_start_matches('_'))
         };
         assert!(
-            has("__tebako_internal_rust_eh_personality"),
-            "the ref to the renamed def rides the prefix: {names:?}"
+            names
+                .iter()
+                .any(|n| n == "__tebako_internal__rust_eh_personality"),
+            "the ref to the renamed def rides the prefix (raw name verbatim): {names:?}"
         );
         assert!(has("malloc"), "the libc ref stays: {names:?}");
         assert!(
-            has("__tebako_internal_consumer_fn"),
-            "the member's own def is renamed: {names:?}"
+            names
+                .iter()
+                .any(|n| n == "__tebako_internal__consumer_fn"),
+            "the member's own def is renamed (raw name verbatim): {names:?}"
         );
         assert_eq!(renamed, 2, "one def + one ref renamed");
+    }
+
+    /// The 0.16.3-era macos-x86_64 regression: blake3's x86-64 assembly
+    /// defines every entry point TWICE in one object — `_name` (the
+    /// Mach-O spelling) and `name` (the ELF spelling), same address.
+    /// Scoping must keep the pair distinct; stripping the leading
+    /// underscore before prefixing collapses them into one scoped name
+    /// and ld64 errors "duplicate symbol" (11 blake3 symbols on the
+    /// miniruby link). The fixture is a raw LC_SYMTAB blob, so the test
+    /// runs on every host.
+    #[test]
+    fn macho_dual_spelling_definitions_stay_distinct() {
+        // Minimal MH_OBJECT: header + one LC_SYMTAB + symtab + strtab.
+        // macho.rs reads nothing else.
+        let strtab: &[u8] = b"\0_dual\0dual\0_tebako_api\0";
+        let strx = |name: &str| {
+            strtab
+                .windows(name.len())
+                .position(|w| w == name.as_bytes())
+                .unwrap() as u32
+        };
+        let nlist = |strx: u32, n_type: u8, value: u64| {
+            let mut e = Vec::with_capacity(16);
+            e.extend_from_slice(&strx.to_le_bytes());
+            e.push(n_type);
+            e.push(1); // n_sect
+            e.extend_from_slice(&[0, 0]); // n_desc
+            e.extend_from_slice(&value.to_le_bytes());
+            e
+        };
+        const N_SECT_EXT: u8 = 0x0e | 0x01; // N_SECT | N_EXT — a global definition
+        const N_UNDF_EXT: u8 = 0x01; // N_UNDF | N_EXT — an undefined reference
+        let mut syms = Vec::new();
+        syms.extend(nlist(strx("_dual"), N_SECT_EXT, 0x100)); // Mach-O spelling
+        syms.extend(nlist(strx("dual"), N_SECT_EXT, 0x100)); // ELF spelling, same address
+        syms.extend(nlist(strx("_tebako_api"), N_SECT_EXT, 0x200)); // kept public
+        syms.extend(nlist(strx("_dual"), N_UNDF_EXT, 0)); // a reference to the def
+
+        let symoff = 32 + 24;
+        let stroff = symoff + syms.len();
+        let mut obj = Vec::new();
+        obj.extend_from_slice(&0xfeedfacfu32.to_le_bytes()); // MH_MAGIC_64
+        obj.extend_from_slice(&[0; 12]); // cputype/cpusubtype/filetype
+        obj.extend_from_slice(&1u32.to_le_bytes()); // ncmds
+        obj.extend_from_slice(&24u32.to_le_bytes()); // sizeofcmds
+        obj.extend_from_slice(&[0; 4]); // flags
+        obj.extend_from_slice(&[0; 4]); // reserved
+        obj.extend_from_slice(&2u32.to_le_bytes()); // LC_SYMTAB
+        obj.extend_from_slice(&24u32.to_le_bytes()); // cmdsize
+        obj.extend_from_slice(&(symoff as u32).to_le_bytes());
+        obj.extend_from_slice(&4u32.to_le_bytes()); // nsyms
+        obj.extend_from_slice(&(stroff as u32).to_le_bytes());
+        obj.extend_from_slice(&(strtab.len() as u32).to_le_bytes());
+        obj.extend_from_slice(&syms);
+        obj.extend_from_slice(strtab);
+
+        let defined = macho::defined(&obj, KEEP_PREFIX).expect("pass A");
+        let (out, exported, renamed, kept) =
+            macho::scope(&obj, KEEP_PREFIX, SCOPE_PREFIX, &defined).expect("scope the fixture");
+        assert_eq!(renamed, 3, "both spellings + the reference ride the prefix");
+        assert_eq!(kept, 1, "the tebako_* definition stays public");
+
+        let (_, symoff, nsyms, stroff, _strsize) =
+            macho::symtab_for_test(&out).expect("parse the scoped symtab");
+        let names: Vec<String> = (0..nsyms)
+            .map(|i| {
+                let at = symoff + i * 16;
+                let strx = u32::from_le_bytes(out[at..at + 4].try_into().unwrap()) as usize;
+                let end = out[stroff + strx..]
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap();
+                String::from_utf8_lossy(&out[stroff + strx..stroff + strx + end]).into_owned()
+            })
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "__tebako_internal__dual"),
+            "the Mach-O spelling scopes verbatim: {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n == "__tebako_internal_dual"),
+            "the ELF spelling scopes verbatim — no collapse: {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n == "_tebako_api"),
+            "the public surface keeps its name: {names:?}"
+        );
+        assert_eq!(names.len(), 4, "no symbol is dropped or added: {names:?}");
+        assert!(
+            exported
+                .iter()
+                .any(|n| n == "__tebako_internal__dual")
+                && exported.iter().any(|n| n == "__tebako_internal_dual"),
+            "both spellings land in the archive index: {exported:?}"
+        );
     }
 
     /// The archive layout ld64 demands, pinned byte-for-byte: BSD "#1/N"


### PR DESCRIPTION
## Root cause

Every macOS x86_64 leg of the 0.16.3-era publish failed at the miniruby link with 11 `duplicate symbol '__tebako_internal_blake3_*'` errors (run 31156945098, e.g. Ruby 3.2.4 job 92804182218). The blake3 x86-64 unix assembly defines each entry point **twice** in one object — `_blake3_hash_many_sse2` (Mach-O spelling) and `blake3_hash_many_sse2` (ELF spelling), same address. arscope stripped the leading underscore before applying the `__tebako_internal_` prefix, collapsing both spellings into one scoped name: an artificial duplicate *within* a single object. ld_prime's earlier "malformed atom files with duplicate names" assert was this same collision in unreadable form.

## Fix

`macho.rs` scopes the raw nlist name **verbatim** (no underscore strip): `_blake3_*` → `__tebako_internal__blake3_*`, `blake3_*` → `__tebako_internal_blake3_*`. Distinct by construction; definitions and references share the one rule, so def/ref consistency is unchanged. No symbol is ever stripped or hidden — the seal is a rename, and this makes it strictly more faithful.

## Local proof (the exact CI offenders)

- Real blake3 1.8.6 `.S` objects assembled for x86_64, archived with a consumer referencing the four `hash_many` entry points:
  - **old formula**: each `__tebako_internal_blake3_hash_many_*` defined **twice**, `ld -ld_classic` link fails — the CI failure reproduced locally;
  - **new formula**: all spellings distinct, refs ride the prefix, `ld -ld_classic` links the scoped archive to a clean executable.
- New regression test `macho_dual_spelling_definitions_stay_distinct` pins the dual-spelling fixture (raw LC_SYMTAB blob, runs on every host); the two existing rename tests updated to the verbatim formula.
- `cargo test -p tebako-arscope`: 5/5 green.
