### PR TITLE
feat(cli): resolve the Rust bootstrap from the product releases into the store (spec 19 §4)

### DIFF
--- a/crates/tebako-cli/README.md
+++ b/crates/tebako-cli/README.md
@@ -145,10 +145,14 @@ download), 125 (SDK lock timeout).
   ([../../docs/runtime-as-image.md](../../docs/runtime-as-image.md));
 - **bootstrap**: `--bootstrap` > `$TEBAKO_BOOTSTRAP` > the Rust
   `tebako-bootstrap` binary next to the `tebako` executable (dogfooding
-  milestone 6) — local sources only; the gem's BootstrapManager download
-  of the v1 C++ release is retired (its argv0-verbatim handoff is rejected
-  by the image-era runtime driver), so a press with no local bootstrap
-  fails closed with the named error 136;
+  milestone 6) > the spec 19 §4 store flow: the per-triplet Rust
+  bootstrap published with the CLI's own release (tamatebako/tebako),
+  resolved into `~/.tebako/bootstraps/<version>-<triplet>/` —
+  sha256-verified against the release's `manifest.json`/`SHA256SUMS`,
+  tmp+rename installed under the per-entry lock, `TEBAKO_OFFLINE=1` =
+  cache-or-named-error (138). The gem's BootstrapManager download of the
+  v1 C++ release stays retired (its argv0-verbatim handoff is rejected by
+  the image-era runtime driver);
 - **downloads**: all in-process via `crates/tebako-http` (ureq + rustls,
   webpki-roots bundled; HTTPS-only, redirects ≤ 5, `file://` mirrors,
   `TEBAKO_OFFLINE`; the OS trust store is opt-in via
@@ -162,9 +166,10 @@ download), 125 (SDK lock timeout).
 ## Deviations from the reference gem (documented, deliberate)
 
 - the bootstrap portion **defaults to the in-workspace Rust
-  tebako-bootstrap**; the gem always uses the C++ release — the C++
-  download is not reachable here at all (retired; no local Rust bootstrap
-  → exit 136);
+  tebako-bootstrap** and otherwise resolves the product release's Rust
+  bootstrap into the store (spec 19 §4); the gem always downloads the C++
+  release — the C++ download is not reachable here at all (retired: its
+  argv0-verbatim handoff is rejected by the image-era runtime driver);
 - **no mkdwarfs anywhere** (owner rule): the gem shells out to a
   provisioned mkdwarfs binary; the CLI builds images in-process and the
   golden test filters the two sides' image-build lines when diffing
@@ -217,7 +222,7 @@ download), 125 (SDK lock timeout).
 
 Everything else is byte-level parity: the press stdout, the produced
 package's trailer fields, the packaged binary's output, the cache layout
-(shared with the gem), and the exit codes (106–136 + the packaging error
+(shared with the gem), and the exit codes (106–142 + the packaging error
 table).
 
 ## Tests
@@ -235,10 +240,9 @@ skip cleanly when `TEBAKO_CLI_SKIP_E2E` is set. Every press embeds the
 in-workspace Rust bootstrap (`target/debug/tebako-bootstrap`, set as
 `$TEBAKO_BOOTSTRAP` by the harness); `cargo test -p tebako-cli` alone
 does not build it, so build it first or run `cargo test --workspace` —
-without it the press fails closed with exit 136 (the v1 C++ bootstrap
-download fallback is retired: its handoff is rejected by the image-era
-runtime driver at run time), and the harness fails fast on its own
-instead. The golden test
+without it the press stops dogfooding and falls to the spec 19 §4 store
+flow (a network fetch of the released bootstrap), so the harness fails
+fast on its own instead. The golden test
 additionally needs a host ruby with the thor gem, a checkout of the
 reference gem at the matching version, and an mkdwarfs binary **for the
 reference gem's own press** (the CLI itself needs none). The

--- a/crates/tebako-cli/src/error.rs
+++ b/crates/tebako-cli/src/error.rs
@@ -66,7 +66,19 @@ pub fn packaging_message(code: i32) -> Option<&'static str> {
                  tebako-runtime-ruby pipeline and resolved automatically by the lean/fat/classic modes",
         134 => "Fat mode requires a payload-capable tebako-bootstrap release",
         135 => "Failed to provision the runtime SDK for native extension builds",
+        // 136 was the fail-closed refusal of the local-only press (#405);
+        // the spec 19 §4 store flow superseded it — the row stays, the
+        // code stays reserved.
         136 => "Press requires a local Rust tebako-bootstrap binary (the v1 C++ bootstrap download is retired)",
+        // 137-142: the spec 19 §4 bootstrap store flow (the Rust
+        // tebako-bootstrap from the product's own releases) — the
+        // bootstrap parallel of the runtime rows 120-125.
+        137 => "No tebako-bootstrap asset for the requested platform in the tebako release",
+        138 => "TEBAKO_OFFLINE is set and the requested tebako-bootstrap is not cached",
+        139 => "SHA256 checksum mismatch for the downloaded tebako-bootstrap",
+        140 => "Failed to download the tebako-bootstrap",
+        141 => "The tebako release carries no usable tebako-bootstrap index",
+        142 => "Timed out waiting for the tebako-bootstrap cache lock",
         201 => "Warning. Could not create cache version file",
         _ => return None,
     })

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -29,12 +29,15 @@
 //! libraries, no process spawns (spec 14 §3).
 //!
 //! Documented deviations from the gem (README carries the full list):
-//! - the bootstrap portion comes from local Rust tebako-bootstrap
-//!   binaries only (--bootstrap / TEBAKO_BOOTSTRAP / the sibling of the
-//!   tebako binary); the gem's BootstrapManager download of the v1 C++
-//!   release is RETIRED — its argv0-verbatim handoff is rejected by the
-//!   image-era runtime driver, so the fallback produced silently-broken
-//!   packages. A press with no local bootstrap fails closed (exit 136);
+//! - the bootstrap portion comes from the local Rust tebako-bootstrap
+//!   binaries first (--bootstrap / TEBAKO_BOOTSTRAP / the sibling of the
+//!   tebako binary), else from the spec 19 §4 store flow: the per-triplet
+//!   Rust bootstrap published with the CLI's own release, resolved into
+//!   ~/.tebako/bootstraps/ (sha256-verified against the release index,
+//!   tmp+rename, per-entry lock; TEBAKO_OFFLINE=1 is cache-or-named-error).
+//!   The gem's BootstrapManager download of the v1 C++ release stays
+//!   RETIRED — its argv0-verbatim handoff is rejected by the image-era
+//!   runtime driver, so the fallback produced silently-broken packages;
 //! - no mkdwarfs binary anywhere: images are built in-process via the
 //!   dwarfs-t Writer and named `.tfs` (dwarfs-t-native FlatBuffers
 //!   metadata; `.dwarfs` stays for upstream-compatible images);
@@ -196,10 +199,11 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     println!("{}", opts.press_announce(&ruby_ver));
 
     let platform = host_platform()?;
-    // The bootstrap comes from local sources only and is refused BEFORE
-    // the runtime download — a missing local bootstrap must not cost a
-    // fetch, and the retired C++ download fallback must never fire.
-    let bootstrap_path = local_bootstrap(opts)?;
+    // The bootstrap is resolved BEFORE the runtime download: the local
+    // sources first, else the spec 19 §4 store flow (the CLI's own
+    // release asset, downloaded once into the store). The retired v1 C++
+    // download fallback never fires.
+    let bootstrap_path = press_bootstrap(opts, &platform)?;
 
     let runtime_resolver = Resolver::new();
     let resolved = runtime_resolver.resolve_runtime(&ruby_ver, &platform, &opts.tebako_version)?;
