### PR TITLE
feat(tfs): spec 24 TFS-layer mechanism — gated COW write gate, TEBAKO_OVERLAYS/TEBAKO_DECRYPT, vfs-deny journaling

### DIFF
--- a/crates/tfs/src/backends_cow.rs
+++ b/crates/tfs/src/backends_cow.rs
@@ -21,6 +21,21 @@
 //! lives inside it (`.tfs-whiteouts`) keeping the overlay self-contained.
 //! The journal file itself is hidden from the merged view.
 //!
+//! ## The declared write gate (spec 24 §5)
+//!
+//! [`CowBackend::new`] stacks the UNGATED programmatic form: every write
+//! lands in the overlay. [`CowBackend::with_write_areas`] stacks the GATED
+//! declarative form: the mount carries a declared write-area set (the
+//! slice's resolved `needs.write` paths) and a write outside every area is
+//! `EROFS` — nothing is transformed that was not declared. Areas are
+//! absolute in-image paths (`/app/var/cache`; `/` = the whole mount),
+//! normalized at construction to the backend convention (no leading or
+//! trailing `/`, `""` for the root); a write to an area itself or any
+//! path below it (component boundary — area `/a/b` never covers
+//! `/a/bc`) is permitted. All four write verbs (`pwrite`, `truncate`,
+//! `mkdir`, `remove`) are gated; reads are never gated. The gate does not
+//! relax the journal file's `EPERM`.
+//!
 //! ## Journal format (v1)
 //!
 //! ```text
