### PR TITLE
driver: name a missing TEBAKO_RUNTIME_IMAGE on stderr + un-mislead the mount journal

### DIFF
--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -265,8 +265,11 @@ fn build_error(
 }
 
 /// The exclusive mount path (the historical behavior): a free point is
-/// claimed, an occupied point is the named EEXIST error.
-fn mount_exclusive(mount: tfs::context::Mount, what: &str) -> Result<(), DriverError> {
+/// claimed, an occupied point is the named EEXIST error. `what` phrases
+/// the failure, `desc` is the success journal's member wording — the two
+/// never share a string (a success line reading "failed to ..." sent
+/// incident 13 hunting a mount that had in fact succeeded).
+fn mount_exclusive(mount: tfs::context::Mount, what: &str, desc: &str) -> Result<(), DriverError> {
     let mount_point = mount.mount_point.clone();
     context()
         .write()
@@ -282,7 +285,7 @@ fn mount_exclusive(mount: tfs::context::Mount, what: &str) -> Result<(), DriverE
     tebako_log::log!(
         tebako_log::Level::Debug,
         "driver",
-        "mounted what={what} at={mount_point}"
+        "mounted {desc} at={mount_point}"
     );
     Ok(())
 }
@@ -303,7 +306,7 @@ fn mount_at_point(
     mounted: &mut Vec<MountedMember>,
 ) -> Result<(), DriverError> {
     if !context().read().unwrap().mount_point_taken(&spec.mount) {
-        mount_exclusive(mount, what)?;
+        mount_exclusive(mount, what, new_desc)?;
         mounted.push(MountedMember {
             point: spec.mount.clone(),
             desc: new_desc.to_string(),
@@ -360,25 +363,36 @@ fn mount_at_point(
 }
 
 /// The env image (`TEBAKO_RUNTIME_IMAGE`): a bare `.tfs`, mounted whole
-/// at the runtime root. Records `runtime_root` in `mounted`.
+/// at the runtime root. Records `runtime_root` in `mounted`. A boot
+/// without it is a legal shape (bare interpreter) but in managed mode a
+/// missing handoff otherwise surfaces much later as load errors with no
+/// obvious cause (incident 13 round 5) — so the absence is named on
+/// stderr (stdout is the payload's, never the log's).
 fn mount_env_image(
     env: &dyn Env,
     runtime_root: &str,
     mounted: &mut Vec<MountedMember>,
 ) -> Result<(), DriverError> {
     let Some(image) = env_var(env, "TEBAKO_RUNTIME_IMAGE") else {
+        eprintln!(
+            "tebako-driver: TEBAKO_RUNTIME_IMAGE is not set — booting with no env image; \
+             the runtime root stays empty (a loader/harness handoff bug unless this is \
+             a deliberate bare boot)"
+        );
         return Ok(());
     };
+    let desc = format!("env image '{image}'");
     mount_exclusive(
         build_error(
             tfs::mount::build_from_file(&image, runtime_root),
             &format!("failed to mount the runtime filesystem image from '{image}'"),
         )?,
         &format!("failed to mount the runtime filesystem image from '{image}'"),
+        &desc,
     )?;
     mounted.push(MountedMember {
         point: runtime_root.to_string(),
-        desc: format!("env image '{image}'"),
+        desc,
     });
     Ok(())
 }
@@ -445,7 +459,7 @@ pub(crate) fn mounted_manifest_at(
 /// the override era refuses by name rather than booting an interpreter
 /// whose load paths point at an unmounted root. A boot without
 /// `TEBAKO_RUNTIME_IMAGE` mounts no env image and has no pair to check
-/// (None). On success the parsed declaration returns — its additive
+/// (None) — the mount side already named the absence on stderr. On success the parsed declaration returns — its additive
 /// grants drive the child injection (spec 22 §3).
 fn check_env_layout(
     env: &dyn Env,

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -206,7 +206,7 @@ fn plain_boot_passes_argv_through_and_mounts_the_env_image() {
 
 #[test]
 fn a_boot_without_the_env_image_is_legal_and_mounts_nothing() {
-    let g = guard("no-env-image");
+    let _g = guard("no-env-image");
     let env = MapEnv::new(); // no TEBAKO_RUNTIME_IMAGE — the warn's shape
 
     // The absence is named on stderr (an eprintln — process-global, not

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -205,6 +205,19 @@ fn plain_boot_passes_argv_through_and_mounts_the_env_image() {
 }
 
 #[test]
+fn a_boot_without_the_env_image_is_legal_and_mounts_nothing() {
+    let g = guard("no-env-image");
+    let env = MapEnv::new(); // no TEBAKO_RUNTIME_IMAGE — the warn's shape
+
+    // The absence is named on stderr (an eprintln — process-global, not
+    // captured here); what this pins is that the warn never became an
+    // error: the bare boot stays a legal shape and nothing mounts.
+    let out = boot(&argv(&["ruby", "--version"]), "/__tfs__", &env).unwrap();
+    assert_eq!(out.argv, argv(&["ruby", "--version"]));
+    assert!(!context().read().unwrap().is_mounted());
+}
+
+#[test]
 fn bare_payload_mounts_whole_with_slot_0() {
     let g = guard("bare-0");
     let payload = write_payload_image(g.path());


### PR DESCRIPTION
## Two incident-13 warts, one small PR

Both surfaced while debugging the msys dogfood (tamatebako/ruby#93,
tebako-runtime-ruby#111); both are diagnostics-only — no behavior change.

### 1. A missing `TEBAKO_RUNTIME_IMAGE` now names itself on stderr

A boot without the env image silently mounted nothing and failed much later
with load errors that never named the cause — incident 13 round 5's lost
harness handoff cost a full diagnostic round precisely because nothing said
"you booted bare". `mount_env_image` now says it:

```
tebako-driver: TEBAKO_RUNTIME_IMAGE is not set — booting with no env image; the runtime root stays empty (a loader/harness handoff bug unless this is a deliberate bare boot)
```

Channel choice: `eprintln!`, matching `ffi/interpose.rs:184` — tebako-log
defaults to `off`, so a `Warn` there is invisible exactly when a harness bug
bites. stdout stays the payload's. The bare boot stays a legal shape
(`Ok`, no mounts) — only loud, never an error. A new boot.rs test pins the
legal-shape behavior.

### 2. The mount journal no longer reads "failed to" on success

`mount_exclusive` journaled success with the failure-phrased context string:

```
mounted what=failed to mount the runtime filesystem image from '...' at=/__tfs__
```

sent incident 13 hunting a mount that had in fact succeeded. It now takes a
separate success `desc` (`mounted env image '...' at=/__tfs__`); the env
image's member description is computed once and reused for both the journal
and the union member table, and the payload path reuses `new_desc`.

### Verification

- `cargo test -p tebako-driver` green, including the new
  `a_boot_without_the_env_image_is_legal_and_mounts_nothing` (56+6+2 across
  the three suites).
- `cargo clippy -p tebako-driver` clean.

**Draft** — stacks behind #415 (touches the same file; rebases after it
lands). Part of the approved owner-nod close-out queue.
