### PR TITLE
docs: spec 22 §2 windows class-L delivery record + windows jail proxy paths (phase W1)

### DIFF
--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -46,9 +46,12 @@ so every consumer is covered at once:
   mechanism the preload layer uses for exec. dyld honors tuples only
   from dylib images, so delivery is driver self-insertion (see "Phase 1
   delivery" below).
-- **Windows:** inside the interpreter's own dln path (the patched
-  `dln.c`); C-extension self-loads via raw `LoadLibrary` are the
-  documented edge (rare — evaluate per case, never silently).
+- **Windows (msys):** inside the interpreter's own dln path (the
+  patched `dln.c` — the `dln_c_dlmap_msys` route carried from v1).
+  Loads that bypass `dln.c` — raw `LoadLibrary`/`LoadLibraryExA` from
+  fiddle, ffi, or a C extension self-loading — are the documented edge
+  (rare — evaluate per case, never silently); the per-case evaluation
+  is the windows delivery record below.
 
 **Phase 1 (POSIX) mechanics.** The interposed symbols are `dlopen` and
 `dlerror`, on both ELF and macOS. `dlsym` is deliberately NOT interposed
@@ -81,6 +84,76 @@ mechanics above are uniform; the DELIVERY is platform-split:
   and `execv`s itself. The sentinel makes the re-exec fire exactly
   once; the re-exec precedes all mounting, so there is no double boot,
   no partial-mount window, and no launcher-ABI change.
