### PR TITLE
install: discard the extract_all count (the #390 follow-up)

### DIFF
--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -1056,6 +1056,7 @@ fn materialize_zero_runtime(
                 .write()
                 .unwrap()
                 .extract_all(&record.tree)
+                .map(|_| ())
                 .map_err(|e| {
                     err(
                         EX_TEBAKO_UNAVAILABLE,


### PR DESCRIPTION
The release legs' E0308: the whole-tree arm's Result<usize> vs the closure's Result<()>. The fix sat uncommitted in my tree during the local checks — committed now.