### PR TITLE
Spec 22 Phase R (R1+R2): declarative boot materialization

### DIFF
--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -1237,6 +1237,10 @@ fn synthesize_manifest(
         },
         provides,
         requires: Vec::new(),
+        // A synthesized mirror declares nothing to materialize — only an
+        // embedded manifest can (the store layout: the embedded manifest
+        // wins; the mirror is synthesized LOUDLY).
+        materialize: Vec::new(),
     })
 }
 

--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -6,7 +6,9 @@
 //! image's `/lib/tebako/layout.yaml`** (post-mount, before any
 //! interpreter handoff — exit 78) → mount each payload triple in order
 //! (bare files whole; package files by trailer region) → install
-//! the jail policy (after the mounts — spec 08 §3) → resolve and verify
+//! the jail policy (after the mounts — spec 08 §3) → materialize each
+//! mounted image's declared `materialize:` resources into the exec
+//! cache (spec 22 §4 class R) → resolve and verify
 //! the entry → rewrite argv. Any failure unmounts everything: never a
 //! partial mount.
 
@@ -110,7 +112,7 @@ impl Env for ProcessEnv {
     }
 }
 
-fn env_var(env: &dyn Env, key: &str) -> Option<String> {
+pub(crate) fn env_var(env: &dyn Env, key: &str) -> Option<String> {
     env.var(key).filter(|s| !s.is_empty())
 }
 
@@ -405,6 +407,28 @@ pub(crate) fn read_mounted_text(path: &str) -> Result<String, i32> {
     }
     ctx.close(fd)?;
     String::from_utf8(out).map_err(|_| libc::EINVAL)
+}
+
+/// The mounted image's own manifest, when readable: no manifest
+/// declares nothing (plain images mount fine); a corrupt one is the
+/// image lying about its self-description — a named 65. Shared by the
+/// path_env bin-dir export (spec 22 §3.2) and the class-R
+/// materialization (spec 22 §4).
+pub(crate) fn mounted_manifest_at(
+    mount: &str,
+) -> Result<Option<tpkg::PayloadManifest>, DriverError> {
+    let path = join_mount(mount, tpkg::PAYLOAD_MANIFEST_PATH);
+    let Ok(text) = read_mounted_text(&path) else {
+        return Ok(None);
+    };
+    tpkg::PayloadManifest::from_yaml(&text)
+        .map(Some)
+        .map_err(|e| {
+            manifest(format!(
+                "corrupt {} in the image mounted at '{mount}' ({e}) — the payload's self-description lies",
+                tpkg::PAYLOAD_MANIFEST_PATH
+            ))
+        })
 }
 
 /// The env-image layout check (spec 18 C3): after the env image mounts
