### PR TITLE
feat(cli)!: retire the v1 C++ bootstrap download — press fails closed (136)

### DIFF
--- a/crates/tebako-cli/README.md
+++ b/crates/tebako-cli/README.md
@@ -145,9 +145,10 @@ download), 125 (SDK lock timeout).
   ([../../docs/runtime-as-image.md](../../docs/runtime-as-image.md));
 - **bootstrap**: `--bootstrap` > `$TEBAKO_BOOTSTRAP` > the Rust
   `tebako-bootstrap` binary next to the `tebako` executable (dogfooding
-  milestone 6) > the C++ tebako-bootstrap release, resolved with the gem's
-  BootstrapManager machinery (`TEBAKO_BOOTSTRAP_VERSION`,
-  `TEBAKO_BOOTSTRAP_MIRROR`);
+  milestone 6) — local sources only; the gem's BootstrapManager download
+  of the v1 C++ release is retired (its argv0-verbatim handoff is rejected
+  by the image-era runtime driver), so a press with no local bootstrap
+  fails closed with the named error 136;
 - **downloads**: all in-process via `crates/tebako-http` (ureq + rustls,
   webpki-roots bundled; HTTPS-only, redirects ≤ 5, `file://` mirrors,
   `TEBAKO_OFFLINE`; the OS trust store is opt-in via
@@ -161,8 +162,9 @@ download), 125 (SDK lock timeout).
 ## Deviations from the reference gem (documented, deliberate)
 
 - the bootstrap portion **defaults to the in-workspace Rust
-  tebako-bootstrap**; the gem always uses the C++ release (reachable via
-  the lookup chain above);
+  tebako-bootstrap**; the gem always uses the C++ release — the C++
+  download is not reachable here at all (retired; no local Rust bootstrap
+  → exit 136);
 - **no mkdwarfs anywhere** (owner rule): the gem shells out to a
   provisioned mkdwarfs binary; the CLI builds images in-process and the
   golden test filters the two sides' image-build lines when diffing
@@ -215,7 +217,7 @@ download), 125 (SDK lock timeout).
 
 Everything else is byte-level parity: the press stdout, the produced
 package's trailer fields, the packaged binary's output, the cache layout
-(shared with the gem), and the exit codes (106–135 + the packaging error
+(shared with the gem), and the exit codes (106–136 + the packaging error
 table).
 
 ## Tests
@@ -233,9 +235,10 @@ skip cleanly when `TEBAKO_CLI_SKIP_E2E` is set. Every press embeds the
 in-workspace Rust bootstrap (`target/debug/tebako-bootstrap`, set as
 `$TEBAKO_BOOTSTRAP` by the harness); `cargo test -p tebako-cli` alone
 does not build it, so build it first or run `cargo test --workspace` —
-without it the press would silently embed the downloaded v1 C++
-bootstrap, whose handoff the image-era runtime driver rejects at run
-time (the harness fails fast instead). The golden test
+without it the press fails closed with exit 136 (the v1 C++ bootstrap
+download fallback is retired: its handoff is rejected by the image-era
+runtime driver at run time), and the harness fails fast on its own
+instead. The golden test
 additionally needs a host ruby with the thor gem, a checkout of the
 reference gem at the matching version, and an mkdwarfs binary **for the
 reference gem's own press** (the CLI itself needs none). The

--- a/crates/tebako-cli/src/error.rs
+++ b/crates/tebako-cli/src/error.rs
@@ -57,12 +57,16 @@ pub fn packaging_message(code: i32) -> Option<&'static str> {
         128 => "Prebuilt runtime press requires the packaging environment (run 'tebako setup' first)",
         129 => "The resolved runtime package does not carry the tebako-runtime gem",
         130 => "Option combination is not supported",
+        // 131/132/134 were emitted by the retired v1 C++ tebako-bootstrap
+        // download path (and its fat-mode version guard); the rows stay as
+        // the gem's table mirror, the codes stay reserved.
         131 => "No tebako-bootstrap package for the requested platform",
         132 => "TEBAKO_OFFLINE is set and the requested tebako-bootstrap package is not cached",
         133 => "The 'runtime' press mode was removed: runtime packages are produced by the \
                  tebako-runtime-ruby pipeline and resolved automatically by the lean/fat/classic modes",
         134 => "Fat mode requires a payload-capable tebako-bootstrap release",
         135 => "Failed to provision the runtime SDK for native extension builds",
+        136 => "Press requires a local Rust tebako-bootstrap binary (the v1 C++ bootstrap download is retired)",
         201 => "Warning. Could not create cache version file",
         _ => return None,
     })

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -29,10 +29,12 @@
 //! libraries, no process spawns (spec 14 §3).
 //!
 //! Documented deviations from the gem (README carries the full list):
-//! - the bootstrap portion defaults to the in-workspace Rust
-//!   tebako-bootstrap (sibling of the tebako binary); --bootstrap /
-//!   TEBAKO_BOOTSTRAP override, otherwise the C++ release is resolved
-//!   with the gem's BootstrapManager machinery;
+//! - the bootstrap portion comes from local Rust tebako-bootstrap
+//!   binaries only (--bootstrap / TEBAKO_BOOTSTRAP / the sibling of the
+//!   tebako binary); the gem's BootstrapManager download of the v1 C++
+//!   release is RETIRED — its argv0-verbatim handoff is rejected by the
+//!   image-era runtime driver, so the fallback produced silently-broken
+//!   packages. A press with no local bootstrap fails closed (exit 136);
 //! - no mkdwarfs binary anywhere: images are built in-process via the
 //!   dwarfs-t Writer and named `.tfs` (dwarfs-t-native FlatBuffers
 //!   metadata; `.dwarfs` stays for upstream-compatible images);
@@ -77,7 +79,7 @@ use std::path::{Path, PathBuf};
 
 use error::{packaging_error, plain_error, TebakoError};
 use options::{host_platform, PressMode, PressOptions};
-use resolve::{Flavor, Resolver};
+use resolve::Resolver;
 use scenario::{check_ruby_version, ruby_version_with_gemfile, ScenarioManager};
 
 /// Launcher ABI v1 — the bootstrap → runtime handoff contract.
@@ -126,15 +128,6 @@ const WARN2: &str = "
 // ---------------------------------------------------------------------
 // press
 // ---------------------------------------------------------------------
-
-/// Where the package's bootstrap portion comes from.
-pub(crate) enum BootstrapSource {
-    /// An explicit local binary (--bootstrap, $TEBAKO_BOOTSTRAP, or the
-    /// Rust tebako-bootstrap sitting next to the tebako binary).
-    Path(PathBuf),
-    /// Resolve the C++ release with the gem's BootstrapManager machinery.
-    Download,
-}
 
 pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     // --suite: one package, N entries (spec 03 §6 — src/suite.rs).
@@ -203,33 +196,14 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     println!("{}", opts.press_announce(&ruby_ver));
 
     let platform = host_platform()?;
-    let bootstrap_source = decide_bootstrap(opts);
-    if opts.mode == PressMode::Fat {
-        if let BootstrapSource::Download = bootstrap_source {
-            check_bootstrap_version()?;
-        }
-    }
+    // The bootstrap comes from local sources only and is refused BEFORE
+    // the runtime download — a missing local bootstrap must not cost a
+    // fetch, and the retired C++ download fallback must never fire.
+    let bootstrap_path = local_bootstrap(opts)?;
 
-    let runtime_resolver = Resolver::new(Flavor::Runtime);
+    let runtime_resolver = Resolver::new();
     let resolved = runtime_resolver.resolve_runtime(&ruby_ver, &platform, &opts.tebako_version)?;
     let runtime_path = resolved.executable.clone();