@@ -282,11 +286,12 @@ fn check_warnings(opts: &PressOptions) {
 }
 
 /// Bootstrap lookup: --bootstrap > $TEBAKO_BOOTSTRAP > the Rust
-/// tebako-bootstrap next to the tebako binary. LOCAL SOURCES ONLY — the
-/// v1 C++ bootstrap download is retired (its argv0-verbatim handoff is
-/// rejected by the image-era runtime driver, so the fallback produced
-/// silently-broken packages). `None` means no local source named a
-/// binary; [`local_bootstrap`] turns that into the named refusal.
+/// tebako-bootstrap next to the tebako binary (the dogfooding /
+/// installed-pair layout). `None` means no local source named a binary —
+/// [`press_bootstrap`] then resolves the published bootstrap into the
+/// store (spec 19 §4). The v1 C++ bootstrap download stays retired (its
+/// argv0-verbatim handoff is rejected by the image-era runtime driver, so
+/// the fallback produced silently-broken packages).
 pub(crate) fn decide_bootstrap(opts: &PressOptions) -> Option<PathBuf> {
     if let Some(path) = &opts.bootstrap {
         return Some(path.clone());
@@ -312,24 +317,36 @@ pub(crate) fn decide_bootstrap(opts: &PressOptions) -> Option<PathBuf> {
     None
 }
 
-/// The package's bootstrap portion from the local sources, or the named
-/// failure: no source at all → 136 (pressing requires a local Rust
-/// tebako-bootstrap; the C++ download is retired); a named file that does
-/// not exist → 127 (the gem's parity error for a bad --bootstrap).
-pub(crate) fn local_bootstrap(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
-    let Some(path) = decide_bootstrap(opts) else {
-        return Err(packaging_error(
-            136,
-            Some("set --bootstrap or $TEBAKO_BOOTSTRAP, or place the Rust tebako-bootstrap next to the tebako executable (the v1 C++ bootstrap download is retired)"),
-        ));
-    };
-    if !path.is_file() {
-        return Err(packaging_error(
-            127,
-            Some(&format!("runtime not found: {}", path.display())),
-        ));
+/// The package's bootstrap portion: the local sources first
+/// ([`decide_bootstrap`]; a named file that does not exist keeps the
+/// gem's parity error 127), else the spec 19 §4 store flow — the Rust
+/// tebako-bootstrap published with the CLI's own release, resolved into
+/// ~/.tebako/bootstraps/<version>-<triplet>/ (downloaded once,
+/// sha256-verified against the release index, tmp+rename installed under
+/// the entry lock; named errors 137-142, TEBAKO_OFFLINE=1 is
+/// cache-or-named-error 138).
+pub(crate) fn press_bootstrap(opts: &PressOptions, platform: &str) -> Result<PathBuf, TebakoError> {
+    press_bootstrap_with(opts, platform, &resolve::BootstrapResolver::new())
+}
+
+/// [`press_bootstrap`] with the store resolver injected (tests pin the
+/// cache root/mirror/version so the unit suite never touches the
+/// network or the real store).
+pub(crate) fn press_bootstrap_with(
+    opts: &PressOptions,
+    platform: &str,
+    store: &resolve::BootstrapResolver,
+) -> Result<PathBuf, TebakoError> {
+    if let Some(path) = decide_bootstrap(opts) {
+        if !path.is_file() {
+            return Err(packaging_error(
+                127,
+                Some(&format!("runtime not found: {}", path.display())),
+            ));
+        }
+        return Ok(path);
     }
-    Ok(path)
+    store.resolve(platform)
 }
 
 /// Stitcher.stitch (lean three-part): validate per the gem's error codes,
@@ -951,21 +968,38 @@ mod tests {
         }
     }
 
+    /// A store resolver that never leaves the fixture directory: offline,
+    /// empty cache root, unreachable mirror — the unit suite never touches
+    /// the network or the real ~/.tebako.
+    fn offline_store(dir: &Path) -> resolve::BootstrapResolver {
+        resolve::BootstrapResolver {
+            cache_root: dir.to_path_buf(),
+            mirror: "file:///nonexistent-tebako-mirror".to_string(),
+            version: "0.0.0".to_string(),
+            offline: true,
+            lock_timeout: std::time::Duration::from_secs(300),
+        }
+    }
+
     #[test]
-    fn local_bootstrap_prefers_the_option_and_rejects_a_missing_file() {
+    fn press_bootstrap_prefers_the_option_and_rejects_a_missing_file() {
         let dir = std::env::temp_dir().join(format!("tebako-cli-boot-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
+        let store = offline_store(&dir);
         let boot = dir.join("tebako-bootstrap");
         std::fs::write(&boot, b"BOOT").unwrap();
         // --bootstrap short-circuits every other source.
         let opts = press_opts(Some(boot.clone()));
-        assert_eq!(local_bootstrap(&opts).unwrap(), boot);
+        assert_eq!(
+            press_bootstrap_with(&opts, "macos-arm64", &store).unwrap(),
+            boot
+        );
         // A named file that does not exist keeps the gem's parity error
         // (127, "runtime not found").
         let missing = dir.join("nope");
         let opts = press_opts(Some(missing.clone()));
-        let err = local_bootstrap(&opts).unwrap_err();
+        let err = press_bootstrap_with(&opts, "macos-arm64", &store).unwrap_err();
         assert_eq!(err.code, 127);
         assert!(
             err.message
@@ -977,7 +1011,7 @@ mod tests {
     }
 
     #[test]
-    fn local_bootstrap_without_any_local_source_fails_closed_136() {
+    fn press_bootstrap_without_a_local_source_resolves_the_store() {
         // The only test that mutates the process env (TEBAKO_BOOTSTRAP) —
         // kept in one function so parallel tests never observe a
         // half-saved environment; restored on the way out.
@@ -991,9 +1025,10 @@ mod tests {
             Some(PathBuf::from("/nonexistent/env-bootstrap"))
         );
 
-        // No option, no env: the retired download does NOT fire — the
-        // press fails closed with the named error. (The unit-test binary
-        // runs from target/debug/deps/, which never holds a plain
+        // No option, no env: the spec 19 §4 store flow fires — with an
+        // offline empty store that is its named error 138 (never the
+        // retired v1 C++ download, never a silent fetch). (The unit-test
+        // binary runs from target/debug/deps/, which never holds a plain
         // `tebako-bootstrap` sibling — assert that precondition so a
         // change in cargo's layout fails diagnosably.)
         std::env::remove_var("TEBAKO_BOOTSTRAP");
@@ -1014,14 +1049,14 @@ mod tests {
         );
         let opts = press_opts(None);
         assert!(decide_bootstrap(&opts).is_none());
-        let err = local_bootstrap(&opts).unwrap_err();
-        assert_eq!(err.code, 136);
-        assert!(
-            err.message
-                .contains("requires a local Rust tebako-bootstrap"),
-            "{}",
-            err.message
-        );
+        let dir =
+            std::env::temp_dir().join(format!("tebako-cli-boot-store-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let err = press_bootstrap_with(&opts, "macos-arm64", &offline_store(&dir)).unwrap_err();
+        assert_eq!(err.code, 138);
+        assert!(err.message.contains("not cached"), "{}", err.message);
+        let _ = std::fs::remove_dir_all(&dir);
 
         if let Some(v) = saved {
             std::env::set_var("TEBAKO_BOOTSTRAP", v);

--- a/crates/tebako-cli/src/resolve.rs
+++ b/crates/tebako-cli/src/resolve.rs
@@ -13,12 +13,19 @@
 //! into place with an atomic rename, so partial downloads never poison the
 //! cache.
 //!
-//! The gem's BootstrapManager half is NOT ported: the v1 C++
-//! tebako-bootstrap download is retired (its argv0-verbatim handoff is
-//! rejected by the image-era runtime driver, so the fallback produced
-//! silently-broken packages). Pressing sources the bootstrap from local
-//! Rust binaries only and fails closed otherwise (src/lib.rs
-//! `local_bootstrap`, exit 136).
+//! The gem's BootstrapManager half is ported for the RUST bootstrap only
+//! (spec 19 §4): [`BootstrapResolver`] resolves the per-triplet
+//! tebako-bootstrap published with the product's own releases
+//! (tamatebako/tebako — the CLI's own version) into
+//!   bootstraps/<version>-<triplet>/
+//!     tebako-bootstrap-<version>-<triplet>[.exe]
+//!     sha256    -- digest the installed file was verified against
+//!     origin    -- URL the asset was downloaded from
+//! with the runtime cache's exact discipline (release-index sha256
+//! verification, tmp + rename, per-entry flock). The v1 C++
+//! tebako-bootstrap download the gem's BootstrapManager fetched stays
+//! retired: its argv0-verbatim handoff is rejected by the image-era
+//! runtime driver, so the fallback produced silently-broken packages.
 
 use std::fs;
 #[cfg(unix)]
@@ -504,9 +511,7 @@ impl Resolver {
     }
 
     fn offline(&self) -> bool {
-        std::env::var("TEBAKO_OFFLINE")
-            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
-            .unwrap_or(false)
+        offline_env()
     }
 
     fn offline_check(&self, entry_ref: &str, tebako_version: &str) -> Result<(), TebakoError> {
@@ -829,47 +834,7 @@ impl Resolver {
     where
         F: FnOnce() -> Result<(), TebakoError>,
     {
-        fs::create_dir_all(dir)
-            .map_err(|e| crate::error::plain_error(format!("{e} creating {}", dir.display())))?;
-        let lock_path = dir.join(LOCK_FILE);
-        let lock = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&lock_path)
-            .map_err(|e| {
-                crate::error::plain_error(format!("{e} opening {}", lock_path.display()))
-            })?;
-        self.acquire_lock(&lock, entry_ref, &lock_path)?;
-        let result = f();
-        flock(&lock, LOCK_UN);
-        result
-    }
-
-    fn acquire_lock(
-        &self,
-        lock: &fs::File,
-        entry_ref: &str,
-        lock_path: &Path,
-    ) -> Result<(), TebakoError> {
-        let deadline = std::time::Instant::now() + self.lock_timeout;
-        loop {
-            if flock(lock, LOCK_EX | LOCK_NB) {
-                return Ok(());
-            }
-            if std::time::Instant::now() >= deadline {
-                return Err(packaging_error(
-                    125,
-                    Some(&format!(
-                        "{entry_ref}: another process is installing this runtime (no lock after {}s; lockfile: {})",
-                        self.lock_timeout.as_secs(),
-                        lock_path.display()
-                    )),
-                ));
-            }
-            std::thread::sleep(std::time::Duration::from_millis(100));
-        }
+        with_install_lock(dir, entry_ref, self.lock_timeout, "runtime", 125, f)
     }
 
     // ---- urls ------------------------------------------------------------
@@ -895,6 +860,434 @@ impl Resolver {
 
     fn package_url(&self, filename: &str, tebako_version: &str) -> String {
         format!("{}/{filename}", self.release_url(tebako_version))
+    }
+}
+
+// ---------------------------------------------------------------------
+// The Rust bootstrap store (spec 19 §4)
+// ---------------------------------------------------------------------
+
+/// The product's own release mirror — the per-triplet Rust
+/// tebako-bootstrap assets publish here (TEBAKO_BOOTSTRAP_MIRROR
+/// overrides; tests use file://).
+const DEFAULT_BOOTSTRAP_MIRROR: &str = "https://github.com/tamatebako/tebako/releases/download";
+const BOOTSTRAP_MIRROR_ENV_VAR: &str = "TEBAKO_BOOTSTRAP_MIRROR";
+/// The store subdirectory the bootstrap resolves into
+/// (`bootstraps/<version>-<triplet>/`, spec 19 §4).
+const BOOTSTRAP_CACHE_SUBDIR: &str = "bootstraps";
+/// The product release's index files, in preference order. The
+/// manifest's top-level `assets` array is exactly the bootstrap set and
+/// SHA256SUMS carries one line per tool asset (both authored by
+/// .github/workflows/lib/finalize.sh).
+const BOOTSTRAP_INDEX_FILES: &[&str] = &["manifest.json", "SHA256SUMS"];
+
+/// One bootstrap asset in the release index (platform + filename +
+/// expected sha256).
+#[derive(Debug, Clone)]
+pub struct BootstrapEntry {
+    pub platform: String,
+    pub filename: String,
+    pub sha256: String,
+}
+
+/// Resolves the Rust tebako-bootstrap a press stitches with (spec 19
+/// §4): the asset published with the product release matching the CLI's
+/// own version (`env!("CARGO_PKG_VERSION")` — the bootstrap and the CLI
+/// ship in one release, so the versions never drift). A store hit
+/// returns immediately (no lock, no network); a miss downloads the
+/// asset sha256-verified against the release index into
+/// `bootstraps/<version>-<triplet>/` under the entry lock, tmp + rename
+/// so a partial download stays invisible. `TEBAKO_OFFLINE=1` is
+/// cache-or-named-error (138).
+#[derive(Debug)]
+pub struct BootstrapResolver {
+    pub cache_root: PathBuf,
+    pub mirror: String,
+    pub version: String,
+    pub offline: bool,
+    pub lock_timeout: std::time::Duration,
+}
+
+impl Default for BootstrapResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BootstrapResolver {
+    pub fn new() -> Self {
+        let mirror = std::env::var(BOOTSTRAP_MIRROR_ENV_VAR)
+            .ok()
+            .filter(|m| !m.is_empty())
+            .unwrap_or_else(|| DEFAULT_BOOTSTRAP_MIRROR.to_string());
+        BootstrapResolver {
+            cache_root: default_cache_root(),
+            mirror: mirror.trim_end_matches('/').to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            offline: offline_env(),
+            lock_timeout: LOCK_TIMEOUT,
+        }
+    }
+
+    /// The bootstrap binary for `platform` (a release-asset triplet like
+    /// `macos-arm64`): the cached store entry when present, else the
+    /// downloaded + verified + installed one.
+    pub fn resolve(&self, platform: &str) -> Result<PathBuf, TebakoError> {
+        let dir = self.entry_dir(platform);
+        let binary = dir.join(self.filename(platform));
+        if binary.is_file() {
+            return Ok(binary);
+        }
+        with_install_lock(
+            &dir,
+            &self.entry_ref(platform),
+            self.lock_timeout,
+            "bootstrap",
+            142,
+            || {
+                // Re-check under the lock: a concurrent press may have
+                // installed the entry while we waited.
+                if binary.is_file() {
+                    return Ok(());
+                }
+                self.install(&binary, platform)
+            },
+        )?;
+        Ok(binary)
+    }
+
+    // ---- entry naming ----------------------------------------------------
+
+    fn entry_dir(&self, platform: &str) -> PathBuf {
+        self.cache_root
+            .join(BOOTSTRAP_CACHE_SUBDIR)
+            .join(format!("{}-{platform}", self.version))
+    }
+
+    fn filename(&self, platform: &str) -> String {
+        let suffix = if platform.starts_with("windows") {
+            ".exe"
+        } else {
+            ""
+        };
+        format!("tebako-bootstrap-{}-{platform}{suffix}", self.version)
+    }
+
+    fn entry_ref(&self, platform: &str) -> String {
+        format!("tebako-bootstrap@{} ({platform})", self.version)
+    }
+
+    // ---- install pipeline ------------------------------------------------
+
+    fn install(&self, binary: &Path, platform: &str) -> Result<(), TebakoError> {
+        let entry_ref = self.entry_ref(platform);
+        self.offline_check(&entry_ref)?;
+        let index = self.fetch_index()?;
+        let entry = self.find_entry(&index, platform)?;
+        let url = self.asset_url(&entry.filename);
+        let tmp = self.download(&url, &entry.filename)?;
+        self.verify(&tmp, entry)?;
+        self.place(&tmp, binary, entry, &url)?;
+        Ok(())
+    }
+
+    fn offline_check(&self, entry_ref: &str) -> Result<(), TebakoError> {
+        if !self.offline {
+            return Ok(());
+        }
+        Err(packaging_error(
+            138,
+            Some(&format!(
+                "{} is not cached and downloads are disabled (release index: {}; {}={})",
+                entry_ref,
+                self.index_urls().join(", "),
+                BOOTSTRAP_MIRROR_ENV_VAR,
+                self.mirror
+            )),
+        ))
+    }
+
+    fn find_entry<'a>(
+        &self,
+        index: &'a [BootstrapEntry],
+        platform: &str,
+    ) -> Result<&'a BootstrapEntry, TebakoError> {
+        if let Some(entry) = index.iter().find(|e| e.platform == platform) {
+            return Ok(entry);
+        }
+        let combos: Vec<String> = index.iter().map(|e| e.platform.clone()).collect();
+        Err(packaging_error(
+            137,
+            Some(&format!(
+                "no tebako-bootstrap asset for {platform} (tebako {}). Available: {}. Set --bootstrap or $TEBAKO_BOOTSTRAP to a local Rust tebako-bootstrap instead.",
+                self.version,
+                combos.join(", ")
+            )),
+        ))
+    }
+
+    fn verify(&self, tmp: &Path, entry: &BootstrapEntry) -> Result<(), TebakoError> {
+        let actual = sha256_file_hex(tmp)
+            .ok_or_else(|| packaging_error(139, Some(&format!("cannot hash {}", tmp.display()))))?;
+        let expected = entry.sha256.to_ascii_lowercase();
+        if actual == expected {
+            return Ok(());
+        }
+        let _ = fs::remove_file(tmp);
+        Err(packaging_error(
+            139,
+            Some(&format!(
+                "{}: expected {expected}, got {actual}; download deleted",
+                entry.filename
+            )),
+        ))
+    }
+
+    fn place(
+        &self,
+        tmp: &Path,
+        binary: &Path,
+        entry: &BootstrapEntry,
+        url: &str,
+    ) -> Result<(), TebakoError> {
+        let err = |e: std::io::Error| {
+            crate::error::plain_error(format!("{e} installing {}", binary.display()))
+        };
+        make_executable(tmp).map_err(err)?;
+        fs::rename(tmp, binary).map_err(err)?;
+        let dir = binary.parent().unwrap_or_else(|| Path::new("."));
+        fs::write(dir.join(SHA256_FILE), format!("{}\n", entry.sha256)).map_err(err)?;
+        fs::write(dir.join(ORIGIN_FILE), format!("{url}\n")).map_err(err)?;
+        Ok(())
+    }
+
+    fn fetch_index(&self) -> Result<Vec<BootstrapEntry>, TebakoError> {
+        let mut tried: Vec<String> = Vec::new();
+        for name in BOOTSTRAP_INDEX_FILES {
+            let url = self.index_url(name);
+            match fetch_text(&url) {
+                Ok(body) => match self.parse_index(name, &body) {
+                    Ok(entries) => return Ok(entries),
+                    Err(FetchError::IndexUnavailable(_)) => tried.push(url),
+                    Err(e @ FetchError::Throttled { .. }) => {
+                        return Err(packaging_error(140, Some(&e.to_string())));
+                    }
+                    Err(FetchError::DownloadFailed(msg)) => {
+                        return Err(packaging_error(140, Some(&msg)));
+                    }
+                },
+                Err(FetchError::IndexUnavailable(_)) => tried.push(url),
+                Err(e @ FetchError::Throttled { .. }) => {
+                    return Err(packaging_error(140, Some(&e.to_string())));
+                }
+                Err(FetchError::DownloadFailed(msg)) => {
+                    return Err(packaging_error(140, Some(&msg)))
+                }
+            }
+        }
+        Err(packaging_error(
+            141,
+            Some(&format!(
+                "the tebako release v{} provides no usable bootstrap index (tried: {})",
+                self.version,
+                tried.join(", ")
+            )),
+        ))
+    }
+
+    fn parse_index(&self, name: &str, body: &str) -> Result<Vec<BootstrapEntry>, FetchError> {
+        if name == "manifest.json" {
+            self.parse_manifest(body)
+        } else {
+            Ok(self.parse_sha256sums(body))
+        }
+    }
+
+    /// The product release's manifest.json is an object whose top-level
+    /// `assets` array is exactly the bootstrap set ({platform, file,
+    /// sha256, size_bytes} — authored by finalize.sh; the per-tool
+    /// `tools` map never leaks into it).
+    fn parse_manifest(&self, body: &str) -> Result<Vec<BootstrapEntry>, FetchError> {
+        let data = json_parse(body).map_err(|_| {
+            FetchError::IndexUnavailable("manifest.json is not valid JSON".to_string())
+        })?;
+        let Some(JsonValue::Array(assets)) = data.find("assets").cloned() else {
+            return Err(FetchError::IndexUnavailable(
+                "manifest.json has no assets array".to_string(),
+            ));
+        };
+        Ok(assets
+            .iter()
+            .filter(|a| {
+                a.find("platform").and_then(|v| v.as_string()).is_some()
+                    && a.find("file").and_then(|v| v.as_string()).is_some()
+                    && a.find("sha256").and_then(|v| v.as_string()).is_some()
+            })
+            .map(|a| BootstrapEntry {
+                platform: a
+                    .find("platform")
+                    .and_then(|v| v.as_string())
+                    .unwrap_or_default(),
+                filename: a
+                    .find("file")
+                    .and_then(|v| v.as_string())
+                    .unwrap_or_default(),
+                sha256: a
+                    .find("sha256")
+                    .and_then(|v| v.as_string())
+                    .unwrap_or_default()
+                    .to_ascii_lowercase(),
+            })
+            .collect())
+    }
+
+    /// `<sha256>  <filename>` lines; filenames may carry a `*` prefix.
+    /// Only the `tebako-bootstrap-<version>-` lines are bootstrap assets
+    /// — the product's SHA256SUMS carries every tool's lines (tfs,
+    /// tebako-pkg, tebako, tebako-shim, the link-unit tarballs).
+    fn parse_sha256sums(&self, body: &str) -> Vec<BootstrapEntry> {
+        let mut out: Vec<BootstrapEntry> = Vec::new();
+        let prefix = format!("tebako-bootstrap-{}-", self.version);
+        for line in body.lines() {
+            let mut parts = line.trim().splitn(2, char::is_whitespace);
+            let (Some(sha256), Some(file)) = (parts.next(), parts.next()) else {
+                continue;
+            };
+            let file = file.trim().trim_start_matches('*');
+            let Some(rest) = file.strip_prefix(&prefix) else {
+                continue;
+            };
+            let platform = rest.strip_suffix(".exe").unwrap_or(rest);
+            if platform.is_empty() {
+                continue;
+            }
+            out.push(BootstrapEntry {
+                platform: platform.to_string(),
+                filename: file.to_string(),
+                sha256: sha256.to_ascii_lowercase(),
+            });
+        }
+        out
+    }
+
+    fn download(&self, url: &str, filename: &str) -> Result<PathBuf, TebakoError> {
+        let tmp_dir = self.cache_root.join(TMP_DIR);
+        fs::create_dir_all(&tmp_dir).map_err(|e| {
+            crate::error::plain_error(format!("{e} creating {}", tmp_dir.display()))
+        })?;
+        let tmp = tmp_dir.join(format!("{filename}.{}.part", std::process::id()));
+        match fetch_bytes(url) {
+            Ok(bytes) => {
+                if let Err(e) = crate::fetch::write_tmp(&tmp, &bytes) {
+                    let _ = fs::remove_file(&tmp);
+                    return Err(packaging_error(140, Some(&format!("{e} writing {url}"))));
+                }
+                Ok(tmp)
+            }
+            Err(FetchError::IndexUnavailable(_)) => {
+                let _ = fs::remove_file(&tmp);
+                Err(packaging_error(140, Some(&format!("{url}: not found"))))
+            }
+            Err(e @ FetchError::Throttled { .. }) => {
+                let _ = fs::remove_file(&tmp);
+                Err(packaging_error(140, Some(&e.to_string())))
+            }
+            Err(FetchError::DownloadFailed(msg)) => {
+                let _ = fs::remove_file(&tmp);
+                Err(packaging_error(140, Some(&msg)))
+            }
+        }
+    }
+
+    // ---- urls ------------------------------------------------------------
+
+    fn release_url(&self) -> String {
+        format!(
+            "{}/v{}",
+            self.mirror,
+            self.version.strip_prefix('v').unwrap_or(&self.version)
+        )
+    }
+
+    fn index_url(&self, name: &str) -> String {
+        format!("{}/{name}", self.release_url())
+    }
+
+    fn index_urls(&self) -> Vec<String> {
+        BOOTSTRAP_INDEX_FILES
+            .iter()
+            .map(|n| self.index_url(n))
+            .collect()
+    }
+
+    fn asset_url(&self, filename: &str) -> String {
+        format!("{}/{filename}", self.release_url())
+    }
+}
+
+/// TEBAKO_OFFLINE (1/true/yes, case-insensitive): every resolution is
+/// cache-or-named-error, never a silent fetch.
+fn offline_env() -> bool {
+    std::env::var("TEBAKO_OFFLINE")
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+/// The store's per-entry install lock (the `.install.lock` file inside
+/// the entry directory): exclusive flock with a bounded wait, then `f`.
+/// A contended lock past `timeout` is the named error `code` naming the
+/// artifact kind (`noun`) — 125 for runtimes, 142 for bootstraps.
+fn with_install_lock<F>(
+    dir: &Path,
+    entry_ref: &str,
+    timeout: std::time::Duration,
+    noun: &str,
+    code: i32,
+    f: F,
+) -> Result<(), TebakoError>
+where
+    F: FnOnce() -> Result<(), TebakoError>,
+{
+    fs::create_dir_all(dir)
+        .map_err(|e| crate::error::plain_error(format!("{e} creating {}", dir.display())))?;
+    let lock_path = dir.join(LOCK_FILE);
+    let lock = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|e| crate::error::plain_error(format!("{e} opening {}", lock_path.display())))?;
+    acquire_install_lock(&lock, entry_ref, &lock_path, timeout, noun, code)?;
+    let result = f();
+    flock(&lock, LOCK_UN);
+    result
+}
+
+fn acquire_install_lock(
+    lock: &fs::File,
+    entry_ref: &str,
+    lock_path: &Path,
+    timeout: std::time::Duration,
+    noun: &str,
+    code: i32,
+) -> Result<(), TebakoError> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if flock(lock, LOCK_EX | LOCK_NB) {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(packaging_error(
+                code,
+                Some(&format!(
+                    "{entry_ref}: another process is installing this {noun} (no lock after {}s; lockfile: {})",
+                    timeout.as_secs(),
+                    lock_path.display()
+                )),
+            ));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
     }
 }
 
@@ -1377,6 +1770,189 @@ mod tests {
         assert_eq!(err.code, 122);
         assert!(err.message.contains("bare file name"), "{}", err.message);
         assert!(!cache.join("runtimes").join("evil.dll").exists());
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    // ---- spec 19 §4: the Rust bootstrap store ---------------------------
+
+    /// A scratch (cache root, release mirror) pair in the product
+    /// release's shape (finalize.sh): the tebako-bootstrap asset plus
+    /// both index files — manifest.json's top-level `assets` IS the
+    /// bootstrap set (a `tools` entry rides along and must not leak in)
+    /// and SHA256SUMS carries every tool's lines. `tamper` poisons the
+    /// declared sha.
+    fn boot_mirror(tag: &str, tamper: bool) -> (PathBuf, PathBuf) {
+        let dir =
+            std::env::temp_dir().join(format!("tebako-resolve-boot-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let cache = dir.join("home");
+        let release = dir.join("mirror").join("v0.1.8");
+        fs::create_dir_all(&release).unwrap();
+        let asset = "tebako-bootstrap-0.1.8-macos-arm64";
+        fs::write(release.join(asset), b"fake rust bootstrap\n").unwrap();
+        let declared = if tamper {
+            "f".repeat(64)
+        } else {
+            sha256_file_hex(&release.join(asset)).unwrap()
+        };
+        let manifest = format!(
+            r#"{{"name":"tebako-rs","version":"0.1.8","assets":[{{"platform":"macos-arm64","file":"{asset}","sha256":"{declared}","size_bytes":19}}],"tools":{{"tfs":[{{"platform":"macos-arm64","file":"tfs-0.1.8-macos-arm64","sha256":"{}","size_bytes":5}}]}}}}"#,
+            "0".repeat(64)
+        );
+        fs::write(release.join("manifest.json"), manifest).unwrap();
+        let sums = format!(
+            "{declared}  {asset}\n{}  tfs-0.1.8-macos-arm64\n{}  tebako-0.1.8-macos-arm64\n{}  tebako-bootstrap-0.1.7-macos-arm64\n{}  link-unit-0.1.8-macos-arm64.tar.gz\n",
+            "0".repeat(64),
+            "1".repeat(64),
+            "2".repeat(64),
+            "3".repeat(64)
+        );
+        fs::write(release.join("SHA256SUMS"), sums).unwrap();
+        (cache, dir.join("mirror"))
+    }
+
+    fn boot_resolver(cache: &Path, mirror: &Path, offline: bool) -> BootstrapResolver {
+        BootstrapResolver {
+            cache_root: cache.to_path_buf(),
+            mirror: format!("file://{}", mirror.display()),
+            version: "0.1.8".to_string(),
+            offline,
+            lock_timeout: LOCK_TIMEOUT,
+        }
+    }
+
+    fn boot_entry_dir(cache: &Path) -> PathBuf {
+        cache.join("bootstraps").join("0.1.8-macos-arm64")
+    }
+
+    #[test]
+    fn bootstrap_manifest_object_parses_the_assets_array() {
+        let (cache, mirror) = boot_mirror("parse-manifest", false);
+        let r = boot_resolver(&cache, &mirror, false);
+        let body = fs::read_to_string(mirror.join("v0.1.8").join("manifest.json")).unwrap();
+        let entries = r.parse_manifest(&body).unwrap();
+        assert_eq!(entries.len(), 1, "the tools map never leaks in");
+        assert_eq!(entries[0].platform, "macos-arm64");
+        assert_eq!(entries[0].filename, "tebako-bootstrap-0.1.8-macos-arm64");
+        // the array shape is mandatory — an object manifest is unusable
+        let err = r.parse_manifest("[{\"platform\":\"x\"}]").unwrap_err();
+        assert!(matches!(err, FetchError::IndexUnavailable(_)));
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn bootstrap_sha256sums_keeps_only_the_versioned_bootstrap_lines() {
+        let (cache, mirror) = boot_mirror("parse-sums", false);
+        let r = boot_resolver(&cache, &mirror, false);
+        let body = fs::read_to_string(mirror.join("v0.1.8").join("SHA256SUMS")).unwrap();
+        let entries = r.parse_sha256sums(&body);
+        // tfs-/tebako-/link-unit- lines and the OTHER version's bootstrap
+        // line are all filtered out
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].platform, "macos-arm64");
+        assert_eq!(entries[0].filename, "tebako-bootstrap-0.1.8-macos-arm64");
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn resolve_bootstrap_installs_from_the_manifest_with_markers() {
+        let (cache, mirror) = boot_mirror("install", false);
+        let r = boot_resolver(&cache, &mirror, false);
+        let path = r.resolve("macos-arm64").unwrap();
+        let dir = boot_entry_dir(&cache);
+        assert_eq!(path, dir.join("tebako-bootstrap-0.1.8-macos-arm64"));
+        assert!(path.is_file());
+        assert_eq!(
+            fs::read_to_string(dir.join("sha256")).unwrap(),
+            format!("{}\n", sha256_file_hex(&path).unwrap())
+        );
+        assert_eq!(
+            fs::read_to_string(dir.join("origin")).unwrap(),
+            format!(
+                "file://{}/v0.1.8/tebako-bootstrap-0.1.8-macos-arm64\n",
+                mirror.display()
+            )
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(path.metadata().unwrap().permissions().mode() & 0o777, 0o755);
+        }
+        // a cache hit needs no mirror at all (a run is a run, offline-safe)
+        fs::remove_dir_all(&mirror).unwrap();
+        let offline_hit = boot_resolver(&cache, &mirror, true);
+        assert_eq!(offline_hit.resolve("macos-arm64").unwrap(), path);
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn resolve_bootstrap_falls_back_to_sha256sums() {
+        let (cache, mirror) = boot_mirror("sums", false);
+        fs::remove_file(mirror.join("v0.1.8").join("manifest.json")).unwrap();
+        let r = boot_resolver(&cache, &mirror, false);
+        let path = r.resolve("macos-arm64").unwrap();
+        assert!(path.is_file());
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn resolve_bootstrap_wrong_sha_is_a_named_error() {
+        let (cache, mirror) = boot_mirror("badsha", true);
+        let r = boot_resolver(&cache, &mirror, false);
+        let err = r.resolve("macos-arm64").unwrap_err();
+        assert_eq!(err.code, 139);
+        assert!(err.message.contains("download deleted"), "{}", err.message);
+        assert!(!boot_entry_dir(&cache)
+            .join("tebako-bootstrap-0.1.8-macos-arm64")
+            .exists());
+        assert!(
+            !fs::read_dir(cache.join(TMP_DIR))
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .any(|e| e.file_name().to_string_lossy().contains("tebako-bootstrap")),
+            "the failed download was deleted"
+        );
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn resolve_bootstrap_offline_miss_is_a_named_error() {
+        let (cache, mirror) = boot_mirror("offline", false);
+        let r = boot_resolver(&cache, &mirror, true);
+        let err = r.resolve("macos-arm64").unwrap_err();
+        assert_eq!(err.code, 138);
+        assert!(err.message.contains("not cached"), "{}", err.message);
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn resolve_bootstrap_unknown_platform_is_a_named_error() {
+        let (cache, mirror) = boot_mirror("noplatform", false);
+        let r = boot_resolver(&cache, &mirror, false);
+        let err = r.resolve("plan9-s390x").unwrap_err();
+        assert_eq!(err.code, 137);
+        assert!(
+            err.message.contains("macos-arm64"),
+            "the available list is named: {}",
+            err.message
+        );
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn resolve_bootstrap_without_an_index_is_a_named_error() {
+        let (cache, mirror) = boot_mirror("noindex", false);
+        let release = mirror.join("v0.1.8");
+        fs::remove_file(release.join("manifest.json")).unwrap();
+        fs::remove_file(release.join("SHA256SUMS")).unwrap();
+        let r = boot_resolver(&cache, &mirror, false);
+        let err = r.resolve("macos-arm64").unwrap_err();
+        assert_eq!(err.code, 141);
+        assert!(
+            err.message.contains("no usable bootstrap index"),
+            "{}",
+            err.message
+        );
         let _ = fs::remove_dir_all(cache.parent().unwrap());
     }
 }

--- a/crates/tebako-cli/src/suite.rs
+++ b/crates/tebako-cli/src/suite.rs
@@ -330,9 +330,9 @@ pub fn press_suite(
     }
     suite_warnings(opts, spec, suite_dir);
     let platform = host_platform()?;
-    // Local sources only — the retired C++ bootstrap download must never
-    // fire (exit 136 when no local Rust tebako-bootstrap is found).
-    let bootstrap_path = crate::local_bootstrap(opts)?;
+    // Local sources first, else the spec 19 §4 store flow — the retired
+    // v1 C++ bootstrap download never fires.
+    let bootstrap_path = crate::press_bootstrap(opts, &platform)?;
 
     // Per-entry imaging; runtimes resolve once per distinct ruby version.
     let mut runtimes: BTreeMap<String, Resolved> = BTreeMap::new();

--- a/crates/tebako-cli/tests/cli_e2e.rs
+++ b/crates/tebako-cli/tests/cli_e2e.rs
@@ -11,10 +11,11 @@
 //!   never builds it (tebako-bootstrap is a lib dependency): build it
 //!   first (`cargo build -p tebako-bootstrap`) or run the suite as CI
 //!   does (`cargo build --workspace` then `cargo test --workspace`).
-//!   The harness fails fast when it is missing (see dogfood_bootstrap);
-//!   the CLI itself now also fails closed (exit 136) — the v1 C++
-//!   bootstrap download fallback whose handoff the image-era runtime
-//!   driver rejects at run time is retired;
+//!   The harness fails fast when it is missing (see dogfood_bootstrap) —
+//!   without it every press would stop dogfooding and fall to the spec 19
+//!   §4 store flow (a network fetch of the released bootstrap). The v1
+//!   C++ bootstrap download fallback whose handoff the image-era runtime
+//!   driver rejects at run time stays retired;
 //! - the golden test additionally needs $TEBAKO_REFERENCE_GEM pointing at
 //!   a checkout of the reference gem (tamatebako/tebako, the three-part
 //!   model) and a host ruby with the thor gem.
@@ -47,15 +48,16 @@ fn e2e_allowed() -> bool {
 
 /// The in-workspace Rust bootstrap every e2e press dogfoods
 /// ($TEBAKO_BOOTSTRAP → the binary next to the tebako bin). REQUIRED:
-/// when no local bootstrap is found the press fails closed (exit 136 —
-/// the v1 C++ bootstrap download is retired: its argv0-verbatim handoff,
-/// no L2 package-manifest selection, no `;image` facet fetch, is rejected
-/// by the image-era runtime driver at run time). The harness still fails
-/// fast on its own so the suite never pays a runtime download for the
-/// named refusal, and `cargo test -p tebako-cli` alone does not build
-/// the sibling; build it first (`cargo build -p tebako-bootstrap`) or
-/// run the suite as CI does (`cargo build --workspace` then `cargo test
-/// --workspace`).
+/// with no local bootstrap the press resolves the released bootstrap
+/// through the spec 19 §4 store flow instead of dogfooding the
+/// in-workspace build (the v1 C++ bootstrap download stays retired: its
+/// argv0-verbatim handoff, no L2 package-manifest selection, no `;image`
+/// facet fetch, is rejected by the image-era runtime driver at run time).
+/// The harness still fails fast on its own so the suite never pays a
+/// store fetch for a bootstrap it must not use, and `cargo test -p
+/// tebako-cli` alone does not build the sibling; build it first (`cargo
+/// build -p tebako-bootstrap`) or run the suite as CI does (`cargo build
+/// --workspace` then `cargo test --workspace`).
 fn dogfood_bootstrap() -> PathBuf {
     let sibling = tebako_bin().parent().unwrap().join(if cfg!(windows) {
         "tebako-bootstrap.exe"
@@ -66,8 +68,8 @@ fn dogfood_bootstrap() -> PathBuf {
         sibling.is_file(),
         "the in-workspace tebako-bootstrap binary is missing ({}): build it first \
          (cargo build -p tebako-bootstrap) or run the suite via cargo test --workspace — \
-         without it every press fails closed with exit 136 (the v1 C++ bootstrap \
-         download fallback is retired)",
+         without it every press falls to the spec 19 §4 store flow (a network fetch of the \
+         released bootstrap) instead of dogfooding the in-workspace build",
         sibling.display()
     );
     sibling
@@ -202,8 +204,8 @@ fn press_command(env: &PressEnv, entry: &str, output: &Path) -> Command {
         .arg(output)
         .arg("-p")
         .arg(&env.prefix);
-    // Dogfood the in-workspace Rust bootstrap (required — the C++
-    // download fallback is retired; without it the press fails closed).
+    // Dogfood the in-workspace Rust bootstrap (required — without it the
+    // press falls to the spec 19 §4 store flow instead of dogfooding).
     cmd.env("TEBAKO_BOOTSTRAP", dogfood_bootstrap());
     cmd
 }

--- a/docs/spec/19-bootstrap-distribution.md
+++ b/docs/spec/19-bootstrap-distribution.md
@@ -26,20 +26,22 @@ from, and why will it run on your machine?**
 The short answer: **we build it, you never do.** The bootstrap is a
 precompiled artifact we publish for every supported platform, alongside
 the rest of the tebako release. A press stitches it onto your payloads —
-today from a **local** Rust bootstrap (`--bootstrap`, `$TEBAKO_BOOTSTRAP`,
-or the `tebako-bootstrap` binary next to the `tebako` executable); the
-download-and-cache flow of §4 (PLANNED) makes that automatic. There is no
-C compiler, no CMake, no Rust toolchain, no vcpkg anywhere in that path —
-and there never will be.
+from a **local** Rust bootstrap when one is present (`--bootstrap`,
+`$TEBAKO_BOOTSTRAP`, or the `tebako-bootstrap` binary next to the `tebako`
+executable), and otherwise from the release-store flow of §4: the
+per-triplet bootstrap published with the press's own release, resolved
+into the store once, verified, and cached. There is no C compiler, no
+CMake, no Rust toolchain, no vcpkg anywhere in that path — and there
+never will be.
 
-> **Shipped vs planned.** The CLI today sources the bootstrap from local
-> binaries only and **fails closed** when none is found (named error,
-> exit 136). The retired v1 C++ `tebako-bootstrap` release download —
-> whose argv0-verbatim handoff the image-era runtime driver rejects — is
-> gone for good: no silent network fetch remains on the press path. The
-> per-triplet Rust bootstrap assets this document describes ARE published
-> with every tebako release (§3.3); teaching `tebako press` to resolve
-> them into the store (once, verified, cached) is the PLANNED part.
+> **Shipped behavior.** The CLI sources the bootstrap from local binaries
+> first and otherwise resolves the published per-triplet Rust bootstrap
+> into the store (§4 — once, verified, cached). The retired v1 C++
+> `tebako-bootstrap` release download — whose argv0-verbatim handoff the
+> image-era runtime driver rejects — is gone for good: no silent network
+> fetch of a v1 artifact remains on the press path. The per-triplet Rust
+> bootstrap assets this document describes are published with every tebako
+> release (§3.3).
 
 ## 2. The audience rule (who needs what)
 
@@ -104,35 +106,37 @@ for your machine; you never pick anything.
 ## 4. How a press gets its bootstrap (no compiler involved)
 
 **Shipped behavior:** `tebako press` sources the bootstrap from local
-Rust binaries, in this order:
+Rust binaries first, in this order:
 
 1. `--bootstrap <path>` — an explicit binary;
 2. `$TEBAKO_BOOTSTRAP` — the environment override;
 3. the `tebako-bootstrap` executable next to the `tebako` binary (the
    dogfooding/installed-pair layout).
 
-With none of these present the press **fails closed** with the named
-error "Press requires a local Rust tebako-bootstrap binary" (exit 136) —
-no network fetch is attempted. (The historical fallback downloaded the
-v1 C++ bootstrap release; its handoff predates the spec 17 driver
-contract and produced packages that fail at run time, so it is retired,
-not merely refused.)
-
-**PLANNED (not yet shipped):** the release-store flow below — resolving
-the published per-triplet Rust bootstrap into `~/.tebako/bootstraps/`
-automatically, with the same verification discipline the runtime cache
-already has:
+With none of these present the press resolves the bootstrap through the
+**release-store flow** below — the published per-triplet Rust bootstrap
+into `~/.tebako/bootstraps/`, with the same verification discipline the
+runtime cache already has (a press never fails closed for want of a
+bootstrap unless the store flow itself fails with a named error;
+`TEBAKO_OFFLINE=1` is cache-or-named-error, exit 138). (The historical
+fallback downloaded the v1 C++ bootstrap release; its handoff predates
+the spec 17 driver contract and produced packages that fail at run time,
+so it is retired, not merely refused. The interim fail-closed refusal,
+exit 136, is superseded by this flow.)
 
 ```
 tebako press app.rb -o myapp
         │
         ▼
-  1. resolve the bootstrap for the target triplet
+  1. resolve the bootstrap for the target triplet — the release
+     matching the press's own version (the bootstrap and the CLI
+     ship in one release, so the two never drift)
         ├── store hit: ~/.tebako/bootstraps/<version>-<triplet> → use it
         └── miss: download from the tebako release page
-                 ├── sha256-verified against the release's SHA256SUMS
-                 └── tmp + rename into the store (a partial download
-                     is invisible — never used)
+                 ├── sha256-verified against the release's
+                 │   manifest.json / SHA256SUMS
+                 └── tmp + rename into the store under the entry lock
+                     (a partial download is invisible — never used)
         │
         ▼
   2. read the bootstrap's embedded contract card
@@ -256,7 +260,7 @@ verify against each other (spec 18).
 The bootstrap is **ours, precompiled, per-triplet, verified, and
 cached** — built once in our pipeline on deliberately old floors (or
 musl, which has no floor), published with sha256 anchors, sourced by the
-press from local binaries today (failing closed otherwise; the release
-store download of §4 is PLANNED), and stitched onto your payloads by a
-press that checks its contract card first. You never compile it, you
-never pick it, and it always starts.
+press from local binaries when present and otherwise resolved from the
+release into the store (§4 — once, verified, cached), and stitched onto
+your payloads by a press that checks its contract card first. You never
+compile it, you never pick it, and it always starts.


### PR DESCRIPTION
## What

Implements spec 19 §4's release-store flow: `tebako press` no longer requires a local Rust `tebako-bootstrap`. The source order is now:

1. `--bootstrap <path>` (explicit),
2. `$TEBAKO_BOOTSTRAP` (env override),
3. the `tebako-bootstrap` sibling next to the `tebako` binary (dogfooding / installed pair),
4. **new:** the product's own releases — the per-triplet `tebako-bootstrap-<version>-<triplet>[.exe]` asset published by `release.yml` since v0.1.x, resolved into the store.

The retired v1 C++ bootstrap download (#405) stays retired — this flow fetches the **Rust** bootstrap only, from `tamatebako/tebako` releases, never the archived C99 repo.

## Resolution-flow semantics (spec 19 §4, now shipped)

- **Version:** the bootstrap resolves from the release matching the CLI's own version (`env!("CARGO_PKG_VERSION")`) — bootstrap and CLI ship in one release, so the two never drift. `TEBAKO_BOOTSTRAP_MIRROR` overrides the mirror root (default `https://github.com/tamatebako/tebako/releases/download`); `file://` mirrors work (the test idiom).
- **Triplet:** `host_platform()` — the same `tpkg::Platform::release_asset_name()` vocabulary the runtime resolver consumes (`macos-arm64`, `linux-gnu-x86_64`, `linux-musl-*`, `windows-ucrt64`, …).
- **Store layout:** `~/.tebako/bootstraps/<version>-<triplet>/tebako-bootstrap-<version>-<triplet>[.exe]` (0755) + `sha256` + `origin` markers — the runtime-exe entry shape of AGENTS.md §8.
- **Index:** the release's `manifest.json` first — its top-level `assets` array is exactly the bootstrap set (authored by `.github/workflows/lib/finalize.sh`; the per-tool `tools` map never leaks in) — then `SHA256SUMS`, filtered to the `tebako-bootstrap-<version>-` lines (it carries every tool's assets).
- **Install discipline:** store hit returns without lock or network; a miss takes the per-entry flock (`.install.lock`, bounded wait → 142), downloads in-process via `tebako-http` (ureq+rustls, webpki-roots bundled — no curl/git anywhere), sha256-verifies against the index **before** install (mismatch → 139, download deleted), and tmp+renames into place (a partial download is invisible). A concurrent installer is awaited and re-checked under the lock.
- **`TEBAKO_OFFLINE=1`:** cache-or-named-error (138) — never a silent fetch.

## Exit codes (tebako-cli packaging table)

The bootstrap store flow gets its own rows, the parallel of the runtime rows 120–125:

| code | meaning |
|---|---|
| 137 | no tebako-bootstrap asset for the requested platform in the tebako release |
| 138 | `TEBAKO_OFFLINE` set and the requested tebako-bootstrap is not cached |
| 139 | SHA256 checksum mismatch for the downloaded tebako-bootstrap |
| 140 | failed to download the tebako-bootstrap |
| 141 | the tebako release carries no usable bootstrap index |
| 142 | timed out waiting for the tebako-bootstrap cache lock |

136 stays as a reserved row (the interim fail-closed refusal, superseded by this flow); the retired 131/132/134 rows are untouched.

## Tests

- `resolve.rs`: `BootstrapResolver` unit tests over `file://` mirror fixtures (no network) — manifest install with `sha256`/`origin` markers + 0755 + offline-safe cache hit; SHA256SUMS fallback; sha mismatch → 139 with the tmp file deleted; offline miss → 138; unknown platform → 137 naming the available set; no index → 141; both parsers (the `tools` map, other tools' SHA256SUMS lines, and other versions' bootstrap lines never leak in).
- `lib.rs`: `press_bootstrap` keeps the `--bootstrap` short-circuit and the 127 parity error; with no local source it falls to the store (asserted as 138 against an offline fixture store — the unit suite never touches the network or the real `~/.tebako`).
- The lock helper is factored (`with_install_lock`) so runtimes (125) and bootstraps (142) share one implementation; `Resolver` behavior is unchanged.

## Docs (same PR)

- `docs/spec/19-bootstrap-distribution.md`: §1 short answer, the shipped-vs-planned note, §4 (PLANNED → shipped, with the store-flow semantics above), §9.
- `crates/tebako-cli/README.md`: the bootstrap bullet in "Where the pieces come from", the deviations list, the exit-code range (106–142), the e2e dogfooding note.
- `crates/tebako-cli/tests/cli_e2e.rs`: comments — a missing dogfood sibling now means "falls to the store flow instead of dogfooding", not the retired fail-closed.

## Verification

(worktree `/Users/mulgogi/src/tamatebako/tebako-wt-bootstrap-store`, base 66ccf740 = origin/main)

```
$ cargo fmt --check            # clean
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 16s   # no warnings
$ cargo build -p tebako-bootstrap && cargo test -p tebako-cli   # EXIT=0 (pipefail)
     Running unittests src/lib.rs
test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
     Running tests/cli_e2e.rs
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1746.31s
     Running tests/info.rs
test result: ok. 9 passed; 0 failed; ... finished in 0.03s
     Running tests/install.rs
test result: ok. 29 passed; 0 failed; ... finished in 0.07s
     Running tests/install_env.rs
test result: ok. 2 passed; 0 failed; ... finished in 0.04s
     Running tests/install_local.rs
test result: ok. 6 passed; 0 failed; ... finished in 0.03s
     Running tests/publish.rs
test result: ok. 10 passed; 0 failed; ... finished in 0.07s
     Running tests/registry_cli.rs
test result: ok. 1 passed; 0 failed; ... finished in 0.07s
     Running tests/run.rs
test result: ok. 6 passed; 0 failed; ... finished in 0.83s
     Running tests/suite.rs
test result: ok. 6 passed; 0 failed; ... finished in 0.00s
   Doc-tests tebako_cli
test result: ok. 0 passed; 0 failed; ... finished in 0.00s
```

150 passed, 0 failed. The new tests in the lib binary: `resolve::tests::bootstrap_manifest_object_parses_the_assets_array`, `bootstrap_sha256sums_keeps_only_the_versioned_bootstrap_lines`, `resolve_bootstrap_installs_from_the_manifest_with_markers`, `resolve_bootstrap_falls_back_to_sha256sums`, `resolve_bootstrap_wrong_sha_is_a_named_error` (139), `resolve_bootstrap_offline_miss_is_a_named_error` (138), `resolve_bootstrap_unknown_platform_is_a_named_error` (137), `resolve_bootstrap_without_an_index_is_a_named_error` (141), `tests::press_bootstrap_prefers_the_option_and_rejects_a_missing_file` (127), `tests::press_bootstrap_without_a_local_source_resolves_the_store` (138 seam).

CI: watch this PR's checks to green.
