### PR TITLE
feat(tfs): PE import-directory parsing + exec-closure walking — Phase W2 part 1 (spec 22 §2.1 / #406)

### DIFF
--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -1077,7 +1077,7 @@ impl FsContext {
     }
 
     /// One closure-extraction step: materialize `path` under the
-    /// destination root, then walk its Mach-O/ELF dependency closure
+    /// destination root, then walk its Mach-O/ELF/PE dependency closure
     /// recursively. `exe` is the original exec target
     /// (`@executable_path` anchor), `chain_rpaths` the rpaths
     /// accumulated down the load chain, `visited` the cycle-breaking
@@ -1190,9 +1190,13 @@ impl FsContext {
             }
         }
         for dep in &parsed.deps {
-            let Some(memfs) =
-                self.resolve_dep(dep, &referrer_dir, &exe_dir, &parsed.rpaths, &chain)
-            else {
+            let resolved = match parsed.format {
+                exec_closure::ImageFormat::Pe => self.resolve_pe_dep(dep, &referrer_dir),
+                exec_closure::ImageFormat::MachO | exec_closure::ImageFormat::Elf => {
+                    self.resolve_dep(dep, &referrer_dir, &exe_dir, &parsed.rpaths, &chain)
+                }
+            };
+            let Some(memfs) = resolved else {
                 continue;
             };
             if visited.contains(&memfs) {
@@ -1249,6 +1253,46 @@ impl FsContext {
             }
         }
         candidates.into_iter().find(|c| self.held_file(c))
+    }
+
+    /// Resolve one PE import name (spec 22 §2.1 — no rpath exists on
+    /// PE). API-set contracts (`api-ms-win-*` / `ext-ms-win-*`) are
+    /// pseudo-modules the OS resolves internally — host surface by
+    /// construction, skipped unconditionally. The runtime's own DLL
+    /// (the PE name the handoff env names via `TEBAKO_RUNTIME_DLL`) is
+    /// never materialized from a payload: the OS's basename-reuse rule
+    /// binds the already-loaded copy, and a vendored copy would be a
+    /// dead file written for no binding. A bare name resolves against
+    /// the IMPORTING image's own in-image directory only (the $ORIGIN
+    /// analogue — never a cross-mount basename probe); a
+    /// separator-carrying name resolves verbatim when rooted,
+    /// referrer-relative otherwise, normalized. A name the mounts do
+    /// not hold at that candidate is a HOST import (None) — the OS
+    /// loader answers for it exactly as before.
+    fn resolve_pe_dep(&self, name: &str, referrer_dir: &str) -> Option<String> {
+        let lower = name.to_ascii_lowercase();
+        if lower.starts_with("api-ms-win-") || lower.starts_with("ext-ms-win-") {
+            return None;
+        }
+        if runtime_dll_name().as_deref() == Some(lower.as_str()) {
+            return None;
+        }
+        // The windows loader's separator is '\\' as often as '/'; the
+        // memfs tree spells only '/'.
+        let name = &name.replace('\\', "/");
+        let rooted = name.starts_with('/')
+            || (name.len() >= 3
+                && name.as_bytes()[0].is_ascii_alphabetic()
+                && name.as_bytes()[1] == b':'
+                && name.as_bytes()[2] == b'/');
+        let candidate = if rooted {
+            Self::normalize(name)
+        } else {
+            // Bare and relative names alike anchor at the importer's
+            // own directory — the one and only PE candidate.
+            Self::normalize(&format!("{referrer_dir}/{name}"))
+        };
+        self.held_file(&candidate).then_some(candidate)
     }
 
     /// True when `path` is held by a mount as a regular file.
@@ -1341,6 +1385,18 @@ fn expand_loader_vars(template: &str, referrer_dir: &str, exe_dir: &str) -> Stri
         .replace("@executable_path", exe_dir)
         .replace("@loader_path", referrer_dir)
         .replace("$ORIGIN", referrer_dir)
+}
+
+/// The runtime's own windows DLL name (the PE name the factory owns —
+/// spec 22 §2.1's closure-walk exclusion), named by the handoff env,
+/// lowercased for the windows loader's case-insensitive comparison.
+/// None when the leg never names one (every POSIX leg; windows legs
+/// before the driver wires the flow) — no exclusion then.
+fn runtime_dll_name() -> Option<String> {
+    std::env::var("TEBAKO_RUNTIME_DLL")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .map(|v| v.to_ascii_lowercase())
 }
 
 /// Open a materialized dlmap copy for real (no TEBAKO_FD_FLAG): the