-
-    let bootstrap_path = match &bootstrap_source {
-        BootstrapSource::Path(path) => {
-            if !path.is_file() {
-                return Err(packaging_error(
-                    127,
-                    Some(&format!("runtime not found: {}", path.display())),
-                ));
-            }
-            path.clone()
-        }
-        BootstrapSource::Download => Resolver::new(Flavor::Bootstrap).resolve(
-            &resolve::default_bootstrap_version(),
-            &platform,
-            &resolve::default_bootstrap_version(),
-        )?,
-    };
 
     let app_image = packager::build_app_image(opts, &mut scenario, &resolved, &ruby_ver)?;
 
@@ -308,14 +282,18 @@ fn check_warnings(opts: &PressOptions) {
 }
 
 /// Bootstrap lookup: --bootstrap > $TEBAKO_BOOTSTRAP > the Rust
-/// tebako-bootstrap next to the tebako binary > the C++ release download.
-pub(crate) fn decide_bootstrap(opts: &PressOptions) -> BootstrapSource {
+/// tebako-bootstrap next to the tebako binary. LOCAL SOURCES ONLY — the
+/// v1 C++ bootstrap download is retired (its argv0-verbatim handoff is
+/// rejected by the image-era runtime driver, so the fallback produced
+/// silently-broken packages). `None` means no local source named a
+/// binary; [`local_bootstrap`] turns that into the named refusal.
+pub(crate) fn decide_bootstrap(opts: &PressOptions) -> Option<PathBuf> {
     if let Some(path) = &opts.bootstrap {
-        return BootstrapSource::Path(path.clone());
+        return Some(path.clone());
     }
     if let Ok(env_path) = std::env::var("TEBAKO_BOOTSTRAP") {
         if !env_path.is_empty() {
-            return BootstrapSource::Path(PathBuf::from(env_path));
+            return Some(PathBuf::from(env_path));
         }
     }
     if let Ok(exe) = std::env::current_exe() {
@@ -327,29 +305,31 @@ pub(crate) fn decide_bootstrap(opts: &PressOptions) -> BootstrapSource {
             };
             let sibling = dir.join(name);
             if sibling.is_file() {
-                return BootstrapSource::Path(sibling);
+                return Some(sibling);
             }
         }
     }
-    BootstrapSource::Download
+    None
 }
 