@@ -142,12 +157,64 @@ pub struct CowBackend {
     /// persistent form, rewritten atomically on every change).
     whiteouts: RwLock<BTreeSet<String>>,
     journal_path: PathBuf,
+    /// The declared write areas (spec 24 §5), backend-normalized (`""` =
+    /// the mount root, covering everything): `Some` gates every write
+    /// verb to the declared set (outside → `EROFS`); `None` is the
+    /// ungated programmatic form (spec 11 §4).
+    write_areas: Option<BTreeSet<String>>,
+}
+
+/// Normalize and validate one declared write area (spec 24 §5): an
+/// absolute in-image path (`/app/var/cache`; `/` = the whole mount)
+/// stored in the backend convention (`app/var/cache`; `""` for the
+/// root). Trailing slashes fold; interior empty components (`//`) and
+/// `.` / `..` components are malformed — EINVAL, fail-closed.
+fn normalize_write_area(area: &str) -> Result<String, i32> {
+    if !area.starts_with('/') {
+        return Err(libc::EINVAL);
+    }
+    let trimmed = area.trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Ok(String::new());
+    }
+    if trimmed[1..]
+        .split('/')
+        .any(|c| c.is_empty() || c == "." || c == "..")
+    {
+        return Err(libc::EINVAL);
+    }
+    Ok(trimmed[1..].to_string())
 }
 
 impl CowBackend {
     /// Stack `overlay` over `base`, loading (or creating) the whiteout
     /// journal inside the overlay directory.
     pub fn new(base: Box<dyn Backend>, overlay: HostDirBackend) -> Result<CowBackend, i32> {
+        Self::stack(base, overlay, None)
+    }
+
+    /// [`CowBackend::new`] with the declared write gate (spec 24 §5):
+    /// writes land in the overlay only under one of `areas`; every other
+    /// write is `EROFS`. Areas are validated ([`normalize_write_area`]) —
+    /// a malformed area fails the mount with EINVAL, never a silent
+    /// widening.
+    pub fn with_write_areas(
+        base: Box<dyn Backend>,
+        overlay: HostDirBackend,
+        areas: &[String],
+    ) -> Result<CowBackend, i32> {
+        let mut normalized = BTreeSet::new();
+        for area in areas {
+            normalized.insert(normalize_write_area(area)?);
+        }
+        Self::stack(base, overlay, Some(normalized))
+    }
+
+    fn stack(
+        base: Box<dyn Backend>,
+        overlay: HostDirBackend,
+        write_areas: Option<BTreeSet<String>>,
+    ) -> Result<CowBackend, i32> {
         let journal_path = overlay.root().join(JOURNAL_FILE);
         let whiteouts = load_journal(&journal_path)?;
         if whiteouts.is_empty() {
@@ -160,6 +227,7 @@ impl CowBackend {
             overlay,
             whiteouts: RwLock::new(whiteouts),
             journal_path,
+            write_areas,
         })
     }
 
@@ -176,6 +244,29 @@ impl CowBackend {
     /// The current whiteout set (snapshot).
     pub fn whiteouts(&self) -> BTreeSet<String> {
         self.whiteouts.read().unwrap().clone()
+    }
+
+    /// The declared write areas (spec 24 §5), backend-normalized; `None`
+    /// for the ungated programmatic form.
+    pub fn write_areas(&self) -> Option<&BTreeSet<String>> {
+        self.write_areas.as_ref()
+    }
+
+    /// The write gate (spec 24 §5): a write to `path` (already
+    /// backend-normalized) is permitted when the mount is ungated or
+    /// `path` is an area itself or below one, at a component boundary
+    /// (area `a/b` never covers `a/bc`; the `""` area covers everything).
+    fn write_permitted(&self, path: &str) -> bool {
+        match &self.write_areas {
+            None => true,
+            Some(areas) => areas.iter().any(|area| {
+                area.is_empty()
+                    || path == area
+                    || (path.len() > area.len()
+                        && path.as_bytes()[area.len()] == b'/'
+                        && path.starts_with(area.as_str()))
+            }),
+        }
     }
 
     /// True when `path` is hidden by a whiteout (a whiteout on a
@@ -427,6 +518,9 @@ impl WritableBackend for CowBackend {
         if path == JOURNAL_FILE {
             return Err(libc::EPERM); // the journal is the audit delta, not content
         }
+        if !self.write_permitted(path) {
+            return Err(libc::EROFS); // outside every declared write area (spec 24 §5)
+        }
         // A whiteouted path recreates FRESH (no base copy-up): the delete
         // stands in the journal; the new overlay entry takes over the name.
         if !self.whiteouts.read().unwrap().contains(path) {
@@ -442,6 +536,9 @@ impl WritableBackend for CowBackend {
         if path.is_empty() || path == JOURNAL_FILE {
             return Err(libc::EINVAL);
         }
+        if !self.write_permitted(path) {
+            return Err(libc::EROFS);
+        }
         // truncate requires an existing file (merged view), then lands in
         // the overlay (copy-up first for base files).
         if self.stat_merged(path)?.entry_type != EntryType::File {
@@ -456,6 +553,9 @@ impl WritableBackend for CowBackend {
         if path.is_empty() || path == JOURNAL_FILE {
             return Err(libc::EEXIST);
         }
+        if !self.write_permitted(path) {
+            return Err(libc::EROFS);
+        }
         match self.stat_merged(path) {
             Ok(_) => return Err(libc::EEXIST),
             Err(libc::ENOENT) => {}
@@ -469,6 +569,9 @@ impl WritableBackend for CowBackend {
         let path = normalize(path);
         if path.is_empty() || path == JOURNAL_FILE {
             return Err(libc::EINVAL);
+        }
+        if !self.write_permitted(path) {
+            return Err(libc::EROFS);
         }
         // The merged view answers existence (hidden → ENOENT) and, for
         // directories, emptiness (rmdir semantics: ENOTEMPTY).
@@ -742,6 +845,228 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
+    // The declared write gate (spec 24 §5)
+    // ---------------------------------------------------------------
+
+    fn gated_cow(areas: &[&str]) -> (tempfile::TempDir, CowBackend) {
+        let dir = tempfile::tempdir().unwrap();
+        let base =
+            Box::new(TarBackend::from_memory(make_base_tar(), TarCompression::None).unwrap());
+        let overlay = HostDirBackend::new(dir.path()).unwrap();
+        let areas: Vec<String> = areas.iter().map(|a| a.to_string()).collect();
+        let cow = CowBackend::with_write_areas(base, overlay, &areas).unwrap();
+        (dir, cow)
+    }
+
+    #[test]
+    fn write_area_normalization_is_fail_closed() {
+        // The manifest spelling (absolute) normalizes to the backend
+        // convention; `/` is the whole mount.
+        assert_eq!(
+            normalize_write_area("/app/var/cache").unwrap(),
+            "app/var/cache"
+        );
+        assert_eq!(
+            normalize_write_area("/app/var/cache/").unwrap(),
+            "app/var/cache"
+        );
+        assert_eq!(normalize_write_area("/").unwrap(), "");
+        // Malformed areas are EINVAL, never a silent widening.
+        for bad in [
+            "relative/path",
+            "",
+            "//double",
+            "/a//b",
+            "/a/./b",
+            "/a/../b",
+            "/..",
+        ] {
+            assert_eq!(normalize_write_area(bad), Err(libc::EINVAL), "{bad:?}");
+        }
+    }
+
+    #[test]
+    fn gated_cow_writes_inside_areas_land_in_overlay() {
+        let (dir, cow) = gated_cow(&["/etc/deep", "/var"]);
+        let w = cow.writable().unwrap();
+        assert_eq!(
+            cow.write_areas()
+                .unwrap()
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            vec!["etc/deep", "var"]
+        );
+        // Modify a base file inside the area (copy-up through the gate)...
+        w.pwrite("etc/deep/nested.txt", b"GATED", 0).unwrap();
+        assert_eq!(pread_all(&cow, "etc/deep/nested.txt"), b"GATEDd\n");
+        assert_eq!(pread_all(cow.base(), "etc/deep/nested.txt"), b"nested\n");
+        // ...create a new file in the area (parents materialize)...
+        w.pwrite("var/cache/new.bin", b"new", 0).unwrap();
+        assert!(dir.path().join("var/cache/new.bin").exists());
+        // ...mkdir and remove (whiteout) inside the area...
+        w.mkdir("var/made", 0o755).unwrap();
+        w.remove("etc/deep/nested.txt").unwrap();
+        assert_eq!(cow.stat("etc/deep/nested.txt").unwrap_err(), libc::ENOENT);
+        assert!(cow.whiteouts().contains("etc/deep/nested.txt"));
+        // ...and truncate inside the area.
+        w.pwrite("var/f.txt", b"abcdef", 0).unwrap();
+        w.truncate("var/f.txt", 3).unwrap();
+        assert_eq!(pread_all(&cow, "var/f.txt"), b"abc");
+    }
+
+    #[test]
+    fn gated_cow_writes_outside_areas_are_erofs_and_reads_untouched() {
+        let (_dir, cow) = gated_cow(&["/etc/deep"]);
+        let w = cow.writable().unwrap();
+        // Every verb on a path outside the declared set: EROFS.
+        assert_eq!(w.pwrite("etc/motd", b"x", 0).unwrap_err(), libc::EROFS);
+        assert_eq!(w.truncate("etc/motd", 0).unwrap_err(), libc::EROFS);
+        assert_eq!(w.mkdir("etc/made", 0o755).unwrap_err(), libc::EROFS);
+        assert_eq!(w.remove("etc/motd").unwrap_err(), libc::EROFS);
+        // The component boundary is exact: `etc/deepx` is not under
+        // `/etc/deep` (a bare string prefix would wrongly admit it).
+        assert_eq!(w.pwrite("etc/deepx", b"x", 0).unwrap_err(), libc::EROFS);
+        assert_eq!(w.pwrite("etc/deepish/x", b"x", 0).unwrap_err(), libc::EROFS);
+        // An area's PARENT is outside it: single-level mkdir of an area
+        // ancestor is the host's own write, not the slice's declaration.
+        assert_eq!(w.mkdir("etc", 0o755).unwrap_err(), libc::EROFS);
+        // Reads are never gated.
+        assert_eq!(pread_all(&cow, "etc/motd"), b"base-motd\n");
+        assert_eq!(names(&cow, "etc"), vec!["deep", "motd"]);
+        // The base stays byte-identical and no whiteout was recorded.
+        assert!(cow.whiteouts().is_empty());
+    }
+
+    #[test]
+    fn gated_cow_area_on_a_file_covers_exactly_it() {
+        let (_dir, cow) = gated_cow(&["/etc/motd"]);
+        let w = cow.writable().unwrap();
+        w.pwrite("etc/motd", b"AREA", 0).unwrap();
+        assert_eq!(pread_all(&cow, "etc/motd"), b"AREA-motd\n");
+        assert_eq!(w.remove("etc/deep/nested.txt").unwrap_err(), libc::EROFS);
+        // The gate is SYNTACTIC: `etc/motd/x` is below the area spelling,
+        // so the gate permits it and the merged view answers ENOTDIR (a
+        // file has no children) — never a silent success.
+        assert_eq!(w.pwrite("etc/motd/x", b"x", 0).unwrap_err(), libc::ENOTDIR);
+    }
+
+    #[test]
+    fn gated_cow_root_area_covers_everything_but_the_journal() {
+        let (_dir, cow) = gated_cow(&["/"]);
+        let w = cow.writable().unwrap();
+        w.pwrite("anywhere/at/all.txt", b"yes", 0).unwrap();
+        w.remove("todelete.txt").unwrap();
+        // The gate never relaxes the journal file's EPERM.
+        assert_eq!(w.pwrite(JOURNAL_FILE, b"x", 0).unwrap_err(), libc::EPERM);
+        assert_eq!(w.remove(JOURNAL_FILE).unwrap_err(), libc::EINVAL);
+    }
+
+    #[test]
+    fn gated_cow_malformed_areas_fail_the_mount() {
+        let dir = tempfile::tempdir().unwrap();
+        let tar_path = dir.path().join("base.tar");
+        std::fs::write(&tar_path, make_base_tar()).unwrap();
+        let path = tar_path.to_str().unwrap();
+
+        // Direct: a malformed area is EINVAL at stack time.
+        let base =
+            Box::new(TarBackend::from_memory(make_base_tar(), TarCompression::None).unwrap());
+        let overlay = HostDirBackend::new(dir.path()).unwrap();
+        assert_eq!(
+            CowBackend::with_write_areas(base, overlay, &["relative".to_string()]).err(),
+            Some(libc::EINVAL)
+        );
+
+        // Through the mount layer (the driver's path): same named failure.
+        let store = dir.path().join("store");
+        assert_eq!(
+            mount::build_from_file_with_mode(
+                path,
+                "/gated",
+                MountMode::Cow,
+                Some(&mount::Overlay::gated(
+                    store.to_str().unwrap(),
+                    vec!["/a//b".to_string()]
+                ))
+            )
+            .err(),
+            Some(libc::EINVAL)
+        );
+        // A well-formed gated mount through the mount layer stacks COW.
+        let ok = mount::build_from_file_with_mode(
+            path,
+            "/gated",
+            MountMode::Cow,
+            Some(&mount::Overlay::gated(
+                store.to_str().unwrap(),
+                vec!["/etc".to_string()],
+            )),
+        )
+        .unwrap();
+        let w = ok.backend.writable().unwrap();
+        w.pwrite("etc/motd", b"G", 0).unwrap();
+        assert_eq!(w.pwrite("bin/tool", b"G", 0).unwrap_err(), libc::EROFS);
+    }
+
+    /// The gate predicate against a reference implementation: every subset
+    /// of a small area alphabet (with and without the root area) against a
+    /// probe list covering equality, containment, and substring traps.
+    #[test]
+    fn write_gate_matches_the_reference_predicate() {
+        let reference = |areas: &BTreeSet<String>, path: &str| {
+            areas
+                .iter()
+                .any(|a| a.is_empty() || path == a || path.starts_with(&format!("{a}/")))
+        };
+        let base_areas = ["app", "app/var", "etc/deep", "a/x1"];
+        for subset_bits in 0..16u32 {
+            let mut areas: BTreeSet<String> = base_areas
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| subset_bits & (1 << i) != 0)
+                .map(|(_, a)| (*a).to_string())
+                .collect();
+            if subset_bits % 3 == 0 {
+                areas.insert(String::new()); // the whole-mount spelling
+            }
+            let cow = {
+                let base = Box::new(
+                    TarBackend::from_memory(make_base_tar(), TarCompression::None).unwrap(),
+                );
+                let dir = tempfile::tempdir().unwrap();
+                let overlay = HostDirBackend::new(dir.path()).unwrap();
+                // `with_write_areas` takes the manifest spelling
+                // (absolute); the reference set stays normalized.
+                let spelled: Vec<String> = areas.iter().map(|a| format!("/{a}")).collect();
+                CowBackend::with_write_areas(base, overlay, &spelled).unwrap()
+            };
+            for probe in [
+                "",
+                "app",
+                "app/var",
+                "app/var/cache",
+                "app2",
+                "app/va",
+                "apple",
+                "etc/deep",
+                "etc/deep/nested.txt",
+                "etc/deepx",
+                "a/x1",
+                "a/x1/y",
+                "a",
+                "a/x",
+            ] {
+                assert_eq!(
+                    cow.write_permitted(probe),
+                    reference(&areas, probe),
+                    "areas {areas:?} probe {probe:?}"
+                );
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
     // The whiteout journal format
     // ---------------------------------------------------------------
 
@@ -824,7 +1149,7 @@ mod tests {
             path,
             "/cow",
             MountMode::Cow,
-            Some(overlay.to_str().unwrap()),
+            Some(&mount::Overlay::new(overlay.to_str().unwrap())),
         )
         .unwrap();
         assert_eq!(cow.mode, MountMode::Cow);
@@ -833,11 +1158,12 @@ mod tests {
         assert!(overlay.join(JOURNAL_FILE).exists());
 
         // COW over a memory image works too.
+        let mem_overlay = tempfile::tempdir().unwrap();
         let cow_mem = mount::build_from_memory_with_mode(
             &make_base_tar(),
             "/cow-mem",
             MountMode::Cow,
-            Some(tempfile::tempdir().unwrap().path().to_str().unwrap()),
+            Some(&mount::Overlay::new(mem_overlay.path().to_str().unwrap())),
         )
         .unwrap();
         assert_eq!(cow_mem.backend.name().to_str().unwrap(), "COW");
@@ -853,7 +1179,7 @@ mod tests {
                 path,
                 "/bad1",
                 MountMode::ReadOnly,
-                Some(overlay.to_str().unwrap())
+                Some(&mount::Overlay::new(overlay.to_str().unwrap()))
             )
             .err(),
             Some(libc::EINVAL)

--- a/crates/tfs/src/c_api.rs
+++ b/crates/tfs/src/c_api.rs
@@ -693,12 +693,15 @@ pub unsafe extern "C" fn tebako_fs_mount_from_file_with_mode(
         Ok(m) => m,
         Err(e) => return fail(e),
     };
-    let overlay_dir = match unsafe { optional_path_arg(overlay_dir) } {
-        Ok(o) => o,
+    // The C ABI speaks the ungated programmatic overlay form (a store
+    // directory, no declared write areas — spec 24's gated form is the
+    // declarative surface, bound by the resolver/driver chain).
+    let overlay = match unsafe { optional_path_arg(overlay_dir) } {
+        Ok(o) => o.map(mount::Overlay::new),
         Err(e) => return fail(e),
     };
     finish_mount(
-        mount::build_from_file_with_mode(archive_path, mount_point, mode, overlay_dir),
+        mount::build_from_file_with_mode(archive_path, mount_point, mode, overlay.as_ref()),
         out_handle,
     )
 }
@@ -765,8 +768,8 @@ pub unsafe extern "C" fn tebako_fs_mount_from_file_at_with_mode(
         Ok(m) => m,
         Err(e) => return fail(e),
     };
-    let overlay_dir = match unsafe { optional_path_arg(overlay_dir) } {
-        Ok(o) => o,
+    let overlay = match unsafe { optional_path_arg(overlay_dir) } {
+        Ok(o) => o.map(mount::Overlay::new),
         Err(e) => return fail(e),
     };
     finish_mount(
@@ -776,7 +779,7 @@ pub unsafe extern "C" fn tebako_fs_mount_from_file_at_with_mode(
             length,
             mount_point,
             mode,
-            overlay_dir,
+            overlay.as_ref(),
         ),
         out_handle,
     )
@@ -834,13 +837,13 @@ pub unsafe extern "C" fn tebako_fs_mount_from_memory_with_mode(
         Ok(m) => m,
         Err(e) => return fail(e),
     };
-    let overlay_dir = match unsafe { optional_path_arg(overlay_dir) } {
-        Ok(o) => o,
+    let overlay = match unsafe { optional_path_arg(overlay_dir) } {
+        Ok(o) => o.map(mount::Overlay::new),
         Err(e) => return fail(e),
     };
     let data = unsafe { std::slice::from_raw_parts(data.cast::<u8>(), size) };
     finish_mount(
-        mount::build_from_memory_with_mode(data, mount_point, mode, overlay_dir),
+        mount::build_from_memory_with_mode(data, mount_point, mode, overlay.as_ref()),
         out_handle,
     )
 }

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -452,6 +452,8 @@ impl FsContext {
             Err(e) if e == libc::ENOENT => {
                 let accmode = flags & O_ACCMODE;
                 if accmode != libc::O_RDONLY && self.path_is_held(path) {
+                    // The spec 24 §5 write gate: EROFS, journaled.
+                    self.journal_write_denial(path, &mount.mount_point);
                     return Err(libc::EROFS);
                 }
                 let need = if accmode == libc::O_RDONLY {
@@ -467,8 +469,10 @@ impl FsContext {
         // Only O_RDONLY is supported: mounted content is read-only
         // (fd-based writes land with the spec 11 §7 write family;
         // path-level writes (pwrite_path & co) are gated by the mount
-        // mode).
+        // mode). A write open of an in-image file is a write into a held
+        // tree by construction — the spec 24 §5 gate: EROFS, journaled.
         if (flags & O_ACCMODE) != libc::O_RDONLY {
+            self.journal_write_denial(path, &mount.mount_point);
             return Err(libc::EROFS);
         }
         match st.entry_type {
@@ -734,46 +738,88 @@ impl FsContext {
     // RO mounts fail EROFS (unchanged behavior), mounts whose backend
     // has no write view fail ENOTSUP. fd-based writes (the spec 11 §7
     // write family) are a later, additive milestone.
+    //
+    // The spec 24 §5 write gate: a denied write into a HELD tree is
+    // journaled `event=vfs-deny op=write` (best-effort — only when a
+    // journal rides the installed policy; the EROFS answer never
+    // depends on it). Two denials journal: an RO mount's EROFS on a
+    // held path, and a gated COW mount's out-of-area EROFS.
     // ---------------------------------------------------------------
 
-    /// The writable backend owning `path`, with the in-image path.
-    fn writable_for(&self, path: &str) -> Result<(&dyn WritableBackend, String), i32> {
+    /// Journal one write-gate denial (spec 24 §5) — best-effort, silent
+    /// when no journal is installed.
+    fn journal_write_denial(&self, path: &str, mount_point: &str) {
+        if let Some(journal) = &self.journal {
+            crate::journal::journal_vfs_deny(
+                journal,
+                std::path::Path::new(path),
+                HostAccess::Rw,
+                mount_point,
+                None,
+            );
+        }
+    }
+
+    /// The writable backend owning `path`, with its mount and the
+    /// in-image path.
+    fn writable_for(&self, path: &str) -> Result<(&Mount, &dyn WritableBackend, String), i32> {
         let path = &Self::normalize(path);
         if self.mounts.is_empty() {
             return Err(libc::ENODEV);
         }
         let mount = self.find_mount(path).ok_or(libc::ENOENT)?;
         if mount.mode == MountMode::ReadOnly {
+            // The write gate (spec 24 §5): a write into a held tree is
+            // EROFS and journaled. A covered-but-not-held path is host
+            // territory — the same EROFS (the path write family does no
+            // passthrough) but never a vfs-deny line.
+            if self.path_is_held(path) {
+                self.journal_write_denial(path, &mount.mount_point);
+            }
             return Err(libc::EROFS);
         }
         let rel = Self::relative_path(mount, path).to_string();
         let w = mount.backend.writable().ok_or(libc::ENOTSUP)?;
-        Ok((w, rel))
+        Ok((mount, w, rel))
+    }
+
+    /// Dispatch one write verb, journaling the gated COW mount's
+    /// out-of-area EROFS (spec 24 §5 — on a COW mount EROFS comes only
+    /// from the declared-area gate; the overlay's own host failures
+    /// surface as their own errnos).
+    fn write_gated<T>(&self, mount: &Mount, path: &str, result: Result<T, i32>) -> Result<T, i32> {
+        match result {
+            Err(e) if e == libc::EROFS && mount.mode == MountMode::Cow => {
+                self.journal_write_denial(path, &mount.mount_point);
+                Err(e)
+            }
+            r => r,
+        }
     }
 
     /// Write `data` at `offset` in `path` (COW: copy-up into the overlay).
     pub fn pwrite_path(&self, path: &str, data: &[u8], offset: u64) -> Result<usize, i32> {
-        let (w, rel) = self.writable_for(path)?;
-        w.pwrite(&rel, data, offset)
+        let (mount, w, rel) = self.writable_for(path)?;
+        self.write_gated(mount, path, w.pwrite(&rel, data, offset))
     }
 
     /// Truncate `path` to `len` bytes.
     pub fn truncate_path(&self, path: &str, len: u64) -> Result<(), i32> {
-        let (w, rel) = self.writable_for(path)?;
-        w.truncate(&rel, len)
+        let (mount, w, rel) = self.writable_for(path)?;
+        self.write_gated(mount, path, w.truncate(&rel, len))
     }
 
     /// Create a single directory.
     pub fn mkdir_path(&self, path: &str, perms: u32) -> Result<(), i32> {
-        let (w, rel) = self.writable_for(path)?;
-        w.mkdir(&rel, perms)
+        let (mount, w, rel) = self.writable_for(path)?;
+        self.write_gated(mount, path, w.mkdir(&rel, perms))
     }
 
     /// Remove a file, symlink or empty directory (COW: whiteouts the
     /// base entry).
     pub fn remove_path(&self, path: &str) -> Result<(), i32> {
-        let (w, rel) = self.writable_for(path)?;
-        w.remove(&rel)
+        let (mount, w, rel) = self.writable_for(path)?;
+        self.write_gated(mount, path, w.remove(&rel))
     }
 
     // ---------------------------------------------------------------
@@ -1585,6 +1631,88 @@ mod tests {
         assert!(!ctx.path_is_held("/elsewhere"));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_gate_denials_journal_vfs_deny() {
+        // Spec 24 §5: writes into held trees are EROFS and journaled
+        // `event=vfs-deny op=write path=<p> mount=<mp>` — across the RO
+        // mount, the write-open path, and the gated COW's out-of-area
+        // gate; allowed and ungated writes journal nothing.
+        let dir = tempfile::tempdir().unwrap();
+        let image = fixture_zip(dir.path());
+        let log = dir.path().join("journal.log");
+        let journal = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log)
+            .unwrap();
+
+        let mut ctx = FsContext::new();
+        ctx.set_host_policy(HostPolicy::open(), Some(journal));
+
+        // The RO mount: write opens and path-level writes on held paths.
+        let ro = crate::mount::build_from_file(image.to_str().unwrap(), "/ro").unwrap();
+        ctx.mount_checked(ro).unwrap();
+        assert_eq!(
+            ctx.open("/ro/data/secret.txt", libc::O_WRONLY).unwrap_err(),
+            libc::EROFS
+        );
+        assert_eq!(
+            ctx.open("/ro/data/new.txt", libc::O_WRONLY).unwrap_err(),
+            libc::EROFS
+        );
+        assert_eq!(
+            ctx.pwrite_path("/ro/data/secret.txt", b"x", 0).unwrap_err(),
+            libc::EROFS
+        );
+        // A covered-but-not-held path-level write: the same EROFS (the
+        // path write family does no passthrough) but NO vfs-deny line —
+        // it is host territory, not the image's.
+        assert_eq!(
+            ctx.pwrite_path("/ro/elsewhere/x", b"x", 0).unwrap_err(),
+            libc::EROFS
+        );
+
+        // The gated COW mount: in-area writes land (no line), out-of-area
+        // writes are EROFS and journaled.
+        let store = dir.path().join("store");
+        let cow = crate::mount::build_from_file_with_mode(
+            image.to_str().unwrap(),
+            "/cow",
+            crate::mount::MountMode::Cow,
+            Some(&crate::mount::Overlay::gated(
+                store.to_str().unwrap(),
+                vec!["/data".to_string()],
+            )),
+        )
+        .unwrap();
+        ctx.mount_checked(cow).unwrap();
+        ctx.pwrite_path("/cow/data/secret.txt", b"x", 0).unwrap();
+        assert_eq!(
+            ctx.pwrite_path("/cow/other.txt", b"x", 0).unwrap_err(),
+            libc::EROFS
+        );
+
+        let text = std::fs::read_to_string(&log).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        // Two write-open denials + one RO path-write denial + one gated
+        // out-of-area denial; the unheld and in-area writes journal none.
+        assert_eq!(lines.len(), 4, "{text}");
+        assert!(
+            text.contains("event=vfs-deny op=write path=/ro/data/secret.txt mount=/ro"),
+            "{text}"
+        );
+        assert!(
+            text.contains("event=vfs-deny op=write path=/ro/data/new.txt mount=/ro"),
+            "{text}"
+        );
+        assert!(
+            text.contains("event=vfs-deny op=write path=/cow/other.txt mount=/cow"),
+            "{text}"
+        );
+        assert!(!text.contains("elsewhere"), "{text}");
+        assert!(!text.contains("/cow/data"), "{text}");
     }
 
     #[cfg(unix)]

--- a/crates/tfs/src/journal.rs
+++ b/crates/tfs/src/journal.rs
@@ -40,6 +40,27 @@ pub const JAIL_DENY_EVENT: &str = "jail-deny";
 /// The event name every record-mode allow line carries (spec 23 §8).
 pub const JAIL_ALLOW_EVENT: &str = "jail-allow";
 
+/// The event name every VFS write-gate denial carries (spec 24 §5): a
+/// write into a held tree the composition did not open (EROFS), or —
+/// with `class=ekey` — a read of a sealed path outside every opened
+/// grant (ENOKEY).
+pub const VFS_DENY_EVENT: &str = "vfs-deny";
+
+/// The event name record-mode VFS writes carry (spec 24 §6): under
+/// `policy: record` a write into a held tree lands in the run's scratch
+/// overlay and is journaled, never denied.
+pub const VFS_WRITE_EVENT: &str = "vfs-write";
+
+/// The event name of the boot-time overlay binding record (spec 24 §8
+/// audit): which store serves which mount, and whether the binding was
+/// declared or ephemeral.
+pub const OVERLAY_EVENT: &str = "overlay";
+
+/// The event name of the boot-time decrypt binding record (spec 24 §8
+/// audit): which recipient reference opened which grants on a mount. Key
+/// MATERIAL never touches a journal (spec 11 §11's log discipline).
+pub const DECRYPT_EVENT: &str = "decrypt";
+
 /// Resolve and open the journal file for append (creating the tebako home
 /// if needed). Call it at POLICY-INSTALL time, BEFORE the context guard is
 /// taken — never from inside a `host_check` (see the module docs). `None`
@@ -74,26 +95,98 @@ pub fn journal_allow(file: &std::fs::File, path: &Path, need: HostAccess, source
 /// The shared line writer: `<ts> event=<event> path=<p> op=read|write
 /// source=<s>` — a bare `write(2)` on the pre-opened file.
 fn journal_event(file: &std::fs::File, event: &str, path: &Path, need: HostAccess, source: &str) {
-    use std::io::Write as _;
     let op = match need {
         HostAccess::Ro => "read",
         HostAccess::Rw => "write",
     };
+    journal_fields(
+        file,
+        &format!(
+            "event={event} path={} op={} source={}",
+            path.display(),
+            op,
+            if source.is_empty() {
+                "unattributed"
+            } else {
+                source
+            }
+        ),
+    );
+}
+
+/// Append one VFS write-gate denial line (spec 24 §5):
+/// `<ts> event=vfs-deny op=read|write path=<p> mount=<mp>[ class=ekey]`.
+/// The path is the FULL namespace path (the mount-relative form is the
+/// needs generator's job); `class` is the denial's errno class when it
+/// is not the plain EROFS write gate (`ekey` = ENOKEY, the sealed read).
+/// Same fd discipline and best-effort rule as [`journal_deny`].
+pub fn journal_vfs_deny(
+    file: &std::fs::File,
+    path: &Path,
+    need: HostAccess,
+    mount: &str,
+    class: Option<&str>,
+) {
+    let op = match need {
+        HostAccess::Ro => "read",
+        HostAccess::Rw => "write",
+    };
+    let class = class.map(|c| format!(" class={c}")).unwrap_or_default();
+    journal_fields(
+        file,
+        &format!(
+            "event={VFS_DENY_EVENT} op={op} path={} mount={mount}{class}",
+            path.display()
+        ),
+    );
+}
+
+/// Append one record-mode VFS write line (spec 24 §6):
+/// `<ts> event=vfs-write path=<p> mount=<mp>` — the write landed in the
+/// run's scratch overlay; the payload observed a writable world it never
+/// owned.
+pub fn journal_vfs_write(file: &std::fs::File, path: &Path, mount: &str) {
+    journal_fields(
+        file,
+        &format!(
+            "event={VFS_WRITE_EVENT} path={} mount={mount}",
+            path.display()
+        ),
+    );
+}
+
+/// Append the boot-time overlay binding record (spec 24 §8 audit):
+/// `<ts> event=overlay mount=<mp> store=<dir> source=<declared|ephemeral>`.
+pub fn journal_overlay(file: &std::fs::File, mount: &str, store: &Path, source: &str) {
+    journal_fields(
+        file,
+        &format!(
+            "event={OVERLAY_EVENT} mount={mount} store={} source={source}",
+            store.display()
+        ),
+    );
+}
+
+/// Append the boot-time decrypt binding record (spec 24 §8 audit):
+/// `<ts> event=decrypt mount=<mp> recipient=<pgp:keyid> grants=<ids>` —
+/// the recipient is the key REFERENCE, never material.
+pub fn journal_decrypt(file: &std::fs::File, mount: &str, recipient: &str, grants: &str) {
+    journal_fields(
+        file,
+        &format!("event={DECRYPT_EVENT} mount={mount} recipient={recipient} grants={grants}"),
+    );
+}
+
+/// The raw line writer: `<unix seconds> <fields>\n` — a bare `write(2)`
+/// on the pre-opened file; write failures are swallowed (best-effort by
+/// design: the journaled answer reaches the caller regardless).
+fn journal_fields(file: &std::fs::File, fields: &str) {
+    use std::io::Write as _;
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    let line = format!(
-        "{now} event={event} path={} op={} source={}\n",
-        path.display(),
-        op,
-        if source.is_empty() {
-            "unattributed"
-        } else {
-            source
-        }
-    );
-    let _ = (&*file).write_all(line.as_bytes());
+    let _ = (&*file).write_all(format!("{now} {fields}\n").as_bytes());
 }
 
 /// The journal file under a tebako home (the bootstrap's convention).
@@ -244,6 +337,53 @@ mod tests {
             "event=jail-allow path=/tmp/x op=write source=record"
         );
         assert!(lines.next().is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn vfs_and_binding_line_shapes() {
+        // The spec-24 vocabulary (§5/§6/§8): vfs-deny (with and without
+        // the ekey class), record-mode vfs-write, and the boot-time
+        // overlay/decrypt binding records. No env mutation — the file is
+        // handed in directly.
+        let dir = std::env::temp_dir().join(format!("tfs-journal-vfs-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let log = dir.join("journal.log");
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log)
+            .unwrap();
+        journal_vfs_deny(
+            &file,
+            Path::new("/app/var/cache/x"),
+            HostAccess::Rw,
+            "/app",
+            None,
+        );
+        journal_vfs_deny(
+            &file,
+            Path::new("/data/fonts/licensed/f.ttf"),
+            HostAccess::Ro,
+            "/data",
+            Some("ekey"),
+        );
+        journal_vfs_write(&file, Path::new("/app/var/cache/y"), "/app");
+        journal_overlay(&file, "/app", Path::new("/tmp/ov/app"), "ephemeral");
+        journal_decrypt(&file, "/data", "pgp:3c8dba971d2b4f01", "g1,g2");
+        drop(file);
+        let text = std::fs::read_to_string(&log).unwrap();
+        let bodies: Vec<&str> = text.lines().map(|l| l.split_once(' ').unwrap().1).collect();
+        assert_eq!(
+            bodies,
+            vec![
+                "event=vfs-deny op=write path=/app/var/cache/x mount=/app",
+                "event=vfs-deny op=read path=/data/fonts/licensed/f.ttf mount=/data class=ekey",
+                "event=vfs-write path=/app/var/cache/y mount=/app",
+                "event=overlay mount=/app store=/tmp/ov/app source=ephemeral",
+                "event=decrypt mount=/data recipient=pgp:3c8dba971d2b4f01 grants=g1,g2",
+            ]
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/tfs/src/lib.rs
+++ b/crates/tfs/src/lib.rs
@@ -45,6 +45,12 @@
 //! `..._from_file_at_with_mode`, `..._from_memory_with_mode` taking
 //! `TEBAKO_MOUNT_RO` (0, default), `_COW` (1, HostDir overlay + whiteout
 //! journal) or `_RW` (2, ENOTSUP — no in-tree backend writes in place).
+//! The COW composite additionally carries the spec 24 §5 declarative
+//! write gate: a mount built with declared write areas
+//! ([`mount::Overlay::gated`], the Rust mount API) admits writes only
+//! under them (EROFS otherwise, journaled `vfs-deny`); the
+//! `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT` env grammars the resolver
+//! exports and the driver consumes live in [`overlay_spec`].
 //! Backends: ZIP (pure-Rust `zip` crate), tar/tar.gz/tar.zst (pure-Rust
 //! offset index — `backends_tar`), COW composite over any image
 //! (`backends_cow` + `backends_hostdir`), DwarFS (external `dwarfs-rs`
@@ -90,6 +96,7 @@ pub mod journal;
 pub mod mount;
 pub mod mount_spec;
 pub mod needs;
+pub mod overlay_spec;
 pub mod policy;
 #[cfg(feature = "enc")]
 pub mod secure_buf;

--- a/crates/tfs/src/mount.rs
+++ b/crates/tfs/src/mount.rs
@@ -39,6 +39,40 @@ pub const TEBAKO_MOUNT_COW: u32 = 1;
 /// Mount-mode flag: read-write in place (no in-tree backend offers it).
 pub const TEBAKO_MOUNT_RW: u32 = 2;
 
+/// The COW overlay binding of a mount (spec 11 §4 + spec 24 §5): the host
+/// directory the overlay lives in (created when missing), plus the
+/// DECLARED write areas when the mount carries them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Overlay {
+    /// Host directory backing the overlay (the COW store).
+    pub dir: String,
+    /// The declared write areas (in-image absolute paths, spec 24 §5's
+    /// `needs.write` spelling): `Some` stacks the gated form — writes
+    /// outside every area are EROFS; `None` is the ungated programmatic
+    /// form (the C ABI's `with_mode` family speaks it).
+    pub write_areas: Option<Vec<String>>,
+}
+
+impl Overlay {
+    /// The ungated programmatic overlay: a store, no declared areas.
+    pub fn new(dir: impl Into<String>) -> Overlay {
+        Overlay {
+            dir: dir.into(),
+            write_areas: None,
+        }
+    }
+
+    /// The declarative overlay (spec 24 §5): a store bound to a declared
+    /// write-area set. Area validity is checked at stack time
+    /// (`CowBackend::with_write_areas` — a malformed area is EINVAL).
+    pub fn gated(dir: impl Into<String>, write_areas: Vec<String>) -> Overlay {
+        Overlay {
+            dir: dir.into(),
+            write_areas: Some(write_areas),
+        }
+    }
+}
+
 /// The mount mode (spec 11 §3); writes on RO mounts fail with EROFS.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MountMode {
@@ -87,24 +121,29 @@ fn open_error(e: std::io::Error) -> i32 {
 
 /// Wrap the image backend for the mount mode (spec 11 §3/§4). COW creates
 /// the overlay directory when missing — it is a scratch area, disposable
-/// by deletion.
+/// by deletion — and stacks the gated composite when the binding carries
+/// declared write areas (spec 24 §5).
 fn apply_mode(
     backend: Box<dyn Backend>,
     mode: MountMode,
-    overlay_dir: Option<&str>,
+    overlay: Option<&Overlay>,
 ) -> Result<Box<dyn Backend>, i32> {
     match mode {
         MountMode::ReadOnly => {
-            if overlay_dir.is_some() {
+            if overlay.is_some() {
                 return Err(libc::EINVAL); // an overlay only makes sense for COW
             }
             Ok(backend)
         }
         MountMode::Cow => {
-            let dir = overlay_dir.ok_or(libc::EINVAL)?;
-            std::fs::create_dir_all(dir).map_err(|e| io_errno(&e))?;
-            let overlay = HostDirBackend::new(std::path::Path::new(dir))?;
-            Ok(Box::new(CowBackend::new(backend, overlay)?))
+            let overlay = overlay.ok_or(libc::EINVAL)?;
+            std::fs::create_dir_all(&overlay.dir).map_err(|e| io_errno(&e))?;
+            let store = HostDirBackend::new(std::path::Path::new(&overlay.dir))?;
+            let cow = match &overlay.write_areas {
+                None => CowBackend::new(backend, store)?,
+                Some(areas) => CowBackend::with_write_areas(backend, store, areas)?,
+            };
+            Ok(Box::new(cow))
         }
         // Honest capability model (spec 11 §3): no in-tree format backend
         // writes in place.
@@ -119,12 +158,13 @@ pub fn build_from_file(archive_path: &str, mount_point: &str) -> Result<Mount, i
 }
 
 /// [`build_from_file`] with an explicit mount mode (spec 11 §3). COW
-/// requires `overlay_dir` (created when missing); RW is ENOTSUP.
+/// requires `overlay` (its store directory is created when missing);
+/// RW is ENOTSUP.
 pub fn build_from_file_with_mode(
     archive_path: &str,
     mount_point: &str,
     mode: MountMode,
-    overlay_dir: Option<&str>,
+    overlay: Option<&Overlay>,
 ) -> Result<Mount, i32> {
     let mut file = File::open(archive_path).map_err(open_error)?;
     let mut magic = [0u8; SNIFF_LEN];
@@ -153,7 +193,7 @@ pub fn build_from_file_with_mode(
         ImageFormat::Limnifs => return Err(libc::ENOTSUP),
         ImageFormat::Unknown => return Err(libc::EINVAL),
     };
-    let backend = apply_mode(backend, mode, overlay_dir)?;
+    let backend = apply_mode(backend, mode, overlay)?;
     Ok(make_mount(mount_point, Some(archive_path), backend, mode))
 }
 
@@ -186,10 +226,10 @@ pub fn build_from_file_at_with_mode(
     length: u64,
     mount_point: &str,
     mode: MountMode,
-    overlay_dir: Option<&str>,
+    overlay: Option<&Overlay>,
 ) -> Result<Mount, i32> {
     if offset == 0 && length == 0 {
-        return build_from_file_with_mode(archive_path, mount_point, mode, overlay_dir);
+        return build_from_file_with_mode(archive_path, mount_point, mode, overlay);
     }
     let mut file = File::open(archive_path).map_err(open_error)?;
     let file_size = file.seek(SeekFrom::End(0)).map_err(|_| libc::EIO)?;
@@ -246,7 +286,7 @@ pub fn build_from_file_at_with_mode(
         ImageFormat::Limnifs => return Err(libc::ENOTSUP),
         ImageFormat::Unknown => return Err(libc::EINVAL),
     };
-    let backend = apply_mode(backend, mode, overlay_dir)?;
+    let backend = apply_mode(backend, mode, overlay)?;
     Ok(make_mount(mount_point, Some(archive_path), backend, mode))
 }
 
@@ -271,7 +311,7 @@ pub fn build_from_memory_with_mode(
     data: &[u8],
     mount_point: &str,
     mode: MountMode,
-    overlay_dir: Option<&str>,
+    overlay: Option<&Overlay>,
 ) -> Result<Mount, i32> {
     if data.is_empty() {
         return Err(libc::EINVAL);
@@ -296,7 +336,7 @@ pub fn build_from_memory_with_mode(
         ImageFormat::Limnifs => return Err(libc::ENOTSUP),
         ImageFormat::Unknown => return Err(libc::EINVAL),
     };
-    let backend = apply_mode(backend, mode, overlay_dir)?;
+    let backend = apply_mode(backend, mode, overlay)?;
     Ok(make_mount(mount_point, None, backend, mode))
 }
 

--- a/crates/tfs/src/needs.rs
+++ b/crates/tfs/src/needs.rs
@@ -18,10 +18,22 @@
 //! YAML with a `why:` TODO the slice developer replaces while reviewing
 //! each `access` bit.
 //!
+//! The spec 24 §6 extension folds the VFS write gate's journal into the
+//! same draft: deny-mode `event=vfs-deny op=write` lines and record-mode
+//! `event=vfs-write` lines (writes into HELD image trees — denied EROFS
+//! or landed in the run's scratch overlay) aggregate into a draft
+//! **`needs.write:`** block — paths mount-relative, persistence
+//! `ephemeral` (the observed minimum), the owning mount named in the
+//! `why` — and sealed-read denials (`event=vfs-deny op=read class=ekey`,
+//! the ENOKEY answer) into a draft **`needs.decrypt:`** block. VFS paths
+//! bypass the host pipeline entirely (no exclusions, substitutions, or
+//! existence probes — they are in-image surface, never host surface).
+//!
 //! The draft is a STARTING POINT, never an authoritative grant: the human
-//! decides ro/rw and drops paths the payload only probed. Paths are
-//! matched as recorded (raw, pre-canonicalization); the reviewer resolves
-//! any symlink ambiguity.
+//! decides ro/rw, flips persistence, assigns write/decrypt entries to the
+//! slice mounted at the named mount, and drops paths the payload only
+//! probed. Paths are matched as recorded (raw, pre-canonicalization); the
+//! reviewer resolves any symlink ambiguity.
 //!
 //! Pure safe Rust; no IO — the caller reads the journal.
 
@@ -38,6 +50,15 @@ struct Observation {
     /// files) get `optional: true`: skipped silently at bind when absent
     /// (the floor's courtesy-surface rule), granted where present.
     present: bool,
+}
+
+/// One observed in-image write or sealed read (spec 24 §6): the count
+/// rides the `why`; the mounts the path was observed under name the
+/// candidate slice for the reviewer.
+#[derive(Default)]
+struct VfsObservation {
+    count: u64,
+    mounts: std::collections::BTreeSet<String>,
 }
 
 /// Fold a journal's contents into a draft `needs:` YAML block (see the
@@ -57,8 +78,24 @@ pub fn needs_from_journal(
     exists: &dyn Fn(&str) -> bool,
 ) -> String {
     let mut observed: std::collections::BTreeMap<String, Observation> = Default::default();
+    let mut writes: std::collections::BTreeMap<String, VfsObservation> = Default::default();
+    let mut sealed: std::collections::BTreeMap<String, VfsObservation> = Default::default();
     let mut omitted = 0u64;
     for line in journal.lines() {
+        if let Some(vfs) = parse_vfs_event_line(line) {
+            // In-image surface (spec 24 §6): mount-relative, aggregated,
+            // never host-pipelined.
+            let (path, mount, into) = match vfs {
+                VfsEvent::Write { path, mount } => (path, mount, &mut writes),
+                VfsEvent::SealedRead { path, mount } => (path, mount, &mut sealed),
+            };
+            if let Some(rel) = mount_relative(&path, &mount) {
+                let o = into.entry(rel.to_string()).or_default();
+                o.count += 1;
+                o.mounts.insert(mount);
+            }
+            continue;
+        }
         let Some((path, write)) = parse_event_line(line) else {
             continue;
         };
@@ -96,7 +133,66 @@ pub fn needs_from_journal(
             observed.remove(p);
         }
     }
-    emit_yaml(&observed, omitted)
+    emit_yaml(&observed, &writes, &sealed, omitted)
+}
+
+/// One parsed spec-24 journal line.
+enum VfsEvent {
+    /// `vfs-deny op=write` (deny mode) or `vfs-write` (record mode): a
+    /// write into a held image tree.
+    Write { path: String, mount: String },
+    /// `vfs-deny op=read class=ekey`: a read of a sealed path outside
+    /// every opened grant (ENOKEY).
+    SealedRead { path: String, mount: String },
+}
+
+/// Parse one journal line into a VFS event; `None` for anything else.
+/// The line shapes are journal.rs's (the vocabulary's owner):
+/// `vfs-deny op=<op> path=<p> mount=<mp>[ class=ekey]` and
+/// `vfs-write path=<p> mount=<mp>` — the ` path=` / ` mount=` delimiters
+/// keep paths containing spaces intact.
+fn parse_vfs_event_line(line: &str) -> Option<VfsEvent> {
+    let event = line.split(' ').find_map(|f| f.strip_prefix("event="))?;
+    let path = line.split_once(" path=")?.1.split_once(" mount=")?.0;
+    let rest = line.split_once(" mount=")?.1;
+    let mount = rest.split_once(" class=").map(|(m, _)| m).unwrap_or(rest);
+    match event {
+        "vfs-write" => Some(VfsEvent::Write {
+            path: path.to_string(),
+            mount: mount.to_string(),
+        }),
+        "vfs-deny" => {
+            let op = line.split_once(" op=")?.1.split_once(" path=")?.0;
+            match op {
+                "write" => Some(VfsEvent::Write {
+                    path: path.to_string(),
+                    mount: mount.to_string(),
+                }),
+                "read" if line.contains(" class=ekey") => Some(VfsEvent::SealedRead {
+                    path: path.to_string(),
+                    mount: mount.to_string(),
+                }),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// The in-image form of a journaled namespace path: `path` relative to
+/// its mount (`/app/var/x` under mount `/app` → `/var/x`; the mount
+/// itself → `/`; under the root mount the namespace path already IS the
+/// in-image path). `None` when the path is not under the mount — a
+/// can't-happen the generator refuses to guess at.
+fn mount_relative<'a>(path: &'a str, mount: &str) -> Option<&'a str> {
+    let base = mount.trim_end_matches('/');
+    if base.is_empty() {
+        return path.starts_with('/').then_some(path);
+    }
+    if path == base {
+        return Some("/");
+    }
+    path.strip_prefix(base).filter(|rest| rest.starts_with('/'))
 }
 
 /// Parse one journal line into (path, is-write) for the jail-allow and
@@ -137,16 +233,27 @@ fn substitute(path: &str, substitutions: &[(PathBuf, &str)]) -> String {
 }
 
 /// Emit the draft YAML: a review header (with the omitted relative/empty
-/// access count when nonzero), then one entry per observed path sorted by
-/// path (deterministic — the input's line order is irrelevant). Paths
-/// arrive already substituted.
-fn emit_yaml(observed: &std::collections::BTreeMap<String, Observation>, omitted: u64) -> String {
+/// access count when nonzero), then the `host:` section per observed host
+/// path, then the spec 24 §6 sections — `write:` (VFS write-gate
+/// observations, mount-relative, persistence `ephemeral`) and `decrypt:`
+/// (sealed-read observations). Sections emit only when non-empty; an
+/// entirely empty observation keeps the historical `host: []` spelling.
+/// Sorted by path (deterministic — the input's line order is irrelevant).
+fn emit_yaml(
+    observed: &std::collections::BTreeMap<String, Observation>,
+    writes: &std::collections::BTreeMap<String, VfsObservation>,
+    sealed: &std::collections::BTreeMap<String, VfsObservation>,
+    omitted: u64,
+) -> String {
     let mut out = String::from(
         "# Drafted by `tfs needs --from-journal` (spec 23 §8): every host path the\n\
          # recorded run touched, strongest observed access. Review each `access`\n\
          # (ro|rw) and replace every `why` before merging into the payload manifest.\n\
          # Strict ancestors of granted paths are traversable by construction\n\
-         # (spec 08 §2.1) — collapsed out of this draft.\n",
+         # (spec 08 §2.1) — collapsed out of this draft.\n\
+         # `write:`/`decrypt:` entries (spec 24 §6) are in-image paths relative to\n\
+         # the mount named in their `why`; assign each to the slice mounted there\n\
+         # and review `persistence` (the observed minimum is ephemeral).\n",
     );
     if omitted > 0 {
         out.push_str(&format!(
@@ -155,25 +262,49 @@ fn emit_yaml(observed: &std::collections::BTreeMap<String, Observation>, omitted
         ));
     }
     out.push_str("needs:\n");
-    if observed.is_empty() {
+    if observed.is_empty() && writes.is_empty() && sealed.is_empty() {
         out.push_str("  host: []\n");
         return out;
     }
-    out.push_str("  host:\n");
-    for (path, o) in observed {
-        let access = if o.writes > 0 { "rw" } else { "ro" };
-        out.push_str(&format!(
-            "    - path: \"{}\"\n      access: {}\n",
-            yaml_escape(path),
-            access
-        ));
-        if !o.present {
-            out.push_str("      optional: true\n");
+    if !observed.is_empty() {
+        out.push_str("  host:\n");
+        for (path, o) in observed {
+            let access = if o.writes > 0 { "rw" } else { "ro" };
+            out.push_str(&format!(
+                "    - path: \"{}\"\n      access: {}\n",
+                yaml_escape(path),
+                access
+            ));
+            if !o.present {
+                out.push_str("      optional: true\n");
+            }
+            out.push_str(&format!(
+                "      why: \"TODO — observed: {} read, {} write\"\n",
+                o.reads, o.writes
+            ));
         }
-        out.push_str(&format!(
-            "      why: \"TODO — observed: {} read, {} write\"\n",
-            o.reads, o.writes
-        ));
+    }
+    if !writes.is_empty() {
+        out.push_str("  write:\n");
+        for (path, o) in writes {
+            out.push_str(&format!(
+                "    - path: \"{}\"\n      persistence: ephemeral\n      why: \"TODO — observed: {} write under mount {}\"\n",
+                yaml_escape(path),
+                o.count,
+                o.mounts.iter().cloned().collect::<Vec<_>>().join(", ")
+            ));
+        }
+    }
+    if !sealed.is_empty() {
+        out.push_str("  decrypt:\n");
+        for (path, o) in sealed {
+            out.push_str(&format!(
+                "    - part: \"{}\"\n      why: \"TODO — observed: {} sealed read under mount {}\"\n",
+                yaml_escape(path),
+                o.count,
+                o.mounts.iter().cloned().collect::<Vec<_>>().join(", ")
+            ));
+        }
     }
     out
 }
@@ -369,6 +500,134 @@ mod tests {
         let yaml = needs_from_journal("", &[], &[], &|_| true);
         assert!(yaml.contains("needs:"), "{yaml}");
         assert!(yaml.contains("host: []"), "{yaml}");
+    }
+
+    // ---------------------------------------------------------------
+    // The spec 24 §6 fold: the VFS write gate's journal → needs.write /
+    // needs.decrypt drafts
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn vfs_write_and_deny_fold_into_a_write_draft() {
+        // Deny-mode vfs-deny write lines and record-mode vfs-write lines
+        // aggregate into one draft write area — paths mount-relative,
+        // persistence ephemeral (the observed minimum), the mount named.
+        let yaml = needs_from_journal(
+            "1 event=vfs-deny op=write path=/app/var/cache/a mount=/app\n\
+             2 event=vfs-write path=/app/var/cache/b mount=/app\n\
+             3 event=vfs-write path=/app/var/cache/a mount=/app\n",
+            &[],
+            &[],
+            &|_| true,
+        );
+        assert!(yaml.contains("  write:\n"), "{yaml}");
+        assert_eq!(
+            yaml.match_indices("path: \"/var/cache/a\"").count(),
+            1,
+            "{yaml}"
+        );
+        assert!(yaml.contains("persistence: ephemeral"), "{yaml}");
+        assert!(
+            yaml.contains("observed: 2 write under mount /app"),
+            "{yaml}"
+        );
+        assert!(yaml.contains("path: \"/var/cache/b\""), "{yaml}");
+        // No host observations → no host section.
+        assert!(!yaml.contains("  host:"), "{yaml}");
+    }
+
+    #[test]
+    fn vfs_events_from_several_mounts_keep_their_attribution() {
+        let yaml = needs_from_journal(
+            "1 event=vfs-deny op=write path=/app/x mount=/app\n\
+             2 event=vfs-deny op=write path=/__tfs__/lib/gems/x mount=/__tfs__\n",
+            &[],
+            &[],
+            &|_| true,
+        );
+        assert!(yaml.contains("path: \"/x\""), "{yaml}");
+        assert!(yaml.contains("under mount /app"), "{yaml}");
+        assert!(yaml.contains("path: \"/lib/gems/x\""), "{yaml}");
+        assert!(yaml.contains("under mount /__tfs__"), "{yaml}");
+    }
+
+    #[test]
+    fn vfs_paths_at_the_mount_and_below_the_root_mount() {
+        // The mount itself maps to `/`; under the root mount the
+        // namespace path already IS the in-image path.
+        let yaml = needs_from_journal(
+            "1 event=vfs-write path=/app mount=/app\n\
+             2 event=vfs-write path=/etc/hosts mount=/\n",
+            &[],
+            &[],
+            &|_| true,
+        );
+        assert!(yaml.contains("path: \"/\""), "{yaml}");
+        assert!(yaml.contains("path: \"/etc/hosts\""), "{yaml}");
+    }
+
+    #[test]
+    fn sealed_read_denials_fold_into_a_decrypt_draft() {
+        let yaml = needs_from_journal(
+            "1 event=vfs-deny op=read path=/data/fonts/licensed/f.ttf mount=/data class=ekey\n\
+             2 event=vfs-deny op=read path=/data/fonts/licensed/g.ttf mount=/data class=ekey\n\
+             3 event=vfs-deny op=read path=/data/fonts/licensed/f.ttf mount=/data class=ekey\n",
+            &[],
+            &[],
+            &|_| true,
+        );
+        assert!(yaml.contains("  decrypt:\n"), "{yaml}");
+        assert!(yaml.contains("part: \"/fonts/licensed/f.ttf\""), "{yaml}");
+        assert!(
+            yaml.contains("observed: 2 sealed read under mount /data"),
+            "{yaml}"
+        );
+        assert!(yaml.contains("part: \"/fonts/licensed/g.ttf\""), "{yaml}");
+        // A plain vfs-deny READ without the ekey class is not a sealed
+        // read — no decrypt SECTION (the header prose names the sections;
+        // the section line is the indented form).
+        let yaml = needs_from_journal(
+            "1 event=vfs-deny op=read path=/data/x mount=/data\n",
+            &[],
+            &[],
+            &|_| true,
+        );
+        assert!(!yaml.contains("  decrypt:\n"), "{yaml}");
+        assert!(yaml.contains("host: []"), "{yaml}");
+    }
+
+    #[test]
+    fn vfs_and_host_events_compose_in_one_draft() {
+        let yaml = needs_from_journal(
+            "1 event=jail-allow path=/home/u/.cfg op=read source=record\n\
+             2 event=vfs-deny op=write path=/app/var mount=/app\n\
+             3 event=overlay mount=/app store=/tmp/ov source=ephemeral\n",
+            &[],
+            &[],
+            &|_| true,
+        );
+        assert!(yaml.contains("path: \"/home/u/.cfg\""), "{yaml}");
+        assert!(yaml.contains("path: \"/var\""), "{yaml}");
+        // The boot-time binding records are audit lines, not needs.
+        assert!(!yaml.contains("/tmp/ov"), "{yaml}");
+    }
+
+    #[test]
+    fn vfs_paths_with_spaces_and_malformed_lines() {
+        let yaml = needs_from_journal(
+            "1 event=vfs-write path=/app/My Docs/f mount=/app\n\
+             2 event=vfs-write path=no-mount-field\n\
+             3 event=vfs-deny op=execute path=/app/x mount=/app\n\
+             4 event=vfs-deny op=write path=/other/x mount=/app\n",
+            &[],
+            &[],
+            &|_| true,
+        );
+        assert!(yaml.contains("path: \"/My Docs/f\""), "{yaml}");
+        // A vfs line whose path is not under its named mount is a
+        // can't-happen the generator refuses to guess at.
+        assert!(!yaml.contains("/other"), "{yaml}");
+        assert!(!yaml.contains("no-mount"), "{yaml}");
     }
 
     #[test]

--- a/crates/tfs/src/overlay_spec.rs
+++ b/crates/tfs/src/overlay_spec.rs
@@ -1,0 +1,342 @@
+//! The `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT` env grammars (spec 24 §4,
+//! export step 5′) — the serialized form of a run's bound overlay stores
+//! and decrypt recipients, handed to the runtime process beside
+//! `TEBAKO_JAIL` and inherited by spawned children (spec 22 class E).
+//! One grammar, one parser, one serializer — the same discipline as
+//! [`crate::mount_spec`].
+//!
+//! ```text
+//! TEBAKO_OVERLAYS=<mount>=<store>;<mount>=<store>;…
+//! TEBAKO_DECRYPT=<mount>=pgp:<keyid>;<mount>=pgp:<keyid>;…
+//! ```
+//!
+//! Entries split on `;` and on the FIRST `=` (the env-var convention: a
+//! store path may contain `=`; a drive-qualified windows store keeps its
+//! `:`; a mount containing `=` is unrepresentable — the surplus folds
+//! into the store side and fails the grammar). Mounts are
+//! VFS-absolute (`/…`, or drive-qualified `X:/…` on windows — the mounts
+//! the driver establishes); stores are host-absolute. A store containing
+//! `;` is unrepresentable: it splits into a second entry that fails the
+//! grammar — fail-closed by construction, never a silent misparse. No key
+//! MATERIAL ever crosses the channel: the decrypt value is a key
+//! REFERENCE (`pgp:` + 16 lowercase hex, the manifest keyid form —
+//! [`tpkg::is_valid_keyid`] is the SSOT predicate), resolved against
+//! `$TEBAKO_HOME/keys/` at the driver's mount.
+//!
+//! Malformed forms are named errors quoting the offending entry; the
+//! consumer (resolver, then the driver) fails closed with exit 68
+//! (`EX_TEBAKO_OVERLAY`, spec 24 §7).
+//!
+//! Pure safe Rust; no IO.
+
+use std::fmt;
+
+/// One `TEBAKO_OVERLAYS` pair: a mount point and its bound COW store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OverlayBinding {
+    /// Absolute virtual mount point (`/…` or drive-qualified `X:/…`).
+    pub mount: String,
+    /// Absolute host directory backing the overlay.
+    pub store: String,
+}
+
+/// One `TEBAKO_DECRYPT` pair: a mount point and its bound key reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecryptBinding {
+    /// Absolute virtual mount point (`/…` or drive-qualified `X:/…`).
+    pub mount: String,
+    /// The recipient reference — `pgp:<keyid>` (16 lowercase hex); never
+    /// key material (spec 24 §3).
+    pub recipient: String,
+}
+
+/// A named, human-readable overlay/decrypt spec parse error (the
+/// offending entry is always quoted).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OverlaySpecError(pub String);
+
+impl fmt::Display for OverlaySpecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid overlay binding spec: {}", self.0)
+    }
+}
+
+impl std::error::Error for OverlaySpecError {}
+
+/// Absolute in the env grammar's sense: POSIX `/…` or drive-qualified
+/// `X:/…` (the windows spelling for both VFS mounts and host stores).
+fn is_absolute(path: &str) -> bool {
+    let b = path.as_bytes();
+    !b.is_empty()
+        && (b[0] == b'/'
+            || (b.len() >= 3 && b[0].is_ascii_alphabetic() && b[1] == b':' && b[2] == b'/'))
+}
+
+/// Split one `<mount>=<value>` entry at the FIRST `=` and validate the
+/// mount side (the env-var convention: the VALUE may carry `=` — host
+/// store paths do; a mount containing `=` is unrepresentable, the surplus
+/// folds into the value side and fails the grammar — fail-closed).
+/// `what` names the value for the error text ("overlay store",
+/// "decrypt recipient").
+fn split_entry<'a>(
+    entry: &'a str,
+    var: &str,
+    what: &str,
+) -> Result<(&'a str, &'a str), OverlaySpecError> {
+    let err = |msg: &str| OverlaySpecError(format!("{msg} in {var} entry {entry:?}"));
+    let Some((mount, value)) = entry.split_once('=') else {
+        return Err(err("needs the <mount>=<value> shape"));
+    };
+    if mount.is_empty() {
+        return Err(err("empty mount"));
+    }
+    if !is_absolute(mount) {
+        return Err(err("mount point is not absolute"));
+    }
+    if value.is_empty() {
+        return Err(err(&format!("empty {what}")));
+    }
+    Ok((mount, value))
+}
+
+/// The entry list of one env value: `;`-separated, no empties, no
+/// duplicate mounts (one binding per mount — spec 24 §3's one-store rule).
+fn entries<'a>(spec: &'a str, var: &str) -> Result<Vec<&'a str>, OverlaySpecError> {
+    if spec.trim().is_empty() {
+        return Err(OverlaySpecError(format!("empty {var} spec")));
+    }
+    let out: Vec<&str> = spec.split(';').collect();
+    if out.iter().any(|e| e.is_empty()) {
+        return Err(OverlaySpecError(format!(
+            "empty entry (stray ';') in {var} {spec:?}"
+        )));
+    }
+    Ok(out)
+}
+
+/// One binding per mount (spec 24 §3's one-store rule): a second entry
+/// naming an already-bound mount is a named error.
+fn reject_duplicate_mount(seen: &[String], mount: &str, var: &str) -> Result<(), OverlaySpecError> {
+    if seen.iter().any(|m| m == mount) {
+        return Err(OverlaySpecError(format!(
+            "duplicate mount {mount:?} in {var} — one binding per mount"
+        )));
+    }
+    Ok(())
+}
+
+/// Parse the `TEBAKO_OVERLAYS` env form: `<mount>=<store>` pairs,
+/// `;`-separated.
+pub fn parse_overlays(spec: &str) -> Result<Vec<OverlayBinding>, OverlaySpecError> {
+    let mut out: Vec<OverlayBinding> = Vec::new();
+    for entry in entries(spec, "TEBAKO_OVERLAYS")? {
+        let (mount, store) = split_entry(entry, "TEBAKO_OVERLAYS", "overlay store")?;
+        if !is_absolute(store) {
+            return Err(OverlaySpecError(format!(
+                "overlay store is not absolute in TEBAKO_OVERLAYS entry {entry:?}"
+            )));
+        }
+        reject_duplicate_mount(
+            &out.iter().map(|b| b.mount.clone()).collect::<Vec<_>>(),
+            mount,
+            "TEBAKO_OVERLAYS",
+        )?;
+        out.push(OverlayBinding {
+            mount: mount.to_string(),
+            store: store.to_string(),
+        });
+    }
+    Ok(out)
+}
+
+/// Serialize overlay bindings to the `TEBAKO_OVERLAYS` env form (the
+/// inverse of [`parse_overlays`]).
+pub fn to_env_overlays(bindings: &[OverlayBinding]) -> String {
+    bindings
+        .iter()
+        .map(|b| format!("{}={}", b.mount, b.store))
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+/// Parse the `TEBAKO_DECRYPT` env form: `<mount>=pgp:<keyid>` pairs,
+/// `;`-separated. The recipient is a key REFERENCE — the `pgp:` scheme
+/// (spec 04's MECE reference axis; room for future schemes without a
+/// grammar break) plus the manifest keyid form ([`tpkg::is_valid_keyid`]).
+pub fn parse_decrypt(spec: &str) -> Result<Vec<DecryptBinding>, OverlaySpecError> {
+    let mut out: Vec<DecryptBinding> = Vec::new();
+    for entry in entries(spec, "TEBAKO_DECRYPT")? {
+        let (mount, recipient) = split_entry(entry, "TEBAKO_DECRYPT", "decrypt recipient")?;
+        let valid = recipient
+            .strip_prefix("pgp:")
+            .is_some_and(tpkg::is_valid_keyid);
+        if !valid {
+            return Err(OverlaySpecError(format!(
+                "decrypt recipient {recipient:?} in TEBAKO_DECRYPT entry {entry:?} is not a key reference (want pgp:<keyid>, 16 lowercase hex) — key material never crosses this channel"
+            )));
+        }
+        reject_duplicate_mount(
+            &out.iter().map(|b| b.mount.clone()).collect::<Vec<_>>(),
+            mount,
+            "TEBAKO_DECRYPT",
+        )?;
+        out.push(DecryptBinding {
+            mount: mount.to_string(),
+            recipient: recipient.to_string(),
+        });
+    }
+    Ok(out)
+}
+
+/// Serialize decrypt bindings to the `TEBAKO_DECRYPT` env form (the
+/// inverse of [`parse_decrypt`]).
+pub fn to_env_decrypt(bindings: &[DecryptBinding]) -> String {
+    bindings
+        .iter()
+        .map(|b| format!("{}={}", b.mount, b.recipient))
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn overlay(mount: &str, store: &str) -> OverlayBinding {
+        OverlayBinding {
+            mount: mount.to_string(),
+            store: store.to_string(),
+        }
+    }
+
+    #[test]
+    fn overlays_parse_and_round_trip() {
+        let spec = "/app=/var/lib/ov/app;/__tfs__=C:/tebako/ov/rt";
+        let bindings = parse_overlays(spec).unwrap();
+        assert_eq!(
+            bindings,
+            vec![
+                overlay("/app", "/var/lib/ov/app"),
+                overlay("/__tfs__", "C:/tebako/ov/rt"),
+            ]
+        );
+        assert_eq!(to_env_overlays(&bindings), spec);
+        // A single pair; the root mount is legitimate.
+        let one = parse_overlays("/=/tmp/scratch").unwrap();
+        assert_eq!(one, vec![overlay("/", "/tmp/scratch")]);
+        assert_eq!(to_env_overlays(&one), "/=/tmp/scratch");
+    }
+
+    #[test]
+    fn overlay_store_may_contain_equals_and_colons() {
+        // Split on the FIRST '=' (the env-var convention): the store
+        // keeps its own '=' and the drive-qualified windows store keeps
+        // its ':'.
+        let bindings = parse_overlays("/data=/srv/a=b/store").unwrap();
+        assert_eq!(bindings[0].store, "/srv/a=b/store");
+        assert_eq!(to_env_overlays(&bindings), "/data=/srv/a=b/store");
+        let bindings = parse_overlays("A:/app=D:/overlays/app").unwrap();
+        assert_eq!(bindings[0].mount, "A:/app");
+        assert_eq!(bindings[0].store, "D:/overlays/app");
+    }
+
+    #[test]
+    fn overlays_reject_malformed_forms_with_named_errors() {
+        for (spec, frag) in [
+            ("", "empty TEBAKO_OVERLAYS spec"),
+            ("  ", "empty TEBAKO_OVERLAYS spec"),
+            ("/app=/store;", "empty entry"),
+            (";/app=/store", "empty entry"),
+            ("/app", "<mount>=<value>"),
+            ("=/store", "empty mount"),
+            ("app=/store", "not absolute"),
+            ("/app=", "empty overlay store"),
+            ("/app=store", "store is not absolute"),
+            ("/app=relative/dir", "store is not absolute"),
+            ("/a=/s;/a=/t", "duplicate mount"),
+        ] {
+            let e = parse_overlays(spec).unwrap_err();
+            assert!(
+                e.0.contains(frag),
+                "spec {spec:?}: error {e:?} should mention {frag:?}"
+            );
+        }
+        // A store containing ';' is unrepresentable: it splits into a
+        // second entry that fails the grammar — fail-closed, never a
+        // silent misparse. A MOUNT containing '=' is unrepresentable the
+        // same way: the first-'=' split folds the surplus into the store
+        // side, which fails the grammar.
+        assert!(parse_overlays("/a=/s;/t").is_err());
+        let e = parse_overlays("/x=y=/tmp/s").unwrap_err();
+        assert!(e.0.contains("store is not absolute"), "{e:?}");
+    }
+
+    #[test]
+    fn decrypt_parse_and_round_trip() {
+        let spec = "/fonts=pgp:3c8dba971d2b4f01;/data=pgp:0000000000000000";
+        let bindings = parse_decrypt(spec).unwrap();
+        assert_eq!(bindings[0].mount, "/fonts");
+        assert_eq!(bindings[0].recipient, "pgp:3c8dba971d2b4f01");
+        assert_eq!(to_env_decrypt(&bindings), spec);
+    }
+
+    #[test]
+    fn decrypt_rejects_non_reference_recipients() {
+        for (recipient, frag) in [
+            ("", "empty decrypt recipient"),
+            ("3c8dba971d2b4f01", "not a key reference"), // no scheme
+            ("pgp:3C8DBA971D2B4F01", "not a key reference"), // uppercase
+            ("pgp:3c8dba97", "not a key reference"),     // short
+            ("pgp:3c8dba971d2b4f01ff", "not a key reference"), // long
+            ("pgp:zz8dba971d2b4f01", "not a key reference"), // non-hex
+            (
+                "-----BEGIN PGP PRIVATE KEY BLOCK-----",
+                "not a key reference",
+            ),
+        ] {
+            let spec = format!("/m={recipient}");
+            let e = parse_decrypt(&spec).unwrap_err();
+            assert!(e.0.contains(frag), "{spec:?}: {e:?}");
+        }
+        // The shared malformed forms apply too.
+        assert!(parse_decrypt("").is_err());
+        assert!(parse_decrypt("/m=pgp:3c8dba971d2b4f01;/m=pgp:3c8dba971d2b4f01").is_err());
+        assert!(parse_decrypt("rel=pgp:3c8dba971d2b4f01").is_err());
+    }
+
+    /// Round-trip property: every binding list built from the grammar's
+    /// representable alphabet parses back to itself. (Mounts containing
+    /// '=' are OUTSIDE the representable alphabet — the split takes the
+    /// first '='; the malformed-forms test pins the fail-closed answer.)
+    #[test]
+    fn env_forms_round_trip_over_the_representable_alphabet() {
+        let mounts = ["/", "/app", "/a b/c", "A:/t", "/data"];
+        let stores = ["/tmp/s", "/srv/a=b", "C:/ov", "/with space/s"];
+        for (mi, m) in mounts.iter().enumerate() {
+            for (si, s) in stores.iter().enumerate() {
+                if si == mi % stores.len() || si == (mi + 1) % stores.len() {
+                    let bindings = vec![overlay(m, s)];
+                    assert_eq!(
+                        parse_overlays(&to_env_overlays(&bindings)).unwrap(),
+                        bindings,
+                        "{m}={s}"
+                    );
+                }
+            }
+        }
+        let keyids = ["pgp:3c8dba971d2b4f01", "pgp:0000000000000000"];
+        for m in mounts {
+            for k in keyids {
+                let bindings = vec![DecryptBinding {
+                    mount: m.to_string(),
+                    recipient: k.to_string(),
+                }];
+                assert_eq!(
+                    parse_decrypt(&to_env_decrypt(&bindings)).unwrap(),
+                    bindings,
+                    "{m}={k}"
+                );
+            }
+        }
+    }
+}

--- a/crates/tpkg/src/envelope.rs
+++ b/crates/tpkg/src/envelope.rs
@@ -113,12 +113,19 @@ pub struct EnvelopeManifest {
     pub grants: Vec<Grant>,
 }
 
-fn check_keyid(keyid: &str) -> Result<(), ManifestError> {
-    if keyid.len() != 16
-        || !keyid
+/// The OpenPGP keyid form (SSOT — spec 03 §2.1's keyid, the trailer's v2
+/// extension, envelope recipients, and spec 24's `pgp:<keyid>` reference
+/// all speak it): exactly 16 lowercase hex chars, the low 64 bits of the
+/// OpenPGP fingerprint.
+pub fn is_valid_keyid(keyid: &str) -> bool {
+    keyid.len() == 16
+        && keyid
             .bytes()
             .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
-    {
+}
+
+fn check_keyid(keyid: &str) -> Result<(), ManifestError> {
+    if !is_valid_keyid(keyid) {
         return Err(ManifestError::Invalid(
             "envelope manifest recipient keyids must be 16 lowercase hex",
         ));

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -160,7 +160,9 @@ pub use codec::{
 };
 pub use contract::{ContractError, PackageContract};
 pub use crc32::{crc32, Crc32};
-pub use envelope::{EnvelopeManifest, Grant, Suite, ENVELOPES_PATH, ENVELOPES_SCHEMA_VERSION};
+pub use envelope::{
+    is_valid_keyid, EnvelopeManifest, Grant, Suite, ENVELOPES_PATH, ENVELOPES_SCHEMA_VERSION,
+};
 pub use error::{strerror, TpkgError};
 pub use ext::{ExtBlock, ExtError};
 pub use io::{read_from, write_to};
@@ -269,6 +271,13 @@ pub const TPKG_CONTRACT_ERA: u32 = 2;
 /// The spec-18 §7 exit code for package/payload contract-era failures
 /// (either direction), raised by any trailer/manifest reader.
 pub const EX_TEBAKO_CONTRACT_ERA: i32 = 77;
+/// The spec-24 §7 exit code (owner-signed-off 2026-08-15; spec 06 §4
+/// table row) for overlay/decrypt BINDING failures: an unbound retained
+/// store, missing or non-opening key material, an unwritable store, an
+/// orphan binding, or a malformed `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT`
+/// env form. Loader-side; raised by the resolver and the driver's mount
+/// path — run-time errnos (EROFS, ENOKEY) stay the syscalls' own.
+pub const EX_TEBAKO_OVERLAY: i32 = 68;
 
 // ---------------------------------------------------------------------
 // v2 chain-of-trust extension (all v2-extension numerics BIG-ENDIAN;

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -589,11 +589,7 @@ impl Identity {
                 let keyid = self.signing.keyid.as_ref().ok_or(ManifestError::Invalid(
                     "identity.signing: signed payloads require keyid",
                 ))?;
-                if keyid.len() != 16
-                    || !keyid
-                        .bytes()
-                        .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
-                {
+                if !crate::envelope::is_valid_keyid(keyid) {
                     return Err(ManifestError::Invalid(
                         "identity.signing.keyid must be 16 lowercase hex (low 64 bits of the OpenPGP fingerprint)",
                     ));

--- a/docs/spec/00-INDEX.md
+++ b/docs/spec/00-INDEX.md
@@ -54,6 +54,7 @@ spec 02 §6).
 21. [21 — Crypto consolidation](21-crypto-consolidation.md) — one crypto home per layer: OpenPGP keeps trust and identity, ENC keeps confidentiality, limnifs-native crypto is evidence, never anchor (PROPOSED DECISION)
 22. [22 — Runtime-native interposition](22-runtime-native-interposition.md) — the generalized hooks: loader/exec/resource interposition inside the runtime, the documented interface, and the death of per-gem adapters (the spec-18 contract's runtime-internal half)
 23. [23 — Declarative composition and needs resolution](23-declarative-composition.md) — the fully declarative slice stack: D1 needs / D2 composition doc / D3 press-baked union / D4-D5 operator surfaces; deny-safe by default, the needs-check law (PLANNED)
+24. [24 — Declarative overlays](24-declarative-overlays.md) — write areas and key bindings: the gated COW write gate, `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT`, the record-mode fold-in, exit 68 (PARTIAL)
 
 ## Locked invariants (all specs subordinate to these)
 

--- a/docs/spec/06-launcher-abi.md
+++ b/docs/spec/06-launcher-abi.md
@@ -69,6 +69,7 @@ republish of v1-era runtimes needed.
 | 65 | `EX_TEBAKO_MANIFEST` | trailer missing/corrupt/invalid |
 | 66 | `EX_TEBAKO_ABI` | launcher_abi mismatch |
 | 67 | `EX_TEBAKO_RUNTIME_REF` | unparseable/unsupported runtime_ref |
+| 68 | `EX_TEBAKO_OVERLAY` | overlay/decrypt binding failure: unbound retained store, missing or non-opening key material, unwritable store, orphan binding, malformed `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT` (spec 24 §7; code constant `tpkg::EX_TEBAKO_OVERLAY`) |
 | 69 | `EX_TEBAKO_UNAVAILABLE` | runtime unresolvable (offline miss, download failure) |
 | 70 | `EX_TEBAKO_SHA` | sha256 mismatch (runtime or image) |
 | 71 | `EX_TEBAKO_SIGNATURE` | invalid signature; or unsigned under `TEBAKO_REQUIRE_SIGNED=1` |

--- a/docs/spec/24-declarative-overlays.md
+++ b/docs/spec/24-declarative-overlays.md
@@ -1,15 +1,34 @@
 # Spec 24 — Declarative overlays: write areas and key bindings
 
-**Status: PLANNED (spec-only; no implementation rides this change).**
-The transform machinery is SHIPPED — `CowBackend` over `HostDirBackend`
-with the `.tfs-whiteouts` journal (spec 11 §4), `EncBackend` +
-`KeySource` with the `/__tpkg__/envelopes.yaml` grant manifest (spec 10
-§7), the `TEBAKO_MOUNT_COW` mode and the `*_with_mode` mount family
-(spec 11 §7). What does not exist is the DECLARATIVE surface: no
-manifest key lets a slice say "I write here" or "I am sealed — bind a
-key", and no composition key lets an operator bind the overlay store or
-the recipient. This spec is the spec-23 amendment that closes that gap.
-One law follows, extending spec 23's declaration law:
+**Status: PARTIAL.** This change ships the TFS-layer mechanism: the
+gated COW composite (`CowBackend::with_write_areas` — the §5 write
+gate), the mount plumbing carrying declared write areas
+(`crates/tfs/src/mount.rs`'s `Overlay`), the `TEBAKO_OVERLAYS` /
+`TEBAKO_DECRYPT` env grammars (`crates/tfs/src/overlay_spec.rs`), the
+journal vocabulary (`vfs-deny` / `vfs-write` / `overlay` / `decrypt` —
+`crates/tfs/src/journal.rs`) with `vfs-deny` journaling live at the
+engine's write denials, the `tfs needs` generator's fold into draft
+`needs.write:` / `needs.decrypt:` blocks (§6), and the exit-68
+taxonomy row (§7 — `tpkg::EX_TEBAKO_OVERLAY`, owner-signed-off
+2026-08-15). Still PLANNED (the implementation chain, in dependency
+order): the D1 `needs.write` / `needs.decrypt` manifest model
+(`crates/tpkg`; open point 3), the D2 `overlays:` / `decrypt:`
+composition keys with resolver steps 3a–3c (§4), the driver's and
+preload shim's consumption of the env forms (the boot-time `overlay` /
+`decrypt` audit producers, the gated restack, and the sealed-read
+`class=ekey` producer), and record mode's ephemeral scratch stacking
+(§6's `vfs-write` producer).
+
+The transform machinery was already SHIPPED — `CowBackend` over
+`HostDirBackend` with the `.tfs-whiteouts` journal (spec 11 §4),
+`EncBackend` + `KeySource` with the `/__tpkg__/envelopes.yaml` grant
+manifest (spec 10 §7), the `TEBAKO_MOUNT_COW` mode and the
+`*_with_mode` mount family (spec 11 §7). What this spec adds is the
+DECLARATIVE surface: a manifest key letting a slice say "I write here"
+or "I am sealed — bind a key", and a composition key letting an
+operator bind the overlay store or the recipient. This spec is the
+spec-23 amendment that closes that gap. One law follows, extending
+spec 23's declaration law:
 
 **Nothing is transformed that was not declared.** A write area, an
 overlay store, a key binding — each is WRITTEN DOWN in exactly one
@@ -229,20 +248,36 @@ ORDER, between spec 23's steps 3 and 4:
   surfaces as a mid-run EROFS/ENOKEY — the needs-check law, extended.
 - **5′. Export** (extends spec 23 step 5): the bound overlay set
   serializes to `TEBAKO_OVERLAYS` (`<mount>=<store>` pairs,
-  `;`-separated, right-split on the LAST `=` — drive-qualified
-  windows stores keep their `:`) and `TEBAKO_DECRYPT`
-  (`<mount>=pgp:<keyid>`). No key material crosses the channel —
-  references resolve at the driver's mount. Spawned children inherit
+  `;`-separated, split on the FIRST `=` — a store keeps its own
+  `=`; drive-qualified windows stores keep their `:`) and
+  `TEBAKO_DECRYPT` (`<mount>=pgp:<keyid>`). No key material
+  crosses the channel — references resolve at the driver's mount. Spawned children inherit
   both alongside `TEBAKO_JAIL` and re-bind identically (spec 22
   class E; spec 08 §2.1's re-derivation discipline). Malformed env
-  forms fail closed: exit 68 (§7).
+  forms fail closed: exit 68 (§7). The parser is the one owner of
+  both grammars (`crates/tfs/src/overlay_spec.rs`); the malformed
+  forms, each a named error quoting the offending entry (SHIPPED):
+  an empty spec; an empty entry (a stray `;`); a missing `=`; an
+  empty or non-absolute mount (absolute = `/…` or drive-qualified
+  `X:/…`); an empty or non-absolute store; a duplicate mount (one
+  binding per mount, §3); a decrypt recipient that is not `pgp:` +
+  16 lowercase hex. A store containing `;` is unrepresentable by
+  construction — it splits into a second entry that fails the
+  grammar; fail-closed, never a silent misparse. A mount containing
+  `=` is unrepresentable the same way: the first-`=` split folds
+  the surplus into the store side, which fails the grammar.
 
 ## 5. Run time: the write gate and the sealed read
 
 - A mount carrying ≥1 write area stacks `CowBackend` per §1; the
-  driver passes the store as `overlay_dir` through the `_with_mode`
-  mount family (`TEBAKO_MOUNT_COW`, spec 11 §7). The jail installs
-  AFTER the mounts (spec 17) with the derived store grants in force.
+  driver passes the store through the `_with_mode` mount family
+  (`TEBAKO_MOUNT_COW`, spec 11 §7) with the declared area set —
+  `mount::Overlay::gated(store, areas)` on the Rust mount API. The
+  jail installs AFTER the mounts (spec 17) with the derived store
+  grants in force. (The C ABI's `*_with_mode` family keeps the
+  UNGATED programmatic form — a store and no areas, spec 11 §4
+  unchanged; the gated form is the declarative surface and never
+  crosses the C ABI.)
 - The write gate (spec 11's `path_is_held` discipline) gains the
   declared-area set: writes under a declared write area land in the
   overlay; writes elsewhere in a held tree stay **EROFS** — the
@@ -250,7 +285,20 @@ ORDER, between spec 23's steps 3 and 4:
   `event=vfs-deny op=write path=<p> mount=<mp>` (best-effort, the
   jail journal's discipline, spec 08 §4). An undeclared write is not
   a needs-check case (nothing was declared) and never silently
-  succeeds.
+  succeeds. The predicate (locked, SHIPPED in
+  `crates/tfs/src/backends_cow.rs`): areas are absolute in-image
+  paths normalized at mount time (no leading or trailing `/`; the
+  root area `/` covers the whole mount); a write to an area itself
+  or any path BELOW it — component boundary, `/a/b` never covers
+  `/a/bc` — is permitted; all four write verbs (`pwrite`,
+  `truncate`, `mkdir`, `remove`) are gated identically; reads are
+  never gated; the whiteout journal file keeps its `EPERM` under
+  every area set. A malformed area (relative, an empty component,
+  `.`/`..`) fails the mount with EINVAL — fail-closed, never a
+  silent widening. The journaled denial covers the RO mount's EROFS
+  on a held path and the gated COW mount's out-of-area EROFS alike
+  (the write-open EROFS included — the fd write family stays the
+  spec 11 §7 later milestone).
 - A read of a sealed path outside every opened grant answers
   **ENOKEY** (126 — the named EKEY class owned by
   `crates/tfs/src/backends_enc.rs`), never garbage, journaled
@@ -286,8 +334,9 @@ Discovery extends to the VFS write gate:
 
 Run-time errnos are existing and unchanged: EROFS (undeclared write),
 ENOKEY (sealed read). Resolution-time failures are named errors; the
-bootstrap/shim exit table (spec 06 §7) gains ONE row — the amendment
-rides the implementation chain:
+bootstrap/shim exit table (spec 06 §4) carries ONE added row —
+**owner-signed-off 2026-08-15**; the code constant is
+`tpkg::EX_TEBAKO_OVERLAY`:
 
 | 68 | `EX_TEBAKO_OVERLAY` | overlay/decrypt binding failure: unbound retained store, missing or non-opening key material, unwritable store, orphan binding, malformed `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT` |
 
@@ -326,11 +375,12 @@ construction:
 | Write-gate semantics; whiteout journal (`.tfs-whiteouts`, v1) | `crates/tfs/src/backends_cow.rs` (+ spec 11 §10) |
 | ENC construction (`tfsenc01`, HKDF labels); `ENOKEY` = 126 | `crates/tfs/src/backends_enc.rs` (+ spec 10) |
 | Envelope manifest path and grammar | `ENVELOPES_BACKEND_PATH` + `tpkg::EnvelopeManifest` (spec 10 §7) |
-| Mount-mode flags (`TEBAKO_MOUNT_*`), `overlay_dir` plumbing | `crates/tfs/src/mount.rs` (spec 11 §7) |
+| Mount-mode flags (`TEBAKO_MOUNT_*`), the `Overlay` plumbing (store + declared write areas) | `crates/tfs/src/mount.rs` (spec 11 §7) |
+| The `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT` env grammars | `crates/tfs/src/overlay_spec.rs` (§4 5′) |
 | Encryption FACTS (state/parts/envelope_refs) | `identity.encryption` (spec 03 §2.1) — `needs.decrypt` only references |
 | Key home and trust layout (`keys/`, `trust/`, `tmp/`) | spec 09 + the store layout (§8 of the ecosystem charter) |
 | The `pgp:<keyid>` reference spelling | spec 04's MECE reference axis (amendment in chain) |
-| Exit codes | spec 06 §7 (the 68 row amends it) |
+| Exit codes | spec 06 §4 (the 68 row; code constant `tpkg::EX_TEBAKO_OVERLAY`) |
 | Journal event vocabulary (`jail-*`, `vfs-*`, `overlay`, `decrypt`) | `crates/tfs/src/journal.rs` |
 | Payload-manifest schema | `docs/spec/schemas/payload-manifest.yaml` → `schema/tpkg-manifest-v1.schema.json` (MINOR bump, spec 18 §3) |
 | Composition-document schema | **`schema/tebako-compose-v1.schema.json`** — the D2 document's versioned JSON Schema, NAMED here; created by the schema pipeline (spec 18 §3.9), not part of this change |
@@ -359,10 +409,11 @@ construction:
 
 ## 11. Open points for the owner (pinned defaults in force until ruled)
 
-1. **Exit code 68** is the one spec-06 amendment this spec proposes;
-   reusing 73 (`EX_TEBAKO_JAIL`) or 74 (`EX_TEBAKO_IO`) was rejected —
-   the jail and IO classes would blur a distinct failure family.
-   Owner sign-off is needed on the new row.
+1. **Exit code 68** — RESOLVED: signed off by the owner 2026-08-15.
+   The spec 06 §4 table carries the row and `tpkg::EX_TEBAKO_OVERLAY`
+   is the code constant. (Reusing 73 `EX_TEBAKO_JAIL` or 74
+   `EX_TEBAKO_IO` was rejected — the jail and IO classes would blur a
+   distinct failure family.)
 2. **External envelope storage** (spec 03 §2.1's `envelope_refs`):
    undeclared by any shipped spec; v1 binds against in-image
    envelopes only.


### PR DESCRIPTION
## Spec 24 (declarative overlays) — the TFS-layer mechanism

Spec 24 was merged spec-only in #401. This PR ships its TFS-layer mechanism and
rewrites the spec's Status header to **PARTIAL**, naming exactly what rides this
change and what stays PLANNED in the implementation chain.

### Shipped here (crates/tfs, one const in tpkg)

- **The gated COW write gate** (`backends_cow.rs`): `CowBackend::with_write_areas`
  stacks the gated declarative form next to the existing ungated programmatic one.
  Areas are absolute in-image paths normalized at construction (`/` = whole mount);
  a write to an area or below it (component boundary — `/a/b` never covers
  `/a/bc`) lands in the overlay; every other write is `EROFS`. All four write verbs
  (`pwrite`/`truncate`/`mkdir`/`remove`) are gated identically; reads are never
  gated; the whiteout journal keeps its `EPERM`. Malformed areas (relative, empty
  component, `.`/`..`) fail the mount `EINVAL` — fail-closed, never a silent
  widening. An exhaustive property test pins the predicate against a reference
  implementation over every subset of a 4-area alphabet (with and without the root
  area) × a probe list covering equality, containment, and substring traps.
- **Mount plumbing** (`mount.rs`): `mount::Overlay { dir, write_areas }` —
  `Overlay::new` (ungated) / `Overlay::gated` (declared areas); the three
  `build_from_*_with_mode` constructors take `Option<&Overlay>`. The C ABI keeps
  the UNGATED programmatic form (`c_api.rs` wraps the store path via
  `Overlay::new`); the gated form never crosses the C ABI.
- **The env grammars** (`overlay_spec.rs`, new): `TEBAKO_OVERLAYS`
  (`<mount>=<store>` pairs) and `TEBAKO_DECRYPT` (`<mount>=pgp:<keyid>`),
  `;`-separated, split on the FIRST `=` (a store may carry `=`; a mount containing
  `=` is unrepresentable and fails closed). Every malformed form is a named error
  quoting the offending entry; the recipient predicate is `tpkg::is_valid_keyid`
  (SSOT — exported from tpkg's envelope module, rewiring `manifest.rs`'s inline
  copy). Round-trip property test over the representable alphabet.
- **Journal vocabulary** (`journal.rs`): `vfs-deny` / `vfs-write` / `overlay` /
  `decrypt` event constants and writers on the shared line writer.
  `vfs-deny` journaling is LIVE at the engine's write denials (`context.rs`): an
  RO mount's EROFS on a held path, the write-open EROFS, and a gated COW mount's
  out-of-area EROFS each journal `event=vfs-deny op=write path=<p> mount=<mp>`
  (best-effort — the EROFS answer never depends on it). A covered-but-not-held
  path journals nothing (host territory, not the image's).
- **`tfs needs` fold-in** (`needs.rs`): deny-mode `vfs-deny op=write` and
  record-mode `vfs-write` lines aggregate into a draft `needs.write:` block
  (mount-relative paths, `persistence: ephemeral`, owning mount named in `why`);
  sealed-read denials (`vfs-deny op=read class=ekey`) into a draft
  `needs.decrypt:` block. VFS paths bypass the host pipeline entirely.
- **Exit 68** `EX_TEBAKO_OVERLAY`: `tpkg` const + the spec 06 §4 table row
  (owner-signed-off 2026-08-15, recorded in spec 24 §7/§11).

### Stays PLANNED (the spec's Status header says exactly this)

The D1 `needs.write`/`needs.decrypt` manifest model (tpkg; open point 3), the D2
`overlays:`/`decrypt:` compose keys with resolver steps 3a–3c, the driver's and
preload shim's consumption of the env forms (the boot-time `overlay`/`decrypt`
audit producers, the gated restack, the sealed-read `class=ekey` producer), and
record mode's ephemeral scratch stacking (the `vfs-write` producer).

### Spec deltas (docs/spec)

- `24-declarative-overlays.md`: Status PLANNED → PARTIAL; §4 5′ gains the
  SHIPPED malformed-forms enumeration and the first-`=` split rule; §5 locks the
  gate predicate as SHIPPED; §7 records the 68 sign-off; §9 SSOT table gains the
  env-grammar row and corrects §7→§4 cross-references; §11 point 1 RESOLVED.
- `06-launcher-abi.md`: the 68 row in §4's exit table.
- `00-INDEX.md`: the spec-24 reading-order entry.

### Verification

- `cargo test -p tfs`: 145 lib + 16 integration passed, 0 failed (debug).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.

Draft per the ecosystem rule — no merge until the whole spec-24 chain is
validated end-to-end and the owner gives the nod.