@@ -735,6 +759,9 @@ pub fn boot_with_mount_modes(
             mount_env_image(env, runtime_root, &mut mounted)?;
             let declaration = check_env_layout(env, baked_root, runtime_root)?;
             apply_jail(env)?;
+            // The env image's own declared resources materialize before
+            // the interpreter runs (spec 22 §4 class R — the cert case).
+            crate::materialize::extract(&h.images, env, runtime_root)?;
             // The standalone interpreter spawns too — arm its children
             // the same way (spec 22 §3).
             crate::injection::export(env, declaration.as_ref(), runtime_root)?;
@@ -758,6 +785,10 @@ pub fn boot_with_mount_modes(
             mount_image(spec, &mut mounted, modes)?;
         }
         apply_jail(env)?;
+        // Declared resources land in the exec cache after the mounts and
+        // the jail, before any handoff (spec 22 §4 class R — Rule R3
+        // fails the boot by name).
+        crate::materialize::extract(&h.images, env, runtime_root)?;
         // The mounts are established — publish the discovery surface
         // (spec 22 §6; v2-1/20), arm the children (spec 22 §3), and wire
         // the dependency bins onto PATH (spec 22 §3.2 — the launcher

--- a/crates/tebako-driver/src/lib.rs
+++ b/crates/tebako-driver/src/lib.rs
@@ -35,6 +35,7 @@ pub mod ffi;
 pub mod handoff;
 pub mod injection;
 pub mod layout;
+pub mod materialize;
 pub mod path_env;
 
 pub use driver::{
@@ -52,6 +53,9 @@ pub const TEBAKO_CONTRACT_VERSION: u32 = 2;
 // The loader's named exit codes (spec 06 §4) the driver reports with.
 pub(crate) const EX_TEBAKO_MANIFEST: i32 = 65;
 pub(crate) const EX_TEBAKO_UNAVAILABLE: i32 = 69;
+// spec 06 §4's sha256-mismatch code — the driver's class-R verification
+// failure (a tampered/corrupt materialized copy; spec 22 §4 Rule R3).
+pub(crate) const EX_TEBAKO_SHA: i32 = 70;
 pub(crate) const EX_TEBAKO_JAIL: i32 = 73;
 pub(crate) const EX_TEBAKO_IO: i32 = 74;
 // spec 18 §7: the env-image layout check (C3) — the driver's own code,

--- a/crates/tebako-driver/src/materialize.rs
+++ b/crates/tebako-driver/src/materialize.rs
@@ -1,0 +1,428 @@
+//! Declarative boot materialization (spec 22 §4 class R): an image's
+//! manifest MAY declare `materialize: [paths]` — absolute in-image paths
+//! of regular files a C library must read through its OWN IO (the
+//! OpenSSL CA cert is the canonical entry: the path must exist on the
+//! host, the interpreter's patched IO never gets asked). The driver
+//! extracts the declared paths after the mounts are established, before
+//! the interpreter handoff — in both boot shapes (the standalone
+//! env-image boot and the `--tebako-image` grammar).
+//!
+//! Each declared path `P` lands at
+//! `<TEBAKO_EXEC_CACHE>/resources/<image-key>/<P>` (the §6 convention):
+//! the exec cache is the namespace every materialization of this boot
+//! shares, and the image key is the same segregation idiom as the
+//! cache root itself (the store sidecar's sha prefix, else the path key
+//! — exec_cache.rs). The copy is whole-file, read-only, and verified
+//! (Rule R3):
+//!
+//! - **Extraction** streams the mounted file to a per-process `part`
+//!   staging file, hashing in flight with the tfs-merkle-1 file
+//!   construction (`tpkg::merkle::FileHasher`), then re-reads the staged
+//!   copy and refuses to install a copy that does not hash to the bytes
+//!   the image served (exit 70). The digest record
+//!   (`<P>.tfs-digest`) is renamed into place BEFORE the content file,
+//!   so a crash never leaves content without its record — and content
+//!   without a record is foreign by construction.
+//! - **Reuse** (the write-once case): an earlier boot's copy is served
+//!   only after it re-hashes to its recorded digest. A mismatch, a
+//!   missing record, or a corrupt record is the cache tampered or
+//!   corrupt — a named 70 (`EX_TEBAKO_SHA`, spec 06 §4's mismatch code),
+//!   never a silently served corruption. The digest's trust chains to
+//!   the image itself: verification of the image happens at
+//!   fetch/install (spec 09), the record pins the cache copy to what
+//!   the image served, and the per-boot rehash pins the copy to the
+//!   record.
+//! - A declared path absent from the image, or not a regular file, is
+//!   the manifest lying — a named 65 (`EX_TEBAKO_MANIFEST`), never a
+//!   skipped entry.
+//!
+//! Concurrent boots of one image race benignly: both stage distinct
+//! `part` files and rename identical content (the image determines the
+//! bytes), so the last rename wins with the same bytes. The namespace
+//! is persistent across boots; stale `part` files are tmp-domain litter
+//! the OS reaps.
+
+use std::path::{Path, PathBuf};
+
+use tfs::context::context;
+use tpkg::merkle::MerkleDigest;
+
+use crate::driver::{env_var, errno_text, join_mount, DriverError, Env};
+use crate::handoff::{ImageSource, ImageSpec};
+use crate::{EX_TEBAKO_IO, EX_TEBAKO_MANIFEST, EX_TEBAKO_SHA};
+
+/// The digest record's suffix next to an extracted file (cache
+/// bookkeeping — not a consumption path; spec 22 §6).
+const RECORD_SUFFIX: &str = ".tfs-digest";
+
+fn manifest(message: impl Into<String>) -> DriverError {
+    DriverError::new(EX_TEBAKO_MANIFEST, message.into())
+}
+
+fn sha(message: impl Into<String>) -> DriverError {
+    DriverError::new(EX_TEBAKO_SHA, message.into())
+}
+
+fn io(message: impl Into<String>) -> DriverError {
+    DriverError::new(EX_TEBAKO_IO, message.into())
+}
+
+/// Materialize every mounted image's declared `materialize:` paths (see
+/// the module doc). Called per boot after the mounts and the jail,
+/// before the interpreter handoff. The env image's own declarations
+/// come first (the runtime's resources — the cert case), then each
+/// payload triple's in order.
+pub fn extract(images: &[ImageSpec], env: &dyn Env, runtime_root: &str) -> Result<(), DriverError> {
+    let Some(cache) = env_var(env, crate::exec_cache::VAR) else {
+        // Unreachable through boot() — exec_cache::export runs first on
+        // both paths — but the surface is contractual, never assumed.
+        return Err(io(format!(
+            "{} is not exported — the exec-cache export runs before materialization at boot",
+            crate::exec_cache::VAR
+        )));
+    };
+    if let Some(image) = env_var(env, "TEBAKO_RUNTIME_IMAGE") {
+        extract_image(&cache, Path::new(&image), runtime_root)?;
+    }
+    for spec in images {
+        let host = match &spec.source {
+            ImageSource::File(path, _) => path.clone(),
+            ImageSource::OwnSlot(_) => std::env::current_exe()
+                .map_err(|e| io(format!("cannot determine own executable path: {e}")))?,
+        };
+        extract_image(&cache, &host, &spec.mount)?;
+    }
+    Ok(())
+}
+
+/// One mounted image's declarations. No manifest declares nothing
+/// (plain images mount fine — the pre-manifest era and the boot-smoke
+/// fixture case); a corrupt one is the image lying about its
+/// self-description (the shared named 65).
+fn extract_image(cache: &str, image: &Path, mount: &str) -> Result<(), DriverError> {
+    let Some(manifest) = crate::driver::mounted_manifest_at(mount)? else {
+        return Ok(());
+    };
+    if manifest.materialize.is_empty() {
+        return Ok(());
+    }
+    let dir = Path::new(cache)
+        .join("resources")
+        .join(crate::exec_cache::image_key(image));
+    for declared in &manifest.materialize {
+        extract_one(&dir, mount, declared)?;
+    }
+    Ok(())
+}
+
+/// The record path of an extraction target (`<target>.tfs-digest`).
+fn record_path(target: &Path) -> PathBuf {
+    let mut p = target.as_os_str().to_os_string();
+    p.push(RECORD_SUFFIX);
+    PathBuf::from(p)
+}
+
+/// The merkle file digest of a host file, streamed.
+fn hash_host_file(path: &Path) -> Result<MerkleDigest, DriverError> {
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| io(format!("cannot read '{}': {e}", path.display())))?;
+    let mut hasher = tpkg::merkle::FileHasher::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = std::io::Read::read(&mut file, &mut buf)
+            .map_err(|e| io(format!("cannot read '{}': {e}", path.display())))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hasher.finish())
+}
+
+/// Stream one mounted regular file to a staging file, hashing in
+/// flight; the returned digest commits the bytes the image served.
+fn stream_out(vfs: &str, tmp: &Path) -> Result<MerkleDigest, DriverError> {
+    let mut ctx = context().write().unwrap();
+    let fd = ctx.open(vfs, libc::O_RDONLY).map_err(|e| {
+        io(format!(
+            "cannot read '{vfs}' from the mounted image: {}",
+            errno_text(e)
+        ))
+    })?;
+    let result = (|| {
+        let mut out = std::fs::File::create(tmp)
+            .map_err(|e| io(format!("cannot stage '{}': {e}", tmp.display())))?;
+        let mut hasher = tpkg::merkle::FileHasher::new();
+        let mut buf = [0u8; 64 * 1024];
+        loop {
+            let n = ctx.read(fd, &mut buf).map_err(|e| {
+                io(format!(
+                    "cannot read '{vfs}' from the mounted image: {}",
+                    errno_text(e)
+                ))
+            })?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+            std::io::Write::write_all(&mut out, &buf[..n])
+                .map_err(|e| io(format!("cannot stage '{}': {e}", tmp.display())))?;
+        }
+        Ok(hasher.finish())
+    })();
+    let _ = ctx.close(fd);
+    result
+}
+
+/// Extract one declared path: whole-file, read-only, verified (the
+/// module doc's protocol). `dir` is the image's resources namespace.
+fn extract_one(dir: &Path, mount: &str, declared: &str) -> Result<(), DriverError> {
+    let vfs = join_mount(mount, declared);
+    // Whole files only: a declared-but-absent or non-file path is the
+    // manifest lying (Rule R3) — a named 65, never a skipped entry.
+    let stat = context().read().unwrap().stat(&vfs).map_err(|e| {
+        if e == libc::ENOENT {
+            manifest(format!(
+                "the image mounted at '{mount}' declares materialize '{declared}' but '{vfs}' is absent from the image — the payload's self-description lies"
+            ))
+        } else {
+            io(format!("cannot stat '{vfs}' in the mounted image: {}", errno_text(e)))
+        }
+    })?;
+    if stat.entry_type != tfs::EntryType::File {
+        return Err(manifest(format!(
+            "the image mounted at '{mount}' declares materialize '{declared}' but '{vfs}' is not a regular file (materialize lists whole files) — the payload's self-description lies"
+        )));
+    }
+    // The manifest grammar (validated at parse: absolute, no '..'
+    // components) makes this join namespace-safe by construction.
+    let target = dir.join(declared.trim_start_matches('/'));
+    if target.exists() {
+        return verify_recorded(&target, dir, declared);
+    }
+    let parent = target.parent().ok_or_else(|| {
+        io(format!(
+            "the materialization target '{}' has no parent directory",
+            target.display()
+        ))
+    })?;
+    std::fs::create_dir_all(parent).map_err(|e| {
+        io(format!(
+            "cannot create the resources dir '{}': {e}",
+            parent.display()
+        ))
+    })?;
+    let tmp = parent.join(format!(
+        ".{}.part-{}",
+        target
+            .file_name()
+            .map(|n| n.to_string_lossy())
+            .unwrap_or_default(),
+        std::process::id()
+    ));
+    let served = stream_out(&vfs, &tmp)?;
+    // The staged copy must carry exactly the bytes the image served —
+    // the record describes the copy, or the boot never installs it.
+    if hash_host_file(&tmp)? != served {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(sha(format!(
+            "the staged copy of '{declared}' does not match the bytes the image served — extraction is not faithful"
+        )));
+    }
+    // The record lands FIRST: content without a record is then foreign
+    // by construction (a crash between the renames leaves a harmless
+    // record-only state the next extraction overwrites).
+    let record = format!("{}\n", tpkg::merkle::render_tree_hash(&served));
+    let record_tmp = parent.join(format!(
+        ".{}{RECORD_SUFFIX}.part-{}",
+        target
+            .file_name()
+            .map(|n| n.to_string_lossy())
+            .unwrap_or_default(),
+        std::process::id()
+    ));
+    std::fs::write(&record_tmp, &record).map_err(|e| {
+        io(format!(
+            "cannot stage the digest record '{}': {e}",
+            record_tmp.display()
+        ))
+    })?;
+    std::fs::rename(&record_tmp, record_path(&target)).map_err(|e| {
+        io(format!(
+            "cannot install the digest record for '{}': {e}",
+            target.display()
+        ))
+    })?;
+    std::fs::rename(&tmp, &target).map_err(|e| {
+        io(format!(
+            "cannot install the materialized '{}': {e}",
+            target.display()
+        ))
+    })?;
+    // Rule R3: read-only. After the rename so the staging writes never
+    // race the attribute.
+    let mut perms = std::fs::metadata(&target)
+        .map_err(|e| {
+            io(format!(
+                "cannot stat the materialized '{}': {e}",
+                target.display()
+            ))
+        })?
+        .permissions();
+    perms.set_readonly(true);
+    std::fs::set_permissions(&target, perms).map_err(|e| {
+        io(format!(
+            "cannot make the materialized '{}' read-only: {e}",
+            target.display()
+        ))
+    })?;
+    tebako_log::log!(
+        tebako_log::Level::Debug,
+        "driver",
+        "materialized declared={declared} at={}",
+        target.display()
+    );
+    Ok(())
+}
+
+/// The write-once case: serve an earlier boot's copy only after it
+/// re-hashes to its recorded digest. Anything else — a missing/corrupt
+/// record, foreign content, a hash mismatch — is the cache tampered or
+/// corrupt: a named 70, never a silently served corruption.
+fn verify_recorded(target: &Path, dir: &Path, declared: &str) -> Result<(), DriverError> {
+    if !target.is_file() {
+        return Err(sha(format!(
+            "the materialized '{declared}' in the exec cache is not a regular file — the cache is tampered or corrupt; remove '{}' to force re-extraction",
+            dir.display()
+        )));
+    }
+    let Ok(record) = std::fs::read_to_string(record_path(target)) else {
+        return Err(sha(format!(
+            "the materialized '{declared}' in the exec cache carries no digest record — refusing to serve unverified content; remove '{}' to force re-extraction",
+            dir.display()
+        )));
+    };
+    let Some(want) = tpkg::merkle::parse_tree_hash(record.trim()) else {
+        return Err(sha(format!(
+            "the digest record of '{declared}' in the exec cache is corrupt — remove '{}' to force re-extraction",
+            dir.display()
+        )));
+    };
+    let got = hash_host_file(target)?;
+    if got != want {
+        return Err(sha(format!(
+            "the materialized '{declared}' in the exec cache fails verification against its recorded digest — the cache is tampered or corrupt; remove '{}' to force re-extraction",
+            dir.display()
+        )));
+    }
+    tebako_log::log!(
+        tebako_log::Level::Debug,
+        "driver",
+        "materialize cache hit declared={declared} at={}",
+        target.display()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    fn temp(tag: &str) -> PathBuf {
+        let uniq = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "tebako-driver-materialize-{tag}-{}-{uniq}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    struct MapEnv(RefCell<HashMap<String, String>>);
+
+    impl Env for MapEnv {
+        fn var(&self, key: &str) -> Option<String> {
+            self.0.borrow().get(key).cloned()
+        }
+        fn set_var(&self, key: &str, value: &str) {
+            self.0
+                .borrow_mut()
+                .insert(key.to_string(), value.to_string());
+        }
+    }
+
+    #[test]
+    fn the_record_path_appends_its_suffix() {
+        assert_eq!(
+            record_path(Path::new("/r/lib/cacert.pem")),
+            Path::new("/r/lib/cacert.pem.tfs-digest")
+        );
+        // A suffix-less name gains one; an existing extension is kept.
+        assert_eq!(
+            record_path(Path::new("/r/ICUDATA")),
+            Path::new("/r/ICUDATA.tfs-digest")
+        );
+    }
+
+    #[test]
+    fn the_record_round_trips_and_detects_tampering() {
+        let dir = temp("record");
+        let target = dir.join("cert.pem");
+        std::fs::write(&target, b"CERT\n").unwrap();
+        let digest = hash_host_file(&target).unwrap();
+        std::fs::write(
+            record_path(&target),
+            format!("{}\n", tpkg::merkle::render_tree_hash(&digest)),
+        )
+        .unwrap();
+        // A faithful copy with its record verifies.
+        verify_recorded(&target, &dir, "/cert.pem").unwrap();
+        // A tampered copy fails verification by name (70).
+        std::fs::write(&target, b"FORGED\n").unwrap();
+        let err = verify_recorded(&target, &dir, "/cert.pem").unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_SHA, "{}", err.message);
+        assert!(err.message.contains("/cert.pem"), "{}", err.message);
+        // A corrupt record is the same family.
+        std::fs::write(record_path(&target), b"not a digest\n").unwrap();
+        let err = verify_recorded(&target, &dir, "/cert.pem").unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_SHA, "{}", err.message);
+        // Content without a record is foreign — never served.
+        std::fs::remove_file(record_path(&target)).unwrap();
+        let err = verify_recorded(&target, &dir, "/cert.pem").unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_SHA, "{}", err.message);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn extract_without_the_exec_cache_export_is_a_named_error() {
+        // boot() always exports first; the surface is contractual.
+        let env = MapEnv(RefCell::new(HashMap::new()));
+        let err = extract(&[], &env, "/__tfs__").unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_IO, "{}", err.message);
+        assert!(
+            err.message.contains(crate::exec_cache::VAR),
+            "{}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn extract_without_declarations_creates_nothing() {
+        let dir = temp("no-decl");
+        let env = MapEnv(RefCell::new(HashMap::from([(
+            crate::exec_cache::VAR.to_string(),
+            dir.to_string_lossy().into_owned(),
+        )])));
+        // No env image, no payload images: nothing to consult, nothing
+        // created.
+        extract(&[], &env, "/__tfs__").unwrap();
+        assert!(!dir.join("resources").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/tebako-driver/src/path_env.rs
+++ b/crates/tebako-driver/src/path_env.rs
@@ -35,14 +35,14 @@ use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
-use crate::driver::{join_mount, read_mounted_text, DriverError, Env};
+use crate::driver::{join_mount, mounted_manifest_at, DriverError, Env};
 use crate::handoff::ImageSpec;
 #[cfg(unix)]
 use crate::EX_TEBAKO_IO;
 use crate::EX_TEBAKO_MANIFEST;
 #[cfg(unix)]
 use tfs::context::context;
-use tpkg::{PayloadManifest, Provides, PAYLOAD_MANIFEST_PATH};
+use tpkg::{PayloadManifest, Provides};
 
 /// Prepend the dependency mounts' declared bin dirs to `PATH` — led by
 /// the launcher dir when the shim was delivered (`shim_host`, unix).
@@ -58,7 +58,7 @@ pub fn export(
     // tier where one is delivered.
     let mut deps: Vec<(String, PayloadManifest)> = Vec::new();
     for spec in images.iter().skip(1) {
-        if let Some(manifest) = mounted_manifest(spec)? {
+        if let Some(manifest) = mounted_manifest_at(&spec.mount)? {
             deps.push((spec.mount.clone(), manifest));
         }
     }
@@ -100,25 +100,6 @@ fn compose(existing: Option<String>, dirs: &[String]) -> Result<Option<OsString>
         DriverError::new(
             EX_TEBAKO_MANIFEST,
             format!("cannot prepend the dependency bin dirs to PATH: {e}"),
-        )
-    })
-}
-
-/// The mounted image's own manifest, when readable (see the module
-/// doc): no manifest declares no bins; a corrupt one is the image lying
-/// about its self-description — a named 65.
-fn mounted_manifest(spec: &ImageSpec) -> Result<Option<PayloadManifest>, DriverError> {
-    let path = join_mount(&spec.mount, PAYLOAD_MANIFEST_PATH);
-    let Ok(text) = read_mounted_text(&path) else {
-        return Ok(None);
-    };
-    PayloadManifest::from_yaml(&text).map(Some).map_err(|e| {
-        DriverError::new(
-            EX_TEBAKO_MANIFEST,
-            format!(
-                "corrupt {PAYLOAD_MANIFEST_PATH} in the image mounted at '{}' ({e}) — the payload's self-description lies",
-                spec.mount
-            ),
         )
     })
 }

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -2156,9 +2156,20 @@ fn a_tampered_extracted_resource_fails_verification() {
     // Tamper with the cached copy: the next boot's verification fails
     // closed (Rule R3) — never a silently served corruption.
     let extracted = resources.join("lib/app.pem");
-    let mut perms = std::fs::metadata(&extracted).unwrap().permissions();
-    perms.set_readonly(false);
-    std::fs::set_permissions(&extracted, perms).unwrap();
+    // Make the read-only-extracted copy writable: an explicit mode on
+    // unix, the readonly attribute on windows.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&extracted, std::fs::Permissions::from_mode(0o644)).unwrap();
+    }
+    #[cfg(windows)]
+    {
+        let mut perms = std::fs::metadata(&extracted).unwrap().permissions();
+        #[allow(clippy::permissions_set_readonly_false)]
+        perms.set_readonly(false);
+        std::fs::set_permissions(&extracted, perms).unwrap();
+    }
     std::fs::write(&extracted, b"PEM-FORGED\n").unwrap();
 
     reset();

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -1801,3 +1801,386 @@ fn a_launcher_re_arms_the_injection_and_execs_the_target() {
         String::from_utf8_lossy(&out.stderr)
     );
 }
+
+// ---------------------------------------------------------------------
+// spec 22 §4 class R: declarative boot materialization
+// ---------------------------------------------------------------------
+
+/// A runtime-kind in-image manifest declaring `materialize` (the env
+/// image's own resource declaration — the cert case).
+fn runtime_manifest(materialize: &[&str]) -> String {
+    let list: String = materialize.iter().map(|p| format!("  - {p}\n")).collect();
+    format!(
+        "identity:\n  schema_version: 1\n  kind: runtime\n  name: rt\n  version: \"1\"\n  \
+         producer: {{tool: t, tool_version: \"1\"}}\n  created: \"2026-08-14T00:00:00Z\"\n  \
+         digest: {{tree_hash: sha256:{z}, blob_sha256: {z}}}\n  \
+         signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+         provides:\n  provides: {{engine: ruby, version: 4.0.6, abi_line: \"4.0\", platform: aarch64-macos}}\n  \
+         built_from: {{src_sha256: {z}, patch_set: v0}}\n  capabilities: {{exec: true, read: true, runtime: true}}\n\
+         materialize:\n{list}",
+        z = "0".repeat(64)
+    )
+}
+
+/// An app-kind in-image manifest declaring `materialize` (a payload's
+/// own resource declaration).
+fn app_manifest(materialize: &[&str]) -> String {
+    let list: String = materialize.iter().map(|p| format!("  - {p}\n")).collect();
+    format!(
+        "identity:\n  schema_version: 1\n  kind: app\n  name: app\n  version: \"1\"\n  \
+         producer: {{tool: t, tool_version: \"1\"}}\n  created: \"2026-08-14T00:00:00Z\"\n  \
+         digest: {{tree_hash: sha256:{z}, blob_sha256: {z}}}\n  \
+         signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+         provides:\n  entrypoints: [{{name: app, path: /bin/app}}]\n  \
+         platforms: universal\n  capabilities: {{exec: true, read: true}}\n\
+         materialize:\n{list}",
+        z = "0".repeat(64)
+    )
+}
+
+/// The env-image fixture carrying a manifest that declares the cert
+/// resource (spec 22 §4: the image-OWNED default — R2's cert case).
+fn write_env_image_with_resource(dir: &Path, cert: &[u8]) -> PathBuf {
+    let p = dir.join("runtime.tfs");
+    build_zip(
+        &p,
+        &["lib/", "lib/ruby/", "lib/tebako/", "__tpkg__/"],
+        &[
+            ("lib/ruby/rubygems.rb", b"# rubygems core\n".as_slice()),
+            ("lib/tebako/layout.yaml", GOOD_LAYOUT.as_bytes()),
+            ("lib/tebako/cacert.pem", cert),
+            (
+                "__tpkg__/manifest.yaml",
+                runtime_manifest(&["/lib/tebako/cacert.pem"]).as_bytes(),
+            ),
+        ],
+    );
+    p
+}
+
+/// A payload fixture carrying a manifest that declares one resource.
+fn write_payload_image_with_resource(dir: &Path, resource: &[u8]) -> PathBuf {
+    let p = dir.join("payload.tfs");
+    build_zip(
+        &p,
+        &["bin/", "lib/", "__tpkg__/"],
+        &[
+            ("bin/app", b"#!/usr/bin/env ruby\nputs 'hi'\n".as_slice()),
+            ("lib/app.pem", resource),
+            (
+                "__tpkg__/manifest.yaml",
+                app_manifest(&["/lib/app.pem"]).as_bytes(),
+            ),
+        ],
+    );
+    p
+}
+
+/// The resources namespace one boot of `image` extracts into
+/// (`<TEBAKO_EXEC_CACHE>/resources/<image-key>`, spec 22 §6) — computed
+/// pre-boot so the test can reset the write-once cache between runs.
+fn resources_dir(image: &Path, env_image: Option<&Path>) -> PathBuf {
+    let root_key = env_image
+        .map(tebako_driver::exec_cache::image_key)
+        .unwrap_or_else(|| "host".to_string());
+    tebako_driver::exec_cache::root_for(&std::env::temp_dir(), &root_key)
+        .join("resources")
+        .join(tebako_driver::exec_cache::image_key(image))
+}
+
+#[test]
+fn boot_materializes_a_declared_env_image_resource() {
+    let g = guard("mat-env");
+    let cert = b"CERT-A\n";
+    let env_image = write_env_image_with_resource(g.path(), cert);
+    write_sidecar(&env_image, &"ca".repeat(32));
+    let resources = resources_dir(&env_image, Some(&env_image));
+    let _ = std::fs::remove_dir_all(&resources);
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    boot(&argv(&["ruby", "--version"]), "/__tfs__", &env).unwrap();
+
+    // The declared path lands at <exec-cache>/resources/<image-key>/<P>,
+    // read-only (Rule R3), content-exact.
+    let extracted = resources.join("lib/tebako/cacert.pem");
+    assert_eq!(std::fs::read(&extracted).unwrap(), cert);
+    assert!(
+        std::fs::metadata(&extracted)
+            .unwrap()
+            .permissions()
+            .readonly(),
+        "the materialized resource is read-only"
+    );
+    // The recorded digest pins the extraction to the bytes the image
+    // served (the tfs-merkle-1 file value).
+    let recorded = std::fs::read_to_string(resources.join("lib/tebako/cacert.pem.tfs-digest"))
+        .expect("the digest record rides alongside");
+    let mut h = tpkg::merkle::FileHasher::new();
+    h.update(cert);
+    assert_eq!(recorded.trim(), tpkg::merkle::render_tree_hash(&h.finish()));
+    // The mount stays live — materialization is additive, never a move.
+    assert_eq!(read_file("/__tfs__/lib/tebako/cacert.pem"), cert);
+    let _ = std::fs::remove_dir_all(&resources);
+}
+
+#[test]
+fn boot_materializes_a_declared_payload_resource() {
+    let g = guard("mat-payload");
+    let payload = write_payload_image_with_resource(g.path(), b"PAYLOAD-PEM\n");
+    let resources = resources_dir(&payload, None);
+    let _ = std::fs::remove_dir_all(&resources);
+    let env = MapEnv::new();
+
+    let out = boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:0:/", payload.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap();
+
+    assert_eq!(out.argv, argv(&["ruby", "/bin/app"]));
+    let extracted = resources.join("lib/app.pem");
+    assert_eq!(std::fs::read(&extracted).unwrap(), b"PAYLOAD-PEM\n");
+    let _ = std::fs::remove_dir_all(&resources);
+}
+
+#[test]
+fn a_listed_but_absent_path_is_a_named_boot_error() {
+    let g = guard("mat-absent");
+    // The manifest declares a path the image does not carry — the
+    // manifest lied (Rule R3), never a skipped entry.
+    let payload = {
+        let p = g.path().join("payload.tfs");
+        build_zip(
+            &p,
+            &["bin/", "__tpkg__/"],
+            &[
+                ("bin/app", b"#!/usr/bin/env ruby\n".as_slice()),
+                (
+                    "__tpkg__/manifest.yaml",
+                    app_manifest(&["/lib/missing.pem"]).as_bytes(),
+                ),
+            ],
+        );
+        p
+    };
+    let env = MapEnv::new();
+
+    let err = boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:0:/", payload.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{}", err.message);
+    assert!(err.message.contains("/lib/missing.pem"), "{}", err.message);
+    assert!(
+        err.message.contains("self-description lies"),
+        "{}",
+        err.message
+    );
+    assert!(
+        !context().read().unwrap().is_mounted(),
+        "the refusal unmounts everything"
+    );
+}
+
+#[test]
+fn a_listed_directory_is_a_named_boot_error() {
+    let g = guard("mat-dir");
+    // Rule R3 is whole-FILE: a listed directory is out of grammar.
+    let payload = {
+        let p = g.path().join("payload.tfs");
+        build_zip(
+            &p,
+            &["bin/", "lib/", "__tpkg__/"],
+            &[
+                ("bin/app", b"#!/usr/bin/env ruby\n".as_slice()),
+                ("lib/app.rb", b"# app\n".as_slice()),
+                ("__tpkg__/manifest.yaml", app_manifest(&["/lib"]).as_bytes()),
+            ],
+        );
+        p
+    };
+    let env = MapEnv::new();
+
+    let err = boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:0:/", payload.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{}", err.message);
+    assert!(
+        err.message.contains("not a regular file"),
+        "{}",
+        err.message
+    );
+}
+
+#[test]
+fn a_materialize_escape_path_is_a_named_error() {
+    let g = guard("mat-escape");
+    // '..' would escape the resources namespace on the host — the
+    // manifest fails validation, so the image's self-description is
+    // corrupt by definition (the driver's named 65).
+    let payload = {
+        let p = g.path().join("payload.tfs");
+        build_zip(
+            &p,
+            &["bin/", "__tpkg__/"],
+            &[
+                ("bin/app", b"#!/usr/bin/env ruby\n".as_slice()),
+                (
+                    "__tpkg__/manifest.yaml",
+                    app_manifest(&["/../../host/x"]).as_bytes(),
+                ),
+            ],
+        );
+        p
+    };
+    let env = MapEnv::new();
+
+    let err = boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:0:/", payload.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{}", err.message);
+    assert!(
+        err.message.contains("self-description lies"),
+        "{}",
+        err.message
+    );
+}
+
+#[test]
+fn a_second_boot_serves_the_verified_write_once_cache() {
+    let g = guard("mat-writeonce");
+    let payload = write_payload_image_with_resource(g.path(), b"PEM-ONE\n");
+    write_sidecar(&payload, &"ef".repeat(32));
+    let resources = resources_dir(&payload, None);
+    let _ = std::fs::remove_dir_all(&resources);
+    let env = MapEnv::new();
+
+    boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:0:/", payload.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap();
+    let extracted = resources.join("lib/app.pem");
+    assert_eq!(std::fs::read(&extracted).unwrap(), b"PEM-ONE\n");
+
+    // Rebuild the image at the same path with DIFFERENT content under
+    // the same sidecar key: the write-once namespace serves the verified
+    // first extraction (the store's content key is the production
+    // segregation; a fixed path key is the documented dev-boot caveat —
+    // exec_cache.rs).
+    write_payload_image_with_resource(g.path(), b"PEM-TWO\n");
+    reset();
+    let env = MapEnv::new();
+    boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:0:/", payload.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap();
+    assert_eq!(
+        std::fs::read(&extracted).unwrap(),
+        b"PEM-ONE\n",
+        "write-once: the verified cache is served, never re-extracted under one key"
+    );
+    let _ = std::fs::remove_dir_all(&resources);
+}
+
+#[test]
+fn a_tampered_extracted_resource_fails_verification() {
+    let g = guard("mat-tamper");
+    let payload = write_payload_image_with_resource(g.path(), b"PEM-ONE\n");
+    write_sidecar(&payload, &"ad".repeat(32));
+    let resources = resources_dir(&payload, None);
+    let _ = std::fs::remove_dir_all(&resources);
+    let env = MapEnv::new();
+    boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:0:/", payload.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap();
+
+    // Tamper with the cached copy: the next boot's verification fails
+    // closed (Rule R3) — never a silently served corruption.
+    let extracted = resources.join("lib/app.pem");
+    let mut perms = std::fs::metadata(&extracted).unwrap().permissions();
+    perms.set_readonly(false);
+    std::fs::set_permissions(&extracted, perms).unwrap();
+    std::fs::write(&extracted, b"PEM-FORGED\n").unwrap();
+
+    reset();
+    let env = MapEnv::new();
+    let err = boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:0:/", payload.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 70, "{}", err.message);
+    assert!(err.message.contains("/lib/app.pem"), "{}", err.message);
+    assert!(err.message.contains("verification"), "{}", err.message);
+    assert!(
+        !context().read().unwrap().is_mounted(),
+        "the refusal unmounts everything"
+    );
+    let _ = std::fs::remove_dir_all(&resources);
+}

