### PR TITLE
feat(tpkg,driver): windows Class-L library aliases — boot extraction + PATH lead (spec 22 §2.1, phase W2)

### DIFF
--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -1241,6 +1241,9 @@ fn synthesize_manifest(
         // embedded manifest can (the store layout: the embedded manifest
         // wins; the mirror is synthesized LOUDLY).
         materialize: Vec::new(),
+        // …and no library aliases (spec 03 §2.5 — the same mirror rule:
+        // declarations live in the embedded manifest only).
+        library_aliases: Vec::new(),
     })
 }
 

--- a/crates/tebako-driver/src/alias.rs
+++ b/crates/tebako-driver/src/alias.rs
@@ -14,13 +14,20 @@
 //!
 //! Two surfaces consume the alias union this module builds per boot:
 //!
-//! - **The covered surface** (the patched `dln.c` / fiddle route —
-//!   vendored-runtime code): a match rewrites the call to the alias
-//!   target's absolute materialized path and loads it with the §2.1
-//!   binding (`LOAD_WITH_ALTERED_SEARCH_PATH`). The load-time check is
-//!   the c_api shim's (PR #406 stream); [`AliasUnion::resolve`] is the
-//!   one decision function — the match semantics are locked here and
-//!   tested here, never re-implemented per consumer (invariant 10).
+//! - **The covered surface** (the patched `dln.c` route — vendored-
+//!   runtime code): the load-time check is `tebako_fs_dlalias2file` on
+//!   the tfs context (the c_api export the patched `dln.c` calls); the
+//!   driver feeds it by registering the union's (name → materialized
+//!   host path) pairs at boot ([`register`]). A match rewrites the call
+//!   to the alias target's absolute materialized path and loads it with
+//!   the §2.1 binding (`LOAD_WITH_ALTERED_SEARCH_PATH`). The match rule
+//!   (the bare-name byte grammar, then a verbatim case-insensitive
+//!   compare) is locked and tested here on [`AliasUnion::resolve`] and
+//!   re-implemented in `tfs::context` by construction — tfs stays
+//!   tpkg-free and the c_api does its own grammar test per the patch's
+//!   contract; the mirrored case matrices on both sides assert parity
+//!   (invariant 10's assert-form — the one deliberate duplication,
+//!   spec-pinned in #406).
 //! - **The raw surface** (ffi's `LoadLibraryExA`, a C extension
 //!   self-loading — windows has no interception surface for them, and
 //!   patching third-party code is the per-gem work spec 22's law
@@ -50,7 +57,8 @@
 //! The `event=lib-load` record-mode journal (spec 23 §8's idiom — the
 //! author learns the exact spelling to declare from the journal instead
 //! of guessing) is owned by the PATCHED LOAD PATH, not by this module:
-//! a bare-name verdict exists only where a load is DECIDED, and the
+//! the verdict lines are emitted inside `tfs::context::dlalias2file`,
+//! where the verdict is MADE (under the record policy only), and the
 //! boot pass decides nothing — it materializes every declaration
 //! unconditionally.
 
