### PR TITLE
test(cli_e2e): fail fast when the dogfood tebako-bootstrap is missing (fixes the local-red suite)

### DIFF
--- a/crates/tebako-cli/README.md
+++ b/crates/tebako-cli/README.md
@@ -221,6 +221,7 @@ table).
 ## Tests
 
 ```console
+$ cargo build -p tebako-bootstrap              # the e2e presses dogfood it
 $ cargo test -p tebako-cli                     # unit + fast CLI tests
 $ TEBAKO_REFERENCE_GEM=/path/to/tebako-gem \   # optional: golden diff
   TEBAKO_MKDWARFS=/path/to/mkdwarfs \          # (for the gem's own press)
@@ -228,7 +229,13 @@ $ TEBAKO_REFERENCE_GEM=/path/to/tebako-gem \   # optional: golden diff
 ```
 
 The e2e tests download the prebuilt runtime into the cache (network) and
-skip cleanly when `TEBAKO_CLI_SKIP_E2E` is set. The golden test
+skip cleanly when `TEBAKO_CLI_SKIP_E2E` is set. Every press embeds the
+in-workspace Rust bootstrap (`target/debug/tebako-bootstrap`, set as
+`$TEBAKO_BOOTSTRAP` by the harness); `cargo test -p tebako-cli` alone
+does not build it, so build it first or run `cargo test --workspace` —
+without it the press would silently embed the downloaded v1 C++
+bootstrap, whose handoff the image-era runtime driver rejects at run
+time (the harness fails fast instead). The golden test
 additionally needs a host ruby with the thor gem, a checkout of the
 reference gem at the matching version, and an mkdwarfs binary **for the
 reference gem's own press** (the CLI itself needs none). The

--- a/crates/tebako-cli/tests/cli_e2e.rs
+++ b/crates/tebako-cli/tests/cli_e2e.rs
@@ -6,6 +6,14 @@
 //! - the press tests need a mkdwarfs binary ($TEBAKO_MKDWARFS or PATH)
 //!   and network access for the runtime download (skipped when
 //!   TEBAKO_CLI_SKIP_E2E is set);
+//! - every press dogfoods the in-workspace Rust bootstrap
+//!   (target/debug/tebako-bootstrap). `cargo test -p tebako-cli` alone
+//!   never builds it (tebako-bootstrap is a lib dependency): build it
+//!   first (`cargo build -p tebako-bootstrap`) or run the suite as CI
+//!   does (`cargo build --workspace` then `cargo test --workspace`).
+//!   The harness fails fast when it is missing (see dogfood_bootstrap)
+//!   rather than silently pressing with the v1 C++ bootstrap download,
+//!   whose handoff the image-era runtime driver rejects at run time;
 //! - the golden test additionally needs $TEBAKO_REFERENCE_GEM pointing at
 //!   a checkout of the reference gem (tamatebako/tebako, the three-part
 //!   model) and a host ruby with the thor gem.