--- a/crates/tebako-info/src/manifest_json.rs
+++ b/crates/tebako-info/src/manifest_json.rs
@@ -397,6 +397,12 @@ pub fn manifest_to_json(m: &PayloadManifest) -> Json {
             Json::Array(m.requires.iter().map(requirement_json).collect()),
         ));
     }
+    if !m.materialize.is_empty() {
+        out.push((
+            "materialize".to_string(),
+            Json::Array(m.materialize.iter().map(|p| s(p)).collect()),
+        ));
+    }
     Json::Object(out)
 }
 
@@ -524,6 +530,24 @@ mod tests {
                 .unwrap(),
             &Json::Bool(true)
         );
+    }
+
+    #[test]
+    fn materialize_maps_to_json_when_present() {
+        // spec 22 §4 class R (schema_minor 1): the additive key renders
+        // 1:1 when declared and stays absent otherwise.
+        let mut m = fixture();
+        m.materialize = vec!["/lib/tebako/cacert.pem".to_string()];
+        let j = manifest_to_json(&m);
+        let Json::Array(paths) = j.find("materialize").unwrap() else {
+            panic!("materialize must be an array");
+        };
+        assert_eq!(paths.len(), 1);
+        assert_eq!(
+            paths[0].as_string().as_deref(),
+            Some("/lib/tebako/cacert.pem")
+        );
+        assert!(manifest_to_json(&fixture()).find("materialize").is_none());
     }
 
     #[test]

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -173,7 +173,9 @@ pub use manifest::{
     SigningState, Source, ToolkitExecutable, ToolkitLibrary, ToolkitProvides,
     PAYLOAD_MANIFEST_PATH, PAYLOAD_SCHEMA_VERSION,
 };
