### PR TITLE
shim: named platform-availability error when no released runtime can run a payload

### DIFF
--- a/crates/tebako-shim/src/runtime.rs
+++ b/crates/tebako-shim/src/runtime.rs
@@ -3,7 +3,12 @@
 //! the entrypoint's `runtime_requirement` → newest COMPATIBLE runtime
 //! already cached (no download) → else download the newest compatible →
 //! verify → cache. Zero-runtime entrypoints (no `runtime_requirement`)
-//! skip this module entirely.
+//! skip this module entirely. The newest compatible to DOWNLOAD is the
+//! release index's pick, not only the config pin's (spec 13 §2a): the
+//! newest interpreter version satisfying the constraint AND released for
+//! this platform — a readable index with nothing satisfiable is the
+//! named platform-availability error (never a bare asset 404); an
+//! unreadable or availability-keyless index leaves the pin the target.
 //!
 //! The download path mirrors tebako-bootstrap's semantics — per-entry
 //! flock (120 s), tmp + rename install, `sha256`/`origin` trust markers,
@@ -343,7 +348,15 @@ pub fn resolve_runtime(
             ),
         );
     }
-    let rt = download_runtime(&req.engine, pref, ctx)?;
+    // The download target is the release index's pick, not only the
+    // config pin's: the newest interpreter version that both satisfies
+    // the constraint and is released for THIS platform. A readable index
+    // with nothing satisfiable fails here with the named
+    // platform-availability error; anything unreadable leaves the pin
+    // the target (all pin-path behaviors unchanged).
+    let target =
+        index_selected_target(req, &constraint, pref, ctx)?.unwrap_or_else(|| pref.clone());
+    let rt = download_runtime(&req.engine, &target, ctx)?;
     // The downloaded runtime's abi line must satisfy the payload too —
     // the release index carries it (abi: None is the compat window).
     if let (Some(want), Some(have)) = (&req.abi, &rt.abi) {
@@ -352,12 +365,125 @@ pub fn resolve_runtime(
                 EX_TEBAKO_UNAVAILABLE,
                 format!(
                     "downloaded runtime {}@{} carries abi \"{have}\" but the payload requires \"{want}\" — the payload was built against a different platform line; rebuild the payload or pin a matching runtime",
-                    req.engine, pref.version
+                    req.engine, target.version
                 ),
             );
         }
     }
     Ok(RuntimeResolution::Ready(rt))
+}
+
+/// The release index's availability facet for `platform` (spec 13 §2a —
+/// the locked entry shape declares `ruby_version` + `platform` +
+/// `tebako_version`): the `(ruby_version, tebako_version)` of every
+/// entry released for this platform. `None` when NO entry declares the
+/// availability keys at all — an index that predates them is
+/// uninformative (the config pin stays the target), never an
+/// availability verdict.
+fn released_versions(text: &str, platform: &str) -> Option<Vec<(String, Option<String>)>> {
+    let parsed = tebako_json::parse(text).ok()?;
+    let tebako_json::Value::Array(entries) = &parsed else {
+        return None;
+    };
+    let mut keyed = false;
+    let mut released = Vec::new();
+    for entry in entries {
+        let (Some(ruby_version), Some(entry_platform)) = (
+            entry.find("ruby_version").and_then(|v| v.as_string()),
+            entry.find("platform").and_then(|v| v.as_string()),
+        ) else {
+            continue;
+        };
+        keyed = true;
+        if entry_platform == platform {
+            released.push((
+                ruby_version,
+                entry.find("tebako_version").and_then(|v| v.as_string()),
+            ));
+        }
+    }
+    keyed.then_some(released)
+}
+
+/// The download-target selection on a cache miss: consult the release
+/// index of the pin's tebako line (`v{pref.tebako}/manifest.json`) for
+/// the newest interpreter version that both satisfies `constraint` and
+/// is released for this platform. Three outcomes:
+///
+/// - `Ok(None)` — the index did not read or carries no availability
+///   keys (and always in offline mode, which never fetches): the config
+///   pin stays the target and every pin-path behavior is unchanged;
+/// - `Ok(Some(target))` — the index's pick (the entry's own
+///   `tebako_version` when declared, else the pin's line);
+/// - `Err` — the index read fine and NOTHING released for this platform
+///   satisfies the constraint: the named platform-availability error
+///   naming the platform, the constraint, and what IS released (a
+///   platform that trails the payload's needs — e.g. windows-ucrt64
+///   released only through ruby 3.2.x — is a diagnosis, never a 404).
+fn index_selected_target(
+    req: &RuntimeRequirement,
+    constraint: &Constraint,
+    pref: &RuntimePref,
+    ctx: &Ctx,
+) -> Result<Option<RuntimePref>, ShimError> {
+    if offline_mode(ctx) {
+        return Ok(None);
+    }
+    let platform = platform_string();
+    let base_raw = releases_base(ctx);
+    let base = skip_file_scheme(&base_raw).to_string();
+    let local = base_is_local(&base_raw);
+    let probe = ctx
+        .home
+        .join("tmp")
+        .join(format!("index-probe.{}", std::process::id()));
+    if std::fs::create_dir_all(&probe).is_err() {
+        // Uninformative, not fatal: the download path re-creates the
+        // store dirs under the install lock and names the IO failure.
+        return Ok(None);
+    }
+    let text = fetch_manifest_text(&base, local, &pref.tebako, &probe);
+    let _ = std::fs::remove_dir_all(&probe);
+    let Some(text) = text else {
+        return Ok(None);
+    };
+    let Some(released) = released_versions(&text, platform) else {
+        return Ok(None);
+    };
+    if let Some((version, tebako)) = released
+        .iter()
+        .filter(|(version, _)| constraint.matches(version))
+        .max_by(|a, b| {
+            versions::compare(&a.0, &b.0).then_with(|| {
+                versions::compare(a.1.as_deref().unwrap_or(""), b.1.as_deref().unwrap_or(""))
+            })
+        })
+    {
+        return Ok(Some(RuntimePref {
+            version: version.clone(),
+            tebako: tebako.clone().unwrap_or_else(|| pref.tebako.clone()),
+        }));
+    }
+    let mut known: Vec<&str> = released
+        .iter()
+        .map(|(version, _)| version.as_str())
+        .collect();
+    known.sort_by(|a, b| versions::compare(a, b));
+    known.dedup();
+    let known = if known.is_empty() {
+        "nothing".to_string()
+    } else {
+        known.join(", ")
+    };
+    fail(
+        EX_TEBAKO_UNAVAILABLE,
+        format!(
+            "no released {} runtime for {platform} satisfies \"{}\"\n  released for {platform}: {known}\n  this payload needs a newer {} than this platform provides yet",
+            req.engine,
+            constraint.source(),
+            req.engine
+        ),
+    )
 }
 
 // ---------------------------------------------------------------------

