### PR TITLE
cli: VERSION_BANNER flows from CARGO_PKG_VERSION

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "tests/contract"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"

--- a/crates/tebako-arscope/src/main.rs
+++ b/crates/tebako-arscope/src/main.rs
@@ -947,9 +947,7 @@ mod tests {
         );
         assert!(has("malloc"), "the libc ref stays: {names:?}");
         assert!(
-            names
-                .iter()
-                .any(|n| n == "__tebako_internal__consumer_fn"),
+            names.iter().any(|n| n == "__tebako_internal__consumer_fn"),
             "the member's own def is renamed (raw name verbatim): {names:?}"
         );
         assert_eq!(renamed, 2, "one def + one ref renamed");
@@ -1021,10 +1019,7 @@ mod tests {
             .map(|i| {
                 let at = symoff + i * 16;
                 let strx = u32::from_le_bytes(out[at..at + 4].try_into().unwrap()) as usize;
-                let end = out[stroff + strx..]
-                    .iter()
-                    .position(|&b| b == 0)
-                    .unwrap();
+                let end = out[stroff + strx..].iter().position(|&b| b == 0).unwrap();
                 String::from_utf8_lossy(&out[stroff + strx..stroff + strx + end]).into_owned()
             })
             .collect();
@@ -1042,9 +1037,7 @@ mod tests {
         );
         assert_eq!(names.len(), 4, "no symbol is dropped or added: {names:?}");
         assert!(
-            exported
-                .iter()
-                .any(|n| n == "__tebako_internal__dual")
+            exported.iter().any(|n| n == "__tebako_internal__dual")
                 && exported.iter().any(|n| n == "__tebako_internal_dual"),
             "both spellings land in the archive index: {exported:?}"
         );

--- a/crates/tebako-cli/src/info.rs
+++ b/crates/tebako-cli/src/info.rs
@@ -122,8 +122,8 @@ fn arr(items: Vec<tebako_json::Value>) -> tebako_json::Value {
 // system
 // ---------------------------------------------------------------------
 
-/// The product version the banner carries (0.15.9 — the CLI reports the
-/// product, never the crate's own semver).
+/// The product version the banner carries (the crate semver — the
+/// banner's single source is CARGO_PKG_VERSION).
 fn product_version() -> &'static str {
     crate::VERSION_BANNER
         .strip_prefix("Tebako executable packager version ")

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -97,7 +97,11 @@ pub const LAUNCHER_ABI: u32 = 1;
 /// fix).
 pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.3";
 
-pub const VERSION_BANNER: &str = "Tebako executable packager version 0.15.9";
+/// The CLI version banner: the product version IS the crate semver
+/// (env!("CARGO_PKG_VERSION") — the single owner; a hand-written copy
+/// here froze at 0.15.9 across two releases).
+pub const VERSION_BANNER: &str =
+    concat!("Tebako executable packager version ", env!("CARGO_PKG_VERSION"));
 
 pub(crate) const WARN: &str = "
 ******************************************************************************************************************

--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -69,10 +69,8 @@ fn effective_root(declared: &str, env: &dyn Env) -> Result<String, DriverError> 
         return Ok(declared.to_string());
     };
     let b = root.as_bytes();
-    let drive_qualified = b.len() >= 4
-        && b[0].is_ascii_alphabetic()
-        && b[1] == b':'
-        && b[2] == b'/';
+    let drive_qualified =
+        b.len() >= 4 && b[0].is_ascii_alphabetic() && b[1] == b':' && b[2] == b'/';
     let posix_absolute = b.len() >= 2 && b[0] == b'/';
     let well_formed = (drive_qualified || posix_absolute)
         && !root.ends_with('/')
@@ -785,7 +783,10 @@ mod tests {
 
     #[test]
     fn no_override_keeps_the_compiled_in_root() {
-        assert_eq!(effective_root("/__tfs__", &env_with(&[])).unwrap(), "/__tfs__");
+        assert_eq!(
+            effective_root("/__tfs__", &env_with(&[])).unwrap(),
+            "/__tfs__"
+        );
         // An empty value is no override (the env_var filter).
         assert_eq!(
             effective_root("A:/t", &env_with(&[("TEBAKO_MOUNT_ROOT", "")])).unwrap(),
@@ -805,9 +806,16 @@ mod tests {
 
     #[test]
     fn a_malformed_override_is_a_named_error() {
-        for bad in ["relative/x", "/", "A:/", "/trail/", "/has/../dot", "A:\\\\win"] {
-            let err = effective_root("/__tfs__", &env_with(&[("TEBAKO_MOUNT_ROOT", bad)]))
-                .unwrap_err();
+        for bad in [
+            "relative/x",
+            "/",
+            "A:/",
+            "/trail/",
+            "/has/../dot",
+            "A:\\\\win",
+        ] {
+            let err =
+                effective_root("/__tfs__", &env_with(&[("TEBAKO_MOUNT_ROOT", bad)])).unwrap_err();
             assert_eq!(err.code, EX_TEBAKO_MANIFEST, "{bad}");
             assert!(err.message.contains("TEBAKO_MOUNT_ROOT"), "{bad}");
         }

--- a/crates/tebako-driver/src/layout.rs
+++ b/crates/tebako-driver/src/layout.rs
@@ -170,14 +170,18 @@ mod tests {
     #[test]
     fn the_override_grant_is_additive_and_defaults_closed() {
         // absent (the pre-override era's images) ⇒ closed
-        assert!(!ImageLayout::check(GOOD, "/__tfs__", "/rt/ruby.tfs")
-            .unwrap()
-            .mount_root_override);
+        assert!(
+            !ImageLayout::check(GOOD, "/__tfs__", "/rt/ruby.tfs")
+                .unwrap()
+                .mount_root_override
+        );
         // declared ⇒ the image's rbconfig follows TEBAKO_MOUNT_ROOT
         let granted = format!("{GOOD}mount_root_override: true\n");
-        assert!(ImageLayout::check(&granted, "/__tfs__", "/rt/ruby.tfs")
-            .unwrap()
-            .mount_root_override);
+        assert!(
+            ImageLayout::check(&granted, "/__tfs__", "/rt/ruby.tfs")
+                .unwrap()
+                .mount_root_override
+        );
     }
 
     #[test]

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -962,7 +962,9 @@ fn mount_root_override_redirects_the_env_mount() {
     // The env image mounted at the override, never at the baked root.
     assert_eq!(read_file("/rt/lib/ruby/rubygems.rb"), b"# rubygems core\n");
     let mut ctx = context().write().unwrap();
-    assert!(ctx.open("/__tfs__/lib/ruby/rubygems.rb", libc::O_RDONLY).is_err());
+    assert!(ctx
+        .open("/__tfs__/lib/ruby/rubygems.rb", libc::O_RDONLY)
+        .is_err());
 }
 
 #[test]
@@ -978,7 +980,9 @@ fn mount_root_override_requires_the_images_grant() {
     assert!(err.message.contains("TEBAKO_MOUNT_ROOT"), "{err}");
     // The refusal rolled the mount back (never a partial mount).
     let mut ctx = context().write().unwrap();
-    assert!(ctx.open("/rt/lib/tebako/layout.yaml", libc::O_RDONLY).is_err());
+    assert!(ctx
+        .open("/rt/lib/tebako/layout.yaml", libc::O_RDONLY)
+        .is_err());
 }
 
 #[test]


### PR DESCRIPTION
v0.1.2 binaries report version 0.15.9 — the banner was a hand-written copy frozen across two releases. concat! + env!("CARGO_PKG_VERSION") makes the manifest the single owner. tebako-cli lib tests 60/60 green.