-pub use merkle::{render_tree_hash, tree_digest, Child, MerkleDigest, NodeKind, TreeWalk};
+pub use merkle::{
+    render_tree_hash, tree_digest, Child, FileHasher, MerkleDigest, NodeKind, TreeWalk,
+};
 pub use model::{Manifest, Slot, V2Extension};
 pub use package::{
     MountMode, PackageEntry, PackageIdentity, PackageManifest, PackageManifestError, PackageMount,

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -1123,6 +1123,14 @@ pub struct PayloadManifest {
     pub provides: Provides,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requires: Vec<Requirement>,
+    /// The spec-22 §4 class-R boot materialization list (additive —
+    /// schema_minor 1; old readers ignore it, new readers enforce):
+    /// absolute in-image paths of regular files the driver extracts to
+    /// the exec cache after the mounts, before the interpreter handoff.
+    /// Any kind may declare it (the runtime env image's own resource
+    /// default is the canonical entry). Absent = nothing to materialize.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub materialize: Vec<String>,
 }
 
 impl<'de> Deserialize<'de> for PayloadManifest {
@@ -1133,6 +1141,8 @@ impl<'de> Deserialize<'de> for PayloadManifest {
             provides: serde_yml::Value,
             #[serde(default)]
             requires: Vec<Requirement>,
+            #[serde(default)]
+            materialize: Vec<String>,
         }
         let raw = Raw::deserialize(d)?;
         let provides = match raw.identity.kind {
@@ -1157,6 +1167,7 @@ impl<'de> Deserialize<'de> for PayloadManifest {
             identity: raw.identity,
             provides,
             requires: raw.requires,
+            materialize: raw.materialize,
         })
     }
 }