-/// The fat payload slot is installed by the bootstrap at first run — a
-/// capability added in tebako-bootstrap 0.2.0 (error 134). Applies to the
-/// downloaded C++ bootstrap; the in-workspace Rust bootstrap is
-/// payload-capable by construction.
-fn check_bootstrap_version() -> Result<(), TebakoError> {
-    let version = resolve::default_bootstrap_version();
-    if scenario::version_cmp(&version, resolve::PAYLOAD_MIN_VERSION) != std::cmp::Ordering::Less {
-        return Ok(());
+/// The package's bootstrap portion from the local sources, or the named
+/// failure: no source at all → 136 (pressing requires a local Rust
+/// tebako-bootstrap; the C++ download is retired); a named file that does
+/// not exist → 127 (the gem's parity error for a bad --bootstrap).
+pub(crate) fn local_bootstrap(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
+    let Some(path) = decide_bootstrap(opts) else {
+        return Err(packaging_error(
+            136,
+            Some("set --bootstrap or $TEBAKO_BOOTSTRAP, or place the Rust tebako-bootstrap next to the tebako executable (the v1 C++ bootstrap download is retired)"),
+        ));
+    };
+    if !path.is_file() {
+        return Err(packaging_error(
+            127,
+            Some(&format!("runtime not found: {}", path.display())),
+        ));
     }
-    Err(packaging_error(
-        134,
-        Some(&format!(
-            "fat mode requires tebako-bootstrap >= {} (selected: {version}; set TEBAKO_BOOTSTRAP_VERSION to a payload-capable release)",
-            resolve::PAYLOAD_MIN_VERSION
-        )),
-    ))
+    Ok(path)
 }
 
 /// Stitcher.stitch (lean three-part): validate per the gem's error codes,
@@ -693,7 +673,7 @@ fn clean_output(opts: &PressOptions) {
 // ---------------------------------------------------------------------
 
 pub fn cache_list() {
-    let manager = Resolver::new(Flavor::Runtime);
+    let manager = Resolver::new();
     let entries = manager.entries();
     if entries.is_empty() {
         println!(
@@ -728,7 +708,7 @@ pub fn cache_list_json() {
     let s = |v: &str| J::String(v.to_string());
     let n = |v: u64| J::Number(v.to_string());
 
-    let manager = Resolver::new(Flavor::Runtime);
+    let manager = Resolver::new();
     let mut total = 0u64;
 
     let mut runtimes = Vec::new();
@@ -796,7 +776,7 @@ pub fn cache_list_json() {
 }
 
 pub fn cache_prune(all: bool, older_than: Option<&str>) -> Result<(), TebakoError> {
-    let manager = Resolver::new(Flavor::Runtime);
+    let manager = Resolver::new();
     let removed = if all {
         manager.prune(true, None)?
     } else if let Some(days) = older_than.and_then(parse_days) {
@@ -945,5 +925,106 @@ mod tests {
         let mut f = std::fs::File::open(&plain).unwrap();
         let m = tpkg::read_from(&mut f).unwrap();
         assert_eq!(m.package_flags & tpkg::TPKG_FLAG_NO_INSTALL, 0);
+    }
+
+    fn press_opts(bootstrap: Option<PathBuf>) -> PressOptions {
+        PressOptions {
+            root_arg: String::new(),
+            entrance: String::new(),
+            output: None,
+            prefix: PathBuf::from("/tmp/prefix"),
+            cwd: None,
+            ruby_requested: None,
+            mode: PressMode::Lean,
+            log_level: "error".to_string(),
+            image_specs: Vec::new(),
+            bootstrap,
+            tebako_version: DEFAULT_TEBAKO_VERSION.to_string(),
+            prefer_local: false,
+            verbose: false,
+            devmode: true,
+            fs_current: "/tmp".to_string(),
+            suite: None,
+            jail: None,
+            no_install: false,
+            format: options::PressImageFormat::Dwarfs,
+        }
+    }
+
+    #[test]
+    fn local_bootstrap_prefers_the_option_and_rejects_a_missing_file() {
+        let dir = std::env::temp_dir().join(format!("tebako-cli-boot-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let boot = dir.join("tebako-bootstrap");
+        std::fs::write(&boot, b"BOOT").unwrap();
+        // --bootstrap short-circuits every other source.
+        let opts = press_opts(Some(boot.clone()));
+        assert_eq!(local_bootstrap(&opts).unwrap(), boot);
+        // A named file that does not exist keeps the gem's parity error
+        // (127, "runtime not found").
+        let missing = dir.join("nope");
+        let opts = press_opts(Some(missing.clone()));
+        let err = local_bootstrap(&opts).unwrap_err();
+        assert_eq!(err.code, 127);
+        assert!(
+            err.message
+                .contains(&format!("runtime not found: {}", missing.display())),
+            "{}",
+            err.message
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn local_bootstrap_without_any_local_source_fails_closed_136() {
+        // The only test that mutates the process env (TEBAKO_BOOTSTRAP) —
+        // kept in one function so parallel tests never observe a
+        // half-saved environment; restored on the way out.
+        let saved = std::env::var("TEBAKO_BOOTSTRAP").ok();
+
+        // $TEBAKO_BOOTSTRAP beats the sibling probe.
+        std::env::set_var("TEBAKO_BOOTSTRAP", "/nonexistent/env-bootstrap");
+        let opts = press_opts(None);
+        assert_eq!(
+            decide_bootstrap(&opts),
+            Some(PathBuf::from("/nonexistent/env-bootstrap"))
+        );
+
+        // No option, no env: the retired download does NOT fire — the
+        // press fails closed with the named error. (The unit-test binary
+        // runs from target/debug/deps/, which never holds a plain
+        // `tebako-bootstrap` sibling — assert that precondition so a
+        // change in cargo's layout fails diagnosably.)
+        std::env::remove_var("TEBAKO_BOOTSTRAP");
+        let exe_dir = std::env::current_exe()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let sibling = exe_dir.join(if cfg!(windows) {
+            "tebako-bootstrap.exe"
+        } else {
+            "tebako-bootstrap"
+        });
+        assert!(
+            !sibling.is_file(),
+            "test precondition: no tebako-bootstrap sibling next to the test binary ({})",
+            sibling.display()
+        );
+        let opts = press_opts(None);
+        assert!(decide_bootstrap(&opts).is_none());
+        let err = local_bootstrap(&opts).unwrap_err();
+        assert_eq!(err.code, 136);
+        assert!(
+            err.message
+                .contains("requires a local Rust tebako-bootstrap"),
+            "{}",
+            err.message
+        );
+
+        if let Some(v) = saved {
+            std::env::set_var("TEBAKO_BOOTSTRAP", v);
+        }
     }
 }

--- a/crates/tebako-cli/src/packager.rs
+++ b/crates/tebako-cli/src/packager.rs
@@ -36,7 +36,7 @@ pub fn build_app_image(
             .join(&img.filename)
     });
     let layout_dir = if image_path.is_none() {
-        let resolver = crate::resolve::Resolver::new(crate::resolve::Flavor::Runtime);
+        let resolver = crate::resolve::Resolver::new();
         Some(resolver.layout(runtime_path, opts.verbose)?)
     } else {
         None

--- a/crates/tebako-cli/src/resolve.rs
+++ b/crates/tebako-cli/src/resolve.rs
@@ -1,21 +1,24 @@
-//! Port of the gem's RuntimeManager / BootstrapManager
-//! (lib/tebako/runtime_manager.rb, lib/tebako/bootstrap_manager.rb):
+//! Port of the gem's RuntimeManager (lib/tebako/runtime_manager.rb):
 //! resolution, download, verification and machine-wide caching of the
-//! prebuilt tebako runtime packages and tebako-bootstrap launchers.
+//! prebuilt tebako runtime packages.
 //!
 //! Cache layout (rooted at $TEBAKO_HOME or ~/.tebako), identical to the gem:
 //!   runtimes/ruby-<ruby-version>-<tebakoabi>-<platform>/
 //!     tebako-runtime-<tebakoabi>-<ruby-version>-<platform>[.exe]
 //!     sha256    -- digest the installed file was verified against
 //!     origin    -- URL the package was downloaded from
-//!   bootstraps/tebako-bootstrap-<version>-<platform>/
-//!     tebako-bootstrap-<version>-<platform>[.exe]
-//!     sha256 / origin
 //!
 //! Installs are serialized per entry with a flock'd lockfile; packages are
 //! downloaded to tmp/, SHA256-verified against the release index and moved
 //! into place with an atomic rename, so partial downloads never poison the
 //! cache.
+//!
+//! The gem's BootstrapManager half is NOT ported: the v1 C++
+//! tebako-bootstrap download is retired (its argv0-verbatim handoff is
+//! rejected by the image-era runtime driver, so the fallback produced
+//! silently-broken packages). Pressing sources the bootstrap from local
+//! Rust binaries only and fails closed otherwise (src/lib.rs
+//! `local_bootstrap`, exit 136).
 
 use std::fs;
 #[cfg(unix)]
@@ -36,27 +39,15 @@ const SHA256_FILE: &str = "sha256";
 const ORIGIN_FILE: &str = "origin";
 const LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
-/// Which release line the resolver consumes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Flavor {
-    /// tamatebako/tebako-runtime-ruby prebuilt runtimes.
-    Runtime,
-    /// tamatebako/tebako-bootstrap launchers.
-    Bootstrap,
-}
-
-/// The default tebako-bootstrap release (TEBAKO_BOOTSTRAP_VERSION
-/// overrides); 0.2.0 is the first payload-capable one.
-pub const BOOTSTRAP_VERSION: &str = "0.2.0";
-/// Fat mode requires a payload-capable bootstrap.
-pub const PAYLOAD_MIN_VERSION: &str = "0.2.0";
-
-pub fn default_bootstrap_version() -> String {
-    match std::env::var("TEBAKO_BOOTSTRAP_VERSION") {
-        Ok(v) if !v.is_empty() => v.strip_prefix('v').unwrap_or(&v).to_string(),
-        _ => BOOTSTRAP_VERSION.to_string(),
-    }
-}
+/// The tebako-runtime-ruby release mirror (TEBAKO_RUNTIME_MIRROR
+/// overrides).
+const DEFAULT_MIRROR: &str = "https://github.com/tamatebako/tebako-runtime-ruby/releases/download";
+const MIRROR_ENV_VAR: &str = "TEBAKO_RUNTIME_MIRROR";
+/// The cache subdirectory and release identity this resolver consumes.
+const CACHE_SUBDIR: &str = "runtimes";
+const RELEASE_NAME: &str = "tebako-runtime-ruby";
+/// The release index files, in preference order.
+const INDEX_FILES: &[&str] = &["manifest.json", "SHA256SUMS.txt"];
 
 /// $TEBAKO_HOME or ~/.tebako (LOCALAPPDATA\tebako on Windows).
 pub fn default_cache_root() -> PathBuf {
@@ -119,7 +110,6 @@ pub struct Resolved {
 
 #[derive(Debug)]
 pub struct Resolver {
-    pub flavor: Flavor,
     pub cache_root: PathBuf,
     pub mirror: String,
     pub lock_timeout: std::time::Duration,
@@ -132,56 +122,23 @@ pub struct CacheEntry {
     pub installed_at: std::time::SystemTime,
 }
 
+impl Default for Resolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Resolver {
-    pub fn new(flavor: Flavor) -> Self {
-        let (env_var, default_mirror) = match flavor {
-            Flavor::Runtime => (
-                "TEBAKO_RUNTIME_MIRROR",
-                "https://github.com/tamatebako/tebako-runtime-ruby/releases/download",
-            ),
-            Flavor::Bootstrap => (
-                "TEBAKO_BOOTSTRAP_MIRROR",
-                "https://github.com/tamatebako/tebako-bootstrap/releases/download",
-            ),
-        };
-        let mirror = std::env::var(env_var)
+    pub fn new() -> Self {
+        let mirror = std::env::var(MIRROR_ENV_VAR)
             .ok()
             .filter(|m| !m.is_empty())
-            .unwrap_or_else(|| default_mirror.to_string());
+            .unwrap_or_else(|| DEFAULT_MIRROR.to_string());
         Resolver {
-            flavor,
             cache_root: default_cache_root(),
             mirror: mirror.trim_end_matches('/').to_string(),
             lock_timeout: LOCK_TIMEOUT,
         }
-    }
-
-    /// Resolve (download/verify/cache when missing) the package for
-    /// `ruby_version` + `platform` at `tebako_version`; returns the cached
-    /// executable path. For the Bootstrap flavor `ruby_version` is the
-    /// bootstrap version and `tebako_version` equals it.
-    pub fn resolve(
-        &self,
-        ruby_version: &str,
-        platform: &str,
-        tebako_version: &str,
-    ) -> Result<PathBuf, TebakoError> {
-        let dir = self.entry_dir(ruby_version, platform, tebako_version);
-        let executable = dir.join(self.filename(ruby_version, platform, tebako_version));
-        if executable.is_file() {
-            return Ok(executable);
-        }
-        self.with_entry_lock(
-            &dir,
-            &self.entry_ref(ruby_version, platform, tebako_version),
-            || {
-                if !executable.is_file() {
-                    self.install(&executable, ruby_version, platform, tebako_version)?;
-                }
-                Ok(())
-            },
-        )?;
-        Ok(executable)
     }
 
     /// Resolve a runtime for press (item 30b): the interpreter plus, when
@@ -235,9 +192,7 @@ impl Resolver {
                     self.offline_check(&entry_ref, tebako_version)?;
                     let (index, card) = self.fetch_index(tebako_version)?;
                     let entry = self.find_entry(&index, ruby_version, platform, tebako_version)?;
-                    if self.flavor == Flavor::Runtime {
-                        contract_gate(&entry_ref, card.as_deref(), &entry.filename)?;
-                    }
+                    contract_gate(&entry_ref, card.as_deref(), &entry.filename)?;
                     if let Some(image) = entry.image.clone() {
                         self.install_image(&dir, &image, tebako_version)?;
                     }
@@ -455,7 +410,7 @@ impl Resolver {
 
     /// Cached entries (newest-dir listing like the gem's `entries`).
     pub fn entries(&self) -> Vec<CacheEntry> {
-        let base = self.cache_root.join(self.cache_subdir());
+        let base = self.cache_root.join(CACHE_SUBDIR);
         let mut out = Vec::new();
         let Ok(children) = fs::read_dir(&base) else {
             return out;
@@ -505,47 +460,12 @@ impl Resolver {
         Ok(removed)
     }
 
-    // ---- flavor specifics ------------------------------------------------
-
-    fn cache_subdir(&self) -> &'static str {
-        match self.flavor {
-            Flavor::Runtime => "runtimes",
-            Flavor::Bootstrap => "bootstraps",
-        }
-    }
-
-    fn index_files(&self) -> &'static [&'static str] {
-        match self.flavor {
-            Flavor::Runtime => &["manifest.json", "SHA256SUMS.txt"],
-            Flavor::Bootstrap => &["manifest.json", "SHA256SUMS"],
-        }
-    }
-
-    fn release_name(&self) -> &'static str {
-        match self.flavor {
-            Flavor::Runtime => "tebako-runtime-ruby",
-            Flavor::Bootstrap => "tebako-bootstrap",
-        }
-    }
-
-    fn mirror_env_var(&self) -> &'static str {
-        match self.flavor {
-            Flavor::Runtime => "TEBAKO_RUNTIME_MIRROR",
-            Flavor::Bootstrap => "TEBAKO_BOOTSTRAP_MIRROR",
-        }
-    }
+    // ---- entry naming ----------------------------------------------------
 
     fn entry_dir(&self, ruby_version: &str, platform: &str, tebako_version: &str) -> PathBuf {
-        match self.flavor {
-            Flavor::Runtime => self
-                .cache_root
-                .join("runtimes")
-                .join(format!("ruby-{ruby_version}-{tebako_version}-{platform}")),
-            Flavor::Bootstrap => self
-                .cache_root
-                .join("bootstraps")
-                .join(format!("tebako-bootstrap-{tebako_version}-{platform}")),
-        }
+        self.cache_root
+            .join(CACHE_SUBDIR)
+            .join(format!("ruby-{ruby_version}-{tebako_version}-{platform}"))
     }
 
     fn filename(&self, ruby_version: &str, platform: &str, tebako_version: &str) -> String {
@@ -554,19 +474,11 @@ impl Resolver {
         } else {
             ""
         };
-        match self.flavor {
-            Flavor::Runtime => {
-                format!("tebako-runtime-{tebako_version}-{ruby_version}-{platform}{suffix}")
-            }
-            Flavor::Bootstrap => format!("tebako-bootstrap-{tebako_version}-{platform}{suffix}"),
-        }
+        format!("tebako-runtime-{tebako_version}-{ruby_version}-{platform}{suffix}")
     }
 
     fn entry_ref(&self, ruby_version: &str, platform: &str, tebako_version: &str) -> String {
-        match self.flavor {
-            Flavor::Runtime => format!("ruby@{ruby_version} (tebako {tebako_version}, {platform})"),
-            Flavor::Bootstrap => format!("tebako-bootstrap@{tebako_version} ({platform})"),
-        }
+        format!("ruby@{ruby_version} (tebako {tebako_version}, {platform})")
     }
 
     // ---- install pipeline ------------------------------------------------
@@ -582,13 +494,8 @@ impl Resolver {
         self.offline_check(&entry_ref, tebako_version)?;
         let (index, card) = self.fetch_index(tebako_version)?;
         let entry = self.find_entry(&index, ruby_version, platform, tebako_version)?;
-        // spec 18 C2: the release card gates BEFORE the runtime download
-        // (the Runtime flavor only — the bootstrap release's
-        // self-description is the embedded artifact-info block, not this
-        // card).
-        if self.flavor == Flavor::Runtime {
-            contract_gate(&entry_ref, card.as_deref(), &entry.filename)?;
-        }
+        // spec 18 C2: the release card gates BEFORE the runtime download.
+        contract_gate(&entry_ref, card.as_deref(), &entry.filename)?;
         let url = self.package_url(&entry.filename, tebako_version);
         let tmp = self.download(&url, &entry.filename)?;
         self.verify(&tmp, entry)?;
@@ -606,17 +513,13 @@ impl Resolver {
         if !self.offline() {
             return Ok(());
         }
-        let code = match self.flavor {
-            Flavor::Runtime => 123,
-            Flavor::Bootstrap => 132,
-        };
         Err(packaging_error(
-            code,
+            123,
             Some(&format!(
                 "{} is not cached and downloads are disabled (release index: {}; {}={})",
                 entry_ref,
                 self.index_urls(tebako_version).join(", "),
-                self.mirror_env_var(),
+                MIRROR_ENV_VAR,
                 self.mirror
             )),
         ))
@@ -629,52 +532,29 @@ impl Resolver {
         platform: &str,
         tebako_version: &str,
     ) -> Result<&'a IndexEntry, TebakoError> {
-        match self.flavor {
-            Flavor::Runtime => {
-                if let Some(entry) = index.iter().find(|c| {
-                    c.ruby_version.as_deref() == Some(ruby_version)
-                        && c.platform.as_deref() == Some(platform)
-                }) {
-                    return Ok(entry);
-                }
-                let combos: Vec<String> = index
-                    .iter()
-                    .map(|c| {
-                        format!(
-                            "{}/{}",
-                            c.ruby_version.as_deref().unwrap_or("?"),
-                            c.platform.as_deref().unwrap_or("?")
-                        )
-                    })
-                    .collect();
-                Err(packaging_error(
-                    120,
-                    Some(&format!(
-                        "no package for ruby {ruby_version} on {platform} (tebako {tebako_version}). Available: {}. Use --build-runtime to build the runtime from source instead.",
-                        combos.join(", ")
-                    )),
-                ))
-            }
-            Flavor::Bootstrap => {
-                if let Some(entry) = index
-                    .iter()
-                    .find(|c| c.platform.as_deref() == Some(platform))
-                {
-                    return Ok(entry);
-                }
-                let platforms: Vec<String> = index
-                    .iter()
-                    .map(|c| c.platform.clone().unwrap_or_else(|| "?".to_string()))
-                    .collect();
-                Err(packaging_error(
-                    131,
-                    Some(&format!(
-                        "no tebako-bootstrap package for {platform} (bootstrap {tebako_version}). Available: {}.",
-                        platforms.join(", ")
-                    )),
-                ))
-            }
+        if let Some(entry) = index.iter().find(|c| {
+            c.ruby_version.as_deref() == Some(ruby_version)
+                && c.platform.as_deref() == Some(platform)
+        }) {
+            return Ok(entry);
         }
+        let combos: Vec<String> = index
+            .iter()
+            .map(|c| {
+                format!(
+                    "{}/{}",
+                    c.ruby_version.as_deref().unwrap_or("?"),
+                    c.platform.as_deref().unwrap_or("?")
+                )
+            })
+            .collect();
+        Err(packaging_error(
+            120,
+            Some(&format!(
+                "no package for ruby {ruby_version} on {platform} (tebako {tebako_version}). Available: {}. Use --build-runtime to build the runtime from source instead.",
+                combos.join(", ")
+            )),
+        ))
     }
 
     fn verify(&self, tmp: &Path, entry: &IndexEntry) -> Result<(), TebakoError> {
@@ -720,7 +600,7 @@ impl Resolver {
         tebako_version: &str,
     ) -> Result<(Vec<IndexEntry>, Option<String>), TebakoError> {
         let mut tried: Vec<String> = Vec::new();
-        for name in self.index_files() {
+        for name in INDEX_FILES {
             let url = self.index_url(name, tebako_version);
             match fetch_text(&url) {
                 Ok(body) => match self.parse_index(name, &body, tebako_version) {
@@ -749,7 +629,7 @@ impl Resolver {
             124,
             Some(&format!(
                 "{} release v{} provides no usable package index (tried: {})",
-                self.release_name(),
+                RELEASE_NAME,
                 tebako_version,
                 tried.join(", ")
             )),
@@ -769,10 +649,8 @@ impl Resolver {
         }
     }
 
-    /// Runtime: the tebako-runtime-ruby manifest.json is an array of
+    /// The tebako-runtime-ruby manifest.json is an array of
     /// {tebako_version, ruby_version, platform, filename, sha256, ...}.
-    /// Bootstrap: the tebako-bootstrap manifest.json is an object
-    /// {name, version, assets: [{platform, file, sha256}]}.
     fn parse_manifest(
         &self,
         body: &str,
@@ -781,91 +659,57 @@ impl Resolver {
         let data = json_parse(body).map_err(|_| {
             FetchError::IndexUnavailable("manifest.json is not valid JSON".to_string())
         })?;
-        match self.flavor {
-            Flavor::Runtime => {
-                let JsonValue::Array(items) = data else {
-                    return Err(FetchError::IndexUnavailable(
-                        "manifest.json is not an array".to_string(),
-                    ));
-                };
-                Ok(items
-                    .iter()
-                    .filter(|e| {
-                        e.find("tebako_version")
-                            .and_then(|v| v.as_string())
-                            .as_deref()
-                            == Some(tebako_version)
-                            && e.find("sha256").and_then(|v| v.as_string()).is_some()
-                            && e.find("filename").and_then(|v| v.as_string()).is_some()
-                    })
-                    .map(|e| IndexEntry {
-                        ruby_version: e.find("ruby_version").and_then(|v| v.as_string()),
-                        platform: e.find("platform").and_then(|v| v.as_string()),
-                        filename: e
-                            .find("filename")
-                            .and_then(|v| v.as_string())
-                            .unwrap_or_default(),
-                        sha256: e
+        let JsonValue::Array(items) = data else {
+            return Err(FetchError::IndexUnavailable(
+                "manifest.json is not an array".to_string(),
+            ));
+        };
+        Ok(items
+            .iter()
+            .filter(|e| {
+                e.find("tebako_version")
+                    .and_then(|v| v.as_string())
+                    .as_deref()
+                    == Some(tebako_version)
+                    && e.find("sha256").and_then(|v| v.as_string()).is_some()
+                    && e.find("filename").and_then(|v| v.as_string()).is_some()
+            })
+            .map(|e| IndexEntry {
+                ruby_version: e.find("ruby_version").and_then(|v| v.as_string()),
+                platform: e.find("platform").and_then(|v| v.as_string()),
+                filename: e
+                    .find("filename")
+                    .and_then(|v| v.as_string())
+                    .unwrap_or_default(),
+                sha256: e
+                    .find("sha256")
+                    .and_then(|v| v.as_string())
+                    .unwrap_or_default()
+                    .to_ascii_lowercase(),
+                image: e.find("image").and_then(|img| {
+                    Some(ImageRef {
+                        filename: img.find("filename").and_then(|v| v.as_string())?,
+                        sha256: img
                             .find("sha256")
-                            .and_then(|v| v.as_string())
-                            .unwrap_or_default()
+                            .and_then(|v| v.as_string())?
                             .to_ascii_lowercase(),
-                        image: e.find("image").and_then(|img| {
-                            Some(ImageRef {
-                                filename: img.find("filename").and_then(|v| v.as_string())?,
-                                sha256: img
-                                    .find("sha256")
-                                    .and_then(|v| v.as_string())?
-                                    .to_ascii_lowercase(),
-                            })
-                        }),
-                        // tebako-runtime-ruby#40: the additive `dll` key
-                        // (windows packages only) — absent on every POSIX
-                        // entry, ignored by consumers that predate it.
-                        dll: e.find("dll").and_then(|d| {
-                            Some(DllRef {
-                                filename: d.find("filename").and_then(|v| v.as_string())?,
-                                install_as: d.find("install_as").and_then(|v| v.as_string()),
-                                sha256: d
-                                    .find("sha256")
-                                    .and_then(|v| v.as_string())?
-                                    .to_ascii_lowercase(),
-                            })
-                        }),
                     })
-                    .collect())
-            }
-            Flavor::Bootstrap => {
-                let Some(JsonValue::Array(assets)) = data.find("assets").cloned() else {
-                    return Err(FetchError::IndexUnavailable(
-                        "manifest.json has no assets array".to_string(),
-                    ));
-                };
-                Ok(assets
-                    .iter()
-                    .filter(|a| {
-                        a.find("platform").and_then(|v| v.as_string()).is_some()
-                            && a.find("file").and_then(|v| v.as_string()).is_some()
-                            && a.find("sha256").and_then(|v| v.as_string()).is_some()
-                    })
-                    .map(|a| IndexEntry {
-                        ruby_version: None,
-                        platform: a.find("platform").and_then(|v| v.as_string()),
-                        filename: a
-                            .find("file")
-                            .and_then(|v| v.as_string())
-                            .unwrap_or_default(),
-                        sha256: a
+                }),
+                // tebako-runtime-ruby#40: the additive `dll` key
+                // (windows packages only) — absent on every POSIX
+                // entry, ignored by consumers that predate it.
+                dll: e.find("dll").and_then(|d| {
+                    Some(DllRef {
+                        filename: d.find("filename").and_then(|v| v.as_string())?,
+                        install_as: d.find("install_as").and_then(|v| v.as_string()),
+                        sha256: d
                             .find("sha256")
-                            .and_then(|v| v.as_string())
-                            .unwrap_or_default()
+                            .and_then(|v| v.as_string())?
                             .to_ascii_lowercase(),
-                        image: None,
-                        dll: None,
                     })
-                    .collect())
-            }
-        }
+                }),
+            })
+            .collect())
     }
 
     /// `<sha256>  <filename>` lines; filenames may carry a `*` prefix.
@@ -885,60 +729,38 @@ impl Resolver {
                 continue;
             };
             let file = file.trim().trim_start_matches('*');
-            match self.flavor {
-                Flavor::Runtime => {
-                    let prefix = format!("tebako-runtime-{tebako_version}-");
-                    let Some(rest) = file.strip_prefix(&prefix) else {
-                        continue;
-                    };
-                    // The image sibling: strip .tfs instead of .exe and
-                    // record for the second pass.
-                    if let Some(rest) = rest.strip_suffix(".tfs") {
-                        if let Some((ruby_version, platform)) = split_ruby_platform(rest) {
-                            images.push((ruby_version, platform, format!("{file}|{sha256}")));
-                        }
-                        continue;
-                    }
-                    // The ruby DLL sibling (tebako-runtime-ruby#40): the
-                    // same treatment.
-                    if let Some(rest) = rest.strip_suffix(".dll") {
-                        if let Some((ruby_version, platform)) = split_ruby_platform(rest) {
-                            dlls.push((ruby_version, platform, format!("{file}|{sha256}")));
-                        }
-                        continue;
-                    }
-                    let rest = rest.strip_suffix(".exe").unwrap_or(rest);
-                    let Some((ruby_version, platform)) = split_ruby_platform(rest) else {
-                        continue;
-                    };
-                    out.push(IndexEntry {
-                        ruby_version: Some(ruby_version),
-                        platform: Some(platform),
-                        filename: file.to_string(),
-                        sha256: sha256.to_ascii_lowercase(),
-                        image: None,
-                        dll: None,
-                    });
+            let prefix = format!("tebako-runtime-{tebako_version}-");
+            let Some(rest) = file.strip_prefix(&prefix) else {
+                continue;
+            };
+            // The image sibling: strip .tfs instead of .exe and
+            // record for the second pass.
+            if let Some(rest) = rest.strip_suffix(".tfs") {
+                if let Some((ruby_version, platform)) = split_ruby_platform(rest) {
+                    images.push((ruby_version, platform, format!("{file}|{sha256}")));
                 }
-                Flavor::Bootstrap => {
-                    let prefix = format!("tebako-bootstrap-{tebako_version}-");
-                    let Some(rest) = file.strip_prefix(&prefix) else {
-                        continue;
-                    };
-                    let platform = rest.strip_suffix(".exe").unwrap_or(rest);
-                    if platform.is_empty() {
-                        continue;
-                    }
-                    out.push(IndexEntry {
-                        ruby_version: None,
-                        platform: Some(platform.to_string()),
-                        filename: file.to_string(),
-                        sha256: sha256.to_ascii_lowercase(),
-                        image: None,
-                        dll: None,
-                    });
-                }
+                continue;
             }
+            // The ruby DLL sibling (tebako-runtime-ruby#40): the
+            // same treatment.
+            if let Some(rest) = rest.strip_suffix(".dll") {
+                if let Some((ruby_version, platform)) = split_ruby_platform(rest) {
+                    dlls.push((ruby_version, platform, format!("{file}|{sha256}")));
+                }
+                continue;
+            }
+            let rest = rest.strip_suffix(".exe").unwrap_or(rest);
+            let Some((ruby_version, platform)) = split_ruby_platform(rest) else {
+                continue;
+            };
+            out.push(IndexEntry {
+                ruby_version: Some(ruby_version),
+                platform: Some(platform),
+                filename: file.to_string(),
+                sha256: sha256.to_ascii_lowercase(),
+                image: None,
+                dll: None,
+            });
         }
         for (ruby_version, platform, parts) in images {
             let Some((filename, sha256)) = parts.split_once('|') else {
@@ -1065,7 +887,7 @@ impl Resolver {
     }
 
     fn index_urls(&self, tebako_version: &str) -> Vec<String> {
-        self.index_files()
+        INDEX_FILES
             .iter()
             .map(|n| self.index_url(n, tebako_version))
             .collect()
@@ -1269,7 +1091,7 @@ mod tests {
 
     #[test]
     fn sha256sums_runtime_entries() {
-        let r = Resolver::new(Flavor::Runtime);
+        let r = Resolver::new();
         let body = "abc123  tebako-runtime-0.15.9-3.3.7-macos-arm64\n\
                     def456  *tebako-runtime-0.15.9-3.1.6-linux-gnu-x86_64\n\
                     000000  tebako-runtime-0.15.8-3.3.7-macos-arm64\n\
@@ -1290,19 +1112,8 @@ mod tests {
     }
 
     #[test]
-    fn sha256sums_bootstrap_entries() {
-        let r = Resolver::new(Flavor::Bootstrap);
-        let body = "aaa111  tebako-bootstrap-0.2.0-macos-arm64\n\
-                    bbb222  tebako-bootstrap-0.2.0-windows-ucrt64.exe\n";
-        let entries = r.parse_sha256sums(body, "0.2.0");
-        assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0].platform.as_deref(), Some("macos-arm64"));
-        assert_eq!(entries[1].platform.as_deref(), Some("windows-ucrt64"));
-    }
-
-    #[test]
     fn manifest_runtime_array() {
-        let r = Resolver::new(Flavor::Runtime);
+        let r = Resolver::new();
         let body = r#"[
           {"tebako_version":"0.15.9","ruby_version":"3.3.7","platform":"macos-arm64",
            "filename":"tebako-runtime-0.15.9-3.3.7-macos-arm64","sha256":"ABC","size_bytes":12},
@@ -1316,21 +1127,9 @@ mod tests {
 
     #[test]
     fn manifest_runtime_rejects_object() {
-        let r = Resolver::new(Flavor::Runtime);
+        let r = Resolver::new();
         let err = r.parse_manifest("{\"assets\":[]}", "0.15.9").unwrap_err();
         assert!(matches!(err, FetchError::IndexUnavailable(_)));
-    }
-
-    #[test]
-    fn manifest_bootstrap_object() {
-        let r = Resolver::new(Flavor::Bootstrap);
-        let body = r#"{"name":"tebako-bootstrap","version":"0.2.0","assets":[
-          {"platform":"macos-arm64","file":"tebako-bootstrap-0.2.0-macos-arm64","sha256":"DEF"}
-        ]}"#;
-        let entries = r.parse_manifest(body, "0.2.0").unwrap();
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].platform.as_deref(), Some("macos-arm64"));
-        assert_eq!(entries[0].sha256, "def");
     }
 
     #[test]
@@ -1372,7 +1171,7 @@ mod tests {
 
     #[test]
     fn sha256sums_dll_lines_attach_to_the_runtime_entry() {
-        let r = Resolver::new(Flavor::Runtime);
+        let r = Resolver::new();
         let body = "aaa111  tebako-runtime-0.16.3-3.3.12-windows-ucrt64.exe\n\
                     bbb222  tebako-runtime-0.16.3-3.3.12-windows-ucrt64.tfs\n\
                     ccc333  tebako-runtime-0.16.3-3.3.12-windows-ucrt64.dll\n\
@@ -1400,7 +1199,7 @@ mod tests {
 
     #[test]
     fn manifest_runtime_dll_facet() {
-        let r = Resolver::new(Flavor::Runtime);
+        let r = Resolver::new();
         let body = r#"[
           {"tebako_version":"0.16.3","ruby_version":"3.3.12","platform":"windows-ucrt64",
            "filename":"tebako-runtime-0.16.3-3.3.12-windows-ucrt64.exe","sha256":"AAA",
@@ -1462,7 +1261,6 @@ mod tests {
 
     fn dll_resolver(cache: &Path, mirror: &Path) -> Resolver {
         Resolver {
-            flavor: Flavor::Runtime,
             cache_root: cache.to_path_buf(),
             mirror: format!("file://{}", mirror.display()),
             lock_timeout: LOCK_TIMEOUT,

--- a/crates/tebako-cli/src/suite.rs
+++ b/crates/tebako-cli/src/suite.rs
@@ -35,7 +35,7 @@ use serde::Deserialize;
 use crate::error::{packaging_error, plain_error, TebakoError};
 use crate::options::{host_platform, PressMode, PressOptions};
 use crate::packager;
-use crate::resolve::{Flavor, Resolved, Resolver};
+use crate::resolve::{Resolved, Resolver};
 use crate::scenario::{self, ruby_version_with_gemfile, ScenarioManager};
 
 // ---------------------------------------------------------------------
@@ -330,22 +330,9 @@ pub fn press_suite(
     }
     suite_warnings(opts, spec, suite_dir);
     let platform = host_platform()?;
-    let bootstrap_path = match crate::decide_bootstrap(opts) {
-        crate::BootstrapSource::Path(path) => {
-            if !path.is_file() {
-                return Err(packaging_error(
-                    127,
-                    Some(&format!("runtime not found: {}", path.display())),
-                ));
-            }
-            path
-        }
-        crate::BootstrapSource::Download => Resolver::new(Flavor::Bootstrap).resolve(
-            &crate::resolve::default_bootstrap_version(),
-            &platform,
-            &crate::resolve::default_bootstrap_version(),
-        )?,
-    };
+    // Local sources only — the retired C++ bootstrap download must never
+    // fire (exit 136 when no local Rust tebako-bootstrap is found).
+    let bootstrap_path = crate::local_bootstrap(opts)?;
 
     // Per-entry imaging; runtimes resolve once per distinct ruby version.
     let mut runtimes: BTreeMap<String, Resolved> = BTreeMap::new();
@@ -362,11 +349,7 @@ pub fn press_suite(
         scenario_mgr.configure_scenario()?;
         let ruby_ver = entry_ruby_version(opts, &scenario_mgr, entry)?;
         if !runtimes.contains_key(&ruby_ver) {
-            let r = Resolver::new(Flavor::Runtime).resolve_runtime(
-                &ruby_ver,
-                &platform,
-                &opts.tebako_version,
-            )?;
+            let r = Resolver::new().resolve_runtime(&ruby_ver, &platform, &opts.tebako_version)?;
             runtimes.insert(ruby_ver.clone(), r);
         }
         let resolved = &runtimes[&ruby_ver];

--- a/crates/tebako-cli/tests/cli_e2e.rs
+++ b/crates/tebako-cli/tests/cli_e2e.rs
@@ -11,9 +11,10 @@
 //!   never builds it (tebako-bootstrap is a lib dependency): build it
 //!   first (`cargo build -p tebako-bootstrap`) or run the suite as CI
 //!   does (`cargo build --workspace` then `cargo test --workspace`).
-//!   The harness fails fast when it is missing (see dogfood_bootstrap)
-//!   rather than silently pressing with the v1 C++ bootstrap download,
-//!   whose handoff the image-era runtime driver rejects at run time;
+//!   The harness fails fast when it is missing (see dogfood_bootstrap);
+//!   the CLI itself now also fails closed (exit 136) — the v1 C++
+//!   bootstrap download fallback whose handoff the image-era runtime
+//!   driver rejects at run time is retired;
 //! - the golden test additionally needs $TEBAKO_REFERENCE_GEM pointing at
 //!   a checkout of the reference gem (tamatebako/tebako, the three-part
 //!   model) and a host ruby with the thor gem.
@@ -45,18 +46,16 @@ fn e2e_allowed() -> bool {
 }
 
 /// The in-workspace Rust bootstrap every e2e press dogfoods
-/// ($TEBAKO_BOOTSTRAP → the binary next to the tebako bin). REQUIRED,
-/// never a silent fallback: when the sibling is absent the CLI's
-/// decide_bootstrap downloads the v1 C++ bootstrap release, whose handoff
-/// (--tebako-entry = argv0 verbatim, no L2 package-manifest selection, no
-/// `;image` facet fetch) the image-era runtime driver rejects at run
-/// time — the suite then fails mid-cold-run with a driver-side
-/// "entrypoint '<package path>' not found at '/__tfs__/...' in the
-/// mounted tree" that indites the wrong component (exit 255), and the
-/// press_lock poison cascade hides the first failure. `cargo test -p
-/// tebako-cli` alone does not build the sibling; build it first
-/// (`cargo build -p tebako-bootstrap`) or run the suite as CI does
-/// (`cargo build --workspace` then `cargo test --workspace`).
+/// ($TEBAKO_BOOTSTRAP → the binary next to the tebako bin). REQUIRED:
+/// when no local bootstrap is found the press fails closed (exit 136 —
+/// the v1 C++ bootstrap download is retired: its argv0-verbatim handoff,
+/// no L2 package-manifest selection, no `;image` facet fetch, is rejected
+/// by the image-era runtime driver at run time). The harness still fails
+/// fast on its own so the suite never pays a runtime download for the
+/// named refusal, and `cargo test -p tebako-cli` alone does not build
+/// the sibling; build it first (`cargo build -p tebako-bootstrap`) or
+/// run the suite as CI does (`cargo build --workspace` then `cargo test
+/// --workspace`).
 fn dogfood_bootstrap() -> PathBuf {
     let sibling = tebako_bin().parent().unwrap().join(if cfg!(windows) {
         "tebako-bootstrap.exe"
@@ -67,8 +66,8 @@ fn dogfood_bootstrap() -> PathBuf {
         sibling.is_file(),
         "the in-workspace tebako-bootstrap binary is missing ({}): build it first \
          (cargo build -p tebako-bootstrap) or run the suite via cargo test --workspace — \
-         without it the press silently embeds the downloaded v1 C++ bootstrap and every \
-         cold run fails in the runtime driver",
+         without it every press fails closed with exit 136 (the v1 C++ bootstrap \
+         download fallback is retired)",
         sibling.display()
     );
     sibling
@@ -203,8 +202,8 @@ fn press_command(env: &PressEnv, entry: &str, output: &Path) -> Command {
         .arg(output)
         .arg("-p")
         .arg(&env.prefix);
-    // Dogfood the in-workspace Rust bootstrap (required — see
-    // dogfood_bootstrap for the failure mode of the download fallback).
+    // Dogfood the in-workspace Rust bootstrap (required — the C++
+    // download fallback is retired; without it the press fails closed).
     cmd.env("TEBAKO_BOOTSTRAP", dogfood_bootstrap());
     cmd
 }
@@ -1141,7 +1140,7 @@ fn official_pair_fixture(tag: &str) -> Option<(PathBuf, String, String, String)>
     // download or the shared cache); resolve_runtime installs — and on a
     // stale entry backfills — the runtime image (item 30b) next to the
     // exe in the same cache entry.
-    let resolver = tebako_cli::resolve::Resolver::new(tebako_cli::resolve::Flavor::Runtime);
+    let resolver = tebako_cli::resolve::Resolver::new();
     let resolved = resolver.resolve_runtime(ruby, &plat, ver).ok()?;
     fs::copy(&resolved.executable, mirror.join(&asset)).unwrap();
 

--- a/docs/spec/19-bootstrap-distribution.md
+++ b/docs/spec/19-bootstrap-distribution.md
@@ -25,10 +25,21 @@ from, and why will it run on your machine?**
 
 The short answer: **we build it, you never do.** The bootstrap is a
 precompiled artifact we publish for every supported platform, alongside
-the rest of the tebako release. When you press a package, `tebako press`
-downloads the right one for your platform (once, verified, cached) and
-stitches it onto your payloads. There is no C compiler, no CMake, no Rust
-toolchain, no vcpkg anywhere in that path — and there never will be.
+the rest of the tebako release. A press stitches it onto your payloads —
+today from a **local** Rust bootstrap (`--bootstrap`, `$TEBAKO_BOOTSTRAP`,
+or the `tebako-bootstrap` binary next to the `tebako` executable); the
+download-and-cache flow of §4 (PLANNED) makes that automatic. There is no
+C compiler, no CMake, no Rust toolchain, no vcpkg anywhere in that path —
+and there never will be.
+
+> **Shipped vs planned.** The CLI today sources the bootstrap from local
+> binaries only and **fails closed** when none is found (named error,
+> exit 136). The retired v1 C++ `tebako-bootstrap` release download —
+> whose argv0-verbatim handoff the image-era runtime driver rejects — is
+> gone for good: no silent network fetch remains on the press path. The
+> per-triplet Rust bootstrap assets this document describes ARE published
+> with every tebako release (§3.3); teaching `tebako press` to resolve
+> them into the store (once, verified, cached) is the PLANNED part.
 
 ## 2. The audience rule (who needs what)
 
@@ -92,7 +103,25 @@ for your machine; you never pick anything.
 
 ## 4. How a press gets its bootstrap (no compiler involved)
 
-When you run `tebako press`, here is exactly what happens:
+**Shipped behavior:** `tebako press` sources the bootstrap from local
+Rust binaries, in this order:
+
+1. `--bootstrap <path>` — an explicit binary;
+2. `$TEBAKO_BOOTSTRAP` — the environment override;
+3. the `tebako-bootstrap` executable next to the `tebako` binary (the
+   dogfooding/installed-pair layout).
+
+With none of these present the press **fails closed** with the named
+error "Press requires a local Rust tebako-bootstrap binary" (exit 136) —
+no network fetch is attempted. (The historical fallback downloaded the
+v1 C++ bootstrap release; its handoff predates the spec 17 driver
+contract and produced packages that fail at run time, so it is retired,
+not merely refused.)
+
+**PLANNED (not yet shipped):** the release-store flow below — resolving
+the published per-triplet Rust bootstrap into `~/.tebako/bootstraps/`
+automatically, with the same verification discipline the runtime cache
+already has:
 
 ```
 tebako press app.rb -o myapp
@@ -226,7 +255,8 @@ verify against each other (spec 18).
 
 The bootstrap is **ours, precompiled, per-triplet, verified, and
 cached** — built once in our pipeline on deliberately old floors (or
-musl, which has no floor), published with sha256 anchors, downloaded
-once per machine, and stitched onto your payloads by a press that
-checks its contract card first. You never compile it, you never pick
-it, and it always starts.
+musl, which has no floor), published with sha256 anchors, sourced by the
+press from local binaries today (failing closed otherwise; the release
+store download of §4 is PLANNED), and stitched onto your payloads by a
+press that checks its contract card first. You never compile it, you
+never pick it, and it always starts.


### PR DESCRIPTION
**DRAFT — owner-gated.** Do not merge without the owner's explicit go-ahead (ecosystem hard rule 2026-08-11).

## What this retires

The tebako CLI's press path had a silent fallback: when no local Rust `tebako-bootstrap` was available (`--bootstrap` / `$TEBAKO_BOOTSTRAP` / the sibling binary), it downloaded the archived **v1 C99 bootstrap** from `tamatebako/tebako-bootstrap` releases (`Flavor::Bootstrap`, default `0.2.0`, `TEBAKO_BOOTSTRAP_VERSION` / `TEBAKO_BOOTSTRAP_MIRROR`). That bootstrap's argv0-verbatim handoff predates the spec 17 driver contract and is rejected by the image-era runtime driver at run time (host-absolute entry → exit 255) — the fallback produced silently-broken packages. PR #404 made the cli_e2e harness fail fast around it; this PR removes the fallback itself.

## What changed

- **`crates/tebako-cli/src/lib.rs`** — `BootstrapSource::Download` is gone. `decide_bootstrap()` now returns `Option<PathBuf>` over the local sources only; the new `local_bootstrap()` boundary turns `None` into the named packaging error **136** *before* the runtime download (a missing bootstrap never costs a fetch). A `--bootstrap`/`$TEBAKO_BOOTSTRAP` path that does not exist keeps the gem's parity error 127 (`runtime not found: <path>`). The fat-mode `check_bootstrap_version()` guard (134) applied only to the downloaded bootstrap and is deleted with it.
- **`crates/tebako-cli/src/suite.rs`** — the suite press uses the same `local_bootstrap()` boundary.
- **`crates/tebako-cli/src/resolve.rs`** — the gem's BootstrapManager half is unported: the `Flavor` enum, `BOOTSTRAP_VERSION` / `PAYLOAD_MIN_VERSION` / `default_bootstrap_version()`, the `TEBAKO_BOOTSTRAP_MIRROR` mirror arm, the `bootstraps/` cache layout, the bootstrap manifest-object and SHA256SUMS index arms, the 131/132 error arms, and the bootstrap-only `Resolver::resolve()` are all deleted. `Resolver` (now `Resolver::new()`, plus `Default`) resolves tebako-runtime-ruby runtimes only.
- **`crates/tebako-cli/src/error.rs`** — **136** joins the packaging table; 131/132/134 stay as reserved rows (the table mirrors the gem's `PACKAGING_ERRORS`) with a retirement note.

### The named error / exit code

**136 — "Press requires a local Rust tebako-bootstrap binary (the v1 C++ bootstrap download is retired)"**, with the extm naming the three local sources. Taxonomy: this is a *press-time* error, so it extends the CLI's packaging table (101–135 + the port's own additions 133/134/135 — 136 is the next free code), the same convention previous port additions followed. The 65–76 band is the loader family's runtime taxonomy and is not reused here.

### On the "keep the Rust-bootstrap download" question

No code path fetching the **Rust** bootstrap from the product's own releases exists to keep: `release.yml` already publishes per-triplet Rust `tebako-bootstrap` assets (with the `assets`-shape `manifest.json`), but the CLI never consumed them — the only implemented bootstrap download targeted the v1 C99 lineage. That future consumption is spec 19 §4's store flow, now explicitly marked **PLANNED** (the spec previously presented it as shipped behavior).

## Tests

- Deleted with the path: `resolve.rs`'s `sha256sums_bootstrap_entries` and `manifest_bootstrap_object` (they tested the retired index arms). No other test exercised the fallback (verified by grep — no test asserted 131/132/134).
- New unit tests (`lib.rs`): `local_bootstrap_without_any_local_source_fails_closed_136` (no option/env/sibling → `decide_bootstrap` is `None`, error code 136; env precedence covered in the same test) and `local_bootstrap_prefers_the_option_and_rejects_a_missing_file` (option wins; missing file → 127).
- The cli_e2e harness from #404 is unchanged in behavior (still fails fast on a missing dogfood sibling, still injects `$TEBAKO_BOOTSTRAP`); its comments now describe the CLI's own fail-closed refusal.
- CLI-level proof: `env -u TEBAKO_BOOTSTRAP <tebako-without-sibling> press -r tests/fixtures/test-00 -e app.rb` prints `Press requires a local Rust tebako-bootstrap binary ... [136]` and exits **136** with no network access attempted.

## Verification (this worktree, macOS arm64)

- `cargo fmt --check` — clean (`FMT CLEAN`).
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0 (`Finished dev profile … in 30.67s`).
- `cargo test -p tebako-cli --lib` — `60 passed; 0 failed` (incl. both new tests).
- `cargo test -p tebako-cli` (full suite incl. the cli_e2e presses/cold runs, dogfood bootstrap built first per #404) — exit code 0; tail: `install.rs 6/6`, `publish.rs 10/10`, `registry_cli.rs 1/1`, `run.rs 6/6`, `suite.rs 6/6`, doc-tests ok.

## Doc sync (same PR)

- `docs/spec/19-bootstrap-distribution.md` — §1 short answer, §4 (shipped behavior: local sources, fail closed 136; the store/download flow marked PLANNED), §9 summary.
- `crates/tebako-cli/README.md` — bootstrap source bullet, deviation bullet, exit-code range (106–136), the e2e note.

CI's `.oracle/tebako-bootstrap` (v1 C++, `TEBAKO_CPP_BOOTSTRAP`) download is untouched: it is the sanctioned v1 behavioral parity oracle for `tebako-bootstrap`'s selftest, not part of the press path.
