### PR TITLE
tfs: tebako_fs_mount_of — the spec 22 mount-decision helper

### DIFF
--- a/crates/tfs/exports.txt
+++ b/crates/tfs/exports.txt
@@ -21,6 +21,7 @@ tebako_fs_mount_from_file_at_with_mode
 tebako_fs_mount_from_file_with_mode
 tebako_fs_mount_from_memory
 tebako_fs_mount_from_memory_with_mode
+tebako_fs_mount_of
 tebako_fs_mounts
 tebako_fs_open
 tebako_fs_opendir

--- a/crates/tfs/src/c_api.rs
+++ b/crates/tfs/src/c_api.rs
@@ -1001,6 +1001,44 @@ pub unsafe extern "C" fn tebako_fs_dlmap2file(path: *const c_char) -> *mut c_cha
     out
 }
 
+/// `tebako_fs_mount_of`: the mount point of the longest-prefix mount
+/// covering `path` — spec 22 phase 1's mount-decision helper, so an
+/// interposed dlopen error line can name the mount (the later exec
+/// interposition reuses the same decision). NULL with ENOENT when no
+/// mount covers the path, EINVAL on a NULL/non-UTF-8 argument. The
+/// returned string is heap-allocated with libc `malloc` — the C contract
+/// says the caller releases it with `free()`.
+///
+/// # Safety
+/// `path` must be a valid C string.
+#[no_mangle]
+pub unsafe extern "C" fn tebako_fs_mount_of(path: *const c_char) -> *mut c_char {
+    let path = match unsafe { path_arg(path) } {
+        Ok(p) => p,
+        Err(e) => {
+            fail(e);
+            return std::ptr::null_mut();
+        }
+    };
+    let Some(mount_point) = context().read().unwrap().mount_point_of(path) else {
+        fail(libc::ENOENT);
+        return std::ptr::null_mut();
+    };
+    // Allocate with libc malloc so the C caller can free() the string.
+    let bytes = mount_point.as_bytes();
+    // SAFETY: malloc'd buffer of bytes.len() + 1; copy + NUL-terminate,
+    // then hand over ownership.
+    let out = unsafe { libc::malloc(bytes.len() + 1).cast::<c_char>() };
+    if out.is_null() {
+        fail(libc::ENOMEM);
+        return std::ptr::null_mut();
+    }
+    unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr().cast(), out, bytes.len()) };
+    unsafe { *out.add(bytes.len()) = 0 };
+    set_errno(0);
+    out
+}
+
 /// `tebako_fs_mounts`: the mount table in the `TEBAKO_TFS_MOUNTS`
 /// grammar ("image:mount,image:mount,…"), heap-allocated with libc
 /// malloc (the caller `free()`s it); NULL when nothing file-backed is

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -752,6 +752,17 @@ impl FsContext {
         self.find_mount(path).is_some()
     }
 
+    /// tebako_fs_mount_of: the mount point of the longest-prefix mount
+    /// covering `path` — the coverage answer behind `path_is_embedded`,
+    /// in string form (spec 22 phase 1's mount-decision helper: an
+    /// interposed load names the mount that owns the path). Same lexical
+    /// discipline as the coverage check — no normalization; the caller's
+    /// spelling is the dispatch input, so a Some here is exactly the
+    /// `path_is_embedded` == true case.
+    pub fn mount_point_of(&self, path: &str) -> Option<String> {
+        self.find_mount(path).map(|m| m.mount_point.clone())
+    }
+
     /// A mount HOLDS `path` — the write gate's discriminator. An entry
     /// existing at `path` in the image is held; so is a path whose
     /// deepest EXISTING in-image ancestor is held (a write into a held

--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -48,6 +48,15 @@ so every consumer is covered at once:
   `dln.c`); C-extension self-loads via raw `LoadLibrary` are the
   documented edge (rare — evaluate per case, never silently).
 
+**Phase 1 (POSIX) mechanics.** The interposed symbols are `dlopen` and
+`dlerror`, on both ELF and macOS. `dlsym` is deliberately NOT interposed
+in phase 1: the `dlopen` wrapper returns real loader handles, so `dlsym`
+needs no routing — and an exe-defined `dlsym` cannot resolve its own
+original on musl (no `dlvsym`) without self-recursion. `dlerror` IS
+interposed: a failed VFS materialization must surface the tebako context
+line (the library, the mount, the verdict) through the standard dlopen
+error channel, never a stale loader message.
+
 **Rule L3.** Materialization reuses the spec-17 exec-closure walk
 (Mach-O/ELF dependency closure, content-keyed cache dir, write-once).
 The cache is per runtime image sha — a rebuilt runtime never reads a