+
+**Windows (msys) delivery record (design-pinned 2026-08-14, phase W1;
+the implementation is W2).** Windows has no process-wide preemption
+surface (no exe-definition preemption as on ELF, no interpose section
+as on macOS), so coverage extends exactly as far as callers that route
+through the interpreter's own `dln.c`. What the msys dln dlmap route
+(tamatebako/ruby `patches/*/dln_c_dlmap_msys.patch`, wired into every
+msys patch manifest) covers TODAY:
+
+- The interpreter's own native-extension load (`require` of a PE
+  extension through `dln_load`/`dln_open`): a
+  `tebako_path_is_embedded`-covered path materializes through
+  `tebako_fs_dlmap2file` and the host twin loads via `LoadLibraryW`.
+  The factory's boot smoke asserts exactly this on the msys legs
+  (`load_native_extension`: racc's `cparse.so` extracts from the memfs
+  and binds).
+- Host passthrough per Rule L1: an uncovered host path loads
+  untouched; a covered path the mounts do not HOLD answers ENOENT from
+  the c_api and the host conversion serves it from the host — the same
+  jail-gated passthrough precedent as POSIX.
+- The extension's import of the ruby DLL binds by LAYOUT, not by
+  closure walking: the loader's standard search order heads with the
+  running exe's own directory, and the store entry carries the
+  PE-named DLL (`x64-ucrt-ruby<ABI>.dll`, the release manifest's
+  `install_as` — single owner: the factory's
+  `RubyVersion#msys_dll_name`, flowed through the manifest and
+  assembled next to the exe, sha256-verified, by the bootstrap's
+  install in `crates/tebako-bootstrap`; the factory boot smoke mirrors
+  the same materialization in-step). Upstream's
+  `rb_w32_check_imported` then rejects an extension bound against a
+  DIFFERENT ruby DLL with its own named "incompatible library version"
+  LoadError — the windows form of the ABI-line guarantee.
+- Symbol resolution needs no routing: the loads above return real
+  loader handles, so `GetProcAddress` works unmodified — the same
+  reasoning as phase 1's `dlsym` decision.
+
+What fiddle/ffi NEED on windows and do not get today: both load
+through RAW loader calls that never enter `dln.c` — fiddle's
+`Fiddle.dlopen` is a `LoadLibrary` macro (`ext/fiddle/fiddle.h` in the
+interpreter's vendored source), ffi's `FFI::DynamicLibrary.open` is
+`LoadLibraryExA` (absolute paths carrying
+`LOAD_WITH_ALTERED_SEARCH_PATH`). Each needs the same
+materialize-then-load the dln route performs; a VFS path through
+either today fails with the OS loader's own honest error (126,
+module-not-found) — an honest failure, never a tebako-intercepted one,
+never a silent success.
+
+The raw-`LoadLibrary` edge cases, per case (the phase-W exit gate's
+record):
+
+| Case | Verdict |
+|---|---|
+| `dln_load` of a VFS-resident extension (the `require` path) | **covered** — the dlmap route above |
+| host path uncovered by any mount | **covered** — passthrough untouched |
+| covered but not held (a host path under a covering mount) | **covered** — ENOENT → host passthrough |
+| extension importing the ruby DLL | **covered** — the exe-dir layout + `rb_w32_check_imported`'s named ABI error |
+| extension importing OTHER VFS-resident DLLs (sibling vendor imports) | **documented gap** — two compounding layers: the closure walk parses Mach-O/ELF only (`crates/tfs` `exec_closure` — no PE import parsing), and plain `LoadLibraryW` does not search the loaded DLL's own directory (no `LOAD_WITH_ALTERED_SEARCH_PATH` in `dln_open`), so even a materialized sibling would not bind; the failure is the OS loader's honest 126. No proven consumer — the only in-image PE import a leg has proven is the ruby DLL itself |
+| fiddle `Fiddle.dlopen` of a VFS path | **documented gap** — raw `LoadLibrary` bypasses `dln.c`; honest OS failure |
+| ffi `FFI::DynamicLibrary.open` of a VFS path | **documented gap** — raw `LoadLibraryExA`; honest OS failure |
+| a C extension self-loading a VFS path via raw `LoadLibrary` | **documented gap** — the same mechanism class as fiddle/ffi |
+| failed materialization through `dln_open` (covered path, non-ENOENT dlmap failure — a directory, a jail-denied passthrough) | **named error — phase-W fix** — the v1-era route's `goto failed` raises `LoadError` WITHOUT the tebako verdict (no library/mount/errno context); W2 delivers the §5 verdict line through the standard error channel, matching the POSIX leg's dlerror contract |
+
+One design question this record deliberately does NOT settle (a W2
+decision, taken with the owner — recorded so no leg of it happens
+silently): fiddle ships IN the env image (the interpreter's vendored
+source), so routing its loader macro through the c_api would be
+runtime-internal in the same sense the `dln.c` patch is; ffi is a
+third-party gem, where that move is the per-gem code this spec's law
+forbids. Whether fiddle gains the vendored route and ffi/self-loads
+stay a permanent documented gap is named here, undecided.
 
 **Rule L3.** Materialization reuses the spec-17 exec-closure walk
 (Mach-O/ELF dependency closure, content-keyed cache dir, write-once).

