### PR TITLE
runtime-manifest schema: A:/t windows root + override note

### DIFF
--- a/docs/spec/schemas/runtime-manifest.yaml
+++ b/docs/spec/schemas/runtime-manifest.yaml
@@ -80,8 +80,10 @@ grammar:
     type: string
     required: true
     notes: >-
-      The exe's compiled-in runtime root (ruby: /__tfs__, A:/__tfs__ on
-      windows — the one name on every platform). FLOWS from
+      The exe's compiled-in runtime root (ruby: /__tfs__ on POSIX, A:/t
+      on windows — per-platform baked defaults, short on windows by
+      owner decision; run-time overridable via TEBAKO_MOUNT_ROOT where
+      the env image's layout grants mount_root_override). FLOWS from
       tamatebako/ruby's patch literals — the single
       owner — through the source tarball's tebako-mount-root manifest;
       nothing downstream re-authors it.


### PR DESCRIPTION
Follow-up to #380: the runtime-manifest schema's mount_root note carried the superseded A:/__tfs__ uniformity value.