@@ -1802,6 +1858,346 @@ mod tests {
         let root = host.parent().unwrap().parent().unwrap();
         assert!(!root.join("lib/modules").exists());
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ---------------------------------------------------------------
+    // PE exec-closure walk (spec 22 §2.1)
+    // ---------------------------------------------------------------
+
+    /// A minimal PE32+ image with an import directory naming `imports`
+    /// and a delay-load import directory naming `delay_imports` (the
+    /// same byte construction as exec_closure's pe64_fixture — fixture
+    /// builders stay local to their test module, like macho64_fixture).
+    fn pe64_fixture(imports: &[&str], delay_imports: &[&str]) -> Vec<u8> {
+        const HEADERS: usize = 0x200;
+        const SECTION_RVA: u32 = 0x1000;
+        let import_dir_size = (imports.len() + 1) * 20;
+        // Section body: the import descriptors (+ all-zero terminator),
+        // then the import name strings, then the delay-load descriptors
+        // (+ terminator) and their name strings.
+        let mut section = vec![0u8; import_dir_size];
+        let mut import_name_rvas = Vec::new();
+        for name in imports {
+            import_name_rvas.push(SECTION_RVA + section.len() as u32);
+            section.extend_from_slice(name.as_bytes());
+            section.push(0);
+        }
+        let delay_base = section.len();
+        let delay_dir_rva = SECTION_RVA + delay_base as u32;
+        let mut delay_name_rvas = Vec::new();
+        if !delay_imports.is_empty() {
+            section.resize(section.len() + (delay_imports.len() + 1) * 20, 0);
+            for name in delay_imports {
+                delay_name_rvas.push(SECTION_RVA + section.len() as u32);
+                section.extend_from_slice(name.as_bytes());
+                section.push(0);
+            }
+        }
+        let mut out = vec![0u8; HEADERS];
+        out[0..2].copy_from_slice(b"MZ");
+        out[0x3C..0x40].copy_from_slice(&0x80_u32.to_le_bytes()); // e_lfanew
+        out[0x80..0x84].copy_from_slice(b"PE\0\0");
+        let coff = 0x84;
+        out[coff..coff + 2].copy_from_slice(&0x8664_u16.to_le_bytes()); // AMD64
+        out[coff + 2..coff + 4].copy_from_slice(&1_u16.to_le_bytes()); // sections
+        out[coff + 16..coff + 18].copy_from_slice(&240_u16.to_le_bytes()); // opt hdr
+        let opt = coff + 20;
+        out[opt..opt + 2].copy_from_slice(&0x20B_u16.to_le_bytes()); // PE32+
+        out[opt + 60..opt + 64].copy_from_slice(&(HEADERS as u32).to_le_bytes());
+        out[opt + 108..opt + 112].copy_from_slice(&16_u32.to_le_bytes()); // dirs count
+        let dirs = opt + 112;
+        out[dirs + 8..dirs + 12].copy_from_slice(&SECTION_RVA.to_le_bytes());
+        out[dirs + 12..dirs + 16].copy_from_slice(&(import_dir_size as u32).to_le_bytes());
+        // Delay-load import directory (index 13) — present, never read.
+        if !delay_imports.is_empty() {
+            let d = dirs + 13 * 8;
+            out[d..d + 4].copy_from_slice(&delay_dir_rva.to_le_bytes());
+            out[d + 4..d + 8]
+                .copy_from_slice(&(((delay_imports.len() + 1) * 20) as u32).to_le_bytes());
+        }
+        // The one section header: .rdata, RVA 0x1000 → file HEADERS.
+        let sec = opt + 240;
+        out[sec..sec + 6].copy_from_slice(b".rdata");
+        out[sec + 8..sec + 12].copy_from_slice(&(section.len() as u32).to_le_bytes());
+        out[sec + 12..sec + 16].copy_from_slice(&SECTION_RVA.to_le_bytes());
+        out[sec + 16..sec + 20].copy_from_slice(&(section.len() as u32).to_le_bytes());
+        out[sec + 20..sec + 24].copy_from_slice(&(HEADERS as u32).to_le_bytes());
+        out.extend_from_slice(&section);
+        for (i, rva) in import_name_rvas.iter().enumerate() {
+            let at = HEADERS + i * 20;
+            out[at..at + 4].copy_from_slice(&1_u32.to_le_bytes()); // OriginalFirstThunk
+            out[at + 12..at + 16].copy_from_slice(&rva.to_le_bytes()); // Name
+            out[at + 16..at + 20].copy_from_slice(&1_u32.to_le_bytes()); // FirstThunk
+        }
+        for (i, rva) in delay_name_rvas.iter().enumerate() {
+            let at = HEADERS + delay_base + i * 20;
+            out[at..at + 4].copy_from_slice(&1_u32.to_le_bytes());
+            out[at + 12..at + 16].copy_from_slice(&rva.to_le_bytes());
+            out[at + 16..at + 20].copy_from_slice(&1_u32.to_le_bytes());
+        }
+        out
+    }
+
+    /// Mount a host-dir fixture tree at `point` on a fresh context.
+    fn mount_hostdir(ctx: &mut FsContext, dir: &std::path::Path, point: &str) {
+        let backend = crate::backends_hostdir::HostDirBackend::new(dir).unwrap();
+        let mount = Mount {
+            handle: 0,
+            mount_point: point.to_string(),
+            mount_point_c: Box::new(std::ffi::CString::new(point).unwrap()),
+            archive_path: None,
+            backend: Box::new(backend),
+            mode: crate::mount::MountMode::ReadOnly,
+        };
+        ctx.mount_checked(mount).unwrap();
+    }
+
+    #[test]
+    fn pe_closure_walk_materializes_the_importer_dir_tree() {
+        // spec 22 §2.1: bare imports resolve against the IMPORTING
+        // image's own in-image directory (the $ORIGIN analogue);
+        // separator-carrying names resolve referrer-relative, or
+        // verbatim when rooted ('/' or '\', normalized); the closure
+        // recurses with a visited set. Everything lands at its mirrored
+        // path under the destination root.
+        let dir = std::env::temp_dir().join(format!("tfs-pe-walk-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let img = dir.join("img");
+        std::fs::create_dir_all(img.join("bin/sub")).unwrap();
+        std::fs::write(img.join("rooted.dll"), pe64_fixture(&[], &[])).unwrap();
+        std::fs::write(
+            img.join("bin/tool.dll"),
+            pe64_fixture(
+                &[
+                    "sibling.dll",
+                    "sub/helper.dll",
+                    "sub\\nested.dll",
+                    "/tfs/rooted.dll",
+                ],
+                &[],
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            img.join("bin/sibling.dll"),
+            pe64_fixture(&["deeper.dll"], &[]),
+        )
+        .unwrap();
+        std::fs::write(img.join("bin/deeper.dll"), pe64_fixture(&[], &[])).unwrap();
+        std::fs::write(img.join("bin/sub/helper.dll"), pe64_fixture(&[], &[])).unwrap();
+        std::fs::write(img.join("bin/sub/nested.dll"), pe64_fixture(&[], &[])).unwrap();
+        let dest = dir.join("out");
+
+        let mut ctx = FsContext::new();
+        mount_hostdir(&mut ctx, &img, "/tfs");
+        let host = ctx
+            .extract_exec_closure("/tfs/bin/tool.dll", &dest)
+            .unwrap();
+
+        assert_eq!(host, dest.join("tfs/bin/tool.dll"));
+        for p in [
+            "tfs/bin/sibling.dll",    // bare, the importer's own dir
+            "tfs/bin/deeper.dll",     // transitive (sibling's bare import)
+            "tfs/bin/sub/helper.dll", // referrer-relative
+            "tfs/bin/sub/nested.dll", // '\' separator, referrer-relative
+            "tfs/rooted.dll",         // rooted, verbatim
+        ] {
+            assert!(dest.join(p).is_file(), "the closure lands at {p}");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pe_closure_bare_import_never_probes_beyond_the_importers_dir() {
+        // spec 22 §2.1: importer-dir-only — a bare import the mounts do
+        // not hold AT the importer's own directory is a HOST import (the
+        // OS loader answers for it). Never a sibling-directory guess,
+        // never a cross-mount basename probe: /tfs-b/bin/lonely.dll
+        // (the same in-image relative dir in a SECOND image) must not
+        // serve /tfs-a/bin/tool.dll's import.
+        let dir = std::env::temp_dir().join(format!("tfs-pe-neg-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let img_a = dir.join("img-a");
+        let img_b = dir.join("img-b");
+        std::fs::create_dir_all(img_a.join("bin")).unwrap();
+        std::fs::create_dir_all(img_a.join("lib")).unwrap();
+        std::fs::create_dir_all(img_b.join("bin")).unwrap();
+        std::fs::write(
+            img_a.join("bin/tool.dll"),
+            pe64_fixture(&["lonely.dll"], &[]),
+        )
+        .unwrap();
+        // The wrong directory of the SAME image…
+        std::fs::write(img_a.join("lib/lonely.dll"), pe64_fixture(&[], &[])).unwrap();
+        // …and the SAME relative directory of another image.
+        std::fs::write(img_b.join("bin/lonely.dll"), pe64_fixture(&[], &[])).unwrap();
+        let dest = dir.join("out");
+
+        let mut ctx = FsContext::new();
+        mount_hostdir(&mut ctx, &img_a, "/tfs-a");
+        mount_hostdir(&mut ctx, &img_b, "/tfs-b");
+        let host = ctx
+            .extract_exec_closure("/tfs-a/bin/tool.dll", &dest)
+            .unwrap();
+
+        assert!(host.is_file());
+        assert!(
+            !dest.join("tfs-a/bin/lonely.dll").exists(),
+            "the bare import is not satisfied from the other image's bin/"
+        );
+        assert!(
+            !dest.join("tfs-a/lib/lonely.dll").exists(),
+            "the bare import is not satisfied from a sibling directory"
+        );
+        assert!(!dest.join("tfs-b/bin/lonely.dll").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pe_closure_skips_api_set_contracts_even_when_held() {
+        // spec 22 §2.1: api-ms-win-* / ext-ms-win-* pseudo-modules are
+        // host surface by construction — skipped unconditionally, even
+        // when the image HOLDS a file by that name next to the importer
+        // (a vendored trap file must never materialize). The comparison
+        // is case-insensitive, like the windows loader's own.
+        let dir = std::env::temp_dir().join(format!("tfs-pe-apiset-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let img = dir.join("img");
+        std::fs::create_dir_all(img.join("bin")).unwrap();
+        std::fs::write(
+            img.join("bin/tool.dll"),
+            pe64_fixture(
+                &[
+                    "api-ms-win-core-file-l1-1-0.dll",
+                    "EXT-MS-WIN-NTUSER-STRING-L1-1-0.DLL",
+                    "real.dll",
+                ],
+                &[],
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            img.join("bin/api-ms-win-core-file-l1-1-0.dll"),
+            pe64_fixture(&[], &[]),
+        )
+        .unwrap();
+        std::fs::write(
+            img.join("bin/EXT-MS-WIN-NTUSER-STRING-L1-1-0.DLL"),
+            pe64_fixture(&[], &[]),
+        )
+        .unwrap();
+        std::fs::write(img.join("bin/real.dll"), pe64_fixture(&[], &[])).unwrap();
+        let dest = dir.join("out");
+
+        let mut ctx = FsContext::new();
+        mount_hostdir(&mut ctx, &img, "/tfs");
+        ctx.extract_exec_closure("/tfs/bin/tool.dll", &dest)
+            .unwrap();
+
+        assert!(dest.join("tfs/bin/real.dll").is_file());
+        assert!(!dest
+            .join("tfs/bin/api-ms-win-core-file-l1-1-0.dll")
+            .exists());
+        assert!(!dest
+            .join("tfs/bin/EXT-MS-WIN-NTUSER-STRING-L1-1-0.DLL")
+            .exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pe_closure_ignores_delay_load_imports() {
+        // spec 22 §2.1: delay-load is out of phase W — the delay
+        // directory is never read, so a planted delayed.dll never
+        // materializes (an honest OS failure at load, never a guess).
+        let dir = std::env::temp_dir().join(format!("tfs-pe-delay-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let img = dir.join("img");
+        std::fs::create_dir_all(img.join("bin")).unwrap();
+        std::fs::write(
+            img.join("bin/tool.dll"),
+            pe64_fixture(&[], &["delayed.dll"]),
+        )
+        .unwrap();
+        std::fs::write(img.join("bin/delayed.dll"), pe64_fixture(&[], &[])).unwrap();
+        let dest = dir.join("out");
+
+        let mut ctx = FsContext::new();
+        mount_hostdir(&mut ctx, &img, "/tfs");
+        ctx.extract_exec_closure("/tfs/bin/tool.dll", &dest)
+            .unwrap();
+
+        assert!(dest.join("tfs/bin/tool.dll").is_file());
+        assert!(!dest.join("tfs/bin/delayed.dll").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pe_closure_never_materializes_the_runtime_dll() {
+        // spec 22 §2.1: the runtime's own ruby DLL (the PE name the
+        // handoff env names via TEBAKO_RUNTIME_DLL) is never
+        // materialized from a payload — the OS's basename-reuse rule
+        // binds the already-loaded copy, so a vendored copy would be a
+        // dead file written for no binding. Case-insensitive, like the
+        // windows loader's own comparison.
+        std::env::set_var("TEBAKO_RUNTIME_DLL", "x64-ucrt-ruby999.dll");
+        let dir = std::env::temp_dir().join(format!("tfs-pe-rubydll-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let img = dir.join("img");
+        std::fs::create_dir_all(img.join("bin")).unwrap();
+        std::fs::write(
+            img.join("bin/tool.dll"),
+            pe64_fixture(
+                &["x64-ucrt-ruby999.dll", "X64-UCRT-RUBY999.DLL", "real.dll"],
+                &[],
+            ),
+        )
+        .unwrap();
+        std::fs::write(img.join("bin/x64-ucrt-ruby999.dll"), pe64_fixture(&[], &[])).unwrap();
+        std::fs::write(img.join("bin/real.dll"), pe64_fixture(&[], &[])).unwrap();
+        let dest = dir.join("out");
+
+        let mut ctx = FsContext::new();
+        mount_hostdir(&mut ctx, &img, "/tfs");
+        ctx.extract_exec_closure("/tfs/bin/tool.dll", &dest)
+            .unwrap();
+        std::env::remove_var("TEBAKO_RUNTIME_DLL");
+
+        assert!(dest.join("tfs/bin/real.dll").is_file());
+        assert!(
+            !dest.join("tfs/bin/x64-ucrt-ruby999.dll").exists(),
+            "the runtime's own DLL stays off disk even when a payload vendors it"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pe_closure_treats_a_malformed_image_as_dependency_free() {
+        // The named answer for a malformed PE is no-dependencies (the
+        // parse answers None): the image itself still materializes and
+        // the OS loader answers for its imports — never a panic, never
+        // a parse error surfaced on the extraction path.
+        let dir = std::env::temp_dir().join(format!("tfs-pe-bad-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let img = dir.join("img");
+        std::fs::create_dir_all(img.join("bin")).unwrap();
+        let mut bad = pe64_fixture(&["sibling.dll"], &[]);
+        bad[0x80..0x84].copy_from_slice(b"PX\0\0"); // a broken PE signature
+        std::fs::write(img.join("bin/tool.dll"), &bad).unwrap();
+        std::fs::write(img.join("bin/sibling.dll"), pe64_fixture(&[], &[])).unwrap();
+        let dest = dir.join("out");
+
+        let mut ctx = FsContext::new();
+        mount_hostdir(&mut ctx, &img, "/tfs");
+        let host = ctx
+            .extract_exec_closure("/tfs/bin/tool.dll", &dest)
+            .unwrap();
+
+        assert!(host.is_file(), "the malformed image itself still lands");
+        assert!(
+            !dest.join("tfs/bin/sibling.dll").exists(),
+            "no dependencies are read from a malformed image"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/tfs/src/exec_closure.rs
+++ b/crates/tfs/src/exec_closure.rs
@@ -1,7 +1,8 @@
 //! Executable dependency-closure parsing for `dlmap2file`.
 //!
 //! A materialized executable or shared library is loaded by the
-//! platform loader (dyld, ld.so), whose path probes are RAW SYSCALLS —
+//! platform loader (dyld, ld.so, the windows loader), whose path probes
+//! are RAW SYSCALLS —
 //! the preload shim cannot interpose them (proven on macOS 15: dyld's
 //! rpath probes never reach the interposed `open`). The only way to
 //! satisfy them is to materialize the dependency closure EAGERLY into
@@ -10,32 +11,55 @@
 //!
 //! This module is the pure parser half: bytes → (dependency names,
 //! rpaths). Resolution of those names against the mounts (rpath
-//! expansion, `@executable_path` / `@loader_path` / `$ORIGIN`,
-//! recursion with a visited set) lives in `context.rs`.
+//! expansion, `@executable_path` / `@loader_path` / `$ORIGIN`, PE's
+//! importer-dir-only rule, recursion with a visited set) lives in
+//! `context.rs`.
 //!
 //! Only the header region is parsed (the first [`HEADER_WINDOW`] bytes
-//! of the extracted copy): Mach-O load commands and the ELF dynamic
-//! string table both live in the first pages of any real image. A
-//! truncated or unparseable header yields no dependencies — the loader
-//! then answers for the host libraries exactly as before.
+//! of the extracted copy): Mach-O load commands, the ELF dynamic
+//! string table, and the PE import directory all live in the first
+//! pages of any real image. A truncated or unparseable header yields no
+//! dependencies — the loader then answers for the host libraries
+//! exactly as before.
 
 /// Header bytes examined for dependency metadata.
 pub(crate) const HEADER_WINDOW: usize = 1 << 20;
 
+/// The executable container format a header parsed as. Resolution
+/// semantics differ per format — PE has no rpath: its bare imports
+/// resolve importer-dir-only (spec 22 §2.1) — so the parse result
+/// carries it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ImageFormat {
+    /// Mach-O (thin 32/64 or a fat slice).
+    #[default]
+    MachO,
+    /// ELF (32/64, either endianness).
+    Elf,
+    /// PE32/PE32+ (a windows DLL/EXE import directory).
+    Pe,
+}
+
 /// A parsed image's dependency names and its own rpath/runpath list.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ImageDeps {
-    /// LC_LOAD_DYLIB / DT_NEEDED names, verbatim.
+    /// The container format the bytes parsed as.
+    pub format: ImageFormat,
+    /// LC_LOAD_DYLIB / DT_NEEDED / import-descriptor names, verbatim.
     pub deps: Vec<String>,
-    /// LC_RPATH / DT_RPATH / DT_RUNPATH entries, verbatim.
+    /// LC_RPATH / DT_RPATH / DT_RUNPATH entries, verbatim. Always empty
+    /// for PE — no rpath exists on PE (spec 22 §2.1).
     pub rpaths: Vec<String>,
 }
 
-/// Parse a Mach-O (thin 32/64 or fat) or ELF (32/64, either endianness)
-/// header. None when the bytes are neither format.
+/// Parse a Mach-O (thin 32/64 or fat), ELF (32/64, either endianness),
+/// or PE (PE32/PE32+) header. None when the bytes are none of the
+/// formats.
 pub fn parse(bytes: &[u8]) -> Option<ImageDeps> {
     let window = &bytes[..bytes.len().min(HEADER_WINDOW)];
-    parse_macho(window).or_else(|| parse_elf(window))
+    parse_macho(window)
+        .or_else(|| parse_elf(window))
+        .or_else(|| parse_pe(window))
 }
 
 // ---------------------------------------------------------------------
@@ -119,7 +143,10 @@ fn parse_thin_macho(bytes: &[u8], magic: u32) -> Option<ImageDeps> {
     let sizeofcmds = u32le(bytes.get(20..24)?)? as usize;
     let mut at: usize = if is64 { 32 } else { 28 };
     let end = at.checked_add(sizeofcmds)?.min(bytes.len());
-    let mut out = ImageDeps::default();
+    let mut out = ImageDeps {
+        format: ImageFormat::MachO,
+        ..ImageDeps::default()
+    };
     for _ in 0..ncmds {
         let cmd = u32le(bytes.get(at..at + 4)?)?;
         let cmdsize = u32le(bytes.get(at + 4..at + 8)?)? as usize;
@@ -308,7 +335,10 @@ fn parse_elf(bytes: &[u8]) -> Option<ImageDeps> {
         }
     };
 
-    let mut out = ImageDeps::default();
+    let mut out = ImageDeps {
+        format: ImageFormat::Elf,
+        ..ImageDeps::default()
+    };
     for offset in needed {
         if let Some(name) = str_at(offset) {
             out.deps.push(name);
@@ -329,8 +359,132 @@ fn parse_elf(bytes: &[u8]) -> Option<ImageDeps> {
 }
 
 // ---------------------------------------------------------------------
+// PE (PE32/PE32+) — spec 22 §2.1: the import directory joins the walk
+// as the third parsed format, the PE analogue of DT_NEEDED/LC_LOAD_DYLIB.
+// ---------------------------------------------------------------------
+
+const PE32_MAGIC: u16 = 0x10B;
+const PE32PLUS_MAGIC: u16 = 0x20B;
+/// Data directory index of the import directory. The DELAY-load import
+/// directory (index 13) is deliberately never read — delay-load is out
+/// of phase W (spec 22 §2.1: no proven consumer).
+const PE_DIRECTORY_IMPORT: usize = 1;
+const PE_SECTION_HEADER_SIZE: usize = 40;
+const PE_IMPORT_DESCRIPTOR_SIZE: usize = 20;
+
+/// Parse a PE32/PE32+ header's import directory: one dependency name
+/// per import descriptor, in descriptor order, verbatim. `rpaths` stays
+/// empty — no rpath exists on PE. A PE with no import directory parses
+/// as a dependency-free image; a structurally broken header (bad DOS/PE
+/// signature, truncated COFF/optional header, an import-directory RVA
+/// that maps nowhere) is None — not an image this walk reads.
+fn parse_pe(bytes: &[u8]) -> Option<ImageDeps> {
+    if bytes.get(..2)? != b"MZ" {
+        return None;
+    }
+    // e_lfanew @ 0x3C → "PE\0\0" + the 20-byte COFF header.
+    let pe_off = u32le(bytes.get(0x3C..0x40)?)? as usize;
+    if bytes.get(pe_off..pe_off + 4)? != b"PE\0\0" {
+        return None;
+    }
+    let coff = pe_off.checked_add(4)?;
+    let nsections = u16le(bytes.get(coff + 2..coff + 4)?)? as usize;
+    let opt_size = u16le(bytes.get(coff + 16..coff + 18)?)? as usize;
+    let opt = coff + 20;
+    let opt_bytes = bytes.get(opt..opt.checked_add(opt_size)?)?;
+    let (ndirs_off, dirs_off): (usize, usize) = match u16le(opt_bytes.get(..2)?)? {
+        PE32_MAGIC => (92, 96),
+        PE32PLUS_MAGIC => (108, 112),
+        _ => return None,
+    };
+    let ndirs = u32le(opt_bytes.get(ndirs_off..ndirs_off + 4)?)? as usize;
+    let size_of_headers = u32le(opt_bytes.get(60..64)?)?;
+
+    // Section table right after the optional header: RVA → file offset.
+    // A section's raw bytes map [va, va + size_of_raw_data); RVAs below
+    // SizeOfHeaders name the mapped header region 1:1 (u64 math — a
+    // malformed va+size must never wrap).
+    let sec_off = opt.checked_add(opt_size)?;
+    let rva_to_off = |rva: u32| -> Option<usize> {
+        let rva = rva as u64;
+        for i in 0..nsections {
+            let base = sec_off.checked_add(i.checked_mul(PE_SECTION_HEADER_SIZE)?)?;
+            let sh = bytes.get(base..base + PE_SECTION_HEADER_SIZE)?;
+            let va = u32le(sh.get(12..16)?)? as u64;
+            let raw_size = u32le(sh.get(16..20)?)? as u64;
+            let raw_off = u32le(sh.get(20..24)?)? as u64;
+            if raw_size != 0 && (va..va + raw_size).contains(&rva) {
+                return usize::try_from(raw_off + (rva - va)).ok();
+            }
+        }
+        if rva < size_of_headers as u64 {
+            usize::try_from(rva).ok()
+        } else {
+            None
+        }
+    };
+
+    let mut out = ImageDeps {
+        format: ImageFormat::Pe,
+        ..ImageDeps::default()
+    };
+    if ndirs <= PE_DIRECTORY_IMPORT {
+        return Some(out); // no import directory at all
+    }
+    let dir_at = dirs_off.checked_add(PE_DIRECTORY_IMPORT.checked_mul(8)?)?;
+    let dir = opt_bytes.get(dir_at..dir_at + 8)?;
+    let dir_rva = u32le(dir.get(..4)?)?;
+    let dir_size = u32le(dir.get(4..8)?)? as usize;
+    if dir_rva == 0 {
+        return Some(out); // no imports
+    }
+    let imp_off = rva_to_off(dir_rva)?;
+    // The descriptor array runs to its all-zero terminator, bounded by
+    // the declared directory size when one is declared.
+    let dir_end = if dir_size == 0 {
+        usize::MAX
+    } else {
+        imp_off.checked_add(dir_size)?
+    };
+    let mut at = imp_off;
+    while at.checked_add(PE_IMPORT_DESCRIPTOR_SIZE)? <= dir_end {
+        let Some(desc) = bytes.get(at..at + PE_IMPORT_DESCRIPTOR_SIZE) else {
+            break;
+        };
+        if desc.iter().all(|&b| b == 0) {
+            break;
+        }
+        // IMAGE_IMPORT_DESCRIPTOR: Name (an RVA) @ +12.
+        let name_rva = u32le(desc.get(12..16)?)?;
+        if name_rva != 0 {
+            if let Some(name) = rva_to_off(name_rva).and_then(|off| c_str_at(bytes, off)) {
+                out.deps.push(name);
+            }
+        }
+        at += PE_IMPORT_DESCRIPTOR_SIZE;
+    }
+    Some(out)
+}
+
+/// Read a NUL-terminated UTF-8 string at `off` (the import name).
+fn c_str_at(bytes: &[u8], off: usize) -> Option<String> {
+    let tail = bytes.get(off..)?;
+    let end = tail.iter().position(|&b| b == 0).unwrap_or(tail.len());
+    let s = std::str::from_utf8(&tail[..end]).ok()?;
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------
 // byte helpers
 // ---------------------------------------------------------------------
+
+fn u16le(r: &[u8]) -> Option<u16> {
+    Some(u16::from_le_bytes(r.get(..2)?.try_into().ok()?))
+}
 
 fn u32le(r: &[u8]) -> Option<u32> {
     Some(u32::from_le_bytes(r.get(..4)?.try_into().ok()?))
@@ -525,5 +679,179 @@ mod tests {
     fn non_image_bytes_parse_as_none() {
         assert_eq!(parse(b"#!/bin/sh\necho hi\n"), None);
         assert_eq!(parse(b""), None);
+    }
+
+    /// A minimal PE32+ image with an import directory naming `imports`
+    /// (descriptor order) and a delay-load import directory naming
+    /// `delay_imports` (which the parser must NEVER read — delay-load
+    /// is out of phase W, spec 22 §2.1). One section (.rdata) maps RVA
+    /// 0x1000 to the file offset right after the headers.
+    fn pe64_fixture(imports: &[&str], delay_imports: &[&str]) -> Vec<u8> {
+        const HEADERS: usize = 0x200;
+        const SECTION_RVA: u32 = 0x1000;
+        let import_dir_size = (imports.len() + 1) * PE_IMPORT_DESCRIPTOR_SIZE;
+        // Section body: the import descriptors (+ all-zero terminator),
+        // then the import name strings, then the delay-load descriptors
+        // (+ terminator) and their name strings.
+        let mut section = vec![0u8; import_dir_size];
+        let mut import_name_rvas = Vec::new();
+        for name in imports {
+            import_name_rvas.push(SECTION_RVA + section.len() as u32);
+            section.extend_from_slice(name.as_bytes());
+            section.push(0);
+        }
+        let delay_base = section.len();
+        let delay_dir_rva = SECTION_RVA + delay_base as u32;
+        let mut delay_name_rvas = Vec::new();
+        if !delay_imports.is_empty() {
+            section.resize(
+                section.len() + (delay_imports.len() + 1) * PE_IMPORT_DESCRIPTOR_SIZE,
+                0,
+            );
+            for name in delay_imports {
+                delay_name_rvas.push(SECTION_RVA + section.len() as u32);
+                section.extend_from_slice(name.as_bytes());
+                section.push(0);
+            }
+        }
+        let mut out = vec![0u8; HEADERS];
+        out[0..2].copy_from_slice(b"MZ");
+        out[0x3C..0x40].copy_from_slice(&0x80_u32.to_le_bytes()); // e_lfanew
+        out[0x80..0x84].copy_from_slice(b"PE\0\0");
+        let coff = 0x84;
+        out[coff..coff + 2].copy_from_slice(&0x8664_u16.to_le_bytes()); // AMD64
+        out[coff + 2..coff + 4].copy_from_slice(&1_u16.to_le_bytes()); // sections
+        out[coff + 16..coff + 18].copy_from_slice(&240_u16.to_le_bytes()); // opt hdr
+        let opt = coff + 20;
+        out[opt..opt + 2].copy_from_slice(&PE32PLUS_MAGIC.to_le_bytes());
+        out[opt + 60..opt + 64].copy_from_slice(&(HEADERS as u32).to_le_bytes()); // SizeOfHeaders
+        out[opt + 108..opt + 112].copy_from_slice(&16_u32.to_le_bytes()); // dirs count
+        let dirs = opt + 112;
+        // Import directory (index 1).
+        out[dirs + 8..dirs + 12].copy_from_slice(&SECTION_RVA.to_le_bytes());
+        out[dirs + 12..dirs + 16].copy_from_slice(&(import_dir_size as u32).to_le_bytes());
+        // Delay-load import directory (index 13) — present, never read.
+        if !delay_imports.is_empty() {
+            let d = dirs + 13 * 8;
+            out[d..d + 4].copy_from_slice(&delay_dir_rva.to_le_bytes());
+            out[d + 4..d + 8].copy_from_slice(
+                &(((delay_imports.len() + 1) * PE_IMPORT_DESCRIPTOR_SIZE) as u32).to_le_bytes(),
+            );
+        }
+        // The one section header: .rdata, RVA 0x1000 → file HEADERS.
+        let sec = opt + 240;
+        out[sec..sec + 6].copy_from_slice(b".rdata");
+        out[sec + 8..sec + 12].copy_from_slice(&(section.len() as u32).to_le_bytes());
+        out[sec + 12..sec + 16].copy_from_slice(&SECTION_RVA.to_le_bytes());
+        out[sec + 16..sec + 20].copy_from_slice(&(section.len() as u32).to_le_bytes());
+        out[sec + 20..sec + 24].copy_from_slice(&(HEADERS as u32).to_le_bytes());
+        out.extend_from_slice(&section);
+        // Fill the descriptors' name RVAs (thunks need not resolve —
+        // the walk reads names only).
+        for (i, rva) in import_name_rvas.iter().enumerate() {
+            let at = HEADERS + i * PE_IMPORT_DESCRIPTOR_SIZE;
+            out[at..at + 4].copy_from_slice(&1_u32.to_le_bytes()); // OriginalFirstThunk
+            out[at + 12..at + 16].copy_from_slice(&rva.to_le_bytes()); // Name
+            out[at + 16..at + 20].copy_from_slice(&1_u32.to_le_bytes()); // FirstThunk
+        }
+        for (i, rva) in delay_name_rvas.iter().enumerate() {
+            let at = HEADERS + delay_base + i * PE_IMPORT_DESCRIPTOR_SIZE;
+            out[at..at + 4].copy_from_slice(&1_u32.to_le_bytes());
+            out[at + 12..at + 16].copy_from_slice(&rva.to_le_bytes());
+            out[at + 16..at + 20].copy_from_slice(&1_u32.to_le_bytes());
+        }
+        out
+    }
+
+    #[test]
+    fn pe64_import_directory_names_in_descriptor_order() {
+        let bytes = pe64_fixture(&["sibling.dll", "vendor2.dll", "KERNEL32.dll"], &[]);
+        let parsed = parse(&bytes).expect("a PE parses");
+        assert_eq!(parsed.format, ImageFormat::Pe);
+        assert_eq!(
+            parsed.deps,
+            vec![
+                "sibling.dll".to_string(),
+                "vendor2.dll".to_string(),
+                "KERNEL32.dll".to_string()
+            ]
+        );
+        assert!(parsed.rpaths.is_empty(), "no rpath exists on PE");
+    }
+
+    #[test]
+    fn pe64_without_imports_parses_dependency_free() {
+        // Import directory present but holding only the terminator.
+        let bytes = pe64_fixture(&[], &[]);
+        let parsed = parse(&bytes).expect("a PE parses");
+        assert_eq!(parsed.format, ImageFormat::Pe);
+        assert!(parsed.deps.is_empty());
+        // A declared-but-null import directory (RVA 0).
+        let mut nulled = bytes.clone();
+        let dirs = 0x84 + 20 + 112;
+        nulled[dirs + 8..dirs + 16].fill(0);
+        let parsed = parse(&nulled).expect("a PE parses");
+        assert_eq!(parsed.format, ImageFormat::Pe);
+        assert!(parsed.deps.is_empty());
+    }
+
+    #[test]
+    fn pe64_delay_load_imports_are_never_read() {
+        let bytes = pe64_fixture(&["real.dll"], &["delayed.dll"]);
+        let parsed = parse(&bytes).expect("a PE parses");
+        assert_eq!(parsed.deps, vec!["real.dll".to_string()]);
+    }
+
+    #[test]
+    fn pe_malformed_headers_are_not_images_and_never_panic() {
+        // The named answer for a malformed PE is None — no dependencies
+        // parsed; the OS loader answers for the file exactly as before
+        // (spec 22 §2.1's honest-failure rule). Never a panic.
+        let good = pe64_fixture(&["sibling.dll"], &[]);
+        // DOS stub only (e_lfanew unreadable).
+        assert_eq!(parse(b"MZ"), None);
+        // e_lfanew pointing past EOF.
+        let mut bad = good.clone();
+        bad[0x3C..0x40].copy_from_slice(&0xFFFF_FF00_u32.to_le_bytes());
+        assert_eq!(parse(&bad), None);
+        // A wrong PE signature.
+        let mut bad = good.clone();
+        bad[0x80..0x84].copy_from_slice(b"PX\0\0");
+        assert_eq!(parse(&bad), None);
+        // An unknown optional-header magic.
+        let mut bad = good.clone();
+        bad[0x98..0x9A].copy_from_slice(&0x9999_u16.to_le_bytes());
+        assert_eq!(parse(&bad), None);
+        // Optional header truncated away (declared size outruns the bytes).
+        let mut bad = good.clone();
+        bad.truncate(0x100);
+        assert_eq!(parse(&bad), None);
+        // Import-directory RVA mapping nowhere (past every section and
+        // above SizeOfHeaders).
+        let mut bad = good.clone();
+        let dirs = 0x84 + 20 + 112;
+        bad[dirs + 8..dirs + 12].copy_from_slice(&0x00F0_0000_u32.to_le_bytes());
+        assert_eq!(parse(&bad), None);
+        // Section table truncated mid-entry.
+        let mut bad = good;
+        bad.truncate(0x84 + 20 + 240 + 10);
+        assert_eq!(parse(&bad), None);
+        // A partial window (cut mid-descriptor) still parses, simply
+        // dependency-free — the truncated-header rule, never a panic.
+        let mut short = pe64_fixture(&["sibling.dll"], &[]);
+        short.truncate(0x210);
+        let parsed = parse(&short).expect("a partial window still parses");
+        assert_eq!(parsed.format, ImageFormat::Pe);
+        assert!(parsed.deps.is_empty());
+    }
+
+    #[test]
+    fn pe_descriptor_with_an_unmappable_name_rva_is_skipped() {
+        let mut bytes = pe64_fixture(&["sibling.dll", "vendor2.dll"], &[]);
+        // Corrupt the FIRST descriptor's name RVA only; the second
+        // descriptor is still read.
+        bytes[0x200 + 12..0x200 + 16].copy_from_slice(&0x00F0_0000_u32.to_le_bytes());
+        let parsed = parse(&bytes).expect("a PE parses");
+        assert_eq!(parsed.deps, vec!["vendor2.dll".to_string()]);
     }
 }


### PR DESCRIPTION
## Phase W2, part 1 — PE import-directory parsing + dependency-closure walking in `crates/tfs`

Implements the `crates/tfs` half of spec 22 §2.1 (the phase-W design, #406): the PE import directory joins the exec-closure walk as the third parsed format beside Mach-O and ELF. Pure byte parsing — platform-independent, exercised on POSIX CI.

**This is part 1 of the W2 implementation.** The windows exec-cache lifecycle switch (leave-in-place, content-keyed `<TEBAKO_EXEC_CACHE>/dlls/<image-key>/<P>` with the Rule-R3 write-once/digest/per-boot-rehash mechanics) and the `library_aliases:` boot surface (the 65s) land in their own streams; this PR is the parser + the walk's PE resolution semantics only.

### What lands

- **`crates/tfs/src/exec_closure.rs`**
  - `ImageDeps` gains `format: ImageFormat` (`MachO` / `Elf` / `Pe`) so resolution can apply per-format semantics. `parse()` now tries Mach-O → ELF → PE.
  - `parse_pe`: PE32/PE32+ import-directory parsing, byte-exact: DOS `MZ` → `e_lfanew` → `PE\0\0` → COFF → optional header (NumberOfRvaAndSizes, data directory index 1) → section-table RVA→file-offset mapping (`[va, va+size_of_raw_data)`, plus the 1:1 header region below `SizeOfHeaders`) → descriptor walk to the all-zero terminator, bounded by the declared directory size → one dep per descriptor name, verbatim, in descriptor order. All reads are bounds-checked `Option` chains (spec 14: no unwraps/panics on these paths; malformed `va+size` math is u64, never wrapping).
  - The **delay-load import directory (index 13) is never read** — delay-load is out of phase W (no proven consumer).
  - The malformed-PE answer is `None` (no dependencies parsed) — the existing truncated/unparseable-header contract; the OS loader answers for the file exactly as before (§2.1's honest-failure rule). No panics, no partial garbage.
  - Parse-level tests: descriptor order, empty/null import directory, delay-load never read, malformed variants (DOS stub only, `e_lfanew` past EOF, bad signature, unknown optional-header magic, truncated optional header, unmappable directory RVA, truncated section table, partial mid-descriptor window), an unmappable name RVA skipped while later descriptors still parse.

- **`crates/tfs/src/context.rs`** — the walk's PE specializations (§2.1, locked):
  - `extract_for_exec` branches on `parsed.format`; PE deps go through `resolve_pe_dep`.
  - **Importer-dir-only bare-import resolution** (the `$ORIGIN` analogue): a bare import resolves against the importing image's own in-image directory only — one candidate path answered by the mount table's normal longest-prefix dispatch. No cross-mount basename probing, ever. A separator-carrying name resolves verbatim when rooted (`/…`, `X:/…`; `\` normalized to `/`), referrer-relative otherwise. A name the mounts do not hold at that candidate is a HOST import (`None`) — the OS loader answers for it exactly as before.
  - **API-set contracts** (`api-ms-win-*` / `ext-ms-win-*`, case-insensitive) are skipped unconditionally — pseudo-modules the OS resolves internally, host surface by construction; skipped even when the image holds a file by that name.
  - **The runtime's own ruby DLL is never materialized from a payload** (the OS's basename-reuse rule binds the already-loaded copy; `rb_w32_check_imported` stays the ABI-line guard): a bare import matching the name case-insensitively is excluded.
  - Walk-level tests: importer-dir-only positive (bare / referrer-relative / `\`-separator / rooted / transitive), negative (wrong dir of the same image, same relative dir of a second co-mounted image — no cross-mount probe), API-set skip with planted trap files, delay-load ignore with a planted file, the runtime-DLL exclusion with a planted vendored copy, malformed PE materializes dependency-free.

### Spec ambiguities resolved (for #406 to absorb)

1. **The ruby-DLL name channel.** §2.1 says the PE name "flows from the factory" but names no wire. This implementation reads `TEBAKO_RUNTIME_DLL` from the handoff env (precedent: `TEBAKO_EXEC_CACHE`, `TEBAKO_JAIL_SOURCE`); the driver-side wiring (from the runtime manifest's `install_as`) is the alias/driver stream's follow-up. Unset ⇒ no exclusion (every POSIX leg today). The spec should name the variable.
2. **Exclusion matches the bare import name only** (case-insensitive, the windows loader's own comparison). A separator-carrying import whose basename matches is not excluded — the proven consumer shape is the bare name; §2.1's wording covers the bare case.
3. **In-image name matching is case-sensitive.** The windows loader's case-insensitivity governs the host binding; the memfs lookup uses the import's verbatim spelling (the spec is silent; guessing at case folding would be a heuristic, and heuristics are forbidden).
4. **Named errors.** The §2.1 65/70/74 taxonomy belongs to the loader/boot layers (alias grammar → tpkg/driver, tamper/cache-IO → the driver's Rule-R3 materialize path); the tfs walk's error surface stays the errno channel (EIO/EISDIR/ENOENT), and malformed PE is the parse-level `None` — no parallel taxonomy invented.
5. **`SizeOfHeaders` mapping.** RVAs below `SizeOfHeaders` map 1:1 to file offsets (the OS maps the header region at the image base) so header-resident import directories parse.

### Verification (this host, macOS arm64)

```
cargo fmt --check                       # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test -p tfs                       # all green (tails in the PR checks discussion)
```

Draft: merges only with the owner's go-ahead, per the standing rule.