@@ -1178,7 +1189,8 @@ impl PayloadManifest {
     /// Semantic checks beyond the serde structure: schema version,
     /// kind ↔ provides binding, the locked capability truth tables,
     /// digest/keyid shapes, signing/encryption state consistency, the
-    /// reserved-triplet rule and absolute-path rules. Unknown keys are
+    /// reserved-triplet rule, the absolute-path rules, and the
+    /// materialize grammar (spec 22 §4). Unknown keys are
     /// tolerated everywhere (only `annotations` is lossless by contract).
     pub fn validate(&self) -> Result<(), ManifestError> {
         self.identity.validate()?;
@@ -1198,6 +1210,14 @@ impl PayloadManifest {
         self.provides.validate()?;
         for req in &self.requires {
             req.validate()?;
+        }
+        for p in &self.materialize {
+            check_abs_path(p, "materialize[] must be absolute (inside the image)")?;
+            if p.split('/').any(|component| component == "..") {
+                return Err(ManifestError::Invalid(
+                    "materialize[] must not contain '..' components (the extraction target derives from the entry)",
+                ));
+            }
         }
         Ok(())
     }
@@ -1425,6 +1445,7 @@ mod tests {
             identity: minimal_identity(PayloadKind::App),
             provides: Provides::Other(BTreeMap::new()),
             requires: Vec::new(),
+            materialize: Vec::new(),
         };
         assert!(matches!(m.validate(), Err(ManifestError::Invalid(_))));
     }
@@ -1522,5 +1543,69 @@ mod tests {
         assert!(id.validate().is_ok());
         id.encryption.parts[0].paths = vec!["relative".into()];
         assert!(id.validate().is_err());
+    }
+
+    /// A minimal kind-data document with `extra` appended verbatim (the
+    /// materialize tests' vehicle).
+    fn minimal_data_yaml(extra: &str) -> String {
+        format!(
+            "identity:\n  schema_version: 1\n  kind: data\n  name: x\n  version: 1.0.0\n\
+             \x20 producer: {{tool: t, tool_version: \"1\"}}\n  created: now\n\
+             \x20 digest: {{tree_hash: \"sha256:{}\", blob_sha256: {}}}\n\
+             \x20 signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+             provides:\n  mount_semantics: {{suggested: /usr/share/x}}\n  capabilities: {{exec: false, read: true}}\n{extra}",
+            sha(1),
+            sha(2),
+        )
+    }
+
+    #[test]
+    fn materialize_defaults_empty_and_round_trips() {
+        // spec 22 §4 class R (schema_minor 1): the additive boot-
+        // materialization key — absolute in-image paths the driver
+        // extracts to the exec cache before the interpreter handoff.
+        let bare = PayloadManifest::from_yaml(&minimal_data_yaml("")).unwrap();
+        assert!(bare.materialize.is_empty());
+        // An absent key never serializes (additive on the wire: old
+        // readers see the document they always saw).
+        assert!(!bare.to_yaml().unwrap().contains("materialize"));
+
+        let with = PayloadManifest::from_yaml(&minimal_data_yaml(
+            "materialize: [/lib/tebako/cacert.pem, /share/icu/icudt.dat]\n",
+        ))
+        .unwrap();
+        assert_eq!(
+            with.materialize,
+            vec![
+                "/lib/tebako/cacert.pem".to_string(),
+                "/share/icu/icudt.dat".to_string()
+            ]
+        );
+        let rendered = with.to_yaml().unwrap();
+        assert!(rendered.contains("materialize:"), "{rendered}");
+        let back = PayloadManifest::from_yaml(&rendered).unwrap();
+        assert_eq!(back, with);
+    }
+
+    #[test]
+    fn materialize_entries_must_be_absolute_and_escape_free() {
+        // A relative entry is a named validation error.
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml("materialize: [lib/x.pem]\n"))
+            .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("materialize")),
+            "{err}"
+        );
+        // A '..' component would escape the exec-cache resources
+        // namespace on the host — rejected at validation, never at write.
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml("materialize: [/../../host/x]\n"))
+            .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("materialize")),
+            "{err}"
+        );
+        // A scalar is a structural error, never a one-item list.
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml("materialize: /x\n")).unwrap_err();
+        assert!(matches!(err, ManifestError::Yaml(_)), "{err}");
     }
 }

