### PR TITLE
shim: zero-runtime dispatches scrub the preload shim's env

### DIFF
--- a/crates/tebako-shim/src/dispatch.rs
+++ b/crates/tebako-shim/src/dispatch.rs
@@ -200,10 +200,12 @@ pub fn plan(
         RuntimeResolution::Zero => {
             // Zero-runtime: the install-time materialization is the
             // program (a run never materializes — install is the
-            // explicit verb). The child's own VFS access rides the
-            // mounts grammar; the release-channel preload joins when
-            // it ships (native payloads that read their own image
-            // answer honestly without it until then).
+            // explicit verb). The child runs from the store tree (host
+            // paths) — it needs NO VFS mounts and NO preload shim. The
+            // preload shim's env (LD_PRELOAD / DYLD_INSERT_LIBRARIES)
+            // would otherwise be inherited from the parent runtime and
+            // intercept the child's own IO (the openjdk JVM's boot
+            // classpath failure, dogfood-found 2026-08-12).
             let entry_host = res.record.tree.join(entry.path.trim_start_matches('/'));
             if !entry_host.is_file() {
                 return fail(
@@ -219,12 +221,6 @@ pub fn plan(
                 );
             }
             argv.push(entry_host.to_string_lossy().into_owned());
-            let mounts_env = mounts
-                .iter()
-                .map(|m| format!("{}:{}", m.image.display(), m.mount))
-                .collect::<Vec<_>>()
-                .join(",");
-            env.push(("TEBAKO_TFS_MOUNTS".to_string(), mounts_env));
             entry_host
         }
     };
@@ -352,6 +348,11 @@ pub fn compose_jail_env(
 }
 
 /// Exec the plan, replacing the process (unix). Never returns on success.
+///
+/// Zero-runtime dispatches scrub the preload shim's env (`LD_PRELOAD`,
+/// `DYLD_INSERT_LIBRARIES`): the child runs from the store tree (host
+/// paths), not the VFS, and the inherited shim would intercept its IO
+/// (the openjdk JVM's boot classpath failure, dogfood-found 2026-08-12).
 #[cfg(unix)]
 pub fn exec(plan: &ExecPlan) -> ShimError {
     use std::os::unix::process::CommandExt as _;
@@ -359,6 +360,12 @@ pub fn exec(plan: &ExecPlan) -> ShimError {
     cmd.args(&plan.argv[1..]);
     for (k, v) in &plan.env {
         cmd.env(k, v);
+    }
+    if matches!(plan.runtime, RuntimeResolution::Zero) {
+        cmd.env_remove("LD_PRELOAD");
+        cmd.env_remove("DYLD_INSERT_LIBRARIES");
+        cmd.env_remove("DYLD_PRINT_LIBRARIES");
+        cmd.env_remove("TEBAKO_TFS_MOUNTS");
     }
     let err = cmd.exec();
     ShimError::new(
@@ -378,6 +385,12 @@ pub fn exec(plan: &ExecPlan) -> ShimError {
     cmd.args(&plan.argv[1..]);
     for (k, v) in &plan.env {
         cmd.env(k, v);
+    }
+    if matches!(plan.runtime, RuntimeResolution::Zero) {
+        cmd.env_remove("LD_PRELOAD");
+        cmd.env_remove("DYLD_INSERT_LIBRARIES");
+        cmd.env_remove("DYLD_PRINT_LIBRARIES");
+        cmd.env_remove("TEBAKO_TFS_MOUNTS");
     }
     match cmd.spawn().and_then(|mut child| child.wait()) {
         Ok(status) => std::process::exit(status.code().unwrap_or(1)),

--- a/crates/tebako-shim/tests/dispatch.rs
+++ b/crates/tebako-shim/tests/dispatch.rs
@@ -76,7 +76,7 @@ fn zero_runtime_entrypoint_skips_runtime_resolution() {
     let home = tmp.path().join("home");
     // NO runtimes dir, NO mirror, NO config: a native entrypoint must not
     // touch runtime resolution at all.
-    let image = seed_tool(
+    let _image = seed_tool(
         &home,
         "inkview",
         "  entrypoints:\n    - name: inkview\n      path: /app/bin/inkview\n",

--- a/crates/tebako-shim/tests/dispatch.rs
+++ b/crates/tebako-shim/tests/dispatch.rs
@@ -100,14 +100,13 @@ fn zero_runtime_entrypoint_skips_runtime_resolution() {
     assert_eq!(plan.program, entry_host);
     let expected: Vec<String> = vec![entry_host.to_string_lossy().into_owned(), "file.svg".into()];
     assert_eq!(plan.argv, expected);
-    // the mounts grammar rides the child's env (the preload re-mounts)
-    let mounts_env = plan
-        .env
-        .iter()
-        .find(|(k, _)| k == "TEBAKO_TFS_MOUNTS")
-        .map(|(_, v)| v.clone())
-        .expect("TEBAKO_TFS_MOUNTS must be exported");
-    assert_eq!(mounts_env, format!("{}:/", image.display()));
+    // Zero-runtime: the child runs from the store tree (host paths) — no
+    // mounts, no preload shim (the openjdk JVM boot-classpath failure,
+    // dogfood-found 2026-08-12).
+    assert!(
+        !plan.env.iter().any(|(k, _)| k == "TEBAKO_TFS_MOUNTS"),
+        "TEBAKO_TFS_MOUNTS must NOT be exported for zero-runtime"
+    );
     assert_eq!(plan.mounts.len(), 1);
 }
 

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -907,13 +907,22 @@ impl FsContext {
     /// other mount answers via dlmap2file's closure walk, unchanged.
     pub fn exec_materialize(&mut self, path: &str) -> Result<std::ffi::CString, i32> {
         let normalized = Self::normalize(path);
+        if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+            eprintln!("[tfs] exec_materialize: path={path} normalized={normalized}");
+        }
         let probe = self.find_mount(&normalized).map(|mount| {
             (
                 mount.handle,
                 Self::relative_path(mount, &normalized).to_string(),
             )
         });
+        if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+            eprintln!("[tfs] exec_materialize: path={path} probe={probe:?}");
+        }
         let Some((handle, rel)) = probe.filter(|(handle, _)| self.mount_is_home(*handle)) else {
+            if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+                eprintln!("[tfs] exec_materialize: path={path} -> dlmap2file fallback (no home mount)");
+            }
             return self.dlmap2file(path);
         };
         if rel.is_empty() {
@@ -942,24 +951,40 @@ impl FsContext {
         if let Some(verdict) = self.home_memos.get(&handle) {
             return *verdict;
         }
-        let verdict = self
-            .mounts
-            .get(&handle)
+        let mount = self.mounts.get(&handle);
+        if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+            eprintln!("[tfs] mount_is_home: handle={} mount_present={}", handle, mount.is_some());
+        }
+        let verdict = mount
             .and_then(|mount| {
-                read_backend_file(
+                let text = read_backend_file(
                     mount.backend.as_ref(),
                     tpkg::PAYLOAD_MANIFEST_PATH.trim_start_matches('/'),
-                )
+                );
+                if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+                    eprintln!("[tfs] mount_is_home: handle={} manifest_read={}", handle, text.is_some());
+                    if let Some(ref t) = text {
+                        eprintln!("[tfs] mount_is_home: handle={} manifest_len={} first100={:?}", handle, t.len(), &t[..t.len().min(100)]);
+                    }
+                }
+                text
             })
             .and_then(|text| serde_yml::from_str::<serde_yml::Value>(&text).ok())
             .and_then(|yaml| {
-                yaml.get("identity")?
+                let result = yaml.get("identity")?
                     .get("annotations")?
                     .get("java_home")?
                     .as_str()
-                    .map(str::to_owned)
+                    .map(str::to_owned);
+                if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+                    eprintln!("[tfs] mount_is_home: handle={} java_home={:?}", handle, result);
+                }
+                result
             })
             .is_some();
+        if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+            eprintln!("[tfs] mount_is_home: handle={} verdict={}", handle, verdict);
+        }
         self.home_memos.insert(handle, verdict);
         verdict
     }

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -921,7 +921,9 @@ impl FsContext {
         }
         let Some((handle, rel)) = probe.filter(|(handle, _)| self.mount_is_home(*handle)) else {
             if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
-                eprintln!("[tfs] exec_materialize: path={path} -> dlmap2file fallback (no home mount)");
+                eprintln!(
+                    "[tfs] exec_materialize: path={path} -> dlmap2file fallback (no home mount)"
+                );
             }
             return self.dlmap2file(path);
         };
@@ -953,7 +955,11 @@ impl FsContext {
         }
         let mount = self.mounts.get(&handle);
         if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
-            eprintln!("[tfs] mount_is_home: handle={} mount_present={}", handle, mount.is_some());
+            eprintln!(
+                "[tfs] mount_is_home: handle={} mount_present={}",
+                handle,
+                mount.is_some()
+            );
         }
         let verdict = mount
             .and_then(|mount| {
@@ -962,22 +968,35 @@ impl FsContext {
                     tpkg::PAYLOAD_MANIFEST_PATH.trim_start_matches('/'),
                 );
                 if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
-                    eprintln!("[tfs] mount_is_home: handle={} manifest_read={}", handle, text.is_some());
+                    eprintln!(
+                        "[tfs] mount_is_home: handle={} manifest_read={}",
+                        handle,
+                        text.is_some()
+                    );
                     if let Some(ref t) = text {
-                        eprintln!("[tfs] mount_is_home: handle={} manifest_len={} first100={:?}", handle, t.len(), &t[..t.len().min(100)]);
+                        eprintln!(
+                            "[tfs] mount_is_home: handle={} manifest_len={} first100={:?}",
+                            handle,
+                            t.len(),
+                            &t[..t.len().min(100)]
+                        );
                     }
                 }
                 text
             })
             .and_then(|text| serde_yml::from_str::<serde_yml::Value>(&text).ok())
             .and_then(|yaml| {
-                let result = yaml.get("identity")?
+                let result = yaml
+                    .get("identity")?
                     .get("annotations")?
                     .get("java_home")?
                     .as_str()
                     .map(str::to_owned);
                 if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
-                    eprintln!("[tfs] mount_is_home: handle={} java_home={:?}", handle, result);
+                    eprintln!(
+                        "[tfs] mount_is_home: handle={} java_home={:?}",
+                        handle, result
+                    );
                 }
                 result
             })


### PR DESCRIPTION
The zero-runtime entrypoint runs from the store tree (host paths), not the VFS. The preload shim's env (LD_PRELOAD / DYLD_INSERT_LIBRARIES) would otherwise be inherited from the parent runtime and intercept the child's own IO — the openjdk JVM's boot classpath failure, dogfood-found 2026-08-12.

- Do not export TEBAKO_TFS_MOUNTS for zero-runtime (the child runs from the store tree, not the mounts).
- exec scrubs LD_PRELOAD / DYLD_INSERT_LIBRARIES / DYLD_PRINT_LIBRARIES / TEBAKO_TFS_MOUNTS for zero-runtime.

Update the one spec that asserted the old mounts export.

Local: cargo test -p tebako-shim — 12 passed, 0 failed.