--- a/crates/tebako-shim/tests/common/mod.rs
+++ b/crates/tebako-shim/tests/common/mod.rs
@@ -247,6 +247,39 @@ pub fn write_config(home: &Path, yaml: &str) {
     std::fs::write(home.join("config.yaml"), yaml).expect("config");
 }
 
+/// A file:// runtime mirror holding one release (`v<ver>`) whose
+/// manifest.json is a MULTI-entry release index in the factory's locked
+/// shape (spec 13 §2a): every entry declares `tebako_version`,
+/// `ruby_version`, `platform`, and the era-2 contract set. Exe + image
+/// assets are written for every listed version, so any index-selected
+/// download target resolves against real, verifiable bytes.
+pub fn write_release_index(root: &Path, ver: &str, lvs: &[&str]) -> PathBuf {
+    let platform = platform();
+    let dir = root.join(format!("v{ver}"));
+    std::fs::create_dir_all(&dir).expect("mirror dir");
+    let mut entries = Vec::new();
+    for lv in lvs {
+        let asset_base = format!("tebako-runtime-{ver}-{lv}-{platform}");
+        let exe_name = format!("{asset_base}{}", tebako_shim::runtime::exe_suffix());
+        let image_name = format!("{asset_base}.tfs");
+        let exe_bytes = format!("mirrored runtime exe {lv}\n");
+        let image_bytes = format!("mirrored runtime image {lv}\n");
+        std::fs::write(dir.join(&exe_name), &exe_bytes).expect("exe");
+        std::fs::write(dir.join(&image_name), &image_bytes).expect("image");
+        entries.push(format!(
+            "{{\"tebako_version\": \"{ver}\", \"contract_era\": 2, \"contract_version\": 2, \"mount_root\": \"/__tfs__\", \"ruby_version\": \"{lv}\", \"platform\": \"{platform}\", \"filename\": \"{exe_name}\", \"sha256\": \"{}\", \"image\": {{\"filename\": \"{image_name}\", \"sha256\": \"{}\"}}}}",
+            sha256_hex(exe_bytes.as_bytes()),
+            sha256_hex(image_bytes.as_bytes())
+        ));
+    }
+    std::fs::write(
+        dir.join("manifest.json"),
+        format!("[{}]\n", entries.join(", ")),
+    )
+    .expect("manifest.json");
+    root.to_path_buf()
+}
+
 /// `write_runtime` plus a release index manifest carrying the runtime's
 /// own `abi` string (spec 13's per-package `abi` key) — the field the
 /// abi-line filter reads.

--- a/crates/tebako-shim/tests/runtime.rs
+++ b/crates/tebako-shim/tests/runtime.rs
@@ -545,3 +545,133 @@ fn a_runtime_without_an_abi_line_stays_eligible() {
     );
     assert_eq!(rt.lang_version, "3.3.7");
 }
