### PR TITLE
tfs: exec_materialize — home-layout mounts materialize whole at exec (release v0.1.6)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "tests/contract"]
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"

--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -271,15 +271,17 @@ pub fn vfs_rewinddir(id: usize) -> Result<(), i32> {
     context().write().unwrap().rewinddir(id)
 }
 
-/// execve/posix_spawn of a MEMFS path (roadmap 39): materialize the file
-/// through the engine's `dlmap2file` host cache (execve needs a host path
-/// — one copy per exec, gc later, stated honestly in the spec) and force
-/// the exec bit (zip-family backends honestly report 0644). The routing
-/// is the dlopen rule: memfs → the host copy; host-or-denied → the
-/// route's answer (an allowed host path execs the original, a denied one
-/// fails EPERM/EROFS).
+/// execve/posix_spawn of a MEMFS path (roadmap 39): materialize through
+/// the engine's exec answer (`exec_materialize` — a home-layout mount
+/// (the in-image manifest's `java_home` annotation) extracts WHOLE once
+/// per process so the tool's self-relative data files (lib/modules,
+/// lib/jvm.cfg) exist next to the binary; any other mount rides the
+/// dlmap2file closure walk) and force the exec bit (zip-family backends
+/// honestly report 0644). The routing is the dlopen rule: memfs → the
+/// host copy; host-or-denied → the route's answer (an allowed host path
+/// execs the original, a denied one fails EPERM/EROFS).
 pub fn vfs_materialize_exec(path: &str) -> PathRoute<std::ffi::CString> {
-    let answer = { context().write().unwrap().dlmap2file(path) };
+    let answer = { context().write().unwrap().exec_materialize(path) };
     match answer {
         Ok(host) => match ensure_exec_bit(&host) {
             Ok(()) => PathRoute::Vfs(host),

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -51,6 +51,11 @@ limnifs-core = { git = "https://github.com/limnifs/limnifs", rev = "eddaea404b76
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
 # buffers. All pure-Rust RustCrypto crates — no shell-outs anywhere.
 tpkg = { version = "0.1.0", path = "../tpkg" }
+# The exec probe's tolerant annotation read (exec_materialize): a value
+# walk of the in-image manifest — never the validating parse, which
+# would fail-closed a newer schema on an older runtime (spec 03's
+# compat rule: consumers ignore keys they predate). Same pin as tpkg.
+serde_yml = "0.0.12"
 tebako-signer = { version = "0.1.0", path = "../tebako-signer", optional = true }
 aes-gcm = "0.10"
 hkdf = "0.12"

--- a/crates/tfs/exports.txt
+++ b/crates/tfs/exports.txt
@@ -8,6 +8,7 @@ tebako_fs_close
 tebako_fs_closedir
 tebako_fs_dir_is_embedded
 tebako_fs_dlmap2file
+tebako_fs_exec_materialize
 tebako_fs_extract_all
 tebako_fs_fstat
 tebako_fs_host_policy

--- a/crates/tfs/src/c_api.rs
+++ b/crates/tfs/src/c_api.rs
@@ -1001,6 +1001,47 @@ pub unsafe extern "C" fn tebako_fs_dlmap2file(path: *const c_char) -> *mut c_cha
     out
 }
 
+/// `tebako_fs_exec_materialize`: the exec surface's materialization —
+/// same malloc/free contract as `tebako_fs_dlmap2file`. A path inside a
+/// home-layout mount (the in-image manifest's
+/// `identity.annotations.java_home` — the payload root IS a tool home)
+/// materializes the mount's WHOLE tree once per process and the answer
+/// is the host twin inside that tree: a home's data files
+/// (lib/modules, lib/jvm.cfg) never ride a linked-library closure, so
+/// the dlmap2file answer boots a java that cannot find its boot class
+/// path. Any other path answers exactly like `tebako_fs_dlmap2file`.
+///
+/// # Safety
+/// `path` must be a valid C string.
+#[no_mangle]
+pub unsafe extern "C" fn tebako_fs_exec_materialize(path: *const c_char) -> *mut c_char {
+    let path = match unsafe { path_arg(path) } {
+        Ok(p) => p,
+        Err(e) => {
+            fail(e);
+            return std::ptr::null_mut();
+        }
+    };
+    let host = match context().write().unwrap().exec_materialize(path) {
+        Ok(h) => h,
+        Err(e) => {
+            fail(e);
+            return std::ptr::null_mut();
+        }
+    };
+    // Allocate with libc malloc so the C caller can free() the string.
+    let bytes = host.as_bytes_with_nul();
+    // SAFETY: malloc'd buffer of bytes.len(); copy then hand over ownership.
+    let out = unsafe { libc::malloc(bytes.len()).cast::<c_char>() };
+    if out.is_null() {
+        fail(libc::ENOMEM);
+        return std::ptr::null_mut();
+    }
+    unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr().cast(), out, bytes.len()) };
+    set_errno(0);
+    out
+}
+
 /// `tebako_fs_mounts`: the mount table in the `TEBAKO_TFS_MOUNTS`
 /// grammar ("image:mount,image:mount,…"), heap-allocated with libc
 /// malloc (the caller `free()`s it); NULL when nothing file-backed is

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -6,7 +6,7 @@
 //! (`src/c_api/fs_context.cpp`) semantics exactly; see each function's
 //! comments for the errno contract.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::RwLock;
 
 use crate::backend::{Backend, EntryType, RawDirEntry, RawStat, WritableBackend};
@@ -124,6 +124,13 @@ pub struct FsContext {
     /// dlmap2file cache: memfs path -> extracted host path. Extractions
     /// live for the process run and are removed at teardown (atexit).
     dl_cache: BTreeMap<String, std::path::PathBuf>,
+    /// The home-layout verdict per mount handle (the in-image manifest's
+    /// `identity.annotations.java_home`), memoized on first exec probe —
+    /// see `exec_materialize`.
+    home_memos: BTreeMap<i32, bool>,
+    /// The home mounts whose whole tree already materialized into the
+    /// dl tmpdir this process run (extract once per mount).
+    home_trees: BTreeSet<i32>,
     /// Host-access policy (spec 08 jails): consulted on every
     /// host-passthrough path decision (a path no memfs mount claims, and
     /// the mount family's image read). Process state, not namespace state:
@@ -151,6 +158,8 @@ impl FsContext {
             compat_handle: None,
             dl_tmpdir: None,
             dl_cache: BTreeMap::new(),
+            home_memos: BTreeMap::new(),
+            home_trees: BTreeSet::new(),
             host_policy: HostPolicy::open(),
             journal: None,
         }
@@ -875,6 +884,89 @@ impl FsContext {
         std::ffi::CString::new(s).map_err(|_| libc::EIO)
     }
 
+    /// The exec surface's answer for a memfs path (the preload's
+    /// execve/posix_spawn routing): a mount whose in-image manifest
+    /// declares the home annotation (`identity.annotations.java_home` —
+    /// the payload root IS a tool home, spec 03's free-form annotations)
+    /// materializes WHOLE once per process and the answer is the host
+    /// twin of `path` inside that tree. A home's data files
+    /// (lib/modules, lib/jvm.cfg) never ride a linked-library closure,
+    /// so the closure walk's answer boots a java that cannot find its
+    /// boot class path (the metanorma dogfood's jing failure). Any
+    /// other mount answers via dlmap2file's closure walk, unchanged.
+    pub fn exec_materialize(&mut self, path: &str) -> Result<std::ffi::CString, i32> {
+        let normalized = Self::normalize(path);
+        let probe = self.find_mount(&normalized).map(|mount| {
+            (
+                mount.handle,
+                Self::relative_path(mount, &normalized).to_string(),
+            )
+        });
+        let Some((handle, rel)) = probe.filter(|(handle, _)| self.mount_is_home(*handle)) else {
+            return self.dlmap2file(path);
+        };
+        if rel.is_empty() {
+            return Err(libc::EISDIR);
+        }
+        let root = self.home_tree_root(handle)?;
+        if self.home_trees.insert(handle) {
+            let mount = self.mounts.get(&handle).ok_or(libc::ENODEV)?;
+            let mut skipped = 0usize;
+            extract_dir_recursive(mount.backend.as_ref(), "", &root, &mut skipped)?;
+        }
+        let host = root.join(&rel);
+        std::ffi::CString::new(host.to_string_lossy().into_owned()).map_err(|_| libc::EIO)
+    }
+
+    /// The mount's home-layout verdict, memoized per handle: the
+    /// in-image manifest carries `identity.annotations.java_home` with
+    /// a string value (the whole mount tree materializes — the shim's
+    /// install-time reading of the same annotation, #388). The read is
+    /// a tolerant value walk, never the validating model parse: a
+    /// schema newer than this runtime must still answer (spec 03's
+    /// compat rule — consumers ignore what they predate). An absent,
+    /// unreadable, or malformed manifest answers false: the closure
+    /// walk stays the default.
+    fn mount_is_home(&mut self, handle: i32) -> bool {
+        if let Some(verdict) = self.home_memos.get(&handle) {
+            return *verdict;
+        }
+        let verdict = self
+            .mounts
+            .get(&handle)
+            .and_then(|mount| {
+                read_backend_file(
+                    mount.backend.as_ref(),
+                    tpkg::PAYLOAD_MANIFEST_PATH.trim_start_matches('/'),
+                )
+            })
+            .and_then(|text| serde_yml::from_str::<serde_yml::Value>(&text).ok())
+            .and_then(|yaml| {
+                yaml.get("identity")?
+                    .get("annotations")?
+                    .get("java_home")?
+                    .as_str()
+                    .map(str::to_owned)
+            })
+            .is_some();
+        self.home_memos.insert(handle, verdict);
+        verdict
+    }
+
+    /// The per-process whole-tree root for a home mount
+    /// (`<dl tmpdir>/tebako-home-<handle>`), creating the dl tmpdir on
+    /// first use — the same lifecycle as dlmap2file's cache (registered
+    /// for cleanup at exit).
+    fn home_tree_root(&mut self, handle: i32) -> Result<std::path::PathBuf, i32> {
+        if self.dl_tmpdir.is_none() {
+            let dir = create_dl_tmpdir().ok_or(libc::EIO)?;
+            register_dl_cleanup(&dir);
+            self.dl_tmpdir = Some(dir);
+        }
+        let tmp = self.dl_tmpdir.as_ref().ok_or(libc::EIO)?;
+        Ok(tmp.join(format!("tebako-home-{handle}")))
+    }
+
     /// The store-side sibling of dlmap2file (tebako install's
     /// zero-runtime materialization): extract `path` plus its exec
     /// dependency closure to `<dest>/<full memfs path>` and return the
@@ -1254,6 +1346,27 @@ fn extract_dir_recursive(
     Ok(())
 }
 
+/// Read a small in-image file whole (the manifest probe): pread chunks
+/// to EOF. Any backend error — the absent file included — answers None
+/// (the probe's caller decides what absence means; it is never an exec
+/// failure of its own).
+fn read_backend_file(backend: &dyn Backend, rel: &str) -> Option<String> {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 8192];
+    let mut offset = 0u64;
+    loop {
+        match backend.pread(rel, &mut chunk, offset) {
+            Ok(0) => break,
+            Ok(n) => {
+                buf.extend_from_slice(&chunk[..n]);
+                offset += n as u64;
+            }
+            Err(_) => return None,
+        }
+    }
+    String::from_utf8(buf).ok()
+}
+
 /// What one walk step did with a non-directory entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ExtractStep {
@@ -1387,6 +1500,96 @@ mod tests {
             !dest.join("lib/link.txt").exists(),
             "the symlink is not materialized"
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A zip with explicit dir entries (the zip backend's readdir is
+    /// explicit-only) carrying a fake tool home: bin/tool + lib/modules,
+    /// and the in-image manifest when `with_annotation` (the tolerant
+    /// exec probe reads only identity.annotations.java_home).
+    fn fixture_home_zip(dir: &std::path::Path, with_annotation: bool) -> std::path::PathBuf {
+        let name = if with_annotation {
+            "home.zip"
+        } else {
+            "plain.zip"
+        };
+        let path = dir.join(name);
+        let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+        let options = zip::write::SimpleFileOptions::default();
+        for d in ["__tpkg__/", "bin/", "lib/"] {
+            writer.add_directory(d, options).unwrap();
+        }
+        if with_annotation {
+            writer
+                .start_file("__tpkg__/manifest.yaml", options)
+                .unwrap();
+            writer
+                .write_all(b"identity:\n  annotations:\n    java_home: \"/\"\n")
+                .unwrap();
+        }
+        writer.start_file("bin/tool", options).unwrap();
+        writer.write_all(b"#!/bin/fake\n").unwrap();
+        writer.start_file("lib/modules", options).unwrap();
+        writer.write_all(b"jimage-bytes").unwrap();
+        let bytes = writer.finish().unwrap().into_inner();
+        std::fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    #[test]
+    fn exec_materialize_lands_the_whole_tree_for_a_home_layout_mount() {
+        let dir = std::env::temp_dir().join(format!("tfs-home-exec-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let image = fixture_home_zip(&dir, true);
+        let mut ctx = FsContext::new();
+        let mount = crate::mount::build_from_file(image.to_str().unwrap(), "/tfs").unwrap();
+        ctx.mount_checked(mount).unwrap();
+
+        let answer = ctx.exec_materialize("/tfs/bin/tool").unwrap();
+        let host = std::path::PathBuf::from(answer.to_string_lossy().into_owned());
+        assert!(host.is_file(), "the exec twin lands: {host:?}");
+        assert_eq!(std::fs::read(&host).unwrap(), b"#!/bin/fake\n");
+        assert!(
+            host.to_string_lossy().contains("tebako-home-"),
+            "home-layout answers from the whole-tree root, not the closure cache: {host:?}"
+        );
+        // The point of the branch: the home's data files exist next to
+        // the binary (lib/modules — never in a linked closure).
+        let root = host.parent().unwrap().parent().unwrap();
+        assert_eq!(
+            std::fs::read(root.join("lib/modules")).unwrap(),
+            b"jimage-bytes"
+        );
+
+        // Idempotent within the process: a second exec reuses the tree.
+        let again = ctx.exec_materialize("/tfs/bin/tool").unwrap();
+        assert_eq!(again, answer);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn exec_materialize_keeps_the_closure_walk_for_a_plain_mount() {
+        let dir = std::env::temp_dir().join(format!("tfs-plain-exec-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let image = fixture_home_zip(&dir, false);
+        let mut ctx = FsContext::new();
+        let mount = crate::mount::build_from_file(image.to_str().unwrap(), "/tfs").unwrap();
+        ctx.mount_checked(mount).unwrap();
+
+        let answer = ctx.exec_materialize("/tfs/bin/tool").unwrap();
+        let host = std::path::PathBuf::from(answer.to_string_lossy().into_owned());
+        assert!(host.is_file(), "the closure-walk twin lands: {host:?}");
+        assert!(
+            !host.to_string_lossy().contains("tebako-home-"),
+            "a manifest-less mount keeps the closure walk: {host:?}"
+        );
+        // No whole-tree: the home's data file never materializes.
+        let root = host.parent().unwrap().parent().unwrap();
+        assert!(!root.join("lib/modules").exists());
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/include/tebako/fs/c_api.h
+++ b/include/tebako/fs/c_api.h
@@ -709,6 +709,29 @@ int tebako_fs_extract_all(const char* dest_path);
 char* tebako_fs_dlmap2file(const char* path);
 
 /**
+ * @brief Materialize a memfs exec target to a host filesystem path
+ *
+ * The exec surface's answer, with the same ownership/lifetime contract
+ * as tebako_fs_dlmap2file(). A path inside a home-layout mount (the
+ * in-image manifest's identity.annotations.java_home — the payload
+ * root IS a tool home) materializes the mount's WHOLE tree once per
+ * process and the returned path is the host twin inside that tree: a
+ * home's data files (lib/modules, lib/jvm.cfg) never ride a
+ * linked-library dependency closure, so the dlmap2file answer boots a
+ * java that cannot find its boot class path. Any other path answers
+ * exactly like tebako_fs_dlmap2file().
+ *
+ * @param path Absolute path within a mounted filesystem
+ * @return Newly allocated host path string on success, NULL on error
+ *         (check errno via tebako_get_errno())
+ *
+ * @note Ownership: the RETURNED STRING is caller-owned and must be
+ *       released with free(). The host file it points to is owned by
+ *       libtfs — do not unlink or modify it.
+ */
+char* tebako_fs_exec_materialize(const char* path);
+
+/**
  * @brief Serialize the mount table in the TEBAKO_TFS_MOUNTS grammar
  * ("image:mount,image:mount,…").
  *


### PR DESCRIPTION
## Why

The metanorma dogfood (run 31507706385) proved the last gap in the
image-era exec chain, one layer below tonight's fixed catalog:

- linux: `Jing failed … Error occurred during initialization of VM /
  Failed setting boot class path.`
- macOS: `java.nio.file.NoSuchFileException: …/tebako-dl-…/opt/openjdk/conf/security/policy/unlimited`

Root cause: an exec of an in-image binary materializes through the
dlmap2file closure walk — the binary plus its *linked* library
dependencies. A tool home's **data** files (`lib/modules`,
`lib/jvm.cfg`, `conf/security/**`) are never in that closure, so the
materialized java resolves its home (from its own real path) into a
tree that has no home content. The shim's install path learned the
home-layout whole-tree materialization in #388; the in-process exec
surface (the ruby spawn patch's `tebako_fs_dlmap2file` call and the
preload's execve routing) never got it.

## What

- `tfs`: new `FsContext::exec_materialize` — the exec surface's answer.
  A mount whose in-image manifest carries
  `identity.annotations.java_home` (spec 03's free-form annotation; the
  payload root IS a tool home) materializes **whole** once per process
  under the dl tmpdir (`tebako-home-<handle>`) and the answer is the
  host twin inside that tree. The manifest read is a tolerant value
  walk, never the validating model parse — a schema newer than the
  runtime must still answer (spec 03's compat rule). Any other mount
  rides the dlmap2file closure walk, unchanged.
- `tfs` C ABI: new export `tebako_fs_exec_materialize` (same malloc
  contract; `exports.txt` + `c_api.h` updated; ABI version stays 1 —
  additive, old consumers unaffected). The ruby spawn patch moves to it
  (tamatebako/ruby sister PR).
- `libtfs-preload`: the execve/posix_spawn routing calls
  `exec_materialize`.
- Release v0.1.6 (workspace version bump).

## Proof

- New engine tests: home-layout mount → whole tree lands (the
  `lib/modules` sibling exists, content byte-true, second call reuses
  the tree); manifest-less mount → closure walk unchanged
  (`lib/modules` never materializes).
- `cargo test -p tfs -p libtfs-preload`: 132/132 green (full workspace
  suite result in the merge comment).
- `cargo clippy -p tfs -p libtfs-preload --all-targets`: zero warnings.
- Dogfood expectation: the jing (linux) and mn2pdf (macOS) legs boot a
  java whose home is whole — re-run lands green after the runtime
  re-cut carries this engine.

## Chain

product v0.1.6 (this PR) → ruby patch swap (spawn hook calls the new
export; 5 ruby lines, lint + compile-smoke green) → source release
v0.2.19 → factory re-pin + catalog re-cut → dogfood re-run.
