### PR TITLE
tfs: parse PE images whole in the closure walk (incident 13 — the deep import-directory 126)

### DIFF
--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -1355,15 +1355,30 @@ impl FsContext {
         // names are host/system libraries — the loader answers for
         // them exactly as before.
         visited.insert(path.to_string());
-        use std::io::Read as _;
-        let mut head = Vec::new();
-        let Ok(_) = std::fs::File::open(&host_path).and_then(|f| {
-            f.take(exec_closure::HEADER_WINDOW as u64)
-                .read_to_end(&mut head)
-        }) else {
-            return Ok(host_path);
-        };
-        let Some(parsed) = exec_closure::parse(&head) else {
+        let Some(parsed) = (|| {
+            use std::io::Read as _;
+            let mut head = Vec::new();
+            std::fs::File::open(&host_path)
+                .and_then(|f| {
+                    f.take(exec_closure::HEADER_WINDOW as u64)
+                        .read_to_end(&mut head)
+                })
+                .ok()?;
+            // Incident 13: a PE import directory is section-resident
+            // (.rdata), past the header window in a multi-MiB module (a
+            // -static-libstdc++ libsass.so) — a windowed parse silently
+            // answers an empty closure and the OS load then 126s on the
+            // vendored siblings that never materialized. A dlmap target
+            // is a load module by construction, so PE images are parsed
+            // WHOLE; the ELF/Mach-O window stands (their load tables
+            // ride the headers).
+            if head.starts_with(b"MZ") {
+                if let Ok(full) = std::fs::read(&host_path) {
+                    head = full;
+                }
+            }
+            exec_closure::parse(&head)
+        })() else {
             return Ok(host_path);
         };
         let referrer_dir = memfs_dirname(path);
@@ -2287,8 +2302,17 @@ mod tests {
     /// same byte construction as exec_closure's pe64_fixture — fixture
     /// builders stay local to their test module, like macho64_fixture).
     fn pe64_fixture(imports: &[&str], delay_imports: &[&str]) -> Vec<u8> {
+        pe64_fixture_deep(0, imports, delay_imports)
+    }
+
+    /// The same fixture with `pad` zero bytes between the headers and
+    /// the section body: the import directory's FILE offset lands at
+    /// 0x200 + pad — a multi-MiB module's .rdata behind a big .text
+    /// (incident 13's libsass.so).
+    fn pe64_fixture_deep(pad: usize, imports: &[&str], delay_imports: &[&str]) -> Vec<u8> {
         const HEADERS: usize = 0x200;
         const SECTION_RVA: u32 = 0x1000;
+        let raw_off = HEADERS + pad;
         let import_dir_size = (imports.len() + 1) * 20;
         // Section body: the import descriptors (+ all-zero terminator),
         // then the import name strings, then the delay-load descriptors
@@ -2333,22 +2357,23 @@ mod tests {
             out[d + 4..d + 8]
                 .copy_from_slice(&(((delay_imports.len() + 1) * 20) as u32).to_le_bytes());
         }
-        // The one section header: .rdata, RVA 0x1000 → file HEADERS.
+        // The one section header: .rdata, RVA 0x1000 → file raw_off.
         let sec = opt + 240;
         out[sec..sec + 6].copy_from_slice(b".rdata");
         out[sec + 8..sec + 12].copy_from_slice(&(section.len() as u32).to_le_bytes());
         out[sec + 12..sec + 16].copy_from_slice(&SECTION_RVA.to_le_bytes());
         out[sec + 16..sec + 20].copy_from_slice(&(section.len() as u32).to_le_bytes());
-        out[sec + 20..sec + 24].copy_from_slice(&(HEADERS as u32).to_le_bytes());
+        out[sec + 20..sec + 24].copy_from_slice(&(raw_off as u32).to_le_bytes());
+        out.resize(raw_off, 0);
         out.extend_from_slice(&section);
         for (i, rva) in import_name_rvas.iter().enumerate() {
-            let at = HEADERS + i * 20;
+            let at = raw_off + i * 20;
             out[at..at + 4].copy_from_slice(&1_u32.to_le_bytes()); // OriginalFirstThunk
             out[at + 12..at + 16].copy_from_slice(&rva.to_le_bytes()); // Name
             out[at + 16..at + 20].copy_from_slice(&1_u32.to_le_bytes()); // FirstThunk
         }
         for (i, rva) in delay_name_rvas.iter().enumerate() {
-            let at = HEADERS + delay_base + i * 20;
+            let at = raw_off + delay_base + i * 20;
             out[at..at + 4].copy_from_slice(&1_u32.to_le_bytes());
             out[at + 12..at + 16].copy_from_slice(&rva.to_le_bytes());
             out[at + 16..at + 20].copy_from_slice(&1_u32.to_le_bytes());
@@ -2475,6 +2500,39 @@ mod tests {
         assert!(
             host.ends_with("A_/t/lib/x.so"),
             "the flattened tail mirrors the memfs path: {host}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pe_closure_with_a_deep_import_directory_still_walks() {
+        // Incident 13: the import directory past the 1-MiB header
+        // window (a multi-MiB module's .rdata — a -static-libstdc++
+        // libsass.so) must still walk. A windowed parse silently
+        // answers no imports, the importer materializes ALONE, and the
+        // OS load then misses the vendored siblings (the msys 126).
+        let dir = std::env::temp_dir().join(format!("tfs-pe-deep-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let img = dir.join("img");
+        std::fs::create_dir_all(img.join("bin")).unwrap();
+        std::fs::write(
+            img.join("bin/tool.dll"),
+            pe64_fixture_deep(exec_closure::HEADER_WINDOW + 0x400, &["sibling.dll"], &[]),
+        )
+        .unwrap();
+        std::fs::write(img.join("bin/sibling.dll"), pe64_fixture(&[], &[])).unwrap();
+        let dest = dir.join("out");
+
+        let mut ctx = FsContext::new();
+        mount_hostdir(&mut ctx, &img, "/tfs");
+        let host = ctx
+            .extract_exec_closure("/tfs/bin/tool.dll", &dest)
+            .unwrap();
+
+        assert_eq!(host, dest.join("tfs/bin/tool.dll"));
+        assert!(
+            dest.join("tfs/bin/sibling.dll").is_file(),
+            "the deep import table's sibling materializes beside the importer"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/tfs/src/exec_closure.rs
+++ b/crates/tfs/src/exec_closure.rs
@@ -15,12 +15,16 @@
 //! importer-dir-only rule, recursion with a visited set) lives in
 //! `context.rs`.
 //!
-//! Only the header region is parsed (the first [`HEADER_WINDOW`] bytes
-//! of the extracted copy): Mach-O load commands, the ELF dynamic
-//! string table, and the PE import directory all live in the first
-//! pages of any real image. A truncated or unparseable header yields no
-//! dependencies — the loader then answers for the host libraries
-//! exactly as before.
+//! Mach-O and ELF parse only the header region (the first
+//! [`HEADER_WINDOW`] bytes of the extracted copy): their load commands
+//! and dynamic tables ride the first pages of any real image. PE is the
+//! exception (incident 13): the import directory is SECTION-resident
+//! (.rdata), which sits past the window in a multi-MiB module (a
+//! -static-libstdc++ build) — a windowed parse silently answers an
+//! empty closure, so [`parse`] hands PE the whole buffer it was given
+//! (the caller reads PE images in full). A truncated or unparseable
+//! header yields no dependencies — the loader then answers for the host
+//! libraries exactly as before.
 
 /// Header bytes examined for dependency metadata.
 pub(crate) const HEADER_WINDOW: usize = 1 << 20;
@@ -57,9 +61,11 @@ pub struct ImageDeps {
 /// formats.
 pub fn parse(bytes: &[u8]) -> Option<ImageDeps> {
     let window = &bytes[..bytes.len().min(HEADER_WINDOW)];
+    // PE parses the WHOLE buffer (the module doc — incident 13): its
+    // import directory is section-resident, not header-resident.
     parse_macho(window)
         .or_else(|| parse_elf(window))
-        .or_else(|| parse_pe(window))
+        .or_else(|| parse_pe(bytes))
 }
 
 // ---------------------------------------------------------------------
@@ -687,8 +693,17 @@ mod tests {
     /// is out of phase W, spec 22 §2.1). One section (.rdata) maps RVA
     /// 0x1000 to the file offset right after the headers.
     fn pe64_fixture(imports: &[&str], delay_imports: &[&str]) -> Vec<u8> {
+        pe64_fixture_deep(0, imports, delay_imports)
+    }
+
+    /// The same fixture with `pad` zero bytes between the headers and the
+    /// section body: the import directory's FILE offset lands at
+    /// 0x200 + pad — a multi-MiB module's .rdata behind a big .text
+    /// (incident 13's libsass.so).
+    fn pe64_fixture_deep(pad: usize, imports: &[&str], delay_imports: &[&str]) -> Vec<u8> {
         const HEADERS: usize = 0x200;
         const SECTION_RVA: u32 = 0x1000;
+        let raw_off = HEADERS + pad;
         let import_dir_size = (imports.len() + 1) * PE_IMPORT_DESCRIPTOR_SIZE;
         // Section body: the import descriptors (+ all-zero terminator),
         // then the import name strings, then the delay-load descriptors
@@ -738,24 +753,25 @@ mod tests {
                 &(((delay_imports.len() + 1) * PE_IMPORT_DESCRIPTOR_SIZE) as u32).to_le_bytes(),
             );
         }
-        // The one section header: .rdata, RVA 0x1000 → file HEADERS.
+        // The one section header: .rdata, RVA 0x1000 → file raw_off.
         let sec = opt + 240;
         out[sec..sec + 6].copy_from_slice(b".rdata");
         out[sec + 8..sec + 12].copy_from_slice(&(section.len() as u32).to_le_bytes());
         out[sec + 12..sec + 16].copy_from_slice(&SECTION_RVA.to_le_bytes());
         out[sec + 16..sec + 20].copy_from_slice(&(section.len() as u32).to_le_bytes());
-        out[sec + 20..sec + 24].copy_from_slice(&(HEADERS as u32).to_le_bytes());
+        out[sec + 20..sec + 24].copy_from_slice(&(raw_off as u32).to_le_bytes());
+        out.resize(raw_off, 0);
         out.extend_from_slice(&section);
         // Fill the descriptors' name RVAs (thunks need not resolve —
         // the walk reads names only).
         for (i, rva) in import_name_rvas.iter().enumerate() {
-            let at = HEADERS + i * PE_IMPORT_DESCRIPTOR_SIZE;
+            let at = raw_off + i * PE_IMPORT_DESCRIPTOR_SIZE;
             out[at..at + 4].copy_from_slice(&1_u32.to_le_bytes()); // OriginalFirstThunk
             out[at + 12..at + 16].copy_from_slice(&rva.to_le_bytes()); // Name
             out[at + 16..at + 20].copy_from_slice(&1_u32.to_le_bytes()); // FirstThunk
         }
         for (i, rva) in delay_name_rvas.iter().enumerate() {
-            let at = HEADERS + delay_base + i * PE_IMPORT_DESCRIPTOR_SIZE;
+            let at = raw_off + delay_base + i * PE_IMPORT_DESCRIPTOR_SIZE;
             out[at..at + 4].copy_from_slice(&1_u32.to_le_bytes());
             out[at + 12..at + 16].copy_from_slice(&rva.to_le_bytes());
             out[at + 16..at + 20].copy_from_slice(&1_u32.to_le_bytes());
@@ -800,6 +816,25 @@ mod tests {
         let bytes = pe64_fixture(&["real.dll"], &["delayed.dll"]);
         let parsed = parse(&bytes).expect("a PE parses");
         assert_eq!(parsed.deps, vec!["real.dll".to_string()]);
+    }
+
+    #[test]
+    fn pe_import_directory_beyond_the_header_window_needs_the_whole_image() {
+        // Incident 13 (the msys libsass 126): a multi-MiB module's
+        // import table sits in .rdata past HEADER_WINDOW, and a
+        // windowed parse silently answers an empty dep set — the
+        // closure walk then materializes the importer ALONE and the OS
+        // load misses the vendored siblings. parse() hands PE the whole
+        // buffer for exactly this reason; this pins both sides of the
+        // hazard.
+        let bytes = pe64_fixture_deep(HEADER_WINDOW + 0x400, &["deep.dll"], &[]);
+        let parsed = parse(&bytes).expect("the whole image parses");
+        assert_eq!(parsed.deps, vec!["deep.dll".to_string()]);
+        let windowed = parse(&bytes[..HEADER_WINDOW]).expect("the window parses");
+        assert!(
+            windowed.deps.is_empty(),
+            "the truncated window silently misses the deep import table"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Incident 13 round 3: the PE closure walk silently truncated at the 1 MiB header window

The factory dogfood (tebako-runtime-ruby#111 rerun #2, job 95745075037)
vendored libsass.so's ucrt closure next to the importer in-image
(verified in the log: `vendored libgcc_s_seh-1.dll`,
`vendored libwinpthread-1.dll`) — and the ffi full-path load still
honestly 126'd. Root cause, in this crate:

`exec_closure::parse` examines only the first `HEADER_WINDOW` (1 MiB) of
an extracted image, on the assumption that dependency metadata rides the
first pages. For PE that assumption is wrong: the import directory is
SECTION-resident (`.rdata`), and in a multi-MiB module — a
`-static-libstdc++` libsass.so — its file offset sits past the window.
`parse_pe`'s `rva_to_off` then maps out-of-window, the descriptor loop
breaks on the first missing slice, and the walk silently answers an
EMPTY closure: the importer materializes alone and the OS loader misses
the vendored siblings. The silent-truncation class — the forbidden
silent fallback.

## Fix

- `exec_closure::parse` hands PE the WHOLE buffer it was given; the
  Mach-O/ELF window stands (their load tables ride the headers). Module
  doc updated — the old text's claim that the PE import directory lives
  in "the first pages of any real image" was the falsified assumption.
- `context::extract_for_exec` reads PE images (MZ sniff) in full before
  parsing. A dlmap target is a load module by construction, so the read
  is module-sized by definition.

## Tests (debug, never --release locally)

- `exec_closure::tests::pe_import_directory_beyond_the_header_window_needs_the_whole_image`
  — a synthetic PE32+ whose import directory sits past the window: the
  full parse finds the dep, the windowed parse silently misses it (the
  hazard pinned).
- `context::tests::pe_closure_with_a_deep_import_directory_still_walks`
  — end-to-end: the deep import table's sibling materializes beside the
  importer.
- Full suite: `cargo test -p tfs` — 166 lib + 16 jails green.

The spec is unchanged (spec 22 §2.1's walk semantics are as locked; this
is an implementation bug against them). The windows dogfood rerun after
merge is the acceptance: `PROBE sassc-main ok`, `PROBE sassc-partial
ok`, the negative oracle pinned-RED, `SPEC22-GEMS-MSYS-ACCEPTANCE-OK`.