--- a/crates/tpkg/src/merkle.rs
+++ b/crates/tpkg/src/merkle.rs
@@ -267,6 +267,13 @@ impl FileHasher {
     }
 }
 
+impl Default for FileHasher {
+    /// A hasher with no content fed yet — the same as [`FileHasher::new`].
+    fn default() -> FileHasher {
+        FileHasher::new()
+    }
+}
+
 // ---------------------------------------------------------------------
 // The driver
 // ---------------------------------------------------------------------

--- a/crates/tpkg/src/merkle.rs
+++ b/crates/tpkg/src/merkle.rs
@@ -236,6 +236,38 @@ fn file_digest_of(fold: Fold) -> MerkleDigest {
 }
 
 // ---------------------------------------------------------------------
+// The single-file digest (spec 22 §4 class R)
+// ---------------------------------------------------------------------
+
+/// A streaming hasher for ONE file's content digest — the file-node
+/// value the tree hash commits (chunk-folded at [`CHUNK_SIZE`], the
+/// empty file as one empty chunk; see the module docs). The spec-22
+/// class-R boot materialization hashes the bytes the image serves and
+/// verifies the materialized host copy against the record.
+pub struct FileHasher {
+    chunker: Chunker,
+}
+
+impl FileHasher {
+    /// A hasher with no content fed yet.
+    pub fn new() -> FileHasher {
+        FileHasher {
+            chunker: Chunker::new(),
+        }
+    }
+
+    /// Feed content (any piece sizes — the re-chunker is exact).
+    pub fn update(&mut self, data: &[u8]) {
+        self.chunker.push(data);
+    }
+
+    /// The file's merkle digest.
+    pub fn finish(self) -> MerkleDigest {
+        self.chunker.finish()
+    }
+}
+
+// ---------------------------------------------------------------------
 // The driver
 // ---------------------------------------------------------------------
 
@@ -600,6 +632,49 @@ mod tests {
             render_tree_hash(&digest_of(&tree)),
             "sha256:d917098c8df4ecc0c1cb6febebcf6df159acfac807f31b17d3af882f564bcf2b"
         );
+    }
+
+    #[test]
+    fn file_hasher_is_the_tree_constructions_file_value() {
+        // The file digest IS the file-node value the tree hash commits
+        // (spec 22 §4 class R reuses this construction for extraction
+        // verification): chunk-folded at CHUNK_SIZE, the empty file as
+        // one empty chunk.
+        assert_eq!(FileHasher::new().finish(), chunk_leaf(b""));
+        let mut h = FileHasher::new();
+        h.update(b"abc");
+        assert_eq!(h.finish(), chunk_leaf(b"abc"));
+        let big = vec![0xAB; CHUNK_SIZE + 1];
+        let mut h = FileHasher::new();
+        h.update(&big);
+        let mut want = Fold::default();
+        want.push(chunk_leaf(&big[..CHUNK_SIZE]));
+        want.push(chunk_leaf(&big[CHUNK_SIZE..]));
+        assert_eq!(h.finish(), want.finish());
+    }
+
+    #[test]
+    fn file_hasher_streaming_is_chunk_size_blind() {
+        // Feeding in odd pieces re-chunks identically to one push…
+        let content: Vec<u8> = (0..9000u32).map(|i| (i % 251) as u8).collect();
+        let mut whole = FileHasher::new();
+        whole.update(&content);
+        let whole = whole.finish();
+        let mut pieces = FileHasher::new();
+        for piece in content.chunks(7) {
+            pieces.update(piece);
+        }
+        assert_eq!(whole, pieces.finish());
+        // …and the digest equals the value the tree walk commits for the
+        // file (the walker feeds odd piece sizes too).
+        let mut tree = MemTree::default();
+        tree.file("d/f", &content, false);
+        let child = Child {
+            name: "f".into(),
+            kind: NodeKind::File,
+            executable: false,
+        };
+        assert_eq!(whole, node_digest(&tree, &child, "d/f").unwrap());
     }
 
     // ---------------------------------------------------------------

--- a/crates/tpkg/tests/manifest.rs
+++ b/crates/tpkg/tests/manifest.rs
@@ -244,6 +244,32 @@ fn data_fixture_shape() {
 }
 
 #[test]
