### PR TITLE
driver: TEBAKO_MOUNT_ROOT run-time root override + the A:/t windows default

### DIFF
--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -87,8 +87,9 @@ pub const LAUNCHER_ABI: u32 = 1;
 /// and the tebako=<...> component of the trailer's runtime_ref. Matches
 /// the reference gem's Tebako::VERSION at port time.
 /// The tebako release line the CLI presses against. New-era only: from
-/// 0.16.1 the runtimes bake the renamed mount root (`/__tfs__`,
-/// `A:/__tfs__` on windows — the one name on every platform); older
+/// 0.16.1 the runtimes bake the renamed mount root (`/__tfs__` on POSIX,
+/// `A:/t` on windows — per-platform baked defaults, run-time overridable
+/// via `TEBAKO_MOUNT_ROOT` where the image grants it; spec 17 §1); older
 /// releases carry the legacy `__tebako_memfs__` layout and are NOT
 /// served (no old contract, no compat readers).
 pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.2";
@@ -479,7 +480,7 @@ pub(crate) fn stitch(
 /// The declared (POSIX) form of a mount point: the uniform VFS
 /// namespace name the trailer slots and L2 `mounts:` rows carry on
 /// every platform — the physical root minus any windows drive
-/// (`A:/__tfs__` → `/__tfs__`; POSIX roots are unchanged). The driver
+/// (`A:/t` → `/t`; POSIX roots are unchanged). The driver
 /// re-qualifies declared mounts onto the VFS drive at boot (spec 17
 /// §1), so the argv grammar never has to carry a drive colon.
 pub(crate) fn declared_mount(mount_point: &str) -> &str {
@@ -498,11 +499,11 @@ pub(crate) fn declared_mount(mount_point: &str) -> &str {
 /// — mount-relative; the driver joins mount+entry, spec 17 §1),
 /// `runtime_ref` mirroring the trailer field, and the `mounts:` row
 /// declaring the app slot's union over the env image at the runtime
-/// root (`mount_point` — the trailer's own mount point, the declared
-/// `/__tfs__` on every platform, so the two stay consistent by
-/// construction). A --jail press composes the policy into the same
-/// block — the package's host-access REQUEST the bootstrap tightens at
-/// handoff (spec 08 §2).
+/// root (`mount_point` — the trailer's own mount point, the root's
+/// declared form: `/__tfs__` on POSIX, `/t` on windows — so the two stay
+/// consistent by construction). A --jail press composes the policy into
+/// the same block — the package's host-access REQUEST the bootstrap
+/// tightens at handoff (spec 08 §2).
 fn press_package_manifest(
     package: &str,
     runtime_ref: &str,

--- a/crates/tebako-cli/src/scenario.rs
+++ b/crates/tebako-cli/src/scenario.rs
@@ -390,7 +390,7 @@ impl ScenarioManager {
             fs_entrance: ent.clone(),
             fs_entry_point: format!("/bin/{ent}"),
             fs_mount_point: if msys {
-                "A:/__tfs__".to_string()
+                "A:/t".to_string()
             } else {
                 "/__tfs__".to_string()
             },

--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -56,6 +56,36 @@ fn jail(message: impl Into<String>) -> DriverError {
     DriverError::new(EX_TEBAKO_JAIL, message.into())
 }
 
+/// The run-time mount-root override (`TEBAKO_MOUNT_ROOT`, spec 17 §1):
+/// the per-platform compiled-in root is the DEFAULT, never the only
+/// spelling — the root is configurable per platform (the factory bakes
+/// `/__tfs__` on POSIX, `A:/t` on windows) and overridable at boot. An
+/// override is form-validated here (fail-closed, exit 65) and gated on
+/// the env image's layout permission post-mount (exit 78): a runtime
+/// whose rbconfig cannot follow the override refuses it by name instead
+/// of booting a broken interpreter.
+fn effective_root(declared: &str, env: &dyn Env) -> Result<String, DriverError> {
+    let Some(root) = env_var(env, "TEBAKO_MOUNT_ROOT") else {
+        return Ok(declared.to_string());
+    };
+    let b = root.as_bytes();
+    let drive_qualified = b.len() >= 4
+        && b[0].is_ascii_alphabetic()
+        && b[1] == b':'
+        && b[2] == b'/';
+    let posix_absolute = b.len() >= 2 && b[0] == b'/';
+    let well_formed = (drive_qualified || posix_absolute)
+        && !root.ends_with('/')
+        && !root.split('/').any(|component| component == "..");
+    if well_formed {
+        Ok(root)
+    } else {
+        Err(manifest(format!(
+            "TEBAKO_MOUNT_ROOT '{root}' is not a usable mount root (want an absolute path — '/…' or drive-qualified 'X:/…' — with no trailing slash and no '..')"
+        )))
+    }
+}
+
 fn errno_text(e: i32) -> String {
     String::from_utf8_lossy(tfs::errno::strerror(e)).into_owned()
 }
@@ -375,13 +405,22 @@ fn read_mounted_text(path: &str) -> Result<String, i32> {
 /// and BEFORE any interpreter handoff, `/lib/tebako/layout.yaml` inside
 /// it is verified against this exe's expectations — fail-closed, exit 78
 /// (S17 absent → era-1 refusal; S18 newer → upgrade refusal; S19
-/// mount_root mismatch). A boot without `TEBAKO_RUNTIME_IMAGE` mounts no
-/// env image and has no pair to check.
-fn check_env_layout(env: &dyn Env, runtime_root: &str) -> Result<(), DriverError> {
+/// mount_root mismatch). The image's declared root is checked against
+/// the exe's BAKED root (`baked_root`); a `TEBAKO_MOUNT_ROOT` override
+/// (`effective_root` ≠ `baked_root`) additionally requires the image's
+/// `mount_root_override` permission — a runtime whose rbconfig predates
+/// the override era refuses by name rather than booting an interpreter
+/// whose load paths point at an unmounted root. A boot without
+/// `TEBAKO_RUNTIME_IMAGE` mounts no env image and has no pair to check.
+fn check_env_layout(
+    env: &dyn Env,
+    baked_root: &str,
+    effective_root: &str,
+) -> Result<(), DriverError> {
     let Some(image) = env_var(env, "TEBAKO_RUNTIME_IMAGE") else {
         return Ok(());
     };
-    let path = join_mount(runtime_root, crate::layout::LAYOUT_IMAGE_PATH);
+    let path = join_mount(effective_root, crate::layout::LAYOUT_IMAGE_PATH);
     let text = read_mounted_text(&path).map_err(|_| {
         DriverError::new(
             EX_TEBAKO_LAYOUT,
@@ -390,7 +429,16 @@ fn check_env_layout(env: &dyn Env, runtime_root: &str) -> Result<(), DriverError
             ),
         )
     })?;
-    crate::layout::ImageLayout::check(&text, runtime_root, &image).map(|_| ())
+    let declaration = crate::layout::ImageLayout::check(&text, baked_root, &image)?;
+    if effective_root != baked_root && !declaration.mount_root_override {
+        return Err(DriverError::new(
+            EX_TEBAKO_LAYOUT,
+            format!(
+                "TEBAKO_MOUNT_ROOT override '{effective_root}' refused: env image '{image}' grants no mount_root_override (its rbconfig is pinned to '{baked_root}') — rebuild the runtime with the current factory"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 fn mount_image(
@@ -496,7 +544,7 @@ fn join_mount(mount_point: &str, entry: &str) -> String {
     )
 }
 
-/// The VFS drive of a runtime root: `A:/__tfs__` → `Some("A:")`;
+/// The VFS drive of a runtime root: `A:/t` → `Some("A:")`;
 /// `/__tfs__` → `None` (POSIX — no drive qualification).
 fn vfs_drive(runtime_root: &str) -> Option<&str> {
     let b = runtime_root.as_bytes();
@@ -508,10 +556,10 @@ fn vfs_drive(runtime_root: &str) -> Option<&str> {
 }
 
 /// Windows (spec 17 §1): a declared mount is a POSIX absolute path in
-/// the VFS namespace (`/`, `/__tfs__`, `/opt/x`); on windows the
+/// the VFS namespace (`/`, `/t`, `/opt/x`); on windows the
 /// namespace presents on its own drive — the drive of the runtime root
-/// (`A:/__tfs__` — the uniform root: the same name on every platform).
-/// The driver therefore mounts every declared point at
+/// (`A:/t`, short by owner decision: MAX_PATH headroom on every in-image
+/// path). The driver therefore mounts every declared point at
 /// `<drive><mount>`. Ruby's C-level path expansion re-roots
 /// drive-relative paths (`/...`) onto the process cwd drive; only
 /// drive-qualified paths are stable across expansion, so qualifying is
@@ -564,8 +612,9 @@ fn resolve_entry(
 /// semantics preserved: the parser scans from index 0 (callers pass the
 /// full argv; non-loader leading args end the scan — the plain-boot
 /// case). `runtime_root` is the mount point the interpreter was compiled
-/// against (ruby: `/__tfs__`, `A:/__tfs__` on windows — the one name on
-/// every platform; spec 17 §1).
+/// against (ruby: `/__tfs__` on POSIX, `A:/t` on windows — per-platform
+/// baked defaults, overridable at boot via `TEBAKO_MOUNT_ROOT`; spec 17
+/// §1).
 pub fn boot(
     argv: &[String],
     runtime_root: &str,
@@ -584,6 +633,16 @@ pub fn boot_with_mount_modes(
     env: &dyn Env,
     modes: &dyn MountModes,
 ) -> Result<BootOutcome, DriverError> {
+    // The root this boot actually uses: the TEBAKO_MOUNT_ROOT override
+    // when handed (form-validated here; the layout permission is gated
+    // post-mount), else the exe's compiled-in value. Everything
+    // downstream — the env-image mount, the drive qualification, the
+    // entry resolution, the io-routing patches via tebako_mount_point —
+    // sees the effective root and nothing else.
+    let effective = effective_root(runtime_root, env)?;
+    let baked_root = runtime_root;
+    let runtime_root = effective.as_str();
+    crate::ffi::set_mount_point(runtime_root);
     let mut h = Handoff::parse(argv)?;
     // Windows: qualify the declared mounts onto the VFS drive (spec 17
     // §1) before any mount/entry use — the mount table, the union-mode
@@ -599,7 +658,7 @@ pub fn boot_with_mount_modes(
         let result = (|| {
             let mut mounted = Vec::new();
             mount_env_image(env, runtime_root, &mut mounted)?;
-            check_env_layout(env, runtime_root)?;
+            check_env_layout(env, baked_root, runtime_root)?;
             apply_jail(env)?;
             Ok(BootOutcome {
                 argv: argv.to_vec(),
@@ -616,7 +675,7 @@ pub fn boot_with_mount_modes(
         mount_env_image(env, runtime_root, &mut mounted)?;
         // The env image's pair-check runs post-mount, before any payload
         // or interpreter touch (spec 18 C3 — exit 78).
-        check_env_layout(env, runtime_root)?;
+        check_env_layout(env, baked_root, runtime_root)?;
         for spec in &h.images {
             mount_image(spec, &mut mounted, modes)?;
         }
@@ -676,7 +735,7 @@ mod tests {
 
     #[test]
     fn vfs_drive_reads_the_root_drive() {
-        assert_eq!(vfs_drive("A:/__tfs__"), Some("A:"));
+        assert_eq!(vfs_drive("A:/t"), Some("A:"));
         assert_eq!(vfs_drive("a:/t"), Some("a:"));
         assert_eq!(vfs_drive("A:"), Some("A:"));
         assert_eq!(vfs_drive("/__tfs__"), None);
@@ -688,11 +747,10 @@ mod tests {
     #[test]
     fn declared_mounts_qualify_onto_the_vfs_drive() {
         // The uniform namespace (spec 17 §1): the POSIX absolute
-        // namespace presents on the runtime root's drive, so the
-        // runtime root is the same NAME on every platform.
-        assert_eq!(qualify_mount("/", "A:/__tfs__"), "A:/");
-        assert_eq!(qualify_mount("/__tfs__", "A:/__tfs__"), "A:/__tfs__");
-        assert_eq!(qualify_mount("/opt/x", "A:/__tfs__"), "A:/opt/x");
+        // namespace presents on the runtime root's drive.
+        assert_eq!(qualify_mount("/", "A:/t"), "A:/");
+        assert_eq!(qualify_mount("/t", "A:/t"), "A:/t");
+        assert_eq!(qualify_mount("/opt/x", "A:/t"), "A:/opt/x");
     }
 
     #[test]
@@ -704,7 +762,54 @@ mod tests {
 
     #[test]
     fn relative_mounts_are_never_qualified() {
-        assert_eq!(qualify_mount("rel", "A:/__tfs__"), "rel");
+        assert_eq!(qualify_mount("rel", "A:/t"), "rel");
         assert_eq!(qualify_mount("rel", "/__tfs__"), "rel");
+    }
+
+    struct MapEnv(std::collections::HashMap<String, String>);
+
+    impl Env for MapEnv {
+        fn var(&self, key: &str) -> Option<String> {
+            self.0.get(key).cloned()
+        }
+    }
+
+    fn env_with(pairs: &[(&str, &str)]) -> MapEnv {
+        MapEnv(
+            pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn no_override_keeps_the_compiled_in_root() {
+        assert_eq!(effective_root("/__tfs__", &env_with(&[])).unwrap(), "/__tfs__");
+        // An empty value is no override (the env_var filter).
+        assert_eq!(
+            effective_root("A:/t", &env_with(&[("TEBAKO_MOUNT_ROOT", "")])).unwrap(),
+            "A:/t"
+        );
+    }
+
+    #[test]
+    fn a_well_formed_override_wins() {
+        let env = env_with(&[("TEBAKO_MOUNT_ROOT", "/rt")]);
+        assert_eq!(effective_root("/__tfs__", &env).unwrap(), "/rt");
+        // The drive-qualified form (the windows spelling) is accepted and
+        // its drive governs the qualification downstream.
+        let env = env_with(&[("TEBAKO_MOUNT_ROOT", "B:/rt")]);
+        assert_eq!(effective_root("A:/t", &env).unwrap(), "B:/rt");
+    }
+
+    #[test]
+    fn a_malformed_override_is_a_named_error() {
+        for bad in ["relative/x", "/", "A:/", "/trail/", "/has/../dot", "A:\\\\win"] {
+            let err = effective_root("/__tfs__", &env_with(&[("TEBAKO_MOUNT_ROOT", bad)]))
+                .unwrap_err();
+            assert_eq!(err.code, EX_TEBAKO_MANIFEST, "{bad}");
+            assert!(err.message.contains("TEBAKO_MOUNT_ROOT"), "{bad}");
+        }
     }
 }

--- a/crates/tebako-driver/src/ffi.rs
+++ b/crates/tebako-driver/src/ffi.rs
@@ -31,16 +31,18 @@ use crate::{EX_TEBAKO_IO, EX_TEBAKO_MANIFEST};
 /// source tarball's tebako-mount-root manifest → the exe's generated fs
 /// TU → tebako_main forwards it here); this default is only for
 /// driver-only consumers and tests and follows the factory convention:
-/// `A:/__tfs__` on windows, where the memfs presents as its own drive —
-/// the one root name on every platform (spec 17 §1) — and `/__tfs__`
-/// elsewhere.
+/// `A:/t` on windows (short by owner decision — MAX_PATH headroom on
+/// every in-image path), `/__tfs__` elsewhere. A boot may redirect the
+/// root via `TEBAKO_MOUNT_ROOT` (spec 17 §1) when the env image's layout
+/// grants `mount_root_override` — the getter below then reports the
+/// effective root the boot established, never this default.
 #[cfg(windows)]
-const RUBY_RUNTIME_ROOT: &str = "A:/__tfs__";
+const RUBY_RUNTIME_ROOT: &str = "A:/t";
 #[cfg(not(windows))]
 const RUBY_RUNTIME_ROOT: &str = "/__tfs__";
 
 #[cfg(windows)]
-static DEFAULT_ROOT: &[u8] = b"A:/__tfs__\0";
+static DEFAULT_ROOT: &[u8] = b"A:/t\0";
 #[cfg(not(windows))]
 static DEFAULT_ROOT: &[u8] = b"/__tfs__\0";
 static EMPTY: &[u8] = b"\0";
@@ -64,8 +66,9 @@ pub unsafe extern "C" fn tebako_driver_contract_version() -> u32 {
     crate::TEBAKO_CONTRACT_VERSION
 }
 
-/// The mount point the boot established (the runtime root). Before any
-/// boot, the ruby default.
+/// The mount point the boot established (the effective runtime root —
+/// the compiled-in value or its `TEBAKO_MOUNT_ROOT` override). Before
+/// any boot, the ruby default.
 ///
 /// # Safety
 /// Returns a process-lifetime C string; never free it.
@@ -75,6 +78,15 @@ pub unsafe extern "C" fn tebako_mount_point() -> *const c_char {
         .get()
         .map(|c| c.as_ptr())
         .unwrap_or(DEFAULT_ROOT.as_ptr() as *const c_char)
+}
+
+/// Record the root a boot established (the effective value, after any
+/// `TEBAKO_MOUNT_ROOT` override). Called once per boot by the driver
+/// core; a repeat boot keeps the first value (process-lifetime state).
+pub(crate) fn set_mount_point(root: &str) {
+    if let Ok(c) = CString::new(root) {
+        let _ = MOUNT_POINT.set(c);
+    }
 }
 
 /// The process cwd captured at boot; empty before any boot.
@@ -192,9 +204,9 @@ fn boot_impl(argc: *mut c_int, argv: *mut *mut *mut c_char, runtime_root: *const
     let root = unsafe { CStr::from_ptr(runtime_root) }
         .to_string_lossy()
         .into_owned();
-    if let Ok(c) = CString::new(root.as_str()) {
-        let _ = MOUNT_POINT.set(c);
-    }
+    // The mount-point export is set by the driver core AFTER the
+    // TEBAKO_MOUNT_ROOT override resolves — never here (the baked value
+    // would be locked in before the override is known).
     if let Ok(cwd) = std::env::current_dir() {
         if let Ok(c) = CString::new(cwd.to_string_lossy().as_ref()) {
             let _ = ORIGINAL_PWD.set(c);

--- a/crates/tebako-driver/src/layout.rs
+++ b/crates/tebako-driver/src/layout.rs
@@ -6,7 +6,10 @@
 //! The grammar's single owner is `docs/spec/schemas/layout.yaml`; this
 //! module is its only reader in the product. Fields: `schema_version`,
 //! `era`, `image_layout`, `mount_root`, `interpreter_api_version` — the
-//! era-2 driver parses the last but does not gate on it.
+//! era-2 driver parses the last but does not gate on it — and the
+//! additive `mount_root_override` (schema_minor 1): the image's grant
+//! that its rbconfig follows `TEBAKO_MOUNT_ROOT`, gating the driver's
+//! run-time root override (spec 17 §1).
 
 use serde::Deserialize;
 
@@ -45,6 +48,11 @@ pub struct ImageLayout {
     /// The interpreter API version line the image carries (parsed, not
     /// gated on in era 2).
     pub interpreter_api_version: String,
+    /// The image's grant that its rbconfig follows `TEBAKO_MOUNT_ROOT`
+    /// (additive, schema_minor 1): absent ⇒ `false` ⇒ the driver refuses
+    /// a run-time root override by name (exit 78) rather than booting an
+    /// interpreter whose load paths point at an unmounted root.
+    pub mount_root_override: bool,
 }
 
 /// The tolerant serde view: every field optional so the checks below can
@@ -57,6 +65,7 @@ struct LayoutView {
     image_layout: Option<u32>,
     mount_root: Option<String>,
     interpreter_api_version: Option<String>,
+    mount_root_override: Option<bool>,
 }
 
 impl ImageLayout {
@@ -125,6 +134,7 @@ impl ImageLayout {
             image_layout,
             mount_root,
             interpreter_api_version: api_version,
+            mount_root_override: view.mount_root_override.unwrap_or(false),
         })
     }
 }
@@ -146,14 +156,28 @@ mod tests {
                 image_layout: 1,
                 mount_root: "/__tfs__".to_string(),
                 interpreter_api_version: "3.4".to_string(),
+                mount_root_override: false,
             }
         );
         // unknown keys within the MAJOR are tolerated (spec 18 §3.2 / S57)
         let with_future = format!("{GOOD}future_field: {{anything: goes}}\n");
         ImageLayout::check(&with_future, "/__tfs__", "/rt/ruby.tfs").unwrap();
         // the windows root spelling pairs the same way
-        let win = GOOD.replace("/__tfs__", "A:/__tfs__");
-        ImageLayout::check(&win, "A:/__tfs__", "C:/rt/ruby.tfs").unwrap();
+        let win = GOOD.replace("/__tfs__", "A:/t");
+        ImageLayout::check(&win, "A:/t", "C:/rt/ruby.tfs").unwrap();
+    }
+
+    #[test]
+    fn the_override_grant_is_additive_and_defaults_closed() {
+        // absent (the pre-override era's images) ⇒ closed
+        assert!(!ImageLayout::check(GOOD, "/__tfs__", "/rt/ruby.tfs")
+            .unwrap()
+            .mount_root_override);
+        // declared ⇒ the image's rbconfig follows TEBAKO_MOUNT_ROOT
+        let granted = format!("{GOOD}mount_root_override: true\n");
+        assert!(ImageLayout::check(&granted, "/__tfs__", "/rt/ruby.tfs")
+            .unwrap()
+            .mount_root_override);
     }
 
     #[test]

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -872,7 +872,7 @@ fn union_row_merges_the_trees_at_the_runtime_root() {
 
 /// The env fixture's layout declaration with the windows root spelling.
 fn write_env_image_windows_root(dir: &Path) -> PathBuf {
-    write_env_image_with_layout(dir, Some(&GOOD_LAYOUT.replace("/__tfs__", "A:/__tfs__")))
+    write_env_image_with_layout(dir, Some(&GOOD_LAYOUT.replace("/__tfs__", "A:/t")))
 }
 
 #[test]
@@ -892,7 +892,7 @@ fn windows_root_qualifies_declared_mounts_onto_the_vfs_drive() {
             "/bin/app",
             "--version",
         ]),
-        "A:/__tfs__",
+        "A:/t",
         &env,
     )
     .unwrap();
@@ -902,10 +902,7 @@ fn windows_root_qualifies_declared_mounts_onto_the_vfs_drive() {
     assert_eq!(out.argv, argv(&["ruby.exe", "A:/bin/app", "--version"]));
     // Both mounts live in the physical namespace: the env image at the
     // qualified root, the payload at the drive root.
-    assert_eq!(
-        read_file("A:/__tfs__/lib/ruby/rubygems.rb"),
-        b"# rubygems core\n"
-    );
+    assert_eq!(read_file("A:/t/lib/ruby/rubygems.rb"), b"# rubygems core\n");
     assert_eq!(read_file("A:/bin/app"), b"#!/usr/bin/env ruby\nputs 'hi'\n");
 }
 
@@ -921,26 +918,77 @@ fn windows_root_union_merges_at_the_qualified_root() {
         &argv(&[
             "ruby.exe",
             "--tebako-image",
-            &format!("{}:0:/__tfs__", payload.display()),
+            &format!("{}:0:/t", payload.display()),
             "--tebako-entry",
             "/local/stub.rb",
         ]),
-        "A:/__tfs__",
+        "A:/t",
         &env,
         &StubModes(Some(union_row())),
     )
     .unwrap();
-    // The declared union target is the SAME NAME the root carries, so
-    // the qualified points coincide and the union row governs.
-    assert_eq!(out.argv, argv(&["ruby.exe", "A:/__tfs__/local/stub.rb"]));
+    // The declared union target is the root's declared form, so the
+    // qualified points coincide and the union row governs.
+    assert_eq!(out.argv, argv(&["ruby.exe", "A:/t/local/stub.rb"]));
     assert_eq!(
-        read_file("A:/__tfs__/local/stub.rb"),
+        read_file("A:/t/local/stub.rb"),
         b"load \"/__tfs__/bin/app\"\n"
     );
     assert_eq!(
-        read_file("A:/__tfs__/lib/ruby/rubygems.rb"),
+        read_file("A:/t/lib/ruby/rubygems.rb"),
         b"# app-shadowed rubygems\n"
     );
+}
+
+// ---------------------------------------------------------------------
+// TEBAKO_MOUNT_ROOT (spec 17 §1): the run-time root override — validated
+// at boot (exit 65), gated on the env image's mount_root_override grant
+// post-mount (exit 78).
+// ---------------------------------------------------------------------
+
+#[test]
+fn mount_root_override_redirects_the_env_mount() {
+    let g = guard("root-override");
+    let env_image = write_env_image_with_layout(
+        g.path(),
+        Some(&format!("{GOOD_LAYOUT}mount_root_override: true\n")),
+    );
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+    env.set("TEBAKO_MOUNT_ROOT", "/rt");
+
+    let out = boot(&argv(&["ruby"]), "/__tfs__", &env).unwrap();
+    assert_eq!(out.argv, argv(&["ruby"]));
+    // The env image mounted at the override, never at the baked root.
+    assert_eq!(read_file("/rt/lib/ruby/rubygems.rb"), b"# rubygems core\n");
+    let mut ctx = context().write().unwrap();
+    assert!(ctx.open("/__tfs__/lib/ruby/rubygems.rb", libc::O_RDONLY).is_err());
+}
+
+#[test]
+fn mount_root_override_requires_the_images_grant() {
+    let g = guard("root-override-refused");
+    let env_image = write_env_image(g.path()); // GOOD_LAYOUT: no grant key
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+    env.set("TEBAKO_MOUNT_ROOT", "/rt");
+
+    let err = boot(&argv(&["ruby"]), "/__tfs__", &env).unwrap_err();
+    assert_eq!(err.code, 78, "{err}");
+    assert!(err.message.contains("TEBAKO_MOUNT_ROOT"), "{err}");
+    // The refusal rolled the mount back (never a partial mount).
+    let mut ctx = context().write().unwrap();
+    assert!(ctx.open("/rt/lib/tebako/layout.yaml", libc::O_RDONLY).is_err());
+}
+
+#[test]
+fn a_malformed_mount_root_override_is_a_named_error() {
+    let _g = guard("root-override-malformed");
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_MOUNT_ROOT", "relative/x");
+    let err = boot(&argv(&["ruby"]), "/__tfs__", &env).unwrap_err();
+    assert_eq!(err.code, 65, "{err}");
+    assert!(err.message.contains("TEBAKO_MOUNT_ROOT"), "{err}");
 }
 
 #[test]

--- a/crates/tebako-driver/tests/ffi.rs
+++ b/crates/tebako-driver/tests/ffi.rs
@@ -165,7 +165,7 @@ fn tebako_main_boots_with_the_ruby_root_and_exports_the_contract() {
     #[cfg(not(windows))]
     assert_eq!(mp, "/__tfs__");
     #[cfg(windows)]
-    assert_eq!(mp, "A:/__tfs__");
+    assert_eq!(mp, "A:/t");
     let pwd =
         unsafe { CStr::from_ptr(tebako_driver::ffi::tebako_original_pwd()) }.to_string_lossy();
     assert!(!pwd.is_empty(), "the original cwd is recorded");

--- a/docs/spec/17-runtime-driver-contract.md
+++ b/docs/spec/17-runtime-driver-contract.md
@@ -29,14 +29,32 @@ exact contract (roadmap 22's "add a language" playbook).
   trailer slot records, and on this wire. On windows the namespace
   presents on its own drive: the driver qualifies every declared mount
   `<mount>` onto the runtime root's drive (`<drive><mount>`) before any
-  mount, union, or entry computation, and the runtime root is the one
-  name on every platform (ruby: `/__tfs__`, presented `A:/__tfs__` on
-  windows). An interpreter's C-level path expansion re-roots
-  drive-relative paths (`/...`) onto the process cwd drive; only
-  drive-qualified paths are stable across expansion, so qualifying is
-  what keeps payload paths inside the VFS. The wire grammar therefore
-  never carries a drive letter: `<mount>` is always the declared form,
-  and a declared mount naming a drive is malformed.
+  mount, union, or entry computation. The runtime root is a
+  per-platform baked default owned by the runtime factory (ruby:
+  `/__tfs__` on POSIX, `A:/t` on windows — short by owner decision,
+  MAX_PATH headroom on every in-image path). An interpreter's C-level
+  path expansion re-roots drive-relative paths (`/...`) onto the
+  process cwd drive; only drive-qualified paths are stable across
+  expansion, so qualifying is what keeps payload paths inside the VFS.
+  The wire grammar therefore never carries a drive letter: `<mount>` is
+  always the declared form, and a declared mount naming a drive is
+  malformed.
+- **Run-time root override (`TEBAKO_MOUNT_ROOT`, locked 2026-08-08):**
+  the baked root is the default, never the only spelling. When
+  `TEBAKO_MOUNT_ROOT` is set in the runtime's environment, the driver
+  mounts the env image at that root instead and reports it from
+  `tebako_mount_point` (the io-routing patches and the interpreter's
+  rbconfig follow — era-2 rbconfig emits
+  `ENV["TEBAKO_MOUNT_ROOT"] || <baked>`). The override is validated
+  before any mount — an absolute path (`/…` or drive-qualified `X:/…`),
+  no trailing slash, no `..` — a malformed value is exit 65 naming the
+  variable. The override is then gated post-mount on the env image's
+  layout grant (`mount_root_override: true`, layout schema_minor 1): an
+  image without the grant predates the override era (its rbconfig is
+  pinned to the baked root), so the driver refuses with exit 78 naming
+  both the override and the image — never a boot whose load paths point
+  at an unmounted root. Declared payload mounts qualify onto the
+  override's drive exactly as they do the baked root's.
 - **Mount modes (locked 2026-08-04):** every mount is `exclusive`
   (default) or `union`, declared per slot in the package manifest's
   `mounts:` block (spec 03 §6). An exclusive mount onto an occupied

--- a/docs/spec/schemas/layout.yaml
+++ b/docs/spec/schemas/layout.yaml
@@ -15,7 +15,7 @@
 
 schema: layout
 schema_version: 1 # MAJOR — breaking changes only
-schema_minor: 0 # MINOR — additive changes only
+schema_minor: 1 # MINOR — additive changes only (1: mount_root_override)
 status: normative
 owner: tebako-runtime-ruby (writer) + crates/tebako-driver (reader); grammar owned here
 edge: C3 (runtime exe ↔ env image)
@@ -79,10 +79,23 @@ grammar:
     notes: >-
       The mount root the image was built for — must equal the exe's
       compiled-in value (the one tebako_main forwards to the driver;
-      ruby: /__tfs__, A:/__tfs__ on windows — the one name on every
-      platform). Mismatch → exit 78, both values
-      printed (S19). The value FLOWS from tamatebako/ruby's patch
-      literals (the single owner); nothing re-authors it.
+      ruby: /__tfs__ on POSIX, A:/t on windows — a per-platform baked
+      default, short on windows by owner decision for MAX_PATH
+      headroom). Mismatch → exit 78, both values printed (S19). The
+      value FLOWS from tamatebako/ruby's patch literals (the single
+      owner); nothing re-authors it.
+  mount_root_override:
+    type: bool
+    required: false
+    since: schema_minor 1
+    notes: >-
+      The image's grant that its interpreter follows TEBAKO_MOUNT_ROOT
+      at run time (ruby: rbconfig emits ENV["TEBAKO_MOUNT_ROOT"] || the
+      baked root). Absent ⇒ false ⇒ the driver refuses a root override
+      by name (exit 78) rather than booting an interpreter whose load
+      paths would point at an unmounted root. The driver validates the
+      override's form before any mount (malformed → exit 65 naming the
+      variable).
   interpreter_api_version:
     type: string
     required: true
@@ -100,5 +113,7 @@ refusals:
     behavior: named refusal — exit 78
   - case: mount_root != the exe's compiled-in root (S19)
     behavior: exit 78 with both values printed — a mismatched pair, never a ruby LoadError
+  - case: TEBAKO_MOUNT_ROOT set but mount_root_override absent/false
+    behavior: exit 78 naming the override and the image — the image's rbconfig cannot follow, never a broken boot
 
 deprecated: [] # no field is in a deprecation window


### PR DESCRIPTION
The runtime root becomes a per-platform default (POSIX `/__tfs__`, windows `A:/t` — owner-final) with a run-time override: `TEBAKO_MOUNT_ROOT` redirects the env-image mount, rbconfig, and the io-routing patches together. Validated pre-mount (exit 65 on malformed), gated post-mount on the env image's additive `mount_root_override` layout grant (schema_minor 1; absent = closed, exit 78). Spec 17 §1 + layout.yaml updated; driver/cli tests green locally. Pairs with tamatebako/ruby v0.2.17 (rbconfig env fallback).
