### PR TITLE
spec 22 phase M2: retire the verify_runtime_gem press gate

### DIFF
--- a/crates/tebako-cli/src/error.rs
+++ b/crates/tebako-cli/src/error.rs
@@ -55,7 +55,10 @@ pub fn packaging_message(code: i32) -> Option<&'static str> {
         126 => "Invalid stitch specification",
         127 => "Stitch input file is not accessible",
         128 => "Prebuilt runtime press requires the packaging environment (run 'tebako setup' first)",
-        129 => "The resolved runtime package does not carry the tebako-runtime gem",
+        // 129 was the v1-parity verify_runtime_gem! gate, retired by spec 22
+        // phase M2 (the env image carries no tebako-runtime gem by design);
+        // the row stays as the gem's table mirror, the code stays reserved.
+        129 => "The resolved runtime package does not carry the tebako-runtime gem (retired: spec 22 M2 env images are gem-less)",
         130 => "Option combination is not supported",
         // 131/132/134 were emitted by the retired v1 C++ tebako-bootstrap
         // download path (and its fat-mode version guard); the rows stay as

--- a/crates/tebako-cli/src/packager.rs
+++ b/crates/tebako-cli/src/packager.rs
@@ -256,7 +256,10 @@ fn deploy(
     // Bundler resolution happens here (ScenarioManagerWithBundler).
     scenario.resolve_bundler()?;
 
-    verify_runtime_gem(&tgd)?;
+    // Spec 22 phase M2: the env image no longer stages the tebako-runtime
+    // gem (its require maps shipped empty and the Rust driver covers the
+    // VFS), so the v1-parity verify_runtime_gem! gate is retired — a
+    // gem-less runtime is the only kind there is.
 
     let mut ops: Vec<Op> = Vec::new();
     if scenario.needs_bundler {
@@ -348,27 +351,6 @@ fn deploy(
     check_cwd(&target, opts.cwd.as_deref())?;
     crate::strip::strip(&target, &scenario.exe_suffix);
     Ok(())
-}
-
-/// DeployHelper#verify_runtime_gem!: the runtime layout carries the
-/// tebako-runtime gem pre-installed (error 129 otherwise).
-fn verify_runtime_gem(tgd: &Path) -> Result<(), TebakoError> {
-    let specs = tgd.join("specifications");
-    let found = fs::read_dir(&specs)
-        .map(|rd| {
-            rd.filter_map(|e| e.ok()).any(|e| {
-                e.file_name()
-                    .to_string_lossy()
-                    .starts_with("tebako-runtime-")
-                    && e.file_name().to_string_lossy().ends_with(".gemspec")
-            })
-        })
-        .unwrap_or(false);
-    if found {
-        Ok(())
-    } else {
-        Err(packaging_error(129, Some(&specs.to_string_lossy())))
-    }
 }
 
 /// DeployHelper#install_gem_op (+ install_argv_tail).


### PR DESCRIPTION
# spec 22 phase M2: retire the verify_runtime_gem press gate

Companion to tamatebako/tebako-runtime-ruby#103 (the factory change that
drops the tebako-runtime gem from the env image).

## Why

`deploy()` carried a v1-parity gate (`DeployHelper#verify_runtime_gem!`):
before running the deploy ops it required
`<prefix gem home>/specifications/tebako-runtime-*.gemspec` to exist and
failed closed with packaging error **129** otherwise. The gem's require
maps already ship empty (spec 22 §7) and the Rust driver covers the VFS;
the factory's M2 change removes the gem from the env image entirely, so
the gate now fails on exactly the runtimes the ecosystem ships. The gate
was a presence check only — nothing in the press/deploy path consumes
the gem — so the fix is removal, not replacement.

## What changed

- `crates/tebako-cli/src/packager.rs`
  - `deploy()`: the `verify_runtime_gem(&tgd)?` call is gone (an M2 note
    records the retirement at the call site);
  - the `verify_runtime_gem` function itself is deleted.
- `crates/tebako-cli/src/error.rs`
  - the 129 row stays as the retired gate's table mirror, marked
    reserved — same pattern as the 131/132/134 rows (the retired v1 C++
    bootstrap download path).

Nothing else in the deploy path changes: the bundler install ops, the
`TEBAKO_PASS_THROUGH=1` deploy env (inert without the gem — its only
consumer was the gem's `Kernel#require` hook; retiring the export is a
separate follow-up), and the runtime-resolution flow are untouched.

## Proof

- `cargo clippy -p tebako-cli -- -D warnings` — clean.
- `cargo test -p tebako-cli` (debug, incl. the cli_e2e press legs —
  simple script, Gemfile/bundler, nokogiri precompiled, the fontist
  modern-resolution closure, native-ext, and the image-era full flow)
  — exit 0, all binaries green.
- End-to-end dogfood against a gem-less runtime (the M2 factory branch's
  0.16.4/3.3.7 macos-arm64 exe+image, served from a local `file://`
  mirror; the same run died at the 129 gate before this branch):
  - fontist-feedstock `tools/build` — the stub press completed
    ("Created tebako package"), the closure (51 sha256-verified gems)
    staged through the deploy shim (`Successfully installed
    brotli-0.8.0`, native ext against the provisioned SDK, `STAGE-OK`),
    the payload imaged (`fontist-3.0.10-aarch64-macos.tfs`,
    sha256 3537dffcea16c32a485abf61cfd0aae0e7f232cd637fb4455b7f03f730f0c8db)
    and the manifest read-back passed;
  - `tools/boot_smoke` — entrypoint assertions, extract round-trip, and
    the exec leg: `'tebako-runtime' was not loaded.` (the patched
    gem_prelude's warn-only M2 signature) then `fontist: 3.0.10` and
    `BOOT-SMOKE-OK`;
  - `tfs find <payload> 'tebako-runtime*'` — empty (no gem paths in the
    pressed payload).