+fn materialize_key_is_schema_legal() {
+    // spec 22 §4 class R (schema_minor 1): the additive `materialize:`
+    // key — the versioned JSON Schema admits it and the model
+    // round-trips it (the runtime env image's cert declaration is the
+    // canonical shape).
+    let text = "identity:\n  schema_version: 1\n  kind: runtime\n  name: tebako-runtime-ruby\n  version: 4.0.6\n\
+        \x20 producer: {tool: tebako-cli, tool_version: 0.16.0}\n  created: \"2026-08-14T00:00:00Z\"\n\
+        \x20 digest:\n    tree_hash: \"sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\"\n\
+        \x20   blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1\n\
+        \x20 signing: {state: unsigned}\n  encryption: {state: none}\n\
+        provides:\n  provides: {engine: ruby, version: 4.0.6, abi_line: \"4.0\", platform: aarch64-macos}\n\
+        \x20 built_from: {src_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1, patch_set: v0.2.8}\n\
+        \x20 capabilities: {exec: true, read: true, runtime: true}\n\
+        materialize: [/lib/tebako/cacert.pem]\n";
+    let m = PayloadManifest::from_yaml(text).unwrap();
+    assert_eq!(m.materialize, vec!["/lib/tebako/cacert.pem".to_string()]);
+    // …and the schema agrees (MECE cross-check).
+    let validator = schema_validator();
+    validator
+        .validate(&yaml_text_to_json(text))
+        .expect("materialize: is schema-legal");
+    let back = PayloadManifest::from_yaml(&m.to_yaml().unwrap()).unwrap();
+    assert_eq!(back, m);
+}
+
+#[test]
 fn unknown_keys_are_tolerated_annotations_preserved() {
     let text = read(&fixture_path("data"));
     let with_extras = format!(

--- a/crates/tpkg/tests/manifest_props.rs
+++ b/crates/tpkg/tests/manifest_props.rs
@@ -278,13 +278,18 @@ fn arb_manifest() -> impl Strategy<Value = PayloadManifest> {
             arb_identity(kind),
             arb_provides(kind),
             prop::collection::vec(arb_requirement(), 0..=3),
+            // spec 22 §4 class R: absolute escape-free in-image paths.
+            prop::collection::vec(arb_path(), 0..=2),
         )
     })
-    .prop_map(|(identity, provides, requires)| PayloadManifest {
-        identity,
-        provides,
-        requires,
-    })
+    .prop_map(
+        |(identity, provides, requires, materialize)| PayloadManifest {
+            identity,
+            provides,
+            requires,
+            materialize,
+        },
+    )
 }
 
 proptest! {

--- a/docs/spec/03-payload-manifest.md
+++ b/docs/spec/03-payload-manifest.md
@@ -126,6 +126,26 @@ requires:
   manifest's declared env → exec. The SAME signed `.tfs` artifact type at
   every graph level — one coherent algebra.
 
+### 2.4 MATERIALIZE (`materialize:`, additive — schema_minor 1)
+
+```yaml
+materialize:
+  - /lib/ssl/certs/cacert.pem    # an absolute in-image path, no '..' components
+```
+
+A top-level list (any kind may declare it; old readers ignore it under
+the unknown-field rule) naming **regular files a C library must read
+through its own IO** — the interpreter's patched IO never gets asked, so
+the bytes must exist on the host filesystem. The OpenSSL CA cert is the
+canonical entry. The driver extracts each declared path after the mounts
+and the jail, before the interpreter handoff, to
+`<TEBAKO_EXEC_CACHE>/resources/<image-key>/<P>` — whole-file, read-only,
+digest-verified. A declared path absent from the image, or not a regular
+file, is the manifest lying: boot fails by name (exit 65), never a
+skipped entry. The full mechanics and the trust chain are spec 22 §4
+(class R); the grammar is registered in
+`docs/spec/schemas/payload-manifest.yaml`.
+
 ## 3. Platform axis (locked, vcpkg-triplet form)
 
 `platforms` is EITHER `"universal"` (pure-ruby/data) OR an explicit list:

--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -303,10 +303,19 @@ journal — never a crash in someone else's library.
 ## 4. Class R — declarative boot materialization
 
 **Rule R1.** An image manifest MAY declare `materialize: [paths]`
-(spec 03 §additive; `schema_minor` bump per the spec-03 rules — old
-readers ignore the key, new readers enforce). The driver extracts the
-listed paths to the runtime cache at boot, before the interpreter
-handoff.
+(spec 03 §2.4; `payload-manifest.yaml` schema_minor 1 — old readers
+ignore the key, new readers enforce). Entries are absolute in-image
+paths of regular files, carry no `..` components (validated at parse),
+and any kind may declare. The driver extracts the listed paths after
+the mounts and the jail, before the interpreter handoff — in both boot
+shapes (the standalone env-image boot and the `--tebako-image`
+grammar); the env image's own declarations extract first (the cert
+case), then each payload's in triple order. Each declared path `P`
+lands at `<TEBAKO_EXEC_CACHE>/resources/<image-key>/<P>`, where
+`<image-key>` is the exec cache's segregation idiom (the store
+sidecar's sha prefix when the image came from the store, else a key
+derived from the image path — the same rule the cache root itself
+uses).
 
 **Rule R2.** The canonical consumer pattern is an image-OWNED default:
 the image that ships a resource also ships the configuration pointing
@@ -315,9 +324,30 @@ default is the first entry). Payloads needing host-visible resources
 declare them in their own manifests; a consumer reads the materialized
 path through the documented cache-root convention (§6).
 