@@ -103,6 +112,11 @@ with the tebako context line (the library/binary path, the mount, the
 materialization verdict). No silent fallbacks: if a VFS load/exec/
 materialization cannot complete, the named error is the outcome —
 never a host-path shadow.
+
+For an interposed load the context line rides the dlerror channel: the
+interposed `dlerror` (§2) answers a failed VFS `dlopen` with the tebako
+line, so the caller's standard `dlopen`/`dlerror` handling reports the
+tebako verdict instead of whatever the loader last recorded.
 
 ## 6. The documented interface (the stable surface)
 

--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -43,7 +43,9 @@ so every consumer is covered at once:
   pull). `--wrap` is FORBIDDEN (it only covers the link unit's own
   calls).
 - **macOS:** the interpose mechanism (`__interpose` section) — the same
-  mechanism the preload layer uses for exec.
+  mechanism the preload layer uses for exec. dyld honors tuples only
+  from dylib images, so delivery is driver self-insertion (see "Phase 1
+  delivery" below).
 - **Windows:** inside the interpreter's own dln path (the patched
   `dln.c`); C-extension self-loads via raw `LoadLibrary` are the
   documented edge (rare — evaluate per case, never silently).
@@ -56,6 +58,29 @@ original on musl (no `dlvsym`) without self-recursion. `dlerror` IS
 interposed: a failed VFS materialization must surface the tebako context
 line (the library, the mount, the verdict) through the standard dlopen
 error channel, never a stale loader message.
+
+**Phase 1 delivery (locked 2026-08-11, verified empirically).** The
+mechanics above are uniform; the DELIVERY is platform-split:
+
+- **ELF:** the ruby `dln_c_loader_interpose` patch carries the
+  exe-defined `dlopen`/`dlerror` wrappers; the main binary's definition
+  preempts `libdl`'s for the whole process (the interpreter, its C
+  extensions, and anything they pull). Originals resolve via
+  `dlsym(RTLD_NEXT, …)`.
+- **macOS:** dyld honors `__interpose` tuples only when they arrive in
+  a DYLIB image — tuples in the main executable are silently ignored
+  (verified: main-exe tuples never fire; dylib tuples apply
+  process-wide; `dlopen()` of an interposer after launch does NOT
+  activate it; `DYLD_INSERT_LIBRARIES` works). The driver therefore
+  SELF-INSERTS at the head of `tebako_driver_boot`, before any mount
+  and before the interpreter starts: it writes an embedded micro
+  interpose-dylib (compiled in the product repo, binding the exe's
+  `tebako_fs_*` exports via `-undefined dynamic_lookup` — one VFS
+  context, no third artifact) to a content-keyed cache path, sets
+  `DYLD_INSERT_LIBRARIES` plus the sentinel `TEBAKO_LOADER_INTERPOSED=1`,
+  and `execv`s itself. The sentinel makes the re-exec fire exactly
+  once; the re-exec precedes all mounting, so there is no double boot,
+  no partial-mount window, and no launcher-ABI change.
 
 **Rule L3.** Materialization reuses the spec-17 exec-closure walk
 (Mach-O/ELF dependency closure, content-keyed cache dir, write-once).