+
+// ---------------------------------------------------------------------
+// the release-index download target (spec 05 §5's download half,
+// completed; spec 13 §2a): on a cache miss the index — not only the
+// config pin — names the newest RELEASED version satisfying the
+// constraint on THIS platform, and a readable index with nothing
+// satisfiable is the named platform-availability error, never a bare
+// asset 404.
+// ---------------------------------------------------------------------
+
+/// The windows-ucrt64 release line as the factory publishes it today:
+/// 3.3+ is deferred (the windows native-extension bug), so the platform
+/// stops at 3.2.x. The fixture carries the CURRENT platform string —
+/// the released-versions line is the point, not the triplet.
+const WINDOWS_LINE: &[&str] = &["3.1.6", "3.2.4", "3.2.5", "3.2.6", "3.2.7", "3.2.11"];
+
+#[test]
+fn a_constraint_nothing_released_satisfies_is_the_platform_availability_error() {
+    let tmp = TempDir::new("index-unsatisfiable");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    write_release_index(&mirror, "0.16.0", WINDOWS_LINE);
+    // the pin satisfies the payload's constraint; the platform's
+    // release line does not — availability, not the pin, is the cause.
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 3.3.7\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+
+    let err = runtime::resolve_runtime(Some(&req(">= 3.3")), true, &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_UNAVAILABLE);
+    let platform = platform();
+    assert!(
+        err.message.contains(&format!(
+            "no released ruby runtime for {platform} satisfies \">= 3.3\""
+        )),
+        "{}",
+        err.message
+    );
+    assert!(
+        err.message.contains(&format!(
+            "released for {platform}: 3.1.6, 3.2.4, 3.2.5, 3.2.6, 3.2.7, 3.2.11"
+        )),
+        "{}",
+        err.message
+    );
+    assert!(
+        err.message
+            .contains("this payload needs a newer ruby than this platform provides yet"),
+        "{}",
+        err.message
+    );
+    assert!(
+        !home.join("runtimes").exists(),
+        "a refused resolution installs nothing"
+    );
+}
+
+#[test]
+fn the_index_target_is_the_newest_released_version_satisfying_the_constraint() {
+    let tmp = TempDir::new("index-target");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    write_release_index(&mirror, "0.16.0", WINDOWS_LINE);
+    // the pin names the tebako line to consult (and satisfies the
+    // constraint); the index, not the pin, picks the ruby version.
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 3.2.4\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+
+    let rt = ready(runtime::resolve_runtime(Some(&req(">= 3.2")), true, &ctx).unwrap());
+    assert_eq!(rt.lang_version, "3.2.11");
+    assert_eq!(rt.tebako_version, "0.16.0");
+    assert!(rt.exe.is_file());
+    assert!(rt.image.is_some());
+    assert!(rt.dir.join("sha256").is_file());
+    assert!(rt.dir.join("origin").is_file());
+}
+
+#[test]
+fn a_cache_hit_never_consults_the_index() {
+    // the cache wins outright: with a satisfying cached runtime the
+    // mirror is never touched — here a mirror that does not even exist,
+    // so any fetch would fall through to the no-preference error.
+    let tmp = TempDir::new("index-cache-wins");
+    let home = tmp.path().join("home");
+    write_runtime(&home, "3.2.5", "0.16.0", false);
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&tmp.path().join("no-such-mirror")),
+    );
+    let rt = ready(runtime::resolve_runtime(Some(&req(">= 3.2")), true, &ctx).unwrap());
+    assert_eq!(rt.lang_version, "3.2.5");
+}
+
+#[test]
+fn offline_never_consults_the_index() {
+    // TEBAKO_OFFLINE is cache-or-named-error: the index consult never
+    // fetches, so the download path's own offline error stands —
+    // unchanged by the index-driven target selection.
+    let tmp = TempDir::new("index-offline");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    write_release_index(&mirror, "0.16.0", &["3.2.11"]);
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 3.2.11\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    ctx.env.insert("TEBAKO_OFFLINE".into(), "1".into());
+    let err = runtime::resolve_runtime(Some(&req(">= 3.2")), true, &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_UNAVAILABLE);
+    assert!(err.message.contains("TEBAKO_OFFLINE"), "{}", err.message);
+}


### PR DESCRIPTION
## Graceful degradation for platform-trailing-payload

When a payload's `runtime_requirement` can't be met by any runtime **released for the current platform**, the loader now says so — a named error, never a crash or a bare 404.

On a cache miss, `resolve_runtime` now consults the release index (`manifest.json`) and selects the newest version that both satisfies the payload's constraint and is released for this platform. If the index is readable but nothing qualifies:

```
no released ruby runtime for windows-ucrt64 satisfies ">= 3.3"
  released for windows-ucrt64: 3.1.6, 3.2.4, 3.2.5, 3.2.6, 3.2.7, 3.2.11
  this payload needs a newer ruby than this platform provides yet
```

This is the product-side companion to the factory's availability deferral (tebako-runtime-ruby#66, which defers windows 3.3+ from the release catalog until its native-ext fix lands). A windows user running a >=3.3 payload gets a clear answer instead of a download 404.

Unreadable/uninformative index or offline mode → falls through to the existing pin path unchanged. Cache-hit and offline named errors preserved.

## Tests
`crates/tebako-shim/tests/runtime.rs` +4: the availability error verbatim, newest-released selection (3.2.11 of `>=3.2`), cache-hit never consults the index, offline never consults. `cargo test -p tebako-shim` all suites green; clippy `-D warnings` and `cargo fmt --check` clean.