@@ -147,11 +155,14 @@ impl AliasUnion {
     /// probe. A name carrying a path separator or a drive qualifier is
     /// not bare: path surface is Rule L1's, so the answer is Host.
     ///
-    /// SEAM (PR #406 — the vendored-route stream): the covered
-    /// surface's load-time check (the patched `dln.c` / fiddle c_api
-    /// shim) consumes exactly this decision; it is wired there, not
-    /// here — the boot pass below materializes unconditionally and never
-    /// resolves a presented name.
+    /// The union-side reference of the match rule: the covered
+    /// surface's load-time check is `tfs::context::dlalias2file` behind
+    /// the `tebako_fs_dlalias2file` c_api export (tfs is tpkg-free, so
+    /// the rule is re-implemented there — the one deliberate
+    /// duplication, parity-asserted by the mirrored case matrices).
+    /// The boot pass below materializes unconditionally and never
+    /// resolves a presented name; the registration feeds the table the
+    /// c_api answers from.
     pub fn resolve(&self, name: &str) -> AliasVerdict<'_> {
         if name.bytes().any(|b| b == b'/' || b == b'\\' || b == b':') {
             return AliasVerdict::Host;
@@ -178,19 +189,34 @@ fn collect_image(union: &mut AliasUnion, desc: &str, mount: &str) -> Result<(), 
     union.add_image(desc, mount, &manifest)
 }
 
-/// The boot pass for the raw surface (spec 22 §2.1): collect the alias
-/// union of every co-mounted image — the env image first, then each
-/// payload triple in order — materialize EVERY declared alias through
-/// the exec-closure entry, and answer the materialized host directories
-/// in union order (deduped) for the PATH lead. Called per boot after
-/// the mounts, the jail, and the class-R pass, before the interpreter
+/// The boot pass's yield (spec 22 §2.1, phase W2): the covered
+/// surface's registration table and the raw surface's PATH lead.
+#[derive(Default)]
+pub struct AliasBoot {
+    /// (declared bare name, materialized absolute host path) per alias,
+    /// in union order — the covered surface's decision table
+    /// ([`register`]).
+    pub pairs: Vec<(String, PathBuf)>,
+    /// The materialized copies' parent directories, union order,
+    /// deduped — the raw surface's PATH lead ([`export_path`]).
+    pub dirs: Vec<String>,
+}
+
+/// The boot pass (spec 22 §2.1): collect the alias union of every
+/// co-mounted image — the env image first, then each payload triple in
+/// order — and materialize EVERY declared alias through the
+/// exec-closure entry. Answers the [`AliasBoot`]: the per-alias (name,
+/// host path) pairs for the covered surface's registration
+/// ([`register`]) and the deduped materialized directories for the raw
+/// surface's PATH lead ([`export_path`]). Called per boot after the
+/// mounts, the jail, and the class-R pass, before the interpreter
 /// handoff — in both boot shapes; the call sites are windows-gated (the
 /// bare-name rule is a windows contract — POSIX boots never run this).
 pub fn extract(
     images: &[ImageSpec],
     env: &dyn Env,
     runtime_root: &str,
-) -> Result<Vec<String>, DriverError> {
+) -> Result<AliasBoot, DriverError> {
     let mut union = AliasUnion::new();
     // The env image's own declarations come first (the class-R
     // precedent: the runtime's resources extract ahead of payloads).
@@ -206,15 +232,31 @@ pub fn extract(
         };
         collect_image(&mut union, &desc, &spec.mount)?;
     }
-    let mut dirs: Vec<String> = Vec::new();
+    let mut boot = AliasBoot::default();
     for entry in &union.entries {
         let host = extract_one(entry)?;
         let dir = parent_dir(&host)?;
-        if !dirs.contains(&dir) {
-            dirs.push(dir);
+        if !boot.dirs.contains(&dir) {
+            boot.dirs.push(dir);
         }
+        boot.pairs.push((entry.name.clone(), host));
     }
-    Ok(dirs)
+    Ok(boot)
+}
+
+/// Register the boot's alias table with the tfs context — the covered
+/// surface's load-time decision input (spec 22 §2.1, phase W2): the
+/// patched `dln.c`'s `tebako_fs_dlalias2file` answers from exactly
+/// these (name → materialized host path) pairs. A direct Rust call on
+/// the shared in-process context, never a c_api round-trip — the c_api
+/// export exists for the runtime's patched C code. An empty union
+/// registers an empty table (the context's default state made
+/// explicit); the call sites are windows-gated like [`extract`]'s.
+pub fn register(boot: &AliasBoot) {
+    context()
+        .write()
+        .unwrap()
+        .register_dlaliases(boot.pairs.clone());
 }
 
 /// Materialize one declared alias and answer its host path. The
@@ -533,13 +575,41 @@ mod tests {
     #[test]
     fn extract_without_mounted_images_extracts_nothing() {
         // No env image handed, no payload triples: the union is empty,
-        // nothing materializes, no PATH dirs arise. (The mount-dependent
-        // paths — manifest reads and dlmap2file — are the factory
-        // dogfood's surface, mirroring materialize.rs's coverage shape.)
+        // nothing materializes, no PATH dirs and no registration pairs
+        // arise. (The mount-dependent paths — manifest reads and
+        // dlmap2file — are the factory dogfood's surface, mirroring
+        // materialize.rs's coverage shape.)
         let env = env_with(&[]);
-        assert_eq!(
-            extract(&[], &env, "/__tfs__").unwrap(),
-            Vec::<String>::new()
-        );
+        let boot = extract(&[], &env, "/__tfs__").unwrap();
+        assert!(boot.pairs.is_empty(), "{:?}", boot.pairs);
+        assert!(boot.dirs.is_empty(), "{:?}", boot.dirs);
+    }
+
+    #[test]
+    fn register_installs_the_table_into_the_tfs_context() {
+        // The covered surface's wiring: the boot's pairs land in the
+        // process-global tfs context the `tebako_fs_dlalias2file` c_api
+        // export reads. (The context is process state shared by this
+        // whole test binary — restore the empty table afterwards so no
+        // other test observes it.)
+        let dir =
+            std::env::temp_dir().join(format!("driver-alias-register-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let host = dir.join("libfoo-3.dll");
+        std::fs::write(&host, b"pe").unwrap();
+        let boot = AliasBoot {
+            pairs: vec![("libfoo-3.dll".to_string(), host.clone())],
+            dirs: Vec::new(),
+        };
+        register(&boot);
+        let answered = context()
+            .read()
+            .unwrap()
+            .dlalias2file("LIBFOO-3.DLL")
+            .unwrap();
+        assert_eq!(answered.to_str().unwrap(), host.to_string_lossy().as_ref());
+        context().write().unwrap().register_dlaliases(Vec::new());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/tebako-driver/src/alias.rs
+++ b/crates/tebako-driver/src/alias.rs
@@ -1,0 +1,545 @@
+//! Windows Class L — the bare-name alias rule (spec 22 §2.1, phase W2).
+//!
+//! A loader call presenting a BARE library name (no path separator, no
+//! drive qualifier — `ffi_lib 'user32'`, `Fiddle.dlopen 'foo'`) means
+//! HOST by default, always: no VFS probe, no extension completion, no
+//! search-order trickery. The ONE exception is declared: a bare name
+//! matching a co-mounted image's `library_aliases:` entry EXACTLY
+//! (verbatim, case-insensitive — the windows loader's own comparison;
+//! `foo` does not match `foo.dll`) is payload-vendored (the grammar is
+//! spec 03 §2.5; the declaration — not a heuristic — is what makes the
+//! decision decidable at all). Rule L1 itself is unchanged: aliases are
+//! a NAME-routing rule for path-less calls, applied before L1's check
+//! runs.
+//!
+//! Two surfaces consume the alias union this module builds per boot:
+//!
+//! - **The covered surface** (the patched `dln.c` / fiddle route —
+//!   vendored-runtime code): a match rewrites the call to the alias
+//!   target's absolute materialized path and loads it with the §2.1
+//!   binding (`LOAD_WITH_ALTERED_SEARCH_PATH`). The load-time check is
+//!   the c_api shim's (PR #406 stream); [`AliasUnion::resolve`] is the
+//!   one decision function — the match semantics are locked here and
+//!   tested here, never re-implemented per consumer (invariant 10).
+//! - **The raw surface** (ffi's `LoadLibraryExA`, a C extension
+//!   self-loading — windows has no interception surface for them, and
+//!   patching third-party code is the per-gem work spec 22's law
+//!   forbids): the driver materializes EVERY declared alias at boot
+//!   ([`extract`]) through the exec-closure entry and PREPENDS the
+//!   materialized directories to the process `PATH` ([`export_path`]),
+//!   so the OS's own standard search order resolves a declared name for
+//!   any caller in the process — interception-free, per-gem-code-free.
+//!   EVERY co-mounted image contributes (the app payload included —
+//!   unlike bin dirs — because any consumer in the process may present
+//!   the name), the env image first, then the payload triples in order.
+//!
+//! The OS's precedence is stated honestly (spec 22 §2.1): the alias
+//! guarantees AVAILABILITY on the search path, not precedence over the
+//! OS's leading dirs — a declared name colliding with a System32 DLL
+//! binds the host copy by OS rule, an aliasing mistake the declaration
+//! surface cannot fix.
+//!
+//! Named errors (the spec 17 §2 slug precedent — never a silent
+//! winner): one alias name declared by two co-mounted images is a named
+//! boot error 65 (a duplicate WITHIN one image fails earlier, at
+//! manifest parse — spec 03 §2.5); an alias whose `path` the image does
+//! not hold, or that is not a regular file, is the manifest lying — a
+//! named 65 (the Rule-R3 precedent), never a skipped entry; a host IO
+//! failure materializing into the cache is a named 74.
+//!
+//! The `event=lib-load` record-mode journal (spec 23 §8's idiom — the
+//! author learns the exact spelling to declare from the journal instead
+//! of guessing) is owned by the PATCHED LOAD PATH, not by this module:
+//! a bare-name verdict exists only where a load is DECIDED, and the
+//! boot pass decides nothing — it materializes every declaration
+//! unconditionally.
+
+use std::path::{Path, PathBuf};
+
+use tfs::context::context;
+
+use crate::driver::{env_var, errno_text, join_mount, DriverError, Env};
+use crate::handoff::ImageSpec;
+use crate::{EX_TEBAKO_IO, EX_TEBAKO_MANIFEST};
+
+fn manifest_err(message: impl Into<String>) -> DriverError {
+    DriverError::new(EX_TEBAKO_MANIFEST, message.into())
+}
+
+fn io(message: impl Into<String>) -> DriverError {
+    DriverError::new(EX_TEBAKO_IO, message.into())
+}
+
+/// One mounted image's contribution to the boot's alias union.
+struct AliasEntry {
+    /// The declared bare name (the manifest's own spelling — the match
+    /// is case-insensitive, the spelling is preserved for errors).
+    name: String,
+    /// The alias target's VFS path (the declared in-image path joined
+    /// under the declaring image's mount).
+    vfs: String,
+    /// Human-readable description of the declaring image, for errors.
+    desc: String,
+}
+
+/// The verdict of a bare-name alias check (spec 22 §2.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AliasVerdict<'u> {
+    /// Payload-vendored: the name matches a declared alias — the value
+    /// is the target's VFS path; materialize it through the exec-closure
+    /// entry and load the host copy with the §2.1 binding (the covered
+    /// surface's rewrite).
+    Alias(&'u str),
+    /// Host-by-default: no declaration matches (or the name is not
+    /// bare — path surface is Rule L1's, never the alias rule's) — the
+    /// name passes to the OS loader untouched.
+    Host,
+}
+
+/// The boot's alias union across every co-mounted image (spec 22 §2.1):
+/// insertion-ordered (the env image first, then the payload triples —
+/// the PATH lead's order), keyed on the match rule's comparison
+/// (verbatim, case-insensitive). Two images declaring one name is an
+/// authoring ambiguity — a named 65, never a silent winner.
+#[derive(Default)]
+pub struct AliasUnion {
+    entries: Vec<AliasEntry>,
+}
+
+impl AliasUnion {
+    pub fn new() -> AliasUnion {
+        AliasUnion::default()
+    }
+
+    /// Fold one mounted image's declared `library_aliases:` into the
+    /// union. `desc` describes the image in errors ("env image '…'",
+    /// "image '…'", "own slot N"); `mount` is the VFS point the
+    /// declared in-image paths join under.
+    pub fn add_image(
+        &mut self,
+        desc: &str,
+        mount: &str,
+        manifest: &tpkg::PayloadManifest,
+    ) -> Result<(), DriverError> {
+        for alias in &manifest.library_aliases {
+            if let Some(prior) = self
+                .entries
+                .iter()
+                .find(|e| e.name.eq_ignore_ascii_case(&alias.name))
+            {
+                return Err(manifest_err(format!(
+                    "library alias '{}' is declared by both {} and {} — an authoring ambiguity, never a silent winner",
+                    alias.name, prior.desc, desc
+                )));
+            }
+            self.entries.push(AliasEntry {
+                name: alias.name.clone(),
+                vfs: join_mount(mount, &alias.path),
+                desc: desc.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// The bare-name decision (spec 22 §2.1): a verbatim,
+    /// case-insensitive match against the union — never
+    /// extension-completed (`foo` does not match `foo.dll`), never a
+    /// probe. A name carrying a path separator or a drive qualifier is
+    /// not bare: path surface is Rule L1's, so the answer is Host.
+    ///
+    /// SEAM (PR #406 — the vendored-route stream): the covered
+    /// surface's load-time check (the patched `dln.c` / fiddle c_api
+    /// shim) consumes exactly this decision; it is wired there, not
+    /// here — the boot pass below materializes unconditionally and never
+    /// resolves a presented name.
+    pub fn resolve(&self, name: &str) -> AliasVerdict<'_> {
+        if name.bytes().any(|b| b == b'/' || b == b'\\' || b == b':') {
+            return AliasVerdict::Host;
+        }
+        match self
+            .entries
+            .iter()
+            .find(|e| e.name.eq_ignore_ascii_case(name))
+        {
+            Some(e) => AliasVerdict::Alias(&e.vfs),
+            None => AliasVerdict::Host,
+        }
+    }
+}
+
+/// Fold one mounted image's declarations into the union. No manifest
+/// declares nothing (plain images mount fine); a corrupt one is the
+/// image lying about its self-description — the shared named 65
+/// (`mounted_manifest_at`).
+fn collect_image(union: &mut AliasUnion, desc: &str, mount: &str) -> Result<(), DriverError> {
+    let Some(manifest) = crate::driver::mounted_manifest_at(mount)? else {
+        return Ok(());
+    };
+    union.add_image(desc, mount, &manifest)
+}
+
+/// The boot pass for the raw surface (spec 22 §2.1): collect the alias
+/// union of every co-mounted image — the env image first, then each
+/// payload triple in order — materialize EVERY declared alias through
+/// the exec-closure entry, and answer the materialized host directories
+/// in union order (deduped) for the PATH lead. Called per boot after
+/// the mounts, the jail, and the class-R pass, before the interpreter
+/// handoff — in both boot shapes; the call sites are windows-gated (the
+/// bare-name rule is a windows contract — POSIX boots never run this).
+pub fn extract(
+    images: &[ImageSpec],
+    env: &dyn Env,
+    runtime_root: &str,
+) -> Result<Vec<String>, DriverError> {
+    let mut union = AliasUnion::new();
+    // The env image's own declarations come first (the class-R
+    // precedent: the runtime's resources extract ahead of payloads).
+    if let Some(image) = env_var(env, "TEBAKO_RUNTIME_IMAGE") {
+        collect_image(&mut union, &format!("env image '{image}'"), runtime_root)?;
+    }
+    for spec in images {
+        let desc = match &spec.source {
+            crate::handoff::ImageSource::File(path, _) => {
+                format!("image '{}'", path.display())
+            }
+            crate::handoff::ImageSource::OwnSlot(n) => format!("own slot {n}"),
+        };
+        collect_image(&mut union, &desc, &spec.mount)?;
+    }
+    let mut dirs: Vec<String> = Vec::new();
+    for entry in &union.entries {
+        let host = extract_one(entry)?;
+        let dir = parent_dir(&host)?;
+        if !dirs.contains(&dir) {
+            dirs.push(dir);
+        }
+    }
+    Ok(dirs)
+}
+
+/// Materialize one declared alias and answer its host path. The
+/// in-image target is statted FIRST: declared-but-absent or not a
+/// regular file is the manifest lying (a named 65, the Rule-R3
+/// precedent), never a skipped entry.
+fn extract_one(entry: &AliasEntry) -> Result<PathBuf, DriverError> {
+    let stat = context().read().unwrap().stat(&entry.vfs).map_err(|e| {
+        if e == libc::ENOENT {
+            manifest_err(format!(
+                "{} declares library alias '{}' but '{}' is absent from the image — the payload's self-description lies",
+                entry.desc, entry.name, entry.vfs
+            ))
+        } else {
+            io(format!(
+                "cannot stat '{}' in the mounted image: {}",
+                entry.vfs,
+                errno_text(e)
+            ))
+        }
+    })?;
+    if stat.entry_type != tfs::EntryType::File {
+        return Err(manifest_err(format!(
+            "{} declares library alias '{}' but '{}' is not a regular file — the payload's self-description lies",
+            entry.desc, entry.name, entry.vfs
+        )));
+    }
+    // SEAM (PR #406 — the W2 PE-closure stream, crates/tfs
+    // exec_closure): dlmap2file's closure walk parses Mach-O/ELF today;
+    // the PE import directory joins as the third parsed format THERE.
+    // This call site is unchanged when that lands — the alias's
+    // sibling-import closure then materializes through the same entry
+    // (one path authority, spec 22 §2.1) — and the windows
+    // leave-in-place, content-keyed `dlls/<image-key>` lifecycle with
+    // the Rule-R3 write-once/per-boot-rehash protocol (tamper = 70) is
+    // the same stream's destination change. An alias whose closure is
+    // trivial — the common case — is fully served today.
+    let host = context()
+        .write()
+        .unwrap()
+        .dlmap2file(&entry.vfs)
+        .map_err(|e| {
+            if e == libc::ENOENT {
+                manifest_err(format!(
+                    "{} declares library alias '{}' but '{}' is not held by the mounts — the payload's self-description lies",
+                    entry.desc, entry.name, entry.vfs
+                ))
+            } else {
+                io(format!(
+                    "cannot materialize library alias '{}' ('{}'): {}",
+                    entry.name,
+                    entry.vfs,
+                    errno_text(e)
+                ))
+            }
+        })?;
+    tebako_log::log!(
+        tebako_log::Level::Debug,
+        "driver",
+        "library alias materialized name={} vfs={} at={}",
+        entry.name,
+        entry.vfs,
+        host.to_string_lossy()
+    );
+    Ok(PathBuf::from(host.to_string_lossy().into_owned()))
+}
+
+/// The materialized copy's parent directory as a PATH component. The
+/// split is on EITHER separator, not `Path::parent`: the only consumer
+/// is a windows boot whose PATH is string-joined, and the derivation
+/// must stay testable on hosts where `\` is not a separator.
+fn parent_dir(host: &Path) -> Result<String, DriverError> {
+    let s = host.to_string_lossy();
+    let Some(cut) = s.rfind(['/', '\\']) else {
+        return Err(io(format!(
+            "the materialized alias '{}' has no parent directory",
+            host.display()
+        )));
+    };
+    Ok(s[..cut].to_string())
+}
+
+/// Prepend the materialized alias directories to the process `PATH`
+/// (spec 22 §2.1's raw-surface wiring — the §3.2 lead's library form):
+/// the OS's own standard search order then resolves a declared bare
+/// name for any caller in the process. The dirs join the lead AFTER
+/// the §3.2 bin dirs (the exec surface's locked lead order stays
+/// byte-stable) and ahead of the inherited value — the call sites run
+/// before `path_env::export`, which prepends in front. Nothing to
+/// prepend leaves PATH untouched, never rewritten.
+pub fn export_path(env: &dyn Env, dirs: &[String]) {
+    if let Some(joined) = compose(env.var("PATH"), dirs) {
+        env.set_var("PATH", &joined);
+    }
+}
+
+/// The windows PATH value with `dirs` prepended ahead of the inherited
+/// value (`None` when there is nothing to prepend). The separator is
+/// the explicit `;` — the windows spelling — rather than
+/// `std::env::join_paths`' host-shaped one: the only consumer is a
+/// windows boot, and the explicit spelling keeps the windows semantics
+/// testable on the legs that build this crate (the repo's windows leg
+/// covers only the pure-Rust crates — tpkg among them — not the
+/// driver). Empty inherited components are dropped (a trailing `;`
+/// never seeds an empty search entry).
+fn compose(existing: Option<String>, dirs: &[String]) -> Option<String> {
+    if dirs.is_empty() {
+        return None;
+    }
+    let mut parts: Vec<String> = dirs.to_vec();
+    if let Some(existing) = existing {
+        parts.extend(
+            existing
+                .split(';')
+                .filter(|c| !c.is_empty())
+                .map(str::to_string),
+        );
+    }
+    Some(parts.join(";"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    struct MapEnv(RefCell<HashMap<String, String>>);
+
+    impl Env for MapEnv {
+        fn var(&self, key: &str) -> Option<String> {
+            self.0.borrow().get(key).cloned()
+        }
+        fn set_var(&self, key: &str, value: &str) {
+            self.0
+                .borrow_mut()
+                .insert(key.to_string(), value.to_string());
+        }
+    }
+
+    fn env_with(pairs: &[(&str, &str)]) -> MapEnv {
+        MapEnv(RefCell::new(
+            pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        ))
+    }
+
+    /// A data-kind manifest carrying the given `library_aliases:` YAML
+    /// block verbatim (the union tests' vehicle — the parse path is the
+    /// real one).
+    fn manifest_with_aliases(aliases: &str) -> tpkg::PayloadManifest {
+        let text = format!(
+            "identity:\n  schema_version: 1\n  kind: data\n  name: x\n  version: \"1\"\n  \
+             producer: {{tool: t, tool_version: \"1\"}}\n  created: \"2026-08-15T00:00:00Z\"\n  \
+             digest: {{tree_hash: sha256:{z}, blob_sha256: {z}}}\n  \
+             signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+             provides:\n  mount_semantics: {{suggested: /usr/share/x}}\n  capabilities: {{exec: false, read: true}}\n{aliases}",
+            z = "0".repeat(64)
+        );
+        tpkg::PayloadManifest::from_yaml(&text).unwrap()
+    }
+
+    #[test]
+    fn the_union_matches_verbatim_case_insensitively() {
+        let mut union = AliasUnion::new();
+        union
+            .add_image(
+                "image 'a.tfs'",
+                "/__app__",
+                &manifest_with_aliases(
+                    "library_aliases:\n  - {name: libfoo-3.dll, path: /lib/libfoo-3.dll}\n",
+                ),
+            )
+            .unwrap();
+        // The windows loader's own comparison: case-insensitive…
+        assert_eq!(
+            union.resolve("LIBFOO-3.DLL"),
+            AliasVerdict::Alias("/__app__/lib/libfoo-3.dll")
+        );
+        assert_eq!(
+            union.resolve("LibFoo-3.Dll"),
+            AliasVerdict::Alias("/__app__/lib/libfoo-3.dll")
+        );
+        // …but verbatim: never extension-completed, never a basename
+        // probe.
+        assert_eq!(union.resolve("libfoo-3"), AliasVerdict::Host);
+        assert_eq!(union.resolve("libfoo-3.dll.dll"), AliasVerdict::Host);
+        // An undeclared bare name is host-by-default — the rule's whole
+        // point.
+        assert_eq!(union.resolve("user32"), AliasVerdict::Host);
+    }
+
+    #[test]
+    fn only_bare_names_reach_the_alias_rule() {
+        let mut union = AliasUnion::new();
+        union
+            .add_image(
+                "image 'a.tfs'",
+                "/vendor",
+                &manifest_with_aliases(
+                    "library_aliases:\n  - {name: foo.dll, path: /lib/foo.dll}\n",
+                ),
+            )
+            .unwrap();
+        // A separator or a drive qualifier makes the name path surface
+        // (Rule L1) — never an alias, even when the basename matches.
+        assert_eq!(union.resolve("/vendor/lib/foo.dll"), AliasVerdict::Host);
+        assert_eq!(union.resolve("lib\\foo.dll"), AliasVerdict::Host);
+        assert_eq!(union.resolve("C:\\lib\\foo.dll"), AliasVerdict::Host);
+    }
+
+    #[test]
+    fn one_name_declared_by_two_images_is_a_named_error() {
+        // The spec 17 §2 slug precedent: an authoring ambiguity is a
+        // named boot error 65, never a silent winner — on the match
+        // rule's own (case-insensitive) comparison.
+        let mut union = AliasUnion::new();
+        union
+            .add_image(
+                "env image 'rt.tfs'",
+                "/__tfs__",
+                &manifest_with_aliases("library_aliases:\n  - {name: Foo.dll, path: /lib/a.dll}\n"),
+            )
+            .unwrap();
+        let err = union
+            .add_image(
+                "image 'app.tfs'",
+                "/__app__",
+                &manifest_with_aliases("library_aliases:\n  - {name: foo.DLL, path: /lib/b.dll}\n"),
+            )
+            .unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_MANIFEST, "{}", err.message);
+        assert!(err.message.contains("foo.DLL"), "{}", err.message);
+        assert!(
+            err.message.contains("env image 'rt.tfs'"),
+            "{}",
+            err.message
+        );
+        assert!(err.message.contains("image 'app.tfs'"), "{}", err.message);
+    }
+
+    #[test]
+    fn compose_prepends_with_the_windows_separator() {
+        assert_eq!(
+            compose(
+                Some("C:\\Windows;C:\\bin".to_string()),
+                &["D:\\dl\\a".to_string(), "D:\\dl\\b".to_string()],
+            ),
+            Some("D:\\dl\\a;D:\\dl\\b;C:\\Windows;C:\\bin".to_string())
+        );
+        // Prepend order is the union order — first declared leads.
+        assert_eq!(
+            compose(None, &["D:\\x".to_string(), "D:\\y".to_string()]),
+            Some("D:\\x;D:\\y".to_string())
+        );
+        // Empty inherited components never seed empty search entries.
+        assert_eq!(
+            compose(Some("C:\\x;;C:\\y;".to_string()), &["D:\\a".to_string()],),
+            Some("D:\\a;C:\\x;C:\\y".to_string())
+        );
+    }
+
+    #[test]
+    fn compose_without_dirs_leaves_path_untouched() {
+        assert_eq!(compose(Some("C:\\Windows".to_string()), &[]), None);
+        assert_eq!(compose(None, &[]), None);
+    }
+
+    #[test]
+    fn export_path_leads_with_the_alias_dirs() {
+        let env = env_with(&[("PATH", "C:\\Windows")]);
+        export_path(&env, &["D:\\dl\\vendor".to_string()]);
+        assert_eq!(
+            env.0.borrow().get("PATH").map(String::as_str),
+            Some("D:\\dl\\vendor;C:\\Windows")
+        );
+    }
+
+    #[test]
+    fn export_path_without_inheritance_and_without_dirs() {
+        let env = env_with(&[]);
+        export_path(&env, &["D:\\dl\\vendor".to_string()]);
+        assert_eq!(
+            env.0.borrow().get("PATH").map(String::as_str),
+            Some("D:\\dl\\vendor")
+        );
+        // Nothing to prepend: PATH rides through untouched, never
+        // rewritten.
+        let env = env_with(&[("PATH", "C:\\Windows")]);
+        export_path(&env, &[]);
+        assert_eq!(
+            env.0.borrow().get("PATH").map(String::as_str),
+            Some("C:\\Windows")
+        );
+    }
+
+    #[test]
+    fn parent_dir_names_the_materialized_copy_home() {
+        // Windows-shaped spellings split on either separator, on any
+        // test host.
+        assert_eq!(
+            parent_dir(Path::new("D:\\cache\\dlls\\abc\\lib\\foo.dll")).unwrap(),
+            "D:\\cache\\dlls\\abc\\lib"
+        );
+        assert_eq!(
+            parent_dir(Path::new("D:/cache/dlls/abc/lib/foo.dll")).unwrap(),
+            "D:/cache/dlls/abc/lib"
+        );
+        // A bare file name has no parent to put on PATH.
+        let err = parent_dir(Path::new("foo.dll")).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_IO, "{}", err.message);
+    }
+
+    #[test]
+    fn extract_without_mounted_images_extracts_nothing() {
+        // No env image handed, no payload triples: the union is empty,
+        // nothing materializes, no PATH dirs arise. (The mount-dependent
+        // paths — manifest reads and dlmap2file — are the factory
+        // dogfood's surface, mirroring materialize.rs's coverage shape.)
+        let env = env_with(&[]);
+        assert_eq!(
+            extract(&[], &env, "/__tfs__").unwrap(),
+            Vec::<String>::new()
+        );
+    }
+}

--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -766,13 +766,16 @@ pub fn boot_with_mount_modes(
             // the interpreter runs (spec 22 §4 class R — the cert case).
             crate::materialize::extract(&h.images, env, runtime_root)?;
             // Windows Class L (spec 22 §2.1): boot-materialize every
-            // declared library alias and lead PATH with the
+            // declared library alias, register the (name → host path)
+            // table for the covered surface's `tebako_fs_dlalias2file`
+            // (the patched dln.c route), and lead PATH with the
             // materialized dirs — the raw LoadLibrary surface's
             // interception-free answer.
             #[cfg(windows)]
             {
-                let alias_dirs = crate::alias::extract(&h.images, env, runtime_root)?;
-                crate::alias::export_path(env, &alias_dirs);
+                let alias_boot = crate::alias::extract(&h.images, env, runtime_root)?;
+                crate::alias::register(&alias_boot);
+                crate::alias::export_path(env, &alias_boot.dirs);
             }
             // The standalone interpreter spawns too — arm its children
             // the same way (spec 22 §3).
@@ -803,14 +806,17 @@ pub fn boot_with_mount_modes(
         crate::materialize::extract(&h.images, env, runtime_root)?;
         // Windows Class L (spec 22 §2.1, phase W2): boot-materialize
         // every co-mounted image's declared library aliases (the app
-        // payload's included) and join the materialized dirs to the PATH
-        // lead — BEFORE path_env::export prepends the §3.2 bin dirs in
-        // front, so the exec surface's locked lead order stays
+        // payload's included), register the (name → host path) table
+        // for the covered surface's `tebako_fs_dlalias2file` (the
+        // patched dln.c route), and join the materialized dirs to the
+        // PATH lead — BEFORE path_env::export prepends the §3.2 bin
+        // dirs in front, so the exec surface's locked lead order stays
         // byte-stable (… launcher → bins → alias dirs → inherited).
         #[cfg(windows)]
         {
-            let alias_dirs = crate::alias::extract(&h.images, env, runtime_root)?;
-            crate::alias::export_path(env, &alias_dirs);
+            let alias_boot = crate::alias::extract(&h.images, env, runtime_root)?;
+            crate::alias::register(&alias_boot);
+            crate::alias::export_path(env, &alias_boot.dirs);
         }
         // The mounts are established — publish the discovery surface
         // (spec 22 §6; v2-1/20), arm the children (spec 22 §3), and wire

--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -8,7 +8,10 @@
 //! (bare files whole; package files by trailer region) → install
 //! the jail policy (after the mounts — spec 08 §3) → materialize each
 //! mounted image's declared `materialize:` resources into the exec
-//! cache (spec 22 §4 class R) → resolve and verify
+//! cache (spec 22 §4 class R) → on windows, boot-materialize every
+//! co-mounted image's declared `library_aliases:` and join the
+//! materialized dirs to the PATH lead (spec 22 §2.1 — the raw
+//! LoadLibrary surface) → resolve and verify
 //! the entry → rewrite argv. Any failure unmounts everything: never a
 //! partial mount.
 
@@ -762,6 +765,15 @@ pub fn boot_with_mount_modes(
             // The env image's own declared resources materialize before
             // the interpreter runs (spec 22 §4 class R — the cert case).
             crate::materialize::extract(&h.images, env, runtime_root)?;
+            // Windows Class L (spec 22 §2.1): boot-materialize every
+            // declared library alias and lead PATH with the
+            // materialized dirs — the raw LoadLibrary surface's
+            // interception-free answer.
+            #[cfg(windows)]
+            {
+                let alias_dirs = crate::alias::extract(&h.images, env, runtime_root)?;
+                crate::alias::export_path(env, &alias_dirs);
+            }
             // The standalone interpreter spawns too — arm its children
             // the same way (spec 22 §3).
             crate::injection::export(env, declaration.as_ref(), runtime_root)?;
@@ -789,6 +801,17 @@ pub fn boot_with_mount_modes(
         // the jail, before any handoff (spec 22 §4 class R — Rule R3
         // fails the boot by name).
         crate::materialize::extract(&h.images, env, runtime_root)?;
+        // Windows Class L (spec 22 §2.1, phase W2): boot-materialize
+        // every co-mounted image's declared library aliases (the app
+        // payload's included) and join the materialized dirs to the PATH
+        // lead — BEFORE path_env::export prepends the §3.2 bin dirs in
+        // front, so the exec surface's locked lead order stays
+        // byte-stable (… launcher → bins → alias dirs → inherited).
+        #[cfg(windows)]
+        {
+            let alias_dirs = crate::alias::extract(&h.images, env, runtime_root)?;
+            crate::alias::export_path(env, &alias_dirs);
+        }
         // The mounts are established — publish the discovery surface
         // (spec 22 §6; v2-1/20), arm the children (spec 22 §3), and wire
         // the dependency bins onto PATH (spec 22 §3.2 — the launcher

--- a/crates/tebako-driver/src/injection.rs
+++ b/crates/tebako-driver/src/injection.rs
@@ -3,7 +3,7 @@
 //! needs to rebuild this namespace — so an exec'd descendant re-enters
 //! the same interposition instead of falling back to the host.
 //!
-//! Two exports, both after the mounts are established:
+//! Three exports, all after the mounts are established:
 //!
 //! 1. `TEBAKO_TFS_MOUNTS` — the mount table in the shim's grammar,
 //!    composed by the context (`mounts_env` — the single composer; the
@@ -18,6 +18,15 @@
 //!    for the interpreter's spawn hook (the SSOT flow: the factory
 //!    stages the file and emits the layout key; the driver flows it; the
 //!    hook consumes it — no second hand-written path).
+//! 3. `TEBAKO_RUNTIME_DLL`, when the env image's layout declares
+//!    `runtime_dll` (schema_minor 3; MSYS images only): the runtime's
+//!    own PE module basename, flowed VERBATIM into the handoff env on
+//!    every platform (POSIX legs never read it — one code path). The
+//!    reader is the tfs PE closure walk (`tfs::context`, the PR #409
+//!    stream): a bare import name matching it case-insensitively is
+//!    never materialized out of a payload image (spec 22 §2.1 — the
+//!    OS's basename-reuse rule binds the already-loaded copy). Absent ⇒
+//!    no export (an older image — the exclusion is simply off).
 //!
 //! Platform notes: on macOS the value reaches EVERY child in the
 //! inherited env — including Apple platform binaries, which dyld
@@ -39,6 +48,10 @@ use tfs::context::context;
 
 /// The spawn hook's source for the shim's in-VFS path (spec 17 §2).
 pub const PRELOAD_SHIM_VAR: &str = "TEBAKO_PRELOAD_SHIM";
+
+/// The runtime's own PE module basename for the tfs PE closure walk's
+/// exclusion (spec 22 §2.1; spec 17 §2's handoff-env row).
+pub const RUNTIME_DLL_VAR: &str = "TEBAKO_RUNTIME_DLL";
 
 /// The mounts list the shim rebuilds the namespace from (spec 17 §2).
 const MOUNTS_VAR: &str = "TEBAKO_TFS_MOUNTS";
@@ -62,6 +75,16 @@ pub fn export(
 ) -> Result<Option<String>, DriverError> {
     if let Some(mounts) = context().read().unwrap().mounts_env() {
         env.set_var(MOUNTS_VAR, &mounts.to_string_lossy());
+    }
+    // The runtime's own PE module name (schema_minor 3): flowed
+    // verbatim into the handoff env on EVERY platform — POSIX legs
+    // never read it, so one code path serves all. The reader is the
+    // tfs PE closure walk (`tfs::context`, the PR #409 stream), which
+    // excludes a bare import name matching it case-insensitively (spec
+    // 22 §2.1). Absent ⇒ no export (an older image — the exclusion is
+    // simply off).
+    if let Some(dll) = declaration.and_then(|d| d.runtime_dll.as_deref()) {
+        env.set_var(RUNTIME_DLL_VAR, dll);
     }
     let Some(rel) = declaration.and_then(|d| d.preload_shim.as_deref()) else {
         return Ok(None); // no env image or an older image — nothing to inject with
@@ -119,6 +142,47 @@ mod tests {
         let m = env.0.borrow();
         assert!(!m.contains_key(PRELOAD_SHIM_VAR));
         assert!(!m.contains_key(MOUNTS_VAR));
+        assert!(!m.contains_key(RUNTIME_DLL_VAR));
+    }
+
+    /// A declaration carrying only the fields under test (the pair-check
+    /// fields are layout.rs's surface, not this module's).
+    fn declaration(runtime_dll: Option<&str>) -> ImageLayout {
+        ImageLayout {
+            schema_version: 1,
+            era: 2,
+            image_layout: 1,
+            mount_root: "/__tfs__".to_string(),
+            interpreter_api_version: "3.4".to_string(),
+            mount_root_override: false,
+            preload_shim: None,
+            runtime_dll: runtime_dll.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn a_declared_runtime_dll_flows_to_the_handoff_env_on_every_platform() {
+        // No cfg gate: POSIX legs never read the var, so the export is
+        // one code path everywhere (spec 17 §2's row). The declared
+        // spelling flows verbatim — the reader (the tfs PE closure
+        // walk) lowercases for the windows loader's comparison.
+        let env = MapEnv(RefCell::new(HashMap::new()));
+        let layout = declaration(Some("x64-ucrt-ruby340.dll"));
+        let delivered = export(&env, Some(&layout), "/__tfs__").unwrap();
+        assert!(delivered.is_none(), "no preload shim declared");
+        assert_eq!(
+            env.0.borrow().get(RUNTIME_DLL_VAR).map(String::as_str),
+            Some("x64-ucrt-ruby340.dll")
+        );
+    }
+
+    #[test]
+    fn an_absent_runtime_dll_exports_nothing() {
+        // An older image: the closure walk's exclusion is simply off.
+        let env = MapEnv(RefCell::new(HashMap::new()));
+        let layout = declaration(None);
+        export(&env, Some(&layout), "/__tfs__").unwrap();
+        assert!(!env.0.borrow().contains_key(RUNTIME_DLL_VAR));
     }
 
     #[cfg(unix)]

--- a/crates/tebako-driver/src/layout.rs
+++ b/crates/tebako-driver/src/layout.rs
@@ -9,7 +9,9 @@
 //! era-2 driver parses the last but does not gate on it — and the
 //! additive `mount_root_override` (schema_minor 1): the image's grant
 //! that its rbconfig follows `TEBAKO_MOUNT_ROOT`, gating the driver's
-//! run-time root override (spec 17 §1).
+//! run-time root override (spec 17 §1); `preload_shim` (schema_minor 2)
+//! and `runtime_dll` (schema_minor 3) — flowed into the handoff env by
+//! the boot (see `crate::injection`).
 
 use serde::Deserialize;
 
@@ -60,6 +62,16 @@ pub struct ImageLayout {
     /// hook (spec 22 §3; no second hand-written copy of the path).
     /// Absent ⇒ no preload env (an older image — children get no VFS).
     pub preload_shim: Option<String>,
+    /// The runtime's own PE module basename, e.g. `x64-ucrt-ruby340.dll`
+    /// (additive, schema_minor 3; MSYS images only): the image declares,
+    /// the driver flows it — exported verbatim as `TEBAKO_RUNTIME_DLL`
+    /// into the handoff env (spec 17 §2), where the tfs PE closure walk
+    /// reads it to exclude the runtime's own DLL from payload
+    /// materialization (spec 22 §2.1). Bare-name grammar enforced here
+    /// (no separator, no drive qualifier — a violation is a named 78).
+    /// Absent ⇒ no export (an older image — the exclusion is simply
+    /// off).
+    pub runtime_dll: Option<String>,
 }
 
 /// The tolerant serde view: every field optional so the checks below can
@@ -74,6 +86,7 @@ struct LayoutView {
     interpreter_api_version: Option<String>,
     mount_root_override: Option<bool>,
     preload_shim: Option<String>,
+    runtime_dll: Option<String>,
 }
 
 impl ImageLayout {
@@ -136,6 +149,16 @@ impl ImageLayout {
                 "env image '{image}' layout.yaml carries an empty interpreter_api_version"
             )));
         }
+        // schema_minor 3: the runtime DLL is a bare PE module basename —
+        // a separator or drive qualifier is the declaration lying.
+        let runtime_dll = view.runtime_dll.filter(|s| !s.is_empty());
+        if let Some(dll) = &runtime_dll {
+            if dll.bytes().any(|b| b == b'/' || b == b'\\' || b == b':') {
+                return Err(layout(format!(
+                    "env image '{image}' layout.yaml declares runtime_dll '{dll}' carrying a path separator or drive qualifier — a basename owns no path: rebuild the runtime with the current factory"
+                )));
+            }
+        }
         Ok(ImageLayout {
             schema_version,
             era,
@@ -144,6 +167,7 @@ impl ImageLayout {
             interpreter_api_version: api_version,
             mount_root_override: view.mount_root_override.unwrap_or(false),
             preload_shim: view.preload_shim.filter(|s| !s.is_empty()),
+            runtime_dll,
         })
     }
 }
@@ -167,6 +191,7 @@ mod tests {
                 interpreter_api_version: "3.4".to_string(),
                 mount_root_override: false,
                 preload_shim: None,
+                runtime_dll: None,
             }
         );
         // unknown keys within the MAJOR are tolerated (spec 18 §3.2 / S57)
@@ -220,6 +245,45 @@ mod tests {
                 .preload_shim,
             None
         );
+    }
+
+    #[test]
+    fn the_runtime_dll_declaration_is_additive_and_grammar_checked() {
+        // absent (older images) ⇒ no TEBAKO_RUNTIME_DLL export downstream
+        assert_eq!(
+            ImageLayout::check(GOOD, "/__tfs__", "/rt/ruby.tfs")
+                .unwrap()
+                .runtime_dll,
+            None
+        );
+        // declared (schema_minor 3) ⇒ the PE module basename flows
+        // verbatim (the reader — the tfs PE closure walk — lowercases
+        // for the windows loader's comparison)
+        let declared = format!("{GOOD}runtime_dll: x64-ucrt-ruby340.dll\n");
+        assert_eq!(
+            ImageLayout::check(&declared, "/__tfs__", "/rt/ruby.tfs")
+                .unwrap()
+                .runtime_dll
+                .as_deref(),
+            Some("x64-ucrt-ruby340.dll")
+        );
+        // an empty declaration is no declaration
+        let empty = format!("{GOOD}runtime_dll: \"\"\n");
+        assert_eq!(
+            ImageLayout::check(&empty, "/__tfs__", "/rt/ruby.tfs")
+                .unwrap()
+                .runtime_dll,
+            None
+        );
+        // a separator or drive qualifier is the declaration lying — a
+        // named 78, never a flowed path (the spec 03 §2.5 byte rule)
+        for bad in ["lib/x64-ucrt-ruby340.dll", "lib\\x.dll", "C:x.dll"] {
+            let text = format!("{GOOD}runtime_dll: {bad}\n");
+            let err = ImageLayout::check(&text, "/__tfs__", "/rt/ruby.tfs").unwrap_err();
+            assert_eq!(err.code, 78, "{bad}: {}", err.message);
+            assert!(err.message.contains(bad), "{err}");
+            assert!(err.message.contains("/rt/ruby.tfs"), "{err}");
+        }
     }
 
     #[test]

--- a/crates/tebako-driver/src/lib.rs
+++ b/crates/tebako-driver/src/lib.rs
@@ -29,6 +29,7 @@
 
 #![deny(unsafe_code)]
 
+pub mod alias;
 pub mod driver;
 pub mod exec_cache;
 pub mod ffi;

--- a/crates/tebako-info/src/manifest_json.rs
+++ b/crates/tebako-info/src/manifest_json.rs
@@ -403,6 +403,22 @@ pub fn manifest_to_json(m: &PayloadManifest) -> Json {
             Json::Array(m.materialize.iter().map(|p| s(p)).collect()),
         ));
     }
+    if !m.library_aliases.is_empty() {
+        out.push((
+            "library_aliases".to_string(),
+            Json::Array(
+                m.library_aliases
+                    .iter()
+                    .map(|a| {
+                        Json::Object(vec![
+                            ("name".to_string(), s(&a.name)),
+                            ("path".to_string(), s(&a.path)),
+                        ])
+                    })
+                    .collect(),
+            ),
+        ));
+    }
     Json::Object(out)
 }
 
@@ -488,6 +504,37 @@ mod tests {
             reqs[1].find("mount").unwrap().as_string().as_deref(),
             Some("/__layers__/gtk")
         );
+    }
+
+    #[test]
+    fn library_aliases_map_and_omit() {
+        // spec 03 §2.5 (schema_minor 2): the additive key maps 1:1…
+        let m = PayloadManifest::from_yaml(
+            "identity:\n  schema_version: 1\n  kind: data\n  name: x\n  version: \"1\"\n  \
+             producer: {tool: t, tool_version: \"1\"}\n  created: \"2026-08-15T00:00:00Z\"\n  \
+             digest: {tree_hash: \"sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\", \
+             blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1}\n  \
+             signing: {state: unsigned}\n  encryption: {state: none}\n\
+             provides:\n  mount_semantics: {suggested: /usr/share/x}\n  capabilities: {exec: false, read: true}\n\
+             library_aliases:\n  - {name: libfoo-3.dll, path: /lib/libfoo-3.dll}\n",
+        )
+        .unwrap();
+        let j = manifest_to_json(&m);
+        let Json::Array(aliases) = j.find("library_aliases").unwrap() else {
+            panic!("library_aliases must be an array");
+        };
+        assert_eq!(aliases.len(), 1);
+        assert_eq!(
+            aliases[0].find("name").unwrap().as_string().as_deref(),
+            Some("libfoo-3.dll")
+        );
+        assert_eq!(
+            aliases[0].find("path").unwrap().as_string().as_deref(),
+            Some("/lib/libfoo-3.dll")
+        );
+        // …and an alias-less manifest omits the key (never a null).
+        let j = manifest_to_json(&fixture());
+        assert!(j.find("library_aliases").is_none());
     }
 
     #[test]

--- a/crates/tfs/exports.txt
+++ b/crates/tfs/exports.txt
@@ -7,6 +7,7 @@ tebako_fs_abi_version
 tebako_fs_close
 tebako_fs_closedir
 tebako_fs_dir_is_embedded
+tebako_fs_dlalias2file
 tebako_fs_dlmap2file
 tebako_fs_exec_materialize
 tebako_fs_extract_all

--- a/crates/tfs/src/c_api.rs
+++ b/crates/tfs/src/c_api.rs
@@ -970,6 +970,51 @@ pub unsafe extern "C" fn tebako_fs_extract_all(dest_path: *const c_char) -> libc
 // Dynamic Loading Support
 // ===================================================================
 
+/// `tebako_fs_dlalias2file`: the windows bare-name alias verdict at
+/// load time (spec 22 §2.1, phase W2 — the covered surface's check; the
+/// patched msys `dln.c` calls this for a presented name). A BARE name
+/// (no path separator, no drive qualifier) matching a boot-registered
+/// `library_aliases:` declaration VERBATIM, case-insensitively, answers
+/// the alias's boot-materialized absolute host path; a path-carrying or
+/// undeclared name is NULL with ENOENT (host-by-default — the name
+/// passes to the OS loader untouched); a registered alias whose
+/// materialized copy vanished under the process is NULL with EIO (the
+/// tamper case — the C side raises the §5 verdict LoadError, never a
+/// host shadow). The returned string is heap-allocated with libc
+/// `malloc` — the C contract says the caller releases it with `free()`
+/// (the `tebako_fs_dlmap2file` ownership contract).
+///
+/// # Safety
+/// `name` must be a valid C string.
+#[no_mangle]
+pub unsafe extern "C" fn tebako_fs_dlalias2file(name: *const c_char) -> *mut c_char {
+    let name = match unsafe { path_arg(name) } {
+        Ok(n) => n,
+        Err(e) => {
+            fail(e);
+            return std::ptr::null_mut();
+        }
+    };
+    let host = match context().read().unwrap().dlalias2file(name) {
+        Ok(h) => h,
+        Err(e) => {
+            fail(e);
+            return std::ptr::null_mut();
+        }
+    };
+    // Allocate with libc malloc so the C caller can free() the string.
+    let bytes = host.as_bytes_with_nul();
+    // SAFETY: malloc'd buffer of bytes.len(); copy then hand over ownership.
+    let out = unsafe { libc::malloc(bytes.len()).cast::<c_char>() };
+    if out.is_null() {
+        fail(libc::ENOMEM);
+        return std::ptr::null_mut();
+    }
+    unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr().cast(), out, bytes.len()) };
+    set_errno(0);
+    out
+}
+
 /// `tebako_fs_dlmap2file`: the returned string is heap-allocated with
 /// libc `malloc` — the C contract says the caller releases it with `free()`.
 ///

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -108,6 +108,15 @@ pub struct DirState {
     pub current: Box<TebakoCDirent>,
 }
 
+/// One registered library alias (spec 22 §2.1, phase W2): the declared
+/// bare name (the manifest's own spelling — the match is
+/// case-insensitive, the spelling is preserved for the journal) and the
+/// alias target's boot-materialized absolute host path.
+struct DlAlias {
+    name: String,
+    host: std::path::PathBuf,
+}
+
 /// The process-global context state (behind a lock; see [`context`]).
 pub struct FsContext {
     mounts: BTreeMap<i32, Mount>,
@@ -144,6 +153,15 @@ pub struct FsContext {
     /// rationale). Follows the policy: replaced alongside it, left alone
     /// by `unmount()`.
     journal: Option<std::fs::File>,
+    /// The boot's registered library-alias table (spec 22 §2.1, phase
+    /// W2 — the windows bare-name rule's covered surface): declared bare
+    /// name → the target's boot-materialized absolute host path.
+    /// Installed by the driver after the class-L extraction pass
+    /// (windows boots only — the registration channel itself is
+    /// platform-neutral); the DEFAULT empty table answers every name
+    /// HOST, the bare-name rule's default. Process state like the
+    /// policy: `unmount()` deliberately leaves it.
+    dlaliases: Vec<DlAlias>,
 }
 
 impl FsContext {
@@ -162,6 +180,7 @@ impl FsContext {
             home_trees: BTreeSet::new(),
             host_policy: HostPolicy::open(),
             journal: None,
+            dlaliases: Vec::new(),
         }
     }
 
@@ -932,6 +951,88 @@ impl FsContext {
             }
         }
         Ok(skipped)
+    }
+
+    // ---------------------------------------------------------------
+    // Library aliases (spec 22 §2.1, phase W2)
+    // ---------------------------------------------------------------
+
+    /// Install the boot's library-alias table: plain (declared bare
+    /// name, boot-materialized absolute host path) pairs from the
+    /// driver's class-L extraction pass — the channel's only writer
+    /// (windows boots gate the call site; the channel itself is
+    /// platform-neutral). The driver registers only manifest-validated
+    /// declarations, so the pairs are trusted as-is — tfs stays
+    /// tpkg-free. Replaces any previous table; the default empty table
+    /// answers every name HOST.
+    pub fn register_dlaliases(&mut self, pairs: Vec<(String, std::path::PathBuf)>) {
+        self.dlaliases = pairs
+            .into_iter()
+            .map(|(name, host)| DlAlias { name, host })
+            .collect();
+    }
+
+    /// tebako_fs_dlalias2file: the bare-name alias verdict at LOAD time
+    /// — the covered surface's decision point (the patched msys `dln.c`
+    /// calls this for a presented name; spec 22 §2.1, phase W2).
+    ///
+    /// - A BARE name (no path separator, no drive qualifier — the byte
+    ///   grammar is this entry's own test, the same rule the manifest's
+    ///   `library_aliases:` validation enforces) matching a registered
+    ///   alias VERBATIM, case-insensitively (never extension-completed:
+    ///   `foo` does not match `foo.dll`) answers the alias's
+    ///   boot-materialized absolute host path — the `alias` verdict.
+    /// - A path-carrying name never reaches the alias rule (the path
+    ///   surface is Rule L1's): ENOENT, and NO verdict exists — nothing
+    ///   is journaled (the spec journals bare-name verdicts only).
+    /// - An undeclared bare name is HOST by default: ENOENT, the
+    ///   `host` verdict — the consumer passes the presented name to the
+    ///   OS loader untouched.
+    /// - A registered alias whose materialized path VANISHED under the
+    ///   process is the cache tampered with: EIO — deliberately NOT
+    ///   ENOENT, so the C side raises the §5 verdict LoadError instead
+    ///   of falling through to a host shadow (the verdict was `alias`;
+    ///   the failure is post-verdict).
+    ///
+    /// The verdict line (`event=lib-load name=<n> verdict=host|alias`)
+    /// is journaled where the verdict is MADE — here — under the RECORD
+    /// policy only (spec 23 §8's discovery instrument; production stays
+    /// silent), on the pre-opened audit file: a bare write(2), never a
+    /// path operation under the lock (the journal module's fd
+    /// discipline). The tamper failure's reporting channel is the §5
+    /// LoadError, not the journal. The covered path's existence probe
+    /// under the guard is safe: a non-empty table exists only on
+    /// windows boots, where no syscall interposition can re-enter.
+    pub fn dlalias2file(&self, name: &str) -> Result<std::ffi::CString, i32> {
+        if name.bytes().any(|b| b == b'/' || b == b'\\' || b == b':') {
+            // Not a bare name — the alias rule never engages; no
+            // bare-name verdict exists, so nothing is journaled.
+            return Err(libc::ENOENT);
+        }
+        let Some(alias) = self
+            .dlaliases
+            .iter()
+            .find(|a| a.name.eq_ignore_ascii_case(name))
+        else {
+            self.journal_lib_load(name, "host");
+            return Err(libc::ENOENT);
+        };
+        self.journal_lib_load(name, "alias");
+        if !alias.host.exists() {
+            return Err(libc::EIO);
+        }
+        std::ffi::CString::new(alias.host.to_string_lossy().into_owned()).map_err(|_| libc::EIO)
+    }
+
+    /// One lib-load verdict line on the audit journal, under the record
+    /// policy only — the helper keeps `dlalias2file` to one journal call
+    /// site per verdict.
+    fn journal_lib_load(&self, name: &str, verdict: &str) {
+        if self.host_policy.is_record() {
+            if let Some(journal) = &self.journal {
+                crate::journal::journal_lib_load(journal, name, verdict);
+            }
+        }
     }
 
     // ---------------------------------------------------------------
@@ -1861,6 +1962,156 @@ mod tests {
         let mut ctx2 = FsContext::new();
         ctx2.set_host_policy(crate::policy::HostPolicy::open(), Some(journal2));
         assert_eq!(ctx2.host_check("/etc/hosts", HostAccess::Ro), Ok(()));
+        drop(ctx2);
+        let text2 = std::fs::read_to_string(&log).unwrap();
+        assert_eq!(
+            text2.lines().count(),
+            2,
+            "open policy journals nothing: {text2}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A fresh context with one registered alias whose materialized host
+    /// copy is a real temp file (the covered verdict re-probes the host
+    /// path — the tamper case's discriminator).
+    fn ctx_with_one_alias(dir: &std::path::Path) -> (FsContext, std::path::PathBuf) {
+        std::fs::create_dir_all(dir).unwrap();
+        let host = dir.join("libfoo-3.dll");
+        std::fs::write(&host, b"pe").unwrap();
+        let mut ctx = FsContext::new();
+        ctx.register_dlaliases(vec![("libfoo-3.dll".to_string(), host.clone())]);
+        (ctx, host)
+    }
+
+    #[test]
+    fn dlalias2file_matches_verbatim_case_insensitively() {
+        let dir = std::env::temp_dir().join(format!("tfs-dlalias-match-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let (ctx, host) = ctx_with_one_alias(&dir);
+        let want = host.to_string_lossy().into_owned();
+        // The windows loader's own comparison: case-insensitive…
+        assert_eq!(
+            ctx.dlalias2file("LIBFOO-3.DLL").unwrap().to_str().unwrap(),
+            want
+        );
+        assert_eq!(
+            ctx.dlalias2file("LibFoo-3.Dll").unwrap().to_str().unwrap(),
+            want
+        );
+        // …but verbatim: never extension-completed, never a basename
+        // probe, never a prefix.
+        assert_eq!(ctx.dlalias2file("libfoo-3"), Err(libc::ENOENT));
+        assert_eq!(ctx.dlalias2file("libfoo-3.dll.dll"), Err(libc::ENOENT));
+        // An undeclared bare name is host-by-default — the rule's whole
+        // point.
+        assert_eq!(ctx.dlalias2file("user32"), Err(libc::ENOENT));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dlalias2file_only_bare_names_reach_the_rule() {
+        let dir = std::env::temp_dir().join(format!("tfs-dlalias-bare-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let (ctx, _host) = ctx_with_one_alias(&dir);
+        // A separator or a drive qualifier makes the name path surface
+        // (Rule L1) — never an alias, even when the basename matches.
+        assert_eq!(
+            ctx.dlalias2file("/vendor/lib/libfoo-3.dll"),
+            Err(libc::ENOENT)
+        );
+        assert_eq!(ctx.dlalias2file("lib\\libfoo-3.dll"), Err(libc::ENOENT));
+        assert_eq!(ctx.dlalias2file("C:\\lib\\libfoo-3.dll"), Err(libc::ENOENT));
+        assert_eq!(ctx.dlalias2file("C:libfoo-3.dll"), Err(libc::ENOENT));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dlalias2file_empty_table_answers_everything_host() {
+        // The default state (no driver registration — every POSIX boot):
+        // every name is HOST, no probe, no journal.
+        let ctx = FsContext::new();
+        assert_eq!(ctx.dlalias2file("user32"), Err(libc::ENOENT));
+        assert_eq!(ctx.dlalias2file("libfoo-3.dll"), Err(libc::ENOENT));
+    }
+
+    #[test]
+    fn dlalias2file_vanished_materialization_is_eio_never_enoent() {
+        // A registered alias whose materialized copy vanished under the
+        // process is the cache tampered with: EIO — deliberately NOT
+        // ENOENT, so the C side raises the §5 verdict LoadError instead
+        // of falling through to a host shadow.
+        let dir = std::env::temp_dir().join(format!("tfs-dlalias-eio-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let (ctx, host) = ctx_with_one_alias(&dir);
+        std::fs::remove_file(&host).unwrap();
+        assert_eq!(ctx.dlalias2file("libfoo-3.dll"), Err(libc::EIO));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dlalias2file_journals_verdicts_under_record_only() {
+        // The lib-load verdict line is the record mode's discovery
+        // instrument (spec 23 §8's idiom): under a record policy both
+        // verdicts journal; under the default open policy nothing does
+        // (production stays silent — the tamper case's reporting channel
+        // is the §5 LoadError, not the journal).
+        let dir = std::env::temp_dir().join(format!("tfs-dlalias-journal-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let log = dir.join("journal.log");
+        let journal = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log)
+            .unwrap();
+
+        let (mut ctx, host) = ctx_with_one_alias(&dir);
+        ctx.set_host_policy(
+            crate::policy::HostPolicy::bind(crate::policy::PolicyDefault::Record, vec![], vec![])
+                .unwrap(),
+            Some(journal),
+        );
+        let covered = ctx.dlalias2file("libfoo-3.dll").unwrap();
+        assert_eq!(covered.to_str().unwrap(), host.to_string_lossy().as_ref());
+        assert_eq!(ctx.dlalias2file("user32"), Err(libc::ENOENT));
+        // A path-carrying name has no bare-name verdict at all — the
+        // spec journals bare-name verdicts only.
+        assert_eq!(
+            ctx.dlalias2file("/vendor/lib/libfoo-3.dll"),
+            Err(libc::ENOENT)
+        );
+        drop(ctx);
+        let text = std::fs::read_to_string(&log).unwrap();
+        let mut lines = text.lines();
+        assert!(
+            lines
+                .next()
+                .unwrap()
+                .contains("event=lib-load name=libfoo-3.dll verdict=alias"),
+            "{text}"
+        );
+        assert!(
+            lines
+                .next()
+                .unwrap()
+                .contains("event=lib-load name=user32 verdict=host"),
+            "{text}"
+        );
+        assert!(lines.next().is_none(), "{text}");
+
+        // The open policy journals no verdicts (the jail-allow precedent:
+        // no noise outside record mode).
+        let journal2 = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log)
+            .unwrap();
+        let (mut ctx2, _host2) = ctx_with_one_alias(&dir);
+        ctx2.set_host_policy(crate::policy::HostPolicy::open(), Some(journal2));
+        assert!(ctx2.dlalias2file("libfoo-3.dll").is_ok());
+        assert_eq!(ctx2.dlalias2file("user32"), Err(libc::ENOENT));
         drop(ctx2);
         let text2 = std::fs::read_to_string(&log).unwrap();
         assert_eq!(

--- a/crates/tfs/src/journal.rs
+++ b/crates/tfs/src/journal.rs
@@ -61,6 +61,11 @@ pub const OVERLAY_EVENT: &str = "overlay";
 /// MATERIAL never touches a journal (spec 11 §11's log discipline).
 pub const DECRYPT_EVENT: &str = "decrypt";
 
+/// The event name every library-load verdict line carries (spec 22
+/// §2.1 phase W2 — the windows bare-name alias rule's audit, in spec 23
+/// §8's record-mode idiom).
+pub const LIB_LOAD_EVENT: &str = "lib-load";
+
 /// Resolve and open the journal file for append (creating the tebako home
 /// if needed). Call it at POLICY-INSTALL time, BEFORE the context guard is
 /// taken — never from inside a `host_check` (see the module docs). `None`
@@ -90,6 +95,33 @@ pub fn journal_deny(file: &std::fs::File, path: &Path, need: HostAccess, source:
 /// through). Same fd discipline and line shape as [`journal_deny`].
 pub fn journal_allow(file: &std::fs::File, path: &Path, need: HostAccess, source: &str) {
     journal_event(file, JAIL_ALLOW_EVENT, path, need, source);
+}
+
+/// Append one library-load verdict line — `<ts> event=lib-load name=<n>
+/// verdict=host|alias`. The windows bare-name alias rule's record
+/// (spec 22 §2.1 phase W2): emitted where the verdict is MADE (the
+/// `tebako_fs_dlalias2file` decision), never at boot — a boot decides
+/// nothing. Rides the same journal file under the record policy (the §8
+/// discovery instrument: one record-mode run shows the author every
+/// bare name a loader presented and which way it went); the `tfs needs`
+/// generator skips the event (its parser knows only the jail events).
+/// Same fd discipline as [`journal_deny`].
+pub fn journal_lib_load(file: &std::fs::File, name: &str, verdict: &str) {
+    use std::io::Write as _;
+    let line = format!(
+        "{} event={LIB_LOAD_EVENT} name={name} verdict={verdict}\n",
+        unix_now()
+    );
+    let _ = (&*file).write_all(line.as_bytes());
+}
+
+/// The journal timestamp: unix seconds (0 before the epoch — a clock
+/// failure never fails the audited operation).
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 /// The shared line writer: `<ts> event=<event> path=<p> op=read|write
@@ -384,6 +416,38 @@ mod tests {
                 "event=decrypt mount=/data recipient=pgp:3c8dba971d2b4f01 grants=g1,g2",
             ]
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn journal_lib_load_line_shape() {
+        // The bare-name alias rule's verdict line (spec 22 §2.1 phase
+        // W2, spec 23 §8's idiom): name + verdict, no path/op fields.
+        // (Private dir: the deny/allow tests above share this process —
+        // a shared journal path would interleave.)
+        let dir =
+            std::env::temp_dir().join(format!("tfs-journal-libload-test-{}", std::process::id()));
+        let log = dir.join("journal.log");
+        std::env::set_var("TEBAKO_JAIL_JOURNAL", &log);
+        let file = open_journal().expect("journal opens");
+        std::env::remove_var("TEBAKO_JAIL_JOURNAL");
+        journal_lib_load(&file, "libfoo-3.dll", "alias");
+        journal_lib_load(&file, "user32", "host");
+        drop(file);
+        let text = std::fs::read_to_string(&log).unwrap();
+        let mut lines = text.lines();
+        let line = lines.next().unwrap();
+        let (ts, rest) = line.split_once(' ').unwrap();
+        assert!(
+            ts.bytes().all(|b| b.is_ascii_digit()) && !ts.is_empty(),
+            "{line}"
+        );
+        assert_eq!(rest, "event=lib-load name=libfoo-3.dll verdict=alias");
+        assert_eq!(
+            lines.next().unwrap().split_once(' ').unwrap().1,
+            "event=lib-load name=user32 verdict=host"
+        );
+        assert!(lines.next().is_none());
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/tfs/src/needs.rs
+++ b/crates/tfs/src/needs.rs
@@ -392,12 +392,17 @@ mod tests {
 
     #[test]
     fn malformed_and_foreign_lines_are_skipped() {
+        // The lib-load verdict lines (spec 22 §2.1 phase W2) ride the
+        // same journal file under record mode; the needs draft consumes
+        // only the jail events.
         let yaml = needs_from_journal(
             "garbage\n\
              1 event=composition source=external(/x.yaml) sha256=abc\n\
              2 event=jail-allow op=read source=record\n\
              3 event=jail-allow path=/no-op-field\n\
-             4 event=jail-allow path=/bad-op op=execute source=record\n",
+             4 event=jail-allow path=/bad-op op=execute source=record\n\
+             5 event=lib-load name=user32 verdict=host\n\
+             6 event=lib-load name=libfoo-3.dll verdict=alias\n",
             &[],
             &[],
             &|_| true,

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -169,9 +169,9 @@ pub use io::{read_from, write_to};
 pub use jail::{ArgumentFiles, HostJail, JailAccess, JailError, JailMount};
 pub use manifest::{
     AppProvides, BuiltFrom, Capabilities, Constraint, DataProvides, Digest, Encryption,
-    EncryptionPart, EncryptionState, EngineProvides, Entrypoint, Identity, ManifestError,
-    MountSemantics, PayloadKind, PayloadManifest, Platform, Platforms, Producer, Provides,
-    Requirement, RuntimeProvides, RuntimeRequirement, Sbom, Signing, SigningMechanism,
+    EncryptionPart, EncryptionState, EngineProvides, Entrypoint, Identity, LibraryAlias,
+    ManifestError, MountSemantics, PayloadKind, PayloadManifest, Platform, Platforms, Producer,
+    Provides, Requirement, RuntimeProvides, RuntimeRequirement, Sbom, Signing, SigningMechanism,
     SigningState, Source, ToolkitExecutable, ToolkitLibrary, ToolkitProvides,
     PAYLOAD_MANIFEST_PATH, PAYLOAD_SCHEMA_VERSION,
 };

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -1106,6 +1106,22 @@ impl Requirement {
 // The manifest itself
 // ---------------------------------------------------------------------
 
+/// One `library_aliases:` entry (spec 03 §2.5, additive — schema_minor
+/// 2): the exact bare name a loader call presents (`name` — no path
+/// separator, no drive qualifier) resolving to the in-image absolute
+/// file `path`. The declarative half of the windows Class-L bare-name
+/// rule (spec 22 §2.1): a bare name matching no entry is a HOST
+/// reference and passes through untouched; matching is verbatim and
+/// case-insensitive (the windows loader's own comparison), never
+/// extension-completed (`foo` does not match `foo.dll`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LibraryAlias {
+    /// The exact bare spelling a loader call presents.
+    pub name: String,
+    /// The in-image absolute file the name resolves to.
+    pub path: String,
+}
+
 /// The payload manifest (spec 03): IDENTITY + PROVIDES + DEPENDS on a
 /// common provenance/trust layer, carried at [`PAYLOAD_MANIFEST_PATH`].
 ///
@@ -1127,6 +1143,14 @@ pub struct PayloadManifest {
     /// default is the canonical entry). Absent = nothing to materialize.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub materialize: Vec<String>,
+    /// The spec-22 §2.1 windows Class-L bare-name declarations
+    /// (additive — schema_minor 2; old readers ignore it, new readers
+    /// enforce): the ONLY bare library names resolving to the image's
+    /// own files. Any kind may declare; no platform filter (native
+    /// images are triplet-bound — an alias is platform surface by
+    /// construction). Absent = no declared aliases.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub library_aliases: Vec<LibraryAlias>,
 }
 
 impl<'de> Deserialize<'de> for PayloadManifest {
@@ -1139,6 +1163,8 @@ impl<'de> Deserialize<'de> for PayloadManifest {
             requires: Vec<Requirement>,
             #[serde(default)]
             materialize: Vec<String>,
+            #[serde(default)]
+            library_aliases: Vec<LibraryAlias>,
         }
         let raw = Raw::deserialize(d)?;
         let provides = match raw.identity.kind {
@@ -1164,6 +1190,7 @@ impl<'de> Deserialize<'de> for PayloadManifest {
             provides,
             requires: raw.requires,
             materialize: raw.materialize,
+            library_aliases: raw.library_aliases,
         })
     }
 }
@@ -1185,8 +1212,9 @@ impl PayloadManifest {
     /// Semantic checks beyond the serde structure: schema version,
     /// kind ↔ provides binding, the locked capability truth tables,
     /// digest/keyid shapes, signing/encryption state consistency, the
-    /// reserved-triplet rule, the absolute-path rules, and the
-    /// materialize grammar (spec 22 §4). Unknown keys are
+    /// reserved-triplet rule, the absolute-path rules, the
+    /// materialize grammar (spec 22 §4), and the library_aliases
+    /// grammar (spec 03 §2.5 / spec 22 §2.1). Unknown keys are
     /// tolerated everywhere (only `annotations` is lossless by contract).
     pub fn validate(&self) -> Result<(), ManifestError> {
         self.identity.validate()?;
@@ -1212,6 +1240,42 @@ impl PayloadManifest {
             if p.split('/').any(|component| component == "..") {
                 return Err(ManifestError::Invalid(
                     "materialize[] must not contain '..' components (the extraction target derives from the entry)",
+                ));
+            }
+        }
+        for (i, alias) in self.library_aliases.iter().enumerate() {
+            check_non_empty(&alias.name, "library_aliases[].name must be non-empty")?;
+            // The bare-name grammar (spec 03 §2.5): no path separator,
+            // no drive qualifier. Rejecting ':' covers the drive form
+            // ('C:foo.dll') and every other qualified spelling.
+            if alias
+                .name
+                .bytes()
+                .any(|b| b == b'/' || b == b'\\' || b == b':')
+            {
+                return Err(ManifestError::Invalid(
+                    "library_aliases[].name must be a bare name — no path separator, no drive qualifier",
+                ));
+            }
+            check_abs_path(
+                &alias.path,
+                "library_aliases[].path must be absolute (inside the image)",
+            )?;
+            if alias.path.split('/').any(|component| component == "..") {
+                return Err(ManifestError::Invalid(
+                    "library_aliases[].path must not contain '..' components (the materialization target derives from the entry)",
+                ));
+            }
+            // A duplicate name within one image is an authoring
+            // ambiguity — a named manifest error, never a silent winner
+            // (the comparison is the match rule: verbatim,
+            // case-insensitive).
+            if self.library_aliases[..i]
+                .iter()
+                .any(|prior| prior.name.eq_ignore_ascii_case(&alias.name))
+            {
+                return Err(ManifestError::Invalid(
+                    "library_aliases[] declares a duplicate name (case-insensitive) — an authoring ambiguity, never a silent winner",
                 ));
             }
         }
@@ -1442,6 +1506,7 @@ mod tests {
             provides: Provides::Other(BTreeMap::new()),
             requires: Vec::new(),
             materialize: Vec::new(),
+            library_aliases: Vec::new(),
         };
         assert!(matches!(m.validate(), Err(ManifestError::Invalid(_))));
     }
@@ -1603,5 +1668,111 @@ mod tests {
         // A scalar is a structural error, never a one-item list.
         let err = PayloadManifest::from_yaml(&minimal_data_yaml("materialize: /x\n")).unwrap_err();
         assert!(matches!(err, ManifestError::Yaml(_)), "{err}");
+    }
+
+    #[test]
+    fn library_aliases_default_empty_and_round_trip() {
+        // spec 03 §2.5 (schema_minor 2): the additive windows Class-L
+        // bare-name declarations — name → in-image file.
+        let bare = PayloadManifest::from_yaml(&minimal_data_yaml("")).unwrap();
+        assert!(bare.library_aliases.is_empty());
+        // An absent key never serializes (additive on the wire: old
+        // readers see the document they always saw).
+        assert!(!bare.to_yaml().unwrap().contains("library_aliases"));
+
+        let with = PayloadManifest::from_yaml(&minimal_data_yaml(
+            "library_aliases:\n  - {name: libfoo-3.dll, path: /lib/libfoo-3.dll}\n  - {name: bar.dll, path: /vendor/bar.dll}\n",
+        ))
+        .unwrap();
+        assert_eq!(
+            with.library_aliases,
+            vec![
+                LibraryAlias {
+                    name: "libfoo-3.dll".to_string(),
+                    path: "/lib/libfoo-3.dll".to_string(),
+                },
+                LibraryAlias {
+                    name: "bar.dll".to_string(),
+                    path: "/vendor/bar.dll".to_string(),
+                },
+            ]
+        );
+        let rendered = with.to_yaml().unwrap();
+        assert!(rendered.contains("library_aliases:"), "{rendered}");
+        let back = PayloadManifest::from_yaml(&rendered).unwrap();
+        assert_eq!(back, with);
+    }
+
+    #[test]
+    fn library_alias_names_must_be_bare() {
+        // The bare-name grammar (spec 03 §2.5): no path separator, no
+        // drive qualifier — a named validation error, never a guess.
+        for bad in [
+            "lib/foo.dll",
+            "lib\\foo.dll",
+            "C:foo.dll",
+            "C:\\lib\\foo.dll",
+        ] {
+            // Single-quoted YAML scalars: a backslash stays literal
+            // (double quotes would eat it as an escape).
+            let err = PayloadManifest::from_yaml(&minimal_data_yaml(&format!(
+                "library_aliases:\n  - {{name: '{bad}', path: /lib/foo.dll}}\n"
+            )))
+            .unwrap_err();
+            assert!(
+                matches!(err, ManifestError::Invalid(m) if m.contains("library_aliases")),
+                "{bad}: {err}"
+            );
+        }
+        // An empty name is a structural nothing.
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml(
+            "library_aliases:\n  - {name: \"\", path: /lib/foo.dll}\n",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("library_aliases")),
+            "{err}"
+        );
+        // A missing name or path key is a structural error.
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml(
+            "library_aliases:\n  - {path: /lib/foo.dll}\n",
+        ))
+        .unwrap_err();
+        assert!(matches!(err, ManifestError::Yaml(_)), "{err}");
+    }
+
+    #[test]
+    fn library_alias_paths_must_be_absolute_and_escape_free() {
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml(
+            "library_aliases:\n  - {name: foo.dll, path: lib/foo.dll}\n",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("library_aliases")),
+            "{err}"
+        );
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml(
+            "library_aliases:\n  - {name: foo.dll, path: /../../host/foo.dll}\n",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("library_aliases")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn library_alias_duplicate_names_are_a_named_error() {
+        // A duplicate within one image — on the match rule's own
+        // comparison (verbatim, case-insensitive) — is an authoring
+        // ambiguity, never a silent winner (spec 03 §2.5).
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml(
+            "library_aliases:\n  - {name: Foo.dll, path: /lib/a.dll}\n  - {name: foo.DLL, path: /lib/b.dll}\n",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("duplicate")),
+            "{err}"
+        );
     }
 }

--- a/crates/tpkg/tests/manifest.rs
+++ b/crates/tpkg/tests/manifest.rs
@@ -270,6 +270,38 @@ fn materialize_key_is_schema_legal() {
 }
 
 #[test]
+fn library_aliases_key_is_schema_legal() {
+    // spec 03 §2.5 / spec 22 §2.1 (schema_minor 2): the additive
+    // `library_aliases:` key — the versioned JSON Schema admits it and
+    // the model round-trips it (the windows Class-L bare-name
+    // declarations).
+    let text = "identity:\n  schema_version: 1\n  kind: runtime\n  name: tebako-runtime-ruby\n  version: 4.0.6\n\
+        \x20 producer: {tool: tebako-cli, tool_version: 0.16.0}\n  created: \"2026-08-15T00:00:00Z\"\n\
+        \x20 digest:\n    tree_hash: \"sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\"\n\
+        \x20   blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1\n\
+        \x20 signing: {state: unsigned}\n  encryption: {state: none}\n\
+        provides:\n  provides: {engine: ruby, version: 4.0.6, abi_line: \"4.0\", platform: x86_64-windows-ucrt}\n\
+        \x20 built_from: {src_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1, patch_set: v0.2.8}\n\
+        \x20 capabilities: {exec: true, read: true, runtime: true}\n\
+        library_aliases:\n  - {name: libfoo-3.dll, path: /lib/libfoo-3.dll}\n";
+    let m = PayloadManifest::from_yaml(text).unwrap();
+    assert_eq!(
+        m.library_aliases,
+        vec![LibraryAlias {
+            name: "libfoo-3.dll".to_string(),
+            path: "/lib/libfoo-3.dll".to_string(),
+        }]
+    );
+    // …and the schema agrees (MECE cross-check).
+    let validator = schema_validator();
+    validator
+        .validate(&yaml_text_to_json(text))
+        .expect("library_aliases: is schema-legal");
+    let back = PayloadManifest::from_yaml(&m.to_yaml().unwrap()).unwrap();
+    assert_eq!(back, m);
+}
+
+#[test]
 fn unknown_keys_are_tolerated_annotations_preserved() {
     let text = read(&fixture_path("data"));
     let with_extras = format!(

--- a/crates/tpkg/tests/manifest_props.rs
+++ b/crates/tpkg/tests/manifest_props.rs
@@ -64,6 +64,14 @@ fn arb_path() -> impl Strategy<Value = String> {
     prop::collection::vec(arb_name(), 1..=3).prop_map(|segs| format!("/{}", segs.join("/")))
 }
 
+/// spec 03 §2.5: a bare name (the generated names carry no separator
+/// and no drive qualifier) resolving to an in-image absolute path. The
+/// index suffix keeps names unique within one image — the validation
+/// rejects a case-insensitive duplicate.
+fn arb_alias() -> impl Strategy<Value = LibraryAlias> {
+    (arb_name(), arb_path()).prop_map(|(name, path)| LibraryAlias { name, path })
+}
+
 fn arb_signing() -> impl Strategy<Value = Signing> {
     prop_oneof![
         Just(Signing {
@@ -280,16 +288,23 @@ fn arb_manifest() -> impl Strategy<Value = PayloadManifest> {
             prop::collection::vec(arb_requirement(), 0..=3),
             // spec 22 §4 class R: absolute escape-free in-image paths.
             prop::collection::vec(arb_path(), 0..=2),
+            // spec 03 §2.5: bare names, unique per image (indexed).
+            prop::collection::vec(arb_alias(), 0..=2),
         )
     })
-    .prop_map(
-        |(identity, provides, requires, materialize)| PayloadManifest {
+    .prop_map(|(identity, provides, requires, materialize, aliases)| {
+        let mut library_aliases = aliases;
+        for (i, a) in library_aliases.iter_mut().enumerate() {
+            a.name = format!("{}{i}", a.name);
+        }
+        PayloadManifest {
             identity,
             provides,
             requires,
             materialize,
-        },
-    )
+            library_aliases,
+        }
+    })
 }
 
 proptest! {

--- a/docs/spec/schemas/layout.yaml
+++ b/docs/spec/schemas/layout.yaml
@@ -15,7 +15,7 @@
 
 schema: layout
 schema_version: 1 # MAJOR — breaking changes only
-schema_minor: 2 # MINOR — additive changes only (1: mount_root_override; 2: preload_shim)
+schema_minor: 3 # MINOR — additive changes only (1: mount_root_override; 2: preload_shim; 3: runtime_dll)
 status: normative
 owner: tebako-runtime-ruby (writer) + crates/tebako-driver (reader); grammar owned here
 edge: C3 (runtime exe ↔ env image)
@@ -105,12 +105,31 @@ grammar:
       (e.g. lib/tebako/libtfs_preload.so). The image declares, the
       driver flows it: materialized to the exec cache for the
       child-injection env (LD_PRELOAD / DYLD_INSERT_LIBRARIES) and
-      exported as TEBAFO_PRELOAD_SHIM for the interpreter's spawn hook
+      exported as TEBAKO_PRELOAD_SHIM for the interpreter's spawn hook
       (spec 22 §3 Rules E2/E3). SSOT: the factory stages the file and
       emits this key in the same deploy pass — declared-but-absent is a
       named boot error (exit 78: the declaration lies). Absent ⇒ no
       preload env (an older image — spawned children get no VFS, the
       honest degradation it always was).
+  runtime_dll:
+    type: string
+    required: false
+    since: schema_minor 3
+    notes: >-
+      The runtime's own PE module basename (e.g. x64-ucrt-ruby340.dll)
+      — MSYS builds only; POSIX builds omit the key. Bare-name grammar
+      (no '/', '\', ':' — the spec 03 §2.5 byte rule); a violation is
+      a named exit 78 (the declaration lies). The image declares, the
+      driver flows it: exported verbatim as TEBAKO_RUNTIME_DLL into the
+      handoff env at boot, on every platform (spec 17 §2 — POSIX legs
+      never read it). The reader is the tfs PE closure walk (spec 22
+      §2.1): a bare import name matching it case-insensitively is never
+      materialized out of a payload image — the OS's basename-reuse
+      rule binds the already-loaded copy, and the exe-dir layout copy
+      stays the only one on disk. SSOT: the factory knows the name at
+      build time (the built tree's bin/<name> is THE file the build
+      produced) and flows it; nothing downstream recomputes it. Absent
+      ⇒ no export (an older image — the exclusion is simply off).
   interpreter_api_version:
     type: string
     required: true
@@ -132,5 +151,7 @@ refusals:
     behavior: exit 78 naming the override and the image — the image's rbconfig cannot follow, never a broken boot
   - case: preload_shim declared but the file absent from the image
     behavior: exit 78 — the declaration lies; rebuild the runtime with the current factory
+  - case: runtime_dll declared with a path separator or drive qualifier
+    behavior: exit 78 — a basename owns no path; the declaration lies
 
 deprecated: [] # no field is in a deprecation window

--- a/schema/tpkg-manifest-v1.schema.json
+++ b/schema/tpkg-manifest-v1.schema.json
@@ -15,6 +15,18 @@
       "type": "array",
       "items": { "$ref": "#/$defs/absPath" },
       "description": "spec 22 §4 class R (payload-manifest schema_minor 1): absolute in-image paths of regular files the driver materializes to <TEBAKO_EXEC_CACHE>/resources/<image-key>/<P> after the mounts, before the interpreter handoff — whole-file, read-only, digest-verified. Any kind may declare; old readers ignore the key. The '..' refusal is semantic (the tpkg validator); only the absolute shape is checked here."
+    },
+    "library_aliases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "path"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "path": { "$ref": "#/$defs/absPath" }
+        }
+      },
+      "description": "spec 22 §2.1 windows Class L bare-name rule (payload-manifest schema_minor 2): the ONLY bare library names resolving to the image's own files — a bare name matching no entry is a host reference and passes through untouched. `name` is the exact bare spelling a loader call presents (the no-separator/no-drive refusal is semantic, the tpkg validator); `path` is the absolute in-image file it resolves to. Any kind may declare; old readers ignore the key."
     }
   },
   "allOf": [


### PR DESCRIPTION
## Phase W2, parts 2+4+5 — windows Class L: `library_aliases:` model + boot wiring + the `tebako_fs_dlalias2file` c_api + the `runtime_dll` layout grant

Implements the driver/tfs half of the phase-W design. The normative text rides
the docs draft **#406** (`docs/phase-w-design`: spec 22 §2.1 — the windows
Class-L bare-name rule; spec 03 §2.5 — the `library_aliases:` grammar; spec 17's
`TEBAKO_EXEC_CACHE`/`PATH` env rows); this PR is the tebako side of its W2
implementation, against the EXISTING exec-closure/materialize surface. The
second commit lands the covered surface's load-time c_api entry that
tamatebako/ruby#60's msys `dln.c` patch calls — the msys runtime link is
fail-closed on it.

### What lands

**tpkg — the model (additive, schema_minor 2):**

- `LibraryAlias { name, path }` on `PayloadManifest`
  (`crates/tpkg/src/manifest.rs`), parse + validate:
  - `name` is a bare name — no path separator, no drive qualifier (`:` covers
    the drive form); empty is a structural error;
  - `path` is absolute in-image, no `..` components (the `materialize`
    precedent);
  - a duplicate `name` within one image — on the match rule's own comparison
    (verbatim, case-insensitive) — is a named manifest error, never a silent
    winner.
- `schema/tpkg-manifest-v1.schema.json` carries the grammar hunk
  **byte-identical with #406's**, so the model↔schema MECE cross-check
  (`crates/tpkg/tests/manifest.rs`) stays green and the two PRs cannot drift
  apart on the wire shape.

**tebako-driver — the boot pass (`src/alias.rs`, spec 22 §2.1):**

- `AliasUnion` — the per-boot union over EVERY co-mounted image (the env image
  first, then the payload triples in order — the app payload included, unlike
  bin dirs, because any consumer in the process may present the name). One
  name declared by two co-mounted images is a named boot error **65** naming
  both images (the spec 17 §2 slug precedent).
- `AliasUnion::resolve` — THE bare-name decision: verbatim, case-insensitive,
  never extension-completed (`foo` does not match `foo.dll`); a name with a
  separator/drive qualifier and a non-matching bare name are both
  **host-by-default**. Locked and tested here; the covered-surface (dln/fiddle)
  load-time check consumes it — one decision function, never re-implemented
  per consumer (invariant 10).
- `extract()` — the raw-surface materialization: each declared target is
  statted through the VFS first (absent / not a regular file = the manifest
  lying = named **65**, the Rule-R3 precedent, never a skipped entry), then
  materialized through `dlmap2file` — the exec-closure entry, the SAME tfs
  path authority the load-time shim computes through; a cache/host IO failure
  is a named **74**. Answers an `AliasBoot`: the per-alias (name →
  materialized host path) pairs and the deduped materialized dirs, both in
  union order.
- `register()` — pushes the pairs into the tfs context's alias table (a direct
  Rust call on the shared in-process context, never a c_api round-trip).
- `export_path()` — prepends those dirs to the process `PATH`: explicit `;`
  windows semantics (NOT host-shaped `std::env::join_paths` — the only consumer
  is a windows boot, and the explicit spelling keeps the semantics testable on
  this repo's mac/linux-only CI), joined AFTER the §3.2 bin-dir lead, ahead of
  the inherited value; nothing declared leaves PATH untouched.

**tfs — the covered surface's c_api (`crates/tfs`, spec 22 §2.1):**

- `tebako_fs_dlalias2file` — the export ruby#60's patched `dln.c` calls (34th
  ABI symbol; added to the checked-in, nm-gated `crates/tfs/exports.txt`). The
  full contract lives behind it, the calling TU staying decision-only:
  - BARE-name grammar test (`/` `\` `:` — the spec 03 §2.5 byte rule) → a
    path-carrying name is NULL + ENOENT with NO journal line (the spec
    journals bare-name verdicts only);
  - verbatim case-insensitive match against the boot-registered table → the
    alias's materialized absolute host path, malloc/free ownership exactly
    like `tebako_fs_dlmap2file`;
  - undeclared bare name → NULL + ENOENT (`verdict=host` journaled);
  - registered alias whose materialized copy VANISHED under the process →
    NULL + **EIO** — deliberately not ENOENT, so the C side's
    `errno != ENOENT` branch raises the §5 verdict LoadError instead of
    falling through to a host shadow (the verdict was `alias`; the failure is
    post-verdict). EIO chosen over other non-ENOENT candidates: "I/O error"
    is the honest reading of a cache entry that vanished.
- `Context::register_dlaliases(Vec<(String, PathBuf)>)` — the boot-time
  registration channel: plain strings/paths, so tfs stays tpkg-free (#406's
  pin: "the union reaches the TFS at BOOT, never by env var"). The channel is
  platform-neutral (compiled + unit-tested everywhere); only the driver's two
  call sites are `#[cfg(windows)]`. The default empty table answers every
  name host.
- The `event=lib-load name=<n> verdict=host|alias` lines are emitted inside
  `tfs::context::dlalias2file` — where the verdict is MADE — under the
  **record policy only** (spec 23 §8's discovery instrument; production stays
  silent), on the pre-opened journal file (bare `write(2)` under the lock —
  the journal module's fd discipline). The `tfs needs` generator provably
  skips the new event (its parser knows only the jail events; test extended).

**Boot wiring (`src/driver.rs`):** both boot shapes (the standalone env-image
boot and the `--tebako-image` grammar), after the class-R pass, before
`path_env::export` — two `#[cfg(windows)]` call sites (the bare-name rule is a
windows contract; POSIX boots are byte-for-byte untouched) running
`extract()` → `register()` → `export_path()`. Final PATH lead:
launcher dir → dependency bin dirs → alias dirs → inherited.

### The seam left for the PE-closure stream (crates/tfs `exec_closure`)

One narrow, named seam: the `context().dlmap2file(&entry.vfs)` call in
`alias::extract_one` (marked in-code, citing #406). The closure walk parses
Mach-O/ELF today; the PE import directory joins as the third parsed format
THERE, and this call site is unchanged when it lands — the alias's
sibling-import closure then materializes through the same entry. The windows
leave-in-place, content-keyed `dlls/<image-key>` lifecycle with the Rule-R3
write-once/per-boot-rehash protocol (tamper = 70) is the same stream's
`ClosureDest` change. **An alias whose closure is trivial — the common case —
is fully functional here.** Nothing is stubbed; what does not exist yet is
named, not implied.

### The record-mode journal (spec 23 §8)

The `event=lib-load name=<n> verdict=host|alias` lines are owned by the PATCHED
LOAD PATH's c_api decision point (`tfs::context::dlalias2file`, riding
`tfs::journal` on the pre-opened file), not by the driver's boot module: a
bare-name verdict exists only where a load is DECIDED, and the boot pass
decides nothing — it materializes every declaration unconditionally. Emitted
under the **record policy only** (the §8 discovery instrument — one record-mode
run shows the author every bare name a loader presented and which way it went);
production stays silent. Only BARE names produce lines — a path-carrying name
has no bare-name verdict. The `tfs needs` generator provably ignores the event
(needs.rs's foreign-line test now carries lib-load lines).

### Spec ambiguities surfaced (for #406 to pin)

1. ~~How the covered-surface shim LEARNS the alias union at load time~~ —
   **RESOLVED by #406's pin** ("the union reaches the TFS at BOOT, never by env
   var: the driver registers every co-mounted image's (name → materialized
   path) pairs into the tfs context — plain strings, so tfs stays tpkg-free")
   and implemented exactly so in the second commit.
2. **PATH order between the §3.2 bin dirs and the alias dirs is unpinned**
   ("join the same lead"). Implemented launcher → bins → alias dirs →
   inherited, keeping the exec surface's locked lead byte-stable.
3. **Whether the env image's own aliases contribute**: read as YES ("every
   co-mounted image", the class-R env-first precedent) and implemented so.
4. **The bare-name byte grammar lives in three places by construction** (the
   patch header demands the c_api's OWN test): tpkg manifest validation,
   `AliasUnion::resolve` (driver — the union-side reference), and
   `tfs::context::dlalias2file`. tfs cannot flow it (tpkg-free by law), so
   parity is ASSERTED by the mirrored case matrices on both sides (invariant
   10's assert-form): same reject set (`/`, `\`, `:` — incl. the `C:x` drive
   form), same verbatim case-insensitive match, same no-extension-completion.

### Testing

- tpkg unit tests: parse/round-trip, bare-name grammar refusals
  (`lib/foo.dll`, `lib\foo.dll`, `C:foo.dll`, empty), path escape refusals,
  within-image case-insensitive duplicate; plus the JSON-schema cross-check
  (`library_aliases_key_is_schema_legal`).
- driver unit tests (all platform-neutral — macOS/linux legs exercise them):
  match semantics (verbatim case-insensitive; no extension completion; host
  default; non-bare → host), cross-image ambiguity → 65, PATH compose (`;`,
  prepend order, empty-component hygiene), `export_path` behavior, the
  empty-boot `extract()` path, and `register()` landing the pairs in the
  process-global tfs context the c_api reads.
- tfs unit tests (platform-neutral): the dlalias2file case matrix mirroring
  the driver's (verbatim case-insensitive match; no extension completion;
  undeclared → ENOENT; non-bare → ENOENT; empty table → all host), the tamper
  case (registered-but-vanished → **EIO**, never ENOENT), record-mode
  journaling of both verdicts + silence under the open policy + no line for
  path-carrying names, the journal line shape, and the needs-generator's
  foreign-line skip.
- Export surface: the built `libtfs.dylib` carries every `exports.txt` entry,
  `tebako_fs_dlalias2file` included (nm-verified; the 2 extra C-dep symbols
  are what the factory's `ld -r` seal strips).
- The mount-dependent paths (manifest read through the VFS, the `dlmap2file`
  materialization itself) mirror `materialize.rs`'s coverage shape: factory
  boot-smoke / msys dogfood surface (the spec 22 §8 windows row), not unit
  tests. The repo's windows leg covers only the pure-Rust crates (tpkg among
  them — the model gets windows coverage there); tebako-driver builds on the
  ubuntu/macos legs, so the two `#[cfg(windows)]` call sites are exercised
  only at release-build time.

### Verification

Local (macOS aarch64, debug — the CI shape; env `DWARFS_RS_VCPKG_ROOT` /
`VCPKG_ROOT` / `SQFS_SYS_VCPKG_ROOT` / `CARGO_NET_GIT_FETCH_WITH_CLI`):

```
$ cargo fmt --check
FMT-GREEN
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.99s
CLIPPY-GREEN
$ cargo test -p tpkg -p tebako-driver -p tebako-info     # part-2 commit
tebako-driver lib:      63 passed; 0 failed   (9 new alias tests)
tebako-driver boot:     55 passed; 0 failed
tebako-driver misc:      6 + 2 passed; 0 failed
tebako-info:            20 passed; 0 failed   (library_aliases_map_and_omit)
tpkg lib:               87 passed; 0 failed   (4 new library_aliases tests)
tpkg integration+props: 9+6+15+6+7+13+3+5+3+13 passed; 0 failed
TESTS-GREEN
$ cargo test -p tfs -p tebako-driver                     # part-4 commit
tfs lib:               130 passed; 0 failed   (5 new dlalias2file + 1 journal
                                               + the needs foreign-line case)
tfs jails:              16 passed; 0 failed
tebako-driver lib:      64 passed; 0 failed   (register → tfs context wiring)
tebako-driver boot:     55 passed; 0 failed;  misc 6+2 passed
TESTS-GREEN
$ nm -gU --defined-only target/debug/libtfs.dylib        # export surface
all 41 exports.txt entries present, tebako_fs_dlalias2file included
EXPORTS-GREEN
$ cargo test -p tebako-driver                        # part-5 commit
tebako-driver lib:      67 passed; 0 failed   (3 new runtime_dll tests)
tebako-driver boot:     55 passed; 0 failed;  misc 6+2 passed
TESTS-GREEN
```

## Part 5 — the `runtime_dll` layout grant (spec 22 §2.1, schema_minor 3)

The MSYS interpreter's own DLL (`x64-ucrt-ruby340.dll` and friends) is a bare
name every extension's import table carries, and the PE closure walk (the
reader, **#409**) must not treat it as an alias candidate or a missing
dependency. The grant follows the `preload_shim` precedent exactly:

- `docs/spec/schemas/layout.yaml`: additive optional `runtime_dll`
  (**schema_minor 3**). Bare-name grammar — no `/`, no `\`, no `:` (drive
  qualifier); MSYS builds only. A separator/drive-qualified value is a named
  boot error **78** naming the image and the value (the override-validation
  precedent). Drive-by: fixed a pre-existing `TEBAFO_PRELOAD_SHIM` typo in
  the same file.
- `ImageLayout` (`src/layout.rs`) parses it through; `LayoutView` exposes it.
- `injection::export` (`src/injection.rs`) exports the declared spelling
  verbatim as `TEBAKO_RUNTIME_DLL` into the handoff env on **every** platform
  when declared — one code path, no `#[cfg]` gate (the declared spelling is
  inert on POSIX: nothing reads it there); an absent declaration exports
  nothing. Both boot shapes already flow through `injection::export`, so no
  `driver.rs` change was needed.
- Reader: `tfs::context::runtime_dll_name()` (#409's branch) reads
  `TEBAKO_RUNTIME_DLL`, filters empty, lowercases; `resolve_pe_dep` compares
  against lowercased bare import names. Driver exports verbatim, reader
  lowercases — aligned. Nothing on THIS branch reads the var yet; the wiring
  is complete per the pinned design.
- Writer: factory draft **tamatebako/tebako-runtime-ruby#104** flows
  `RubyVersion#msys_dll_name` (the single naming owner — no hand-rolled
  formula) into `deploy_layout` for MSYS builds only; disjoint from #103's
  hunks.

---

Draft. Stacked on the phase-W design (#406); per the ecosystem rule nothing
merges without the owner's explicit go-ahead.
