### PR TITLE
install: home-layout payloads materialize whole

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "tests/contract"]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"

--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -1028,6 +1028,12 @@ fn install_dependency_closure<T: Transport>(
 /// the native program plus its Mach-O/ELF dependency closure, so the
 /// dispatcher execs it without linking tfs (spec 07 §2 — install is
 /// the materialization verb; a run never extracts).
+///
+/// A payload declaring a home layout (`annotations.java_home` — the
+/// root IS a runtime home: a JRE's bin/java probes lib/jvm.cfg relative
+/// to its own real path) materializes WHOLE: the closure walk only
+/// ever sees linked binaries, never the home's data files (the openjdk
+/// jvm.cfg miss, dogfood-found 2026-08-10).
 fn materialize_zero_runtime(
     home: &Path,
     entry: &tebako_resolve::CacheEntry,
@@ -1042,8 +1048,25 @@ fn materialize_zero_runtime(
     if zero.is_empty() {
         return Ok(());
     }
+    let whole_tree = mirror.home_layout().is_some();
     let record: PayloadRecord = manifest::payload_record(home, mirror.name(), mirror.version());
     image_manifest::with_image_mounted(&entry.path, || {
+        if whole_tree {
+            return tfs::context::context()
+                .write()
+                .unwrap()
+                .extract_all(&record.tree)
+                .map_err(|e| {
+                    err(
+                        EX_TEBAKO_UNAVAILABLE,
+                        format!(
+                            "cannot materialize the home-layout payload {}: {}",
+                            entry.path.display(),
+                            String::from_utf8_lossy(tfs::errno::strerror(e)).into_owned()
+                        ),
+                    )
+                });
+        }
         for path in &zero {
             tfs::context::context()
                 .write()

--- a/crates/tebako-cli/tests/install.rs
+++ b/crates/tebako-cli/tests/install.rs
@@ -701,6 +701,63 @@ fn embedded_manifest_yaml(name: &str, version: &str) -> String {
     )
 }
 
+/// A home-layout toolkit manifest (the openjdk shape): the payload root
+/// IS a runtime home — `annotations.java_home` — and the executable
+/// probes its data files relative to its own real path.
+fn toolkit_home_manifest_yaml(name: &str, exe: &str, version: &str) -> String {
+    format!(
+        "identity:\n  schema_version: 1\n  kind: toolkit\n  name: {name}\n  version: \"{version}\"\n  producer: {{tool: tebako, tool_version: 0.15.9}}\n  created: \"2026-07-26T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{}\"\n    blob_sha256: \"{}\"\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\n  annotations: {{java_home: \"/\"}}\nprovides:\n  executables:\n    - {{name: {exe}, path: /bin/{exe}, version: \"{version}\"}}\n  platforms: universal\n  capabilities: {{exec: true, read: true}}\n",
+        sha(b'a'),
+        sha(b'b')
+    )
+}
+
+/// A zip image in the home layout: the manifest, the executable at
+/// bin/<exe>, and a load-bearing data file at lib/jvm.cfg (the exec
+/// closure never sees it — only whole-tree extraction carries it).
+/// Directory entries are EXPLICIT (add_directory): the zip backend
+/// mirrors the C++ iterator's explicit-only semantics and never
+/// synthesizes implicit parents (TODO.v2-1/24).
+fn zip_image_with_home(name: &str, exe: &str, version: &str) -> Vec<u8> {
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let options = zip::write::SimpleFileOptions::default();
+    for dir in ["__tpkg__/", "bin/", "lib/"] {
+        writer.add_directory(dir, options).unwrap();
+    }
+    writer
+        .start_file("__tpkg__/manifest.yaml", options)
+        .unwrap();
+    writer
+        .write_all(toolkit_home_manifest_yaml(name, exe, version).as_bytes())
+        .unwrap();
+    writer.start_file(format!("bin/{exe}"), options).unwrap();
+    writer.write_all(b"#!/bin/sh\n").unwrap();
+    writer.start_file("lib/jvm.cfg", options).unwrap();
+    writer.write_all(b"-server KNOWN\n").unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+#[test]
+fn home_layout_payloads_materialize_the_whole_tree() {
+    let fx = Fixture::new("homelayout");
+    let image = zip_image_with_home("jre", "java", "21");
+    let payload_ref = fx.payload("jre-21.tfs", &image);
+    let yaml = format!(
+        "schema_version: 1\npayloads:\n  - name: jre\n    kind: toolkit\n    versions:\n      - version: \"21\"\n        platforms: universal\n        release: {{ref: {payload_ref}}}\n        entrypoints: [java]\n    default: \"21\"\n"
+    );
+    let reg_ref = fx.registry("tpkg-registry.yaml", &yaml);
+    install::add_registry(&fx.home, &reg_ref).unwrap();
+
+    let out = install::install(&fx.home, "jre", None, Some(&fx.shim_binary)).unwrap();
+    assert_eq!(out.commands, vec!["java"]);
+    let tree = fx.payloads_dir().join("jre/21.tree");
+    assert!(tree.join("bin/java").is_file(), "the executable lands");
+    assert!(
+        tree.join("lib/jvm.cfg").is_file(),
+        "the home's data files ride the whole-tree materialization (the openjdk jvm.cfg miss)"
+    );
+}
+
 #[test]
 fn embedded_manifest_drives_the_mirror_when_present() {
     let fx = Fixture::new("embedded");

--- a/crates/tebako-http/src/lib.rs
+++ b/crates/tebako-http/src/lib.rs
@@ -26,6 +26,8 @@ pub const REDIRECT_LIMIT: u32 = 5;
 pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 /// Global per-request timeout (the gem's read_timeout).
 pub const GLOBAL_TIMEOUT: Duration = Duration::from_secs(300);
+/// Upload timeout (the release-asset channel — see [`upload_agent`]).
+pub const UPLOAD_TIMEOUT: Duration = Duration::from_secs(1800);
 
 /// Set to opt into the OS trust store instead of the bundled
 /// webpki-roots (corporate MITM proxies and the like).
@@ -73,35 +75,47 @@ impl fmt::Display for FetchError {
 
 impl std::error::Error for FetchError {}
 
+fn build_agent(global_timeout: Duration) -> ureq::Agent {
+    let root_certs = if std::env::var_os(PLATFORM_ROOTS_ENV).is_some() {
+        ureq::tls::RootCerts::PlatformVerifier
+    } else {
+        ureq::tls::RootCerts::WebPki
+    };
+    let tls_builder = ureq::tls::TlsConfig::builder().root_certs(root_certs);
+    // windows-gnu: ureq is built `rustls-no-provider` (ring does not
+    // compile under mingw), so the provider must be named explicitly —
+    // ureq's documented aws-lc-rs swap.
+    #[cfg(all(windows, target_env = "gnu"))]
+    let tls_builder = tls_builder.unversioned_rustls_crypto_provider(std::sync::Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ));
+    let tls = tls_builder.build();
+    ureq::Agent::config_builder()
+        .tls_config(tls)
+        .https_only(true)
+        .max_redirects(REDIRECT_LIMIT)
+        .timeout_connect(Some(CONNECT_TIMEOUT))
+        .timeout_global(Some(global_timeout))
+        // statuses are mapped by the caller: the rate-limit headers
+        // ride the RESPONSE, and ureq's StatusCode error drops them.
+        .http_status_as_error(false)
+        .build()
+        .into()
+}
+
 fn agent() -> &'static ureq::Agent {
     static AGENT: OnceLock<ureq::Agent> = OnceLock::new();
-    AGENT.get_or_init(|| {
-        let root_certs = if std::env::var_os(PLATFORM_ROOTS_ENV).is_some() {
-            ureq::tls::RootCerts::PlatformVerifier
-        } else {
-            ureq::tls::RootCerts::WebPki
-        };
-        let tls_builder = ureq::tls::TlsConfig::builder().root_certs(root_certs);
-        // windows-gnu: ureq is built `rustls-no-provider` (ring does not
-        // compile under mingw), so the provider must be named explicitly —
-        // ureq's documented aws-lc-rs swap.
-        #[cfg(all(windows, target_env = "gnu"))]
-        let tls_builder = tls_builder.unversioned_rustls_crypto_provider(std::sync::Arc::new(
-            rustls::crypto::aws_lc_rs::default_provider(),
-        ));
-        let tls = tls_builder.build();
-        ureq::Agent::config_builder()
-            .tls_config(tls)
-            .https_only(true)
-            .max_redirects(REDIRECT_LIMIT)
-            .timeout_connect(Some(CONNECT_TIMEOUT))
-            .timeout_global(Some(GLOBAL_TIMEOUT))
-            // statuses are mapped by the caller: the rate-limit headers
-            // ride the RESPONSE, and ureq's StatusCode error drops them.
-            .http_status_as_error(false)
-            .build()
-            .into()
-    })
+    AGENT.get_or_init(|| build_agent(GLOBAL_TIMEOUT))
+}
+
+/// The upload channel (release assets): 100 MB+ payloads on a degraded
+/// backend blow the 300 s global request timeout (the metanorma 1.16.9
+/// publish died at it, 2026-08-10; the factory's publish learned the
+/// same lesson the same night). Bounded but generous — 30 min covers a
+/// 150 MB asset at ~100 KB/s.
+fn upload_agent() -> &'static ureq::Agent {
+    static UPLOAD_AGENT: OnceLock<ureq::Agent> = OnceLock::new();
+    UPLOAD_AGENT.get_or_init(|| build_agent(UPLOAD_TIMEOUT))
 }
 
 /// Seconds from a Retry-After header value (delta-seconds form; the
@@ -339,7 +353,7 @@ pub fn post(
     bearer: Option<&str>,
 ) -> Result<Vec<u8>, FetchError> {
     require_https(url)?;
-    let mut req = agent()
+    let mut req = upload_agent()
         .post(url)
         .header("Content-Type", content_type)
         .header("Accept", "application/vnd.github+json")

--- a/crates/tebako-shim/src/manifest.rs
+++ b/crates/tebako-shim/src/manifest.rs
@@ -136,6 +136,20 @@ impl Manifest {
         &self.inner.requires
     }
 
+    /// The home-layout annotation (`identity.annotations.java_home` —
+    /// spec 03's free-form annotations): a payload whose root IS a
+    /// runtime home (a JRE — its bin/java probes lib/jvm.cfg relative
+    /// to its own real path) materializes WHOLE at install; the
+    /// exec-closure walk only ever sees linked binaries, never the
+    /// home's data files (the openjdk jvm.cfg miss, dogfood-found).
+    pub fn home_layout(&self) -> Option<&str> {
+        self.inner
+            .identity
+            .annotations
+            .get("java_home")
+            .and_then(|v| v.as_str())
+    }
+
     /// The payload's declared host-access request (spec 08 §4 — the app
     /// PROVIDES `capabilities.host`; the dispatcher composes it with the
     /// user's tightening flags, spec 08 §2).


### PR DESCRIPTION
The exec-closure extraction carries linked binaries only — a JRE's jvm.cfg (probed relative to the java binary's real path) never lands, killing the payload java (metanorma dogfood run 31442158908). Payloads with identity.annotations.java_home now materialize the whole image at install. Test included; tfs+cli+shim suites green.