-**Rule R3.** Materialization is whole-file, read-only, and verified
-against the image's content hashes. A listed path absent from the
-image is a named boot error (the manifest lied), never a skipped entry.
+**Rule R3.** Materialization is whole-file, read-only, and verified.
+The mechanics (locked):
+
+- **Write-once.** The first boot to need `P` streams it from the
+  mounted image to a per-process staging file, hashing in flight with
+  the tfs-merkle-1 file construction, re-hashes the staged copy, and
+  refuses to install a copy that does not hash to the bytes the image
+  served. The digest record `<P>.tfs-digest` is renamed into place
+  BEFORE the content file, so a crash never leaves content without its
+  record — and content without a record is foreign by construction.
+  Later boots reuse the existing copy.
+- **Per-boot verification.** A reused copy is served only after it
+  re-hashes to its recorded digest. A mismatch, a missing record, or a
+  corrupt record is the cache tampered or corrupt — a named 70 (spec
+  06 §4's sha256-mismatch code), never a silently served corruption.
+  The remedy is named in the error: remove the image's resources
+  directory to force re-extraction.
+- **The trust chain.** The image itself is verified at fetch/install
+  (spec 09); the record pins the cache copy to the bytes the image
+  served; the per-boot rehash pins the copy to the record.
+- **Read-only.** The installed copy is made read-only after the rename.
+- **Named failures.** A listed path absent from the image, or not a
+  regular file, is a named 65 (the manifest lied), never a skipped
+  entry.
 
 ## 5. Error model
 
@@ -346,7 +376,9 @@ Payload authors and runtime factories may rely on, forever:
   process's lifetime. Its content is an implementation detail; its
   existence and per-image-sha segregation are contractual.
 - **The materialized-resource convention.** A manifest's
-  `materialize:` entry `P` lands at `<exec-cache>/resources/<image-sha>/<P>`.
+  `materialize:` entry `P` lands at `<exec-cache>/resources/<image-key>/<P>`
+  (`<image-key>` per Rule R1). The sidecar `<P>.tfs-digest` is cache
+  bookkeeping — the verification record, never a consumption path.
   Images that ship resources document their consumption path in their
   own manifests (spec 03 annotations).
 - **The discovery surface.** `TEBAKO_MOUNT_<SLUG>` per dependency mount

--- a/docs/spec/schemas/payload-manifest.yaml
+++ b/docs/spec/schemas/payload-manifest.yaml
@@ -18,7 +18,7 @@
 
 schema: payload-manifest
 schema_version: 1 # MAJOR — breaking changes only
-schema_minor: 0 # MINOR — additive changes only
+schema_minor: 1 # MINOR — additive changes only (1: materialize)
 status: normative
 owner: crates/tpkg (the model) in tamatebako/tebako
 edge: C7 (driver → payload images), C10 (executable payload → runtime), C11 (feature payload → consumers)
@@ -232,6 +232,20 @@ grammar:
       "language": {engine: "string, required", constraint: "string, required"}
       "toolkit": {name: "string, required", constraint: "string, required", triplets: "list of vcpkg triplets, optional", mount: "absolute path, optional"}
       "data": {name: "string, required", constraint: "string, required", mount: "absolute path, optional"}
+  materialize:
+    type: list of absolute in-image paths
+    required: false
+    since: schema_minor 1
+    notes: >-
+      spec 22 §4 class R — regular files a C library must read through
+      its own IO (the OpenSSL CA cert is the canonical entry). Any kind
+      may declare. The driver extracts each declared path P to
+      <TEBAKO_EXEC_CACHE>/resources/<image-key>/<P> after the mounts and
+      the jail, before the interpreter handoff; the copy is whole-file,
+      read-only, and digest-verified (a <P>.tfs-digest record, the
+      tfs-merkle-1 file digest). Entries are absolute and carry no '..'
+      components (validated at parse). Old readers ignore the key
+      (unknown-field rule).
 
 refusals:
   - case: identity.schema_version missing
@@ -242,5 +256,9 @@ refusals:
     behavior: named error naming the entrypoint and the requirement — never a segfault
   - case: provides_abi mismatch at bind (C11)
     behavior: named refusal, both versions printed (exit 79 reserved)
+  - case: a materialize entry absent from the image, or not a regular file (schema_minor 1)
+    behavior: the manifest lies — boot fails with a named error (exit 65), never a skipped entry
+  - case: a materialized copy failing digest verification at boot (schema_minor 1)
+    behavior: the exec cache is tampered or corrupt — boot fails with a named error (exit 70), never a silently served corruption
 
 deprecated: [] # no field is in a deprecation window

--- a/schema/tpkg-manifest-v1.schema.json
+++ b/schema/tpkg-manifest-v1.schema.json
@@ -10,6 +10,11 @@
     "requires": {
       "type": "array",
       "items": { "$ref": "#/$defs/requirement" }
+    },
+    "materialize": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/absPath" },
+      "description": "spec 22 §4 class R (payload-manifest schema_minor 1): absolute in-image paths of regular files the driver materializes to <TEBAKO_EXEC_CACHE>/resources/<image-key>/<P> after the mounts, before the interpreter handoff — whole-file, read-only, digest-verified. Any kind may declare; old readers ignore the key. The '..' refusal is semantic (the tpkg validator); only the absolute shape is checked here."
     }
   },
   "allOf": [


### PR DESCRIPTION
# Spec 22 Phase R (R1+R2): declarative boot materialization

Implements **spec 22 §4 class R** — a payload manifest MAY declare
`materialize: [paths]`, and the driver extracts those regular files to
the host at boot so C libraries that do their own IO (the OpenSSL CA
cert is the canonical case) find real host paths. Two parts, one PR:

- **R1 — the spec/schema amendment** (first commit): the additive
  top-level `materialize:` key on the L1 payload manifest, registered
  as `payload-manifest.yaml` **schema_minor 1** (in-place bump, the
  `layout.yaml` precedent — spec 18 §2.1's one-file-per-schema
  registry), documented in spec 03 §2.4, the mechanics pinned in spec
  22 §4 Rules R1–R3, and the versioned JSON Schema extended.
- **R2 — the model + the driver** (second commit): `tpkg`'s
  `PayloadManifest.materialize` (parse, validate, round-trip) and
  `tebako-driver`'s new `materialize` module, wired into both boot
  paths after the mounts and the jail, before any interpreter handoff.

R3 (the runtime factory declaring the cert + the gem consuming it) is a
separate workstream and is NOT in this PR.

## The mechanics (spec 22 §4 Rule R3, locked)

- **Where:** `<TEBAKO_EXEC_CACHE>/resources/<image-key>/<P>` —
  `<image-key>` is the exec cache's own segregation idiom (store
  sidecar sha prefix, else the path key).
- **Extraction:** whole regular files only, streamed VFS → per-process
  staging file, hashed in flight with the tfs-merkle-1 file
  construction (new `tpkg::merkle::FileHasher`); the staged copy is
  re-hashed and never installed if it differs from the bytes the image
  served.
- **Verification:** the digest record `<P>.tfs-digest` is renamed into
  place BEFORE the content file (content without a record is foreign by
  construction); a reused copy is served only after it re-hashes to its
  record — mismatch / missing / corrupt record is a named **70**
  (`EX_TEBAKO_SHA`, spec 06 §4's mismatch code, newly wired into the
  driver), with the remove-to-force-re-extraction remedy in the
  message. Trust chain: image verified at install (spec 09) → record
  pins copy to served bytes → per-boot rehash pins copy to record.
- **Named failures:** a declared path absent from the image or not a
  regular file is a named **65** ("the payload's self-description
  lies", the path_env idiom), never a skipped entry.
- **Read-only:** installed copies are chmod'd read-only after the
  rename. Concurrent boots race benignly (distinct staging files,
  identical bytes, last rename wins).

## Design decisions (for review)

1. Top-level `materialize:` key, any kind may declare — not a
   provides-specialized field.
2. In-place `schema_minor` 0→1 bump on `payload-manifest.yaml` instead
   of a new schema file — the registry's one-file-per-schema rule and
   the `layout.yaml` precedent.
3. Verification is the tfs-merkle-1 **file digest** recorded in
   `<P>.tfs-digest` with a reuse-time rehash — per-file verification
   against the image tree root is impossible without a full tree walk.
4. Exit 65 for absent/non-file declarations; `EX_TEBAKO_SHA` (70) newly
   wired into the driver for verification failures.
5. Extraction runs after `apply_jail` in both boot paths — the writes
   are process-internal, not policy-gated (the context.rs precedent).
6. Write-once cache; the path-key dev-boot staleness caveat is
   documented (a rewritten image under the same path key keeps serving
   the first extraction — verified by test).
7. `mounted_manifest_at` moved from `path_env.rs` to `driver.rs` and
   shared — one "corrupt manifest = named 65" idiom.
8. `tebako-info` renders the key 1:1 when present; `tebako-cli`'s
   synthesized manifest mirror gets the empty default (compile-forced).
9. §6's `<image-sha>` component renamed to `<image-key>` (16-hex), and
   `<P>.tfs-digest` documented as cache bookkeeping, never a
   consumption path.

## Test evidence (macOS aarch64, debug)

- `cargo test -p tpkg`: all suites green — 83 lib + 172 integration
  (incl. 3 new manifest unit tests, 2 FileHasher unit tests, the
  `materialize_key_is_schema_legal` model↔JSON-Schema cross-check, and
  `materialize` in the property-test generator).
- `cargo test -p tebako-driver`: 54 lib (incl. 4 new materialize unit
  tests: record suffix, record round-trip + tamper/corrupt/foreign →
  70, missing exec-cache export → 74, no declarations → nothing
  created) + 55 boot integration (incl. 7 new class-R tests: env-image
  cert extraction with `.tfs-digest` content assertion and live mount,
  payload resource extraction, absent path → 65, directory → 65, `..`
  escape → 65, write-once reuse under rewritten image bytes, tampered
  copy → 70) + 6 ffi + 2 interpose — all green.
- `cargo test -p tfs --lib` (124), `cargo test -p tebako-info`,
  `cargo test -p tebako-cli --lib` (60): green.
- `cargo test -p tebako-cli --test cli_e2e`: 9 press/packaged-run
  failures — **pre-existing, proven environmental**: the identical
  failure (`tebako-driver: entrypoint '<host tmp path>' not found … in
  the mounted tree`, from the PUBLISHED runtime's driver) reproduces on
  the base commit `2267360c` with this branch's changes stashed. The
  e2e presses dogfood published runtime artifacts mid-release-flux;
  nothing in this PR's diff reaches that path (tpkg's new field is
  skip-serialized when empty; the driver ships inside factory-built
  runtimes). Needs an owner look, independently of this PR.

## References

- spec 22 §4 (Rules R1–R3, mechanics locked by this PR),
  `docs/spec/22-runtime-native-interposition.md`
- spec 03 §2.4 (the additive key), `docs/spec/03-payload-manifest.md`
- `docs/spec/schemas/payload-manifest.yaml` (schema_minor 1),
  `schema/tpkg-manifest-v1.schema.json`
- spec 06 §4 (exit codes 65/70), spec 09 (install-time verification)