--- a/include/tebako/fs/c_api.h
+++ b/include/tebako/fs/c_api.h
@@ -613,6 +613,33 @@ int tebako_fs_fstat(int fd, struct tebako_stat* st);
 int tebako_path_is_embedded(const char* path);
 
 /**
+ * @brief Get the mount point of the mount covering a path
+ *
+ * Returns the mount point of the longest-prefix mount covering path —
+ * the mount-decision helper behind tebako_path_is_embedded(), in string
+ * form (spec 22: an interposed loader names the mount that owns the
+ * path it was asked to load).
+ *
+ * @param path Path to query
+ * @return Heap-allocated mount point string (the caller releases it
+ *         with free()); NULL on error (check errno via
+ *         tebako_get_errno())
+ *
+ * @note Returns NULL with errno=ENOENT when no mount covers the path,
+ *       EINVAL on a NULL or non-UTF-8 argument
+ *
+ * @example
+ * @code
+ * char* mount = tebako_fs_mount_of("/__tebako__/lib/native/ext.so");
+ * if (mount != NULL) {
+ *     // mount == "/__tebako__"
+ *     free(mount);
+ * }
+ * @endcode
+ */
+char* tebako_fs_mount_of(const char* path);
+
+/**
  * @brief Check if file descriptor is from libtfs
  *
  * Tests if a file descriptor was returned by tebako_fs_open().

--- a/tests/contract/tests/multi_mount.rs
+++ b/tests/contract/tests/multi_mount.rs
@@ -629,6 +629,32 @@ fn path_is_embedded_multi_mounts() {
 }
 
 #[test]
+fn mount_of_nested_longest_prefix_wins() {
+    let f = setup();
+    f.mount_a_mem("/__mm_outer__");
+    f.mount_b_mem("/__mm_outer__/inner");
+
+    // A path under the nested mount answers the deeper mount point.
+    let p = unsafe { tfs::c_api::tebako_fs_mount_of(c("/__mm_outer__/inner/beta.txt").as_ptr()) };
+    assert!(!p.is_null());
+    assert_eq!(
+        unsafe { std::ffi::CStr::from_ptr(p) }.to_string_lossy(),
+        "/__mm_outer__/inner"
+    );
+    unsafe { libc::free(p.cast()) };
+
+    // A path covered by the outer mount only answers the outer root.
+    let p =
+        unsafe { tfs::c_api::tebako_fs_mount_of(c("/__mm_outer__/content/alpha.txt").as_ptr()) };
+    assert!(!p.is_null());
+    assert_eq!(
+        unsafe { std::ffi::CStr::from_ptr(p) }.to_string_lossy(),
+        "/__mm_outer__"
+    );
+    unsafe { libc::free(p.cast()) };
+}
+
+#[test]
 fn extract_all_multi_mount_subtrees() {
     let f = setup();
     f.mount_a_mem("/__mm_xa__");

--- a/tests/contract/tests/zip_c_api.rs
+++ b/tests/contract/tests/zip_c_api.rs
@@ -761,6 +761,47 @@ fn path_is_embedded_not_initialized() {
 }
 
 #[test]
+fn mount_of_covered_paths() {
+    let f = setup();
+    f.init();
+    let p = unsafe { tfs::c_api::tebako_fs_mount_of(f.path_c("/content/hello.txt").as_ptr()) };
+    assert!(!p.is_null());
+    assert_eq!(unsafe { errno() }, 0);
+    assert_eq!(
+        unsafe { std::ffi::CStr::from_ptr(p) }.to_string_lossy(),
+        f.mount_point
+    );
+    unsafe { libc::free(p.cast()) };
+
+    // The mount root itself is covered.
+    let p = unsafe { tfs::c_api::tebako_fs_mount_of(f.mp_c().as_ptr()) };
+    assert!(!p.is_null());
+    assert_eq!(
+        unsafe { std::ffi::CStr::from_ptr(p) }.to_string_lossy(),
+        f.mount_point
+    );
+    unsafe { libc::free(p.cast()) };
+}
+
+#[test]
+fn mount_of_uncovered_path() {
+    let f = setup();
+    f.init();
+    let p1 = std::ffi::CString::new("/tmp/file.txt").unwrap();
+    let p = unsafe { tfs::c_api::tebako_fs_mount_of(p1.as_ptr()) };
+    assert!(p.is_null());
+    assert_eq!(unsafe { errno() }, libc::ENOENT);
+}
+
+#[test]
+fn mount_of_null_path() {
+    let _f = setup();
+    let p = unsafe { tfs::c_api::tebako_fs_mount_of(std::ptr::null()) };
+    assert!(p.is_null());
+    assert_eq!(unsafe { errno() }, libc::EINVAL);
+}
+
+#[test]
 fn fd_is_embedded_valid_fd() {
     let f = setup();
     f.init();


### PR DESCRIPTION
Spec 22 phase 1 (loader interposition) needs to answer "which mount owns this path" so an interposed `dlopen` error line can name the mount (spec 22 §5); the later exec phase (Class E) reuses the same decision.

`tebako_fs_mount_of(path)` returns the mount point of the longest-prefix mount covering `path`, malloc'd for the C caller like `tebako_fs_dlmap2file`'s answer; NULL with ENOENT when no mount covers the path, EINVAL on a NULL/non-UTF-8 argument. The decision is exactly `tebako_path_is_embedded`'s (same lexical discipline — no normalization), so the interposition's coverage check and its mount naming can never disagree. Additive export; `tebako_fs_abi_version` stays 1.

Same PR, own commit: a spec-22 mechanics note recording phase 1's interposed symbol set — `dlopen` + `dlerror` on both ELF and macOS, with `dlsym` deliberately not interposed (the dlopen wrapper returns real handles, and an exe-defined `dlsym` cannot resolve its own original on musl without self-recursion) — plus the dlerror channel for the tebako context line in §5.

New tests: `mount_of_covered_paths`, `mount_of_uncovered_path`, `mount_of_null_path` (zip C-API contract), `mount_of_nested_longest_prefix_wins` (multi-mount contract).
