### PR TITLE
tfs: drop the leftover debug eprintln

### DIFF
--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -1056,6 +1056,7 @@ fn materialize_zero_runtime(
                 .write()
                 .unwrap()
                 .extract_all(&record.tree)
+                .map(|_| ())
                 .map_err(|e| {
                     err(
                         EX_TEBAKO_UNAVAILABLE,

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -1282,10 +1282,7 @@ fn extract_file(
     let mut offset = 0u64;
     let mut buf = vec![0u8; 8192];
     loop {
-        let n = backend.pread(rel, &mut buf, offset).map_err(|e| {
-            eprintln!("extract debug: pread({rel}, offset {offset}) -> errno {e}");
-            e
-        })?;
+        let n = backend.pread(rel, &mut buf, offset)?;
         if n == 0 {
             break;
         }


### PR DESCRIPTION
The diagnostic line from the symlink hunt tripped the clippy manual_inspect gate on main. Removed; the count+journal carries the information.