@@ -34,6 +42,36 @@ fn press_lock() -> &'static Mutex<()> {
 
 fn e2e_allowed() -> bool {
     std::env::var_os("TEBAKO_CLI_SKIP_E2E").is_none()
+}
+
+/// The in-workspace Rust bootstrap every e2e press dogfoods
+/// ($TEBAKO_BOOTSTRAP → the binary next to the tebako bin). REQUIRED,
+/// never a silent fallback: when the sibling is absent the CLI's
+/// decide_bootstrap downloads the v1 C++ bootstrap release, whose handoff
+/// (--tebako-entry = argv0 verbatim, no L2 package-manifest selection, no
+/// `;image` facet fetch) the image-era runtime driver rejects at run
+/// time — the suite then fails mid-cold-run with a driver-side
+/// "entrypoint '<package path>' not found at '/__tfs__/...' in the
+/// mounted tree" that indites the wrong component (exit 255), and the
+/// press_lock poison cascade hides the first failure. `cargo test -p
+/// tebako-cli` alone does not build the sibling; build it first
+/// (`cargo build -p tebako-bootstrap`) or run the suite as CI does
+/// (`cargo build --workspace` then `cargo test --workspace`).
+fn dogfood_bootstrap() -> PathBuf {
+    let sibling = tebako_bin().parent().unwrap().join(if cfg!(windows) {
+        "tebako-bootstrap.exe"
+    } else {
+        "tebako-bootstrap"
+    });
+    assert!(
+        sibling.is_file(),
+        "the in-workspace tebako-bootstrap binary is missing ({}): build it first \
+         (cargo build -p tebako-bootstrap) or run the suite via cargo test --workspace — \
+         without it the press silently embeds the downloaded v1 C++ bootstrap and every \
+         cold run fails in the runtime driver",
+        sibling.display()
+    );
+    sibling
 }
 
 fn workdir(tag: &str) -> PathBuf {
@@ -165,17 +203,9 @@ fn press_command(env: &PressEnv, entry: &str, output: &Path) -> Command {
         .arg(output)
         .arg("-p")
         .arg(&env.prefix);
-    // Dogfood the in-workspace Rust bootstrap when it sits next to the
-    // tebako binary (the decide_bootstrap default); otherwise the C++
-    // release is downloaded — both are valid press paths.
-    let sibling = tebako_bin().parent().unwrap().join(if cfg!(windows) {
-        "tebako-bootstrap.exe"
-    } else {
-        "tebako-bootstrap"
-    });
-    if sibling.is_file() {
-        cmd.env("TEBAKO_BOOTSTRAP", sibling);
-    }
+    // Dogfood the in-workspace Rust bootstrap (required — see
+    // dogfood_bootstrap for the failure mode of the download fallback).
+    cmd.env("TEBAKO_BOOTSTRAP", dogfood_bootstrap());
     cmd
 }
 
@@ -973,14 +1003,7 @@ fn press_against_mirror(
     for (key, value) in extra_env {
         cmd.env(key, value);
     }
-    let sibling = tebako_bin().parent().unwrap().join(if cfg!(windows) {
-        "tebako-bootstrap.exe"
-    } else {
-        "tebako-bootstrap"
-    });
-    if sibling.is_file() {
-        cmd.env("TEBAKO_BOOTSTRAP", sibling);
-    }
+    cmd.env("TEBAKO_BOOTSTRAP", dogfood_bootstrap());
     run(&mut cmd)
 }
 
@@ -1396,14 +1419,8 @@ fn native_ext_press_builds_and_packages() {
         )
         .env("TEBAKO_HOME", work.join("home"))
         .env("TEBAKO_SDK_SRC_MIRROR", tebako_http::file_url(&sdk_mirror));
-    let sibling = tebako_bin().parent().unwrap().join(if cfg!(windows) {
-        "tebako-bootstrap.exe"
-    } else {
-        "tebako-bootstrap"
-    });
-    if sibling.is_file() {
-        cmd.env("TEBAKO_BOOTSTRAP", &sibling);
-    }
+    let sibling = dogfood_bootstrap();
+    cmd.env("TEBAKO_BOOTSTRAP", &sibling);
     let (code, log) = run(&mut cmd);
     assert!(code == 0, "native-ext press failed:\n{log}");
     assert!(
@@ -1490,9 +1507,7 @@ fn native_ext_press_builds_and_packages() {
         )
         .env("TEBAKO_HOME", work.join("home"))
         .env("TEBAKO_SDK_SRC_MIRROR", tebako_http::file_url(&sdk_mirror));
-    if sibling.is_file() {
-        cmd.env("TEBAKO_BOOTSTRAP", &sibling);
-    }
+    cmd.env("TEBAKO_BOOTSTRAP", &sibling);
     let (code, log) = run(&mut cmd);
     assert_eq!(
         code, 255,


### PR DESCRIPTION
# Fix the local-red `cli_e2e` suite: fail fast when the dogfood bootstrap is missing

## Root cause (established by byte-level evidence + reproduction)

`cargo test -p tebako-cli --test cli_e2e` on a fresh checkout/worktree (or after
`cargo clean`) was red 8/13 locally while green in CI on identical source.

The chain:

1. The e2e presses dogfood the in-workspace Rust bootstrap only "when it sits
   next to the tebako binary" (old `cli_e2e.rs` guard: `if sibling.is_file()`).
   `cargo test -p tebako-cli` never builds `target/debug/tebako-bootstrap` —
   tebako-bootstrap is a **lib** dependency of tebako-cli, and cargo builds
   binary targets only for selected packages. CI's shape (`cargo build
   --workspace` + `cargo test --workspace`, ci.yml) always produces the
   sibling; the focused local invocation does not.
2. With no sibling, the harness set no `TEBAKO_BOOTSTRAP`, and the CLI's
   `decide_bootstrap` fell through to `BootstrapSource::Download`
   (`crates/tebako-cli/src/lib.rs:312`) — the **v1 C99 bootstrap release**
   (default 0.2.0, `crates/tebako-cli/src/resolve.rs:50`, downloaded from
   `tamatebako/tebako-bootstrap` releases).
3. The C99 bootstrap speaks the v1 handoff: `--tebako-entry` is **argv0
   verbatim** (no L2 type-2 package-manifest selection — it has no parser for
   the block every runnable press writes, `crates/tebako-cli/src/lib.rs:534`),
   and it does not fetch the `;image` facet (the cold-run cache entry held the
   runtime exe but **no `.tfs`**).
4. The image-era runtime's spec-17 driver (`crates/tebako-driver/src/driver.rs:652`)
   resolves the entry against the first `--tebako-image` mount; the
   host-absolute argv0 becomes `/__tfs__/var/folders/.../pkg-test-00`, which
   does not exist → `entrypoint '...' not found at '/__tfs__/...' in the
   mounted tree`, exit 255. The remaining 7 failures were `press_lock()`
   PoisonError cascades off the first failure.

Evidence:

- Failed package (from the red run's persisted work dir) is 8,087,164 bytes
  with a ~44 KB Mach-O stub whose strings are C99 printf patterns
  (`%s carries no tebako manifest trailer`, `%s/runtimes/%s`); the green
  package is 17,770,412 bytes with the ~9.7 MB Rust bootstrap. Trailers are
  byte-identical and correct (`entrypoint: /local/stub.rb`, union mounts) —
  the press was never the problem.
- Reproduced in a clean worktree on unmodified `origin/main` (2267360c) by
  hiding `target/debug/tebako-bootstrap`: `press_simple_script_runs` fails
  with the exact 255 / argv0-entry signature. With the sibling present, the
  same test (and the full suite) is green.
- The runtime (factory v0.16.3) and its release assets were previously
  exonerated (byte-identical to CI's download).

## Fix (test harness only — no product code changes)

- New `dogfood_bootstrap()` helper in `crates/tebako-cli/tests/cli_e2e.rs`:
  returns the sibling path or **fails fast** with the remedy
  (`cargo build -p tebako-bootstrap`, or `cargo test --workspace`). The three
  press sites (`press_command`, `press_against_mirror`,
  `native_ext_press_builds_and_packages`) now set `TEBAKO_BOOTSTRAP`
  unconditionally. The silent "download the C++ release" fallback is gone from
  the suite: invariant 9 (named errors, never silent fallbacks) applied to the
  harness itself.
- Suite header gate list and `crates/tebako-cli/README.md` (Tests section)
  document the prerequisite; the README previously recommended exactly the
  trapping invocation.

Verified: with the sibling hidden, the suite now fails in 0.00s with the
actionable message (was: ~20 min of downloads then a misleading driver error).
Full suite green locally: **13/13** (run log on the PR checks / locally
reproducible).

## Deliberately out of scope (finding, not fixed here)

The cross-artifact contract gap remains real for end users: `tebako press`
with the downloaded v1 C99 bootstrap against an image-era (v0.16.x) runtime
produces a package that cannot run (argv0 handoff rejected by the spec-17
driver; `;image` facet never fetched). The press stays silent about it.
Options for a follow-up (owner's call): press-time refusal when the resolved
runtime is image-era and the bootstrap is the C99 download, or retiring the
C99 download path. Not hacked around here.
