### PR TITLE
chore(cli): retire inert TEBAKO_PASS_THROUGH — no v2 consumer

### DIFF
--- a/crates/tebako-cli/README.md
+++ b/crates/tebako-cli/README.md
@@ -46,10 +46,9 @@ audit journal (`$TEBAKO_HOME/journal.log`, spec 08 §2).
    (bundle config/install for the Gemfile scenario) are serialized into a
    stub driver placed at `/local/stub.rb` of a throwaway image, which is
    imaged in-process, stitched onto an empty base and exec'd as
-   `runtime --tebako-image <driver>:0:/__tebako_memfs__` with a scrubbed
+   `runtime --tebako-image <driver>:0:<declared-mount>` with a scrubbed
    environment (`RUBYOPT`/`RUBYLIB`/`BUNDLE_*`/`BUNDLER_*` unset,
-   `GEM_HOME`/`GEM_PATH`/`GEM_SPEC_CACHE`/`SSL_CERT_*`/
-   `TEBAKO_PASS_THROUGH` set);
+   `GEM_HOME`/`GEM_PATH`/`GEM_SPEC_CACHE`/`SSL_CERT_*` set);
 4. **strip** build artefacts, align the arch layout to the runtime, write
    the entry dispatcher at `/local/stub.rb`;
 5. **image** the app (in-process dwarfs-t Writer → `fs.tfs`) and

--- a/crates/tebako-cli/src/deploy.rs
+++ b/crates/tebako-cli/src/deploy.rs
@@ -74,10 +74,10 @@ pub struct RuntimeDeployer {
 impl RuntimeDeployer {
     /// env: GEM_HOME/GEM_PATH/GEM_SPEC_CACHE/SSL_CERT_* for the deploy; it
     /// travels in the process environment because Gem::PathSupport
-    /// snapshots it at interpreter boot. TEBAKO_PASS_THROUGH joins it: the
-    /// tebako-patched rubygems filters gem paths to the memfs mount point
-    /// unless it is set, and the driver installs into the packaging
-    /// environment on the host.
+    /// snapshots it at interpreter boot. The deploy installs no jail, so
+    /// the driver writes the packaging environment on the host directly
+    /// (v1's TEBAKO_PASS_THROUGH memfs-filter escape is retired — no v2
+    /// runtime patch reads it).
     pub fn execute(
         &self,
         ops: &[Op],
@@ -109,7 +109,6 @@ impl RuntimeDeployer {
         }
         let mut full_env = self.toolchain_env();
         full_env.extend(env.iter().cloned());
-        full_env.push(("TEBAKO_PASS_THROUGH".to_string(), "1".to_string()));
         // The v2 handoff needs the entry explicitly (spec 17 §1): with no
         // --tebako-entry the boot is the smoke form — the interpreter
         // starts with its own args and the driver script never runs (the

--- a/crates/tebako-cli/tests/cli_e2e.rs
+++ b/crates/tebako-cli/tests/cli_e2e.rs
@@ -1267,8 +1267,8 @@ fn sdk_mirror_fixture(work: &Path, ruby: &str) -> Option<PathBuf> {
 
 /// Run the runtime against a throwaway driver image whose /local/stub.rb
 /// is `stub_source` — the same launcher-ABI handoff the CLI's deploy uses
-/// (the driver image is the full runtime layout plus the stub) — with
-/// TEBAKO_PASS_THROUGH so the stub reads/writes host paths.
+/// (the driver image is the full runtime layout plus the stub). No jail is
+/// installed, so the stub reads/writes host paths directly.
 fn runtime_driver_exec(
     work: &Path,
     layout_src: &Path,
@@ -1310,8 +1310,7 @@ fn runtime_driver_exec(
     cmd.arg("--tebako-image")
         .arg(format!("{}:0:/__tfs__", pkg.display()))
         .arg("--tebako-entry")
-        .arg("/local/stub.rb")
-        .env("TEBAKO_PASS_THROUGH", "1");
+        .arg("/local/stub.rb");
     run(&mut cmd)
 }
 


### PR DESCRIPTION
## What

Retires `TEBAKO_PASS_THROUGH` from the v2 product: the deploy no longer
sets it, the e2e harness no longer sets it, and the README no longer
documents it.

## Why it is inert (verified, not asserted)

The var was a v1 escape hatch: the v1 tebako-patched rubygems filtered gem
paths to the memfs mount point unless `TEBAKO_PASS_THROUGH` was set, and
the deploy needed host paths for the packaging environment. In v2:

- **No producer-side reader in the product**: nothing under `crates/`
  reads the var (grep: only the deploy setter, the e2e setter, and the
  README mention it).
- **No consumer in the runtime patches**: tamatebako/ruby's current v2
  patch set carries zero references — the v1 `path_support.rb` memfs
  filter (the var's only consumer besides the retired tebako-runtime gem)
  no longer exists in shipped runtimes.
- **No behavioral need**: the deploy installs no jail (`TEBAKO_JAIL`
  unset), so the driver writes the packaging environment on the host
  directly.

## Proof

- `cargo test -p tebako-cli --lib`: 60/60 green.
- `native_ext_press_builds_and_packages` e2e (downloads the current
  published runtime, builds the toyext fixture gem under it through the
  driver handoff **without** the var, presses a native-ext package,
  cold-runs it, and exercises the loud failure path): green in 131 s on
  macOS arm64.

## Also fixed on the touched lines

- README's deploy step claimed the driver image is mounted at the v1
  spelling `/__tebako_memfs__`; it mounts at the runtime's declared mount
  (`driver_image_ref` → `declared_mount`). Now says `<declared-mount>`.