--- a/docs/windows-jail-proxy.md
+++ b/docs/windows-jail-proxy.md
@@ -1,0 +1,192 @@
+# Windows jail proxy paths — the declarative host-surface contract
+
+Status: the enforcement layer and the windows platform floor are
+SHIPPED (`crates/tfs` `HostPolicy`, spec 08). The declaration surface
+they compose with is spec 23: its record mode and image-layer compose
+are IMPLEMENTED (`TEBAKO_JAIL=record`, `tfs needs --from-journal`,
+`tfs exec --compose`); the D1–D5 manifest/shim/press wiring is
+Phase-R (PLANNED, owner-signed 2026-08-14). This document is the
+windows reading of those two specs — it is not a third authority;
+every rule cites its owner.
+
+A tebako process never touches the host filesystem silently. Every
+host path a payload can read or write is PROXIED through the TFS
+host-passthrough under one bound policy (spec 08 §3's single choke):
+declared by the slice, the composition, or the operator; resolved into
+one effective policy before the interpreter runs; enforced identically
+by the bootstrap, the runtime driver, the shim, and `tebako run`.
+"Proxied" means exactly spec 08's grant semantics — the host path
+stays at its own spelling (or at a declared VFS mount point), reads
+answer the real file, writes against a read-only grant answer EROFS,
+and everything undeclared answers EPERM under the deny default:
+journaled, named, never a silent fallback.
+
+## 1. The windows platform floor (proxied read-only, automatic)
+
+Under the `deny` default every bound policy gains the **platform
+floor** (spec 08 §2.1): the surface a spawned interpreter or runtime
+physically cannot boot without, granted so a missing grant surfaces as
+the workload's own named error — never a segfault in someone else's
+library (the macOS JVM `getMacOSXLocale` SIGSEGV, spec 22 §3.4's
+journal-pinned chain). On windows the floor is (spec 08 §2.1;
+implementation: `crates/tfs/src/policy.rs` `platform_floor()` +
+`HostPolicy::bind`):
+
+| Host path | Why it is floor |
+|---|---|
+| `%SystemRoot%\System32` | the loader's DLL root — no process resolves its imports without it |
+| `%SystemRoot%\SysWOW64` | the 32-bit view for 32-bit children |
+| `%SystemRoot%\Fonts` | the GDI font tree GUI runtimes enumerate (the JVM's AWT init reads it) |
+
+Semantics (all spec 08 §2.1, all in `HostPolicy::bind`):
+
+- `%SystemRoot%` resolves AT BIND (`C:\Windows` when unset). A floor
+  path absent on the host is skipped silently — it is a courtesy
+  surface, not an authored request whose absence must fail the bind.
+- The floor binds ONLY under the `deny` default. Under `open` it
+  grants nothing the default does not already allow (`never_denies`
+  keeps its exact meaning); under `record` everything is allowed
+  anyway.
+- Read-only, always: writes to a floor path answer EROFS. An authored
+  grant covering a floor path (same or ancestor prefix) SUPERSEDES the
+  floor entry — the floor never narrows what an author allowed, so
+  widening a floor path to `rw` is one authored grant away; there is
+  no way to drop a floor path short of not denying — that is the point
+  of a floor.
+- Ancestor traverse: every bound grant (floor included) derives its
+  strict ancestors as exact-path reads — never prefix (no sideways
+  exposure), never write — so the platform's canonicalization walks
+  pass by construction.
+- The floor is NEVER serialized into `TEBAKO_JAIL`: the env grammar's
+  `host:mount:ro|rw` right-split cannot carry a drive-qualified
+  windows spelling. Every consumer RE-DERIVES the floor at its own
+  bind (supersede makes that idempotent), so a spawned child
+  re-binding its inherited spec enforces exactly its parent's policy.
+- The floor mount's VFS-side spelling on windows is the
+  drive-qualified forward-slash form (`C:/Windows/System32`,
+  `floor_mount_point()`); it is informational — enforcement matches
+  host prefixes.
+
+What never joins the floor (spec 08 §2.1's boundary): the workload's
+own tool tree (a JRE, a third-party install) and the user's home stay
+AUTHORED grants — an operator's `deny` must not silently read-expose
+private data, and the prefix grammar cannot express the "stat-only"
+grant the macOS CFPreferences home probe needs. A floor entry joins
+the list only with a proven platform-process consumer, cited by run —
+evidence, never anticipation.
+
+## 2. How a payload declares additional host paths (spec 23 D1)
+
+A slice declares its host surface in its in-image manifest's `needs:`
+block (spec 23 §2 — the ONLY spelling; the pre-spec-23
+`capabilities.host` key is a named validation error naming the rename,
+never an alias, never a dual-key merge):
+
+```yaml
+needs:
+  host:
+    - path: 'C:\Vendor\Tool'      # absolute, or a symbolic atom below
+      access: ro                  # ro | rw
+      mount: /vendor/tool         # OPTIONAL: present the host path at
+                                  # this VFS point (bind-mount spelling);
+                                  # absent = enforcement-only passthrough
+                                  # at the host spelling
+      when: [windows]             # OPTIONAL platform filter
+      optional: true              # OPTIONAL: absent at bind = silently
+                                  # skipped; absent WITHOUT it = a named
+                                  # error (fail-closed)
+      why: "the tool probes its install root at boot"   # MANDATORY
+```
+
+Symbolic atoms resolve at bind, per invocation, per user — never
+baked: `%USERPROFILE%` / `$HOME`, `%TEMP%` / `$TMPDIR`, `$CWD` (the
+invoking cwd), `$TEBAKO_HOME` (the store). An atom that does not
+resolve fails the bind only when the need is otherwise in force; under
+a platform-filter mismatch the entry is inert.
+
+Declaration rules (spec 23 §2, fail-closed): the same canonical path
+declared twice by one slice with disagreeing accesses is a named
+manifest error; an ancestor's access must be at least the
+descendant's (an ro ancestor may not hide an rw need); `access: rw`
+on a symbolic atom outside `$TEBAKO_HOME` requires the composition's
+explicit consent; a data slice carrying a `needs:` block is a named
+manifest error.
+
+Discovery (spec 23 §8): when the author does not KNOW the surface —
+the usual case — run the workload under `policy: record`
+(`TEBAKO_JAIL=record`): every host access is allowed and journaled
+(`event=jail-allow path=<p> op=read|write`), and
+`tfs needs --from-journal <journal.log>` emits a draft `needs:` block
+with floor, store, and exec-cache paths already excluded (they are
+automatic — never declared) and per-user paths re-substituted to
+atoms. The draft is the OBSERVED MINIMUM; the author reviews it and
+merges it into the slice manifest (D1) or the composition (D2). The
+generator never edits a manifest itself.
+
+## 3. How the running configuration binds them
+
+The resolver (spec 23 §6 — the shim in managed mode, the bootstrap in
+standalone, `tebako run` / `tebako press` up front) computes ONE
+effective policy before exec, in order: the slice set → the needs
+union (every slice's D1 `needs.host`, platform-filtered, atoms
+resolved at bind) → composed with the running configuration (D2
+`mounts:`/`needs:`, D4 operator config, D5 CLI flags) and the operator
+tightening (declarations request; the operator tightens — spec 08
+§4's locked precedence) → the needs-check → export.
+
+- **Managed dispatch (shim):** resolved per invocation — the slice
+  mirrors ∪ the runtime's release-manifest needs ∪ the composition
+  document (`tebako.yaml`, D2) ∪ operator config (D4) ∪ CLI (D5).
+  Swapping the configuration IS editing `tebako.yaml` or passing
+  flags; nothing is baked, nothing recompiles (spec 23 §9).
+- **Standalone package (bootstrap):** the press-baked D3 needs union ∪
+  a lean runtime's manifest needs ∪ the operator env. An external
+  composition document overrides the baked block (first hit wins:
+  `--compose` on argv, `TEBAKO_COMPOSE`, the `<package>.tebako.yaml`
+  sidecar — spec 23 §9; the override channels are Phase-R, the
+  image-layer form is `tfs exec --compose`, implemented).
+- **The shipped CLI surface today** (spec 08 §4): `tebako run` and
+  `tebako-shim` take `--jail <spec>` (`open` | `deny` | `deny:arg` |
+  a YAML file | the env grammar), repeatable `--mount
+  <host:mount:ro|rw>`, and `--no-host`; spec 23 §3's wider D5 flag set
+  (`--policy`, `--need`, `--slice`, …) is Phase-R.
+- **Export and bind:** the authored part serializes to `TEBAKO_JAIL`
+  (+`TEBAKO_JAIL_SOURCE`, +`TEBAKO_JAIL_JOURNAL`) — the env grammar
+  `open` | `deny` | `deny;host:mount:ro|rw;@argfile…` (`crates/tpkg`
+  `jail.rs` owns the authored model). The floor and the system
+  self-surface are NOT serialized — every bind re-derives them. The
+  driver parses `TEBAKO_JAIL` (`tfs::policy::JailSpec`) and installs
+  the policy via `HostPolicy::bind` AFTER the mounts (spec 08 §3 — the
+  mount family's image read is itself policy-gated once a policy is
+  active). A spawned child inherits `TEBAKO_JAIL` and re-binds: same
+  policy, floor included.
+
+The default matrix (spec 23 §5): a run with ANY declaration in force
+defaults to `policy: deny`; `open` is asked for by name; a run with no
+declarations anywhere runs open (`never_denies`) — a first-class rule,
+not a compatibility mode. The effective world under deny is exactly:
+the VFS (read-only by construction, spec 11) + the platform floor (§1)
++ the system self-surface (`$TEBAKO_HOME`, `TEBAKO_EXEC_CACHE`) + the
+declared needs ∪ composition/operator grants + auto-allowed argument
+files. Everything else is EPERM/EROFS, journaled.
+
+## 4. The named errors (never a silent anything)
+
+| Boundary | Verdict |
+|---|---|
+| host read outside every grant (deny default) | EPERM from the IO route, journaled `event=jail-deny path=<p> op=read source=<s>`; the line names the covering declaration when one exists (`would-need=slice:<name>`) and says so when none does — the operator learns the exact key to add from the denial itself |
+| write against an ro grant (floor or authored) | EROFS, journaled the same way |
+| malformed `TEBAKO_JAIL`, or a bind failure (a relative mount point → EINVAL; a missing authored mount source or argument file → its canonicalization errno, ENOENT included) | exit 73 (`EX_TEBAKO_JAIL`), fail-closed, at the bootstrap/driver surface that binds it |
+| a declared need the effective policy does not cover | named resolution failure BEFORE exec: `slice <name> needs <path> (<access>, why: <why>) — denied by <source>` (spec 23 §6 step 4; the exit code is pinned at implementation per the spec 05/07 table — never a fallback) |
+| `capabilities.host` in a manifest | named validation error naming the rename (`→ needs.host`) |
+| `record` carrying grants | EINVAL at bind — inert configuration is a named error, never silently ignored |
+| a composition override naming a slice the trailer does not carry (fat package) | named error, never a silent skip (spec 23 §9) |
+
+## 5. Honest scope
+
+Jails are FILESYSTEM-ONLY (spec 08 §5). No network confinement is
+claimed (`capabilities.network` is advisory). Coverage is every IO
+route through the TFS layer — interpreted payloads and native binaries
+under the preload shim alike; NOT covered: statically-linked binaries
+(direct syscalls, no interposition point) and any process that escapes
+the shim — stated honestly, never implied otherwise.


### PR DESCRIPTION
# Phase W1 — spec 22 §2 windows class-L design pin + windows jail proxy docs

Docs-only draft (hard rule: no merges until the whole change chain is green end-to-end and the owner says go). This is Phase W, Task W1 of `docs/superpowers/plans/2026-08-13-spec22-phases-e-r-w-merge.md`, plus the owner directive on windows jail proxy-path documentation.

## What this pins

**Spec 22 §2 windows bullet → the delivery record** (the phase-W exit gate's "the documented raw-`LoadLibrary` edge is evaluated per case (spec 22 §2 windows bullet) and recorded"):

- The msys dln dlmap route (`tamatebako/ruby` `patches/*/dln_c_dlmap_msys.patch`, wired into every msys patch manifest) covers TODAY: the interpreter's own `dln_load`/`dln_open` (the require-of-extension path — the factory boot smoke's `load_native_extension` canary), Rule-L1 host passthrough, the ENOENT covered-not-held fall-through, and ruby-DLL import binding via the exe-directory layout (the release manifest's `install_as` PE name — single owner the factory's `RubyVersion#msys_dll_name`, assembled sha256-verified next to the exe by `crates/tebako-bootstrap`'s install; upstream `rb_w32_check_imported` gives the named ABI-line error).
- fiddle/ffi need materialize-then-load and do NOT get it: fiddle's `Fiddle.dlopen` is a `LoadLibrary` macro (`ext/fiddle/fiddle.h` in the interpreter's vendored source), ffi's `FFI::DynamicLibrary.open` is `LoadLibraryExA` (absolute paths with `LOAD_WITH_ALTERED_SEARCH_PATH`) — both bypass `dln.c`; a VFS path through either fails with the OS loader's own honest error 126.
- The raw-`LoadLibrary` edge cases, per case — covered ×4 / documented gap ×4 / named-error fix ×1:
  - covered: `dln_load` of a VFS extension; uncovered host path; covered-but-not-held (ENOENT → passthrough); extension importing the ruby DLL (exe-dir layout + named ABI error).
  - documented gaps: fiddle, ffi, C-extension self-loads, and sibling-DLL imports (two compounding layers — `crates/tfs` `exec_closure` parses Mach-O/ELF only, no PE import parsing; and plain `LoadLibraryW` does not search the loaded DLL's own directory, no `LOAD_WITH_ALTERED_SEARCH_PATH` in `dln_open`).
  - named error, phase-W fix: a failed materialization through `dln_open` raises `LoadError` WITHOUT the tebako verdict line (the v1-era `goto failed` wart); W2 delivers the §5 verdict line, matching the POSIX dlerror contract.
- Named and deliberately NOT settled (recorded so no leg happens silently): whether fiddle (vendored in the env image — a c_api route there is runtime-internal in the same sense the `dln.c` patch is) gains that route, while ffi (a third-party gem — the same move is per-gem code the spec's law forbids) and self-loads stay a permanent documented gap. A W2 decision, taken with the owner.

**`docs/windows-jail-proxy.md`** — the windows reading of spec 08 §2.1 + spec 23 (declarative/explicit, per the governing principle):

- Which host paths are proxied read-only on windows: the `%SystemRoot%\System32` / `SysWOW64` / `Fonts` floor, automatic under the deny default (implementation cited: `crates/tfs/src/policy.rs` `platform_floor()` + `HostPolicy::bind`; `%SystemRoot%` resolved at bind, absent paths skipped, supersede rule, ancestor traverse, re-derived per bind — never serialized into `TEBAKO_JAIL`).
- How a payload DECLARES additional paths: the spec-23 D1 `needs:` block (the only spelling; `capabilities.host` is a named rename error), symbolic atoms (`%USERPROFILE%`/`%TEMP%`/`$CWD`/`$TEBAKO_HOME`), and the record-mode discovery loop (`TEBAKO_JAIL=record` → `tfs needs --from-journal`).
- How the running configuration binds them: D2 composition / shim per-invocation resolution vs the bootstrap's press-baked D3 union, `TEBAKO_JAIL` export, the driver's `JailSpec` parse → `HostPolicy::bind` after the mounts, inheritance by spawned children — with the named errors at every boundary (EPERM/EROFS + audit journal, exit 73, the pre-exec needs-check failure, EINVAL cases).

## Sources pinned (evidence)

- `tamatebako/ruby` origin/main: `patches/{3.1,3.2,3.3,3.4,4.0}/dln_c_dlmap_msys.patch` (uniform across lines) and `patches/3.4/patch-3.4.yaml` (manifest wiring); `ci/spec22/README.md` (the POSIX class-L acceptance harness).
- `tamatebako/tebako-runtime-ruby`: `build/lib/tebako_runtime_builder/boot_smoke.rb` (`materialize_ruby_dll`), `boot_smoke/probe.rb` (`native_extension_check`), `.github/workflows/_build-platform.yml` (the PE-named-DLL groundwork).
- Product repo: `crates/tfs/src/context.rs` (`dlmap2file`/`extract_for_exec` — extraction writes are process-internal, not policy-gated), `crates/tfs/src/exec_closure.rs` (`parse()` = Mach-O or ELF — no PE), `crates/tfs/src/policy.rs` (`platform_floor`, `HostPolicy::bind`, `floor_mount_point`, `JailSpec`), `crates/tebako-bootstrap/src/lib.rs` (the dll facet install), `crates/tebako-driver/src/driver.rs` (`apply_jail` after the mounts, exit 73).
- Upstream: the ruby 3.4.8 tree's `ext/fiddle/fiddle.h` (the `LoadLibrary` macro); the ffi gem's `ext/ffi_c/DynamicLibrary.c` (`LoadLibraryExA` + `LOAD_WITH_ALTERED_SEARCH_PATH`).

Docs only — no code, no schema changes; `docs/spec/03-*` and `docs/spec/schemas/` are untouched (the parallel agent's lane).
