### PR TITLE
tpkg: the checks: manifest block (spec 26 §1) — model + schema + validation

### DIFF
--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -1244,6 +1244,8 @@ fn synthesize_manifest(
         // …and no library aliases (spec 03 §2.5 — the same mirror rule:
         // declarations live in the embedded manifest only).
         library_aliases: Vec::new(),
+        // …and no checks (spec 26 §1 — the same mirror rule).
+        checks: Default::default(),
     })
 }
 

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -168,10 +168,11 @@ pub use ext::{ExtBlock, ExtError};
 pub use io::{read_from, write_to};
 pub use jail::{ArgumentFiles, HostJail, JailAccess, JailError, JailMount};
 pub use manifest::{
-    AppProvides, BuiltFrom, Capabilities, Constraint, DataProvides, Digest, Encryption,
-    EncryptionPart, EncryptionState, EngineProvides, Entrypoint, Identity, LibraryAlias,
-    ManifestError, MountSemantics, PayloadKind, PayloadManifest, Platform, Platforms, Producer,
-    Provides, Requirement, RuntimeProvides, RuntimeRequirement, Sbom, Signing, SigningMechanism,
+    AppProvides, BuiltFrom, Capabilities, Check, CheckEntry, CheckExpect, CheckNeed,
+    CheckPlatform, CheckRequires, Constraint, DataProvides, Digest, Encryption, EncryptionPart,
+    EncryptionState, EngineProvides, Entrypoint, Identity, LibraryAlias, ManifestError,
+    MountSemantics, PayloadKind, PayloadManifest, Platform, Platforms, Producer, Provides,
+    Requirement, RuntimeProvides, RuntimeRequirement, Sbom, Signing, SigningMechanism,
     SigningState, Source, ToolkitExecutable, ToolkitLibrary, ToolkitProvides,
     PAYLOAD_MANIFEST_PATH, PAYLOAD_SCHEMA_VERSION,
 };

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -168,13 +168,12 @@ pub use ext::{ExtBlock, ExtError};
 pub use io::{read_from, write_to};
 pub use jail::{ArgumentFiles, HostJail, JailAccess, JailError, JailMount};
 pub use manifest::{
-    AppProvides, BuiltFrom, Capabilities, Check, CheckEntry, CheckExpect, CheckNeed,
-    CheckPlatform, CheckRequires, Constraint, DataProvides, Digest, Encryption, EncryptionPart,
-    EncryptionState, EngineProvides, Entrypoint, Identity, LibraryAlias, ManifestError,
-    MountSemantics, PayloadKind, PayloadManifest, Platform, Platforms, Producer, Provides,
-    Requirement, RuntimeProvides, RuntimeRequirement, Sbom, Signing, SigningMechanism,
-    SigningState, Source, ToolkitExecutable, ToolkitLibrary, ToolkitProvides,
-    PAYLOAD_MANIFEST_PATH, PAYLOAD_SCHEMA_VERSION,
+    AppProvides, BuiltFrom, Capabilities, Check, CheckEntry, CheckExpect, CheckNeed, CheckPlatform,
+    CheckRequires, Constraint, DataProvides, Digest, Encryption, EncryptionPart, EncryptionState,
+    EngineProvides, Entrypoint, Identity, LibraryAlias, ManifestError, MountSemantics, PayloadKind,
+    PayloadManifest, Platform, Platforms, Producer, Provides, Requirement, RuntimeProvides,
+    RuntimeRequirement, Sbom, Signing, SigningMechanism, SigningState, Source, ToolkitExecutable,
+    ToolkitLibrary, ToolkitProvides, PAYLOAD_MANIFEST_PATH, PAYLOAD_SCHEMA_VERSION,
 };
 pub use merkle::{
     render_tree_hash, tree_digest, Child, FileHasher, MerkleDigest, NodeKind, TreeWalk,

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -1122,6 +1122,316 @@ pub struct LibraryAlias {
     pub path: String,
 }
 
+/// A check's `entry` (spec 26 §1): EITHER the reserved spelling `self` —
+/// legal only when `identity.kind == Runtime` (§1.1: the runtime exe
+/// itself, with the env image mounted) — OR the absolute in-image path
+/// of the executable the check runs. A check never names a host system
+/// executable (invariant 1). ABSENT `entry` is not this type's question:
+/// it makes the check STRUCTURAL (see [`Check`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckEntry {
+    /// `self` — the runtime exe (runtime slices only, spec 26 §1.1).
+    SelfExe,
+    /// An absolute in-image path.
+    Path(String),
+}
+
+impl Serialize for CheckEntry {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            CheckEntry::SelfExe => s.serialize_str("self"),
+            CheckEntry::Path(p) => s.serialize_str(p),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CheckEntry {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<CheckEntry, D::Error> {
+        let s = String::deserialize(d)?;
+        Ok(if s == "self" {
+            CheckEntry::SelfExe
+        } else {
+            CheckEntry::Path(s)
+        })
+    }
+}
+
+/// A platform family of a check's `when:` filter (spec 26 §1): the OS
+/// family axis (`windows | macos | linux`), NOT the spec 03 §3 triplet
+/// axis — a check's filter is behavioral (the engine's per-platform
+/// SKIP), never ABI-bound.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckPlatform {
+    Windows,
+    Macos,
+    Linux,
+}
+
+/// One `needs:` entry of a check (spec 26 §1: additive host needs for
+/// the check run ONLY — rare): a minimal mirror of the spec 23 §2 D1
+/// entry grammar, `{path, access, when?, why?}`. The engine composes
+/// them into the run's effective policy; the model only carries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckNeed {
+    /// Host path (absolute, or a spec 23 §2 symbolic atom).
+    pub path: String,
+    /// The grant bit — the same `ro | rw` axis as the jail model.
+    pub access: crate::jail::JailAccess,
+    /// Optional platform filter (the OS family axis).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub when: Vec<CheckPlatform>,
+    /// Documentation for the reviewer (spec 23 §2's `why`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub why: Option<String>,
+}
+
+/// A check's `requires:` block (spec 26 §1): the capabilities the
+/// resolved composition must provide. An unmet prerequisite SKIPs the
+/// check (loud, the missing capability named), never FAILs it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckRequires {
+    pub provides: Vec<String>,
+}
+
+/// A check's `expect:` block (spec 26 §1) — the assertions. Byte-golden
+/// assertions do not exist by construction: there is no such field
+/// (output bytes churn with dependency versions; the Homebrew test's
+/// `assert_path_exists` is the parity bar, invariant 8).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckExpect {
+    /// Expected exit status (default 0).
+    #[serde(default, skip_serializing_if = "u32_is_zero")]
+    pub exit: u32,
+    /// Scratch-relative paths asserted to exist and be non-empty after
+    /// the run.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<String>,
+    /// One regex the run's stdout must match. Carried UNCOMPILED — tpkg
+    /// has no regex dependency by design; the check engine (spec 26 §2)
+    /// compiles it at run time. Validated here only for non-emptiness.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+    /// In-image absolute paths asserted to exist and be non-empty — the
+    /// STRUCTURAL check's assertion channel (spec 26 §1.1).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub image_files: Vec<String>,
+}
+
+impl CheckExpect {
+    fn is_default(&self) -> bool {
+        self == &CheckExpect::default()
+    }
+}
+
+fn u32_is_zero(v: &u32) -> bool {
+    *v == 0
+}
+
+/// One `checks:` entry (spec 26 §1, additive — schema_minor 3): the
+/// payload's own acceptance contract, declared in-image — "given my
+/// declared needs, I do my one real thing". Any kind may declare checks.
+///
+/// The shape is decided by ONE key, never a `kind:` flag (MECE, spec 26
+/// §1.1): a check WITH `entry` is an EXEC check (the engine runs it
+/// under the resolved composition); a check WITHOUT `entry` is a
+/// STRUCTURAL check (the data-slice shape — the engine mounts the image
+/// and asserts `expect.image_files`, no runtime, no composition).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Check {
+    /// Exec checks: the in-image executable — or `self` on a runtime
+    /// slice (spec 26 §1.1). Absent ⇒ STRUCTURAL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry: Option<CheckEntry>,
+    /// Exec-check argv. `{scratch}` is the ONE substitution token (the
+    /// per-run host scratch directory, spec 26 §2) — at most one
+    /// occurrence per entry; every other spelling is literal
+    /// passthrough. The engine substitutes; the model only carries.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub argv: Vec<String>,
+    /// In-image fixtures directory whose CONTENTS land at the HOST
+    /// scratch root (never VFS-spelled — the consumer may be the
+    /// payload's own raw-surface component, spec 26 §1). Exec-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixtures: Option<String>,
+    /// The assertions (absent = the default `exit: 0`).
+    #[serde(default, skip_serializing_if = "CheckExpect::is_default")]
+    pub expect: CheckExpect,
+    /// Additive host needs for the check run ONLY (spec 23 §2 grammar).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub needs: Vec<CheckNeed>,
+    /// Composition prerequisites; unmet ⇒ SKIP, never FAIL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires: Option<CheckRequires>,
+    /// Platform filter (the OS family axis); absent = every platform.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub when: Vec<CheckPlatform>,
+    /// Per-check timeout in seconds; expiry is a FAIL (spec 26 §2).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<u64>,
+}
+
+/// The check-name grammar (spec 26 §1): names appear in report lines
+/// and scratch dir names — `[A-Za-z0-9][A-Za-z0-9._-]*`. Uniqueness is
+/// enforced by the map's own deserializer (see `checks_map`).
+fn check_check_name(name: &str) -> Result<(), ManifestError> {
+    let ok = matches!(name.bytes().next(), Some(b) if b.is_ascii_alphanumeric())
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'));
+    if !ok {
+        return Err(ManifestError::Invalid(
+            "checks[] names must match [A-Za-z0-9][A-Za-z0-9._-]* (they surface in report lines and scratch dir names)",
+        ));
+    }
+    Ok(())
+}
+
+/// Serde helper: the checks map refuses a re-declared name — an
+/// authoring ambiguity is a named structural error, never a silent
+/// winner (the duplicate-alias discipline; serde_yml's plain map read
+/// is last-wins, so the refusal lives here, not in `validate`).
+mod checks_map {
+    use super::Check;
+    use serde::{Deserializer, de};
+    use std::collections::BTreeMap;
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<BTreeMap<String, Check>, D::Error> {
+        struct Visitor;
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = BTreeMap<String, Check>;
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a map of check name to check")
+            }
+            fn visit_map<A: de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut out = BTreeMap::new();
+                while let Some((name, check)) = map.next_entry::<String, Check>()? {
+                    if out.insert(name.clone(), check).is_some() {
+                        return Err(de::Error::custom(format_args!(
+                            "checks: duplicate check name {name:?} — an authoring ambiguity, never a silent winner"
+                        )));
+                    }
+                }
+                Ok(out)
+            }
+        }
+        d.deserialize_map(Visitor)
+    }
+}
+
+impl Check {
+    fn validate(&self, kind: PayloadKind) -> Result<(), ManifestError> {
+        match &self.entry {
+            Some(CheckEntry::SelfExe) => {
+                // §1.1: the reserved spelling names the runtime exe — a
+                // tebako artifact paired with the env image. On any
+                // other kind it names nothing.
+                if kind != PayloadKind::Runtime {
+                    return Err(ManifestError::Invalid(
+                        "checks[].entry: \"self\" is reserved for kind runtime (spec 26 §1.1)",
+                    ));
+                }
+            }
+            Some(CheckEntry::Path(p)) => {
+                check_abs_path(p, "checks[].entry must be absolute (inside the image)")?;
+                if p.split('/').any(|component| component == "..") {
+                    return Err(ManifestError::Invalid(
+                        "checks[].entry must not contain '..' components",
+                    ));
+                }
+            }
+            None => {
+                // STRUCTURAL (spec 26 §1.1 — the data-slice shape): no
+                // exec surface at all, so the exec-only keys are a named
+                // error and the only assertion channel is image_files.
+                if !self.argv.is_empty() {
+                    return Err(ManifestError::Invalid(
+                        "checks[].argv is exec-only — a structural check (no entry) declares none",
+                    ));
+                }
+                if self.fixtures.is_some() {
+                    return Err(ManifestError::Invalid(
+                        "checks[].fixtures is exec-only — a structural check (no entry) declares none",
+                    ));
+                }
+                if self.expect.image_files.is_empty() {
+                    return Err(ManifestError::Invalid(
+                        "a structural check (no entry) requires a non-empty expect.image_files — its only assertion channel (spec 26 §1.1)",
+                    ));
+                }
+            }
+        }
+        for arg in &self.argv {
+            if arg.matches("{scratch}").count() > 1 {
+                return Err(ManifestError::Invalid(
+                    "checks[].argv carries the {scratch} token at most once per entry",
+                ));
+            }
+        }
+        if let Some(fixtures) = &self.fixtures {
+            check_abs_path(
+                fixtures,
+                "checks[].fixtures must be absolute (inside the image)",
+            )?;
+            if fixtures.split('/').any(|component| component == "..") {
+                return Err(ManifestError::Invalid(
+                    "checks[].fixtures must not contain '..' components",
+                ));
+            }
+        }
+        for f in &self.expect.files {
+            if f.is_empty() || f.starts_with('/') || f.split('/').any(|c| c == "..") {
+                return Err(ManifestError::Invalid(
+                    "checks[].expect.files entries must be non-empty scratch-relative paths (never absolute, no '..' components)",
+                ));
+            }
+        }
+        if let Some(stdout) = &self.expect.stdout {
+            check_non_empty(
+                stdout,
+                "checks[].expect.stdout must not be empty (one regex the run's stdout must match)",
+            )?;
+        }
+        for f in &self.expect.image_files {
+            check_abs_path(
+                f,
+                "checks[].expect.image_files entries must be absolute (inside the image)",
+            )?;
+            if f.split('/').any(|component| component == "..") {
+                return Err(ManifestError::Invalid(
+                    "checks[].expect.image_files entries must not contain '..' components",
+                ));
+            }
+        }
+        for need in &self.needs {
+            check_non_empty(&need.path, "checks[].needs[].path must not be empty")?;
+            if let Some(why) = &need.why {
+                check_non_empty(why, "checks[].needs[].why must not be empty when present")?;
+            }
+        }
+        if let Some(requires) = &self.requires {
+            if requires.provides.is_empty() || requires.provides.iter().any(|p| p.is_empty()) {
+                return Err(ManifestError::Invalid(
+                    "checks[].requires.provides must be a non-empty list of non-empty capabilities",
+                ));
+            }
+        }
+        if let Some(timeout) = self.timeout {
+            if timeout == 0 {
+                return Err(ManifestError::Invalid(
+                    "checks[].timeout must be positive (seconds)",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
 /// The payload manifest (spec 03): IDENTITY + PROVIDES + DEPENDS on a
 /// common provenance/trust layer, carried at [`PAYLOAD_MANIFEST_PATH`].
 ///
@@ -1151,6 +1461,18 @@ pub struct PayloadManifest {
     /// construction). Absent = no declared aliases.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub library_aliases: Vec<LibraryAlias>,
+    /// The spec-26 §1 payload checks (additive — schema_minor 3; old
+    /// readers ignore the key, new readers enforce): the payload's own
+    /// acceptance contracts, check-name → [`Check`]. Any kind may
+    /// declare; a re-declared name is a named structural error (the
+    /// duplicate-alias discipline, never a silent winner). Absent = no
+    /// declared checks (an executable kind declaring none is a
+    /// press-time lint WARNING — spec 26 §1 — never a manifest error).
+    /// Note the map renders sorted on serialize; spec 26 §2's
+    /// declaration-order run rule is the ENGINE's read of the in-image
+    /// YAML mapping, not this model's storage order.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub checks: BTreeMap<String, Check>,
 }
 
 impl<'de> Deserialize<'de> for PayloadManifest {
@@ -1165,6 +1487,8 @@ impl<'de> Deserialize<'de> for PayloadManifest {
             materialize: Vec<String>,
             #[serde(default)]
             library_aliases: Vec<LibraryAlias>,
+            #[serde(default, deserialize_with = "checks_map::deserialize")]
+            checks: BTreeMap<String, Check>,
         }
         let raw = Raw::deserialize(d)?;
         let provides = match raw.identity.kind {
@@ -1191,6 +1515,7 @@ impl<'de> Deserialize<'de> for PayloadManifest {
             requires: raw.requires,
             materialize: raw.materialize,
             library_aliases: raw.library_aliases,
+            checks: raw.checks,
         })
     }
 }
@@ -1213,8 +1538,10 @@ impl PayloadManifest {
     /// kind ↔ provides binding, the locked capability truth tables,
     /// digest/keyid shapes, signing/encryption state consistency, the
     /// reserved-triplet rule, the absolute-path rules, the
-    /// materialize grammar (spec 22 §4), and the library_aliases
-    /// grammar (spec 03 §2.5 / spec 22 §2.1). Unknown keys are
+    /// materialize grammar (spec 22 §4), the library_aliases
+    /// grammar (spec 03 §2.5 / spec 22 §2.1), and the checks grammar
+    /// (spec 26 §1: name grammar, exec/structural split, `entry: self`
+    /// kind binding, path rules, platform filter). Unknown keys are
     /// tolerated everywhere (only `annotations` is lossless by contract).
     pub fn validate(&self) -> Result<(), ManifestError> {
         self.identity.validate()?;
@@ -1278,6 +1605,10 @@ impl PayloadManifest {
                     "library_aliases[] declares a duplicate name (case-insensitive) — an authoring ambiguity, never a silent winner",
                 ));
             }
+        }
+        for (name, check) in &self.checks {
+            check_check_name(name)?;
+            check.validate(self.identity.kind)?;
         }
         Ok(())
     }
@@ -1507,6 +1838,7 @@ mod tests {
             requires: Vec::new(),
             materialize: Vec::new(),
             library_aliases: Vec::new(),
+            checks: BTreeMap::new(),
         };
         assert!(matches!(m.validate(), Err(ManifestError::Invalid(_))));
     }
@@ -1773,6 +2105,362 @@ mod tests {
         assert!(
             matches!(err, ManifestError::Invalid(m) if m.contains("duplicate")),
             "{err}"
+        );
+    }
+
+    /// A minimal kind-app document with `extra` appended verbatim (the
+    /// checks tests' vehicle).
+    fn minimal_app_yaml(extra: &str) -> String {
+        format!(
+            "identity:\n  schema_version: 1\n  kind: app\n  name: x\n  version: 1.0.0\n\
+             \x20 producer: {{tool: t, tool_version: \"1\"}}\n  created: now\n\
+             \x20 digest: {{tree_hash: \"sha256:{}\", blob_sha256: {}}}\n\
+             \x20 signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+             provides:\n  entrypoints: [{{name: x, path: /x}}]\n  platforms: universal\n  capabilities: {{exec: true, read: true}}\n{extra}",
+            sha(1),
+            sha(2),
+        )
+    }
+
+    /// A minimal kind-runtime document with `extra` appended verbatim.
+    fn minimal_runtime_yaml(extra: &str) -> String {
+        format!(
+            "identity:\n  schema_version: 1\n  kind: runtime\n  name: x\n  version: 4.0.6\n\
+             \x20 producer: {{tool: t, tool_version: \"1\"}}\n  created: now\n\
+             \x20 digest: {{tree_hash: \"sha256:{}\", blob_sha256: {}}}\n\
+             \x20 signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+             provides:\n  provides: {{engine: ruby, version: 4.0.6, abi_line: \"4.0\", platform: aarch64-macos}}\n\
+             \x20 built_from: {{src_sha256: {}, patch_set: v0.2.8}}\n  capabilities: {{exec: true, read: true, runtime: true}}\n{extra}",
+            sha(1),
+            sha(2),
+            sha(3),
+        )
+    }
+
+    #[test]
+    fn checks_default_empty_and_round_trip() {
+        // spec 26 §1 (schema_minor 3): the additive `checks:` key —
+        // the payload's own acceptance contracts, declared in-image.
+        let bare = PayloadManifest::from_yaml(&minimal_data_yaml("")).unwrap();
+        assert!(bare.checks.is_empty());
+        // An absent key never serializes (additive on the wire: old
+        // readers see the document they always saw).
+        assert!(!bare.to_yaml().unwrap().contains("checks"));
+
+        // A full EXEC check (the spec 26 §4 metanorma shape) round-trips.
+        let with = PayloadManifest::from_yaml(&minimal_app_yaml(
+            "checks:\n  html-xml:\n    entry: /bin/metanorma\n\
+             \x20   argv: [\"--type\", \"iso\", \"{scratch}/test-iso.adoc\", \"--agree-to-terms\"]\n\
+             \x20   fixtures: /__tpkg__/check/html-xml\n\
+             \x20   expect: {exit: 0, files: [test-iso.xml, test-iso.html], stdout: '\"ok\":1'}\n\
+             \x20   needs: [{path: /opt/vendor-tool, access: ro, when: [macos], why: \"probes its install root\"}]\n\
+             \x20   requires: {provides: [jvm]}\n\
+             \x20   when: [windows, macos, linux]\n\
+             \x20   timeout: 180\n",
+        ))
+        .unwrap();
+        let check = &with.checks["html-xml"];
+        assert_eq!(
+            check.entry,
+            Some(CheckEntry::Path("/bin/metanorma".to_string()))
+        );
+        assert_eq!(
+            check.argv,
+            vec!["--type", "iso", "{scratch}/test-iso.adoc", "--agree-to-terms"]
+        );
+        assert_eq!(
+            check.fixtures.as_deref(),
+            Some("/__tpkg__/check/html-xml")
+        );
+        assert_eq!(check.expect.exit, 0);
+        assert_eq!(check.expect.files, vec!["test-iso.xml", "test-iso.html"]);
+        assert_eq!(check.expect.stdout.as_deref(), Some("\"ok\":1"));
+        assert_eq!(
+            check.needs,
+            vec![CheckNeed {
+                path: "/opt/vendor-tool".to_string(),
+                access: crate::jail::JailAccess::Ro,
+                when: vec![CheckPlatform::Macos],
+                why: Some("probes its install root".to_string()),
+            }]
+        );
+        assert_eq!(
+            check.requires,
+            Some(CheckRequires {
+                provides: vec!["jvm".to_string()]
+            })
+        );
+        assert_eq!(
+            check.when,
+            vec![
+                CheckPlatform::Windows,
+                CheckPlatform::Macos,
+                CheckPlatform::Linux
+            ]
+        );
+        assert_eq!(check.timeout, Some(180));
+        let back = PayloadManifest::from_yaml(&with.to_yaml().unwrap()).unwrap();
+        assert_eq!(back, with);
+
+        // A STRUCTURAL check (no entry — the data-slice shape, spec 26
+        // §1.1) round-trips; the all-default expect stays absent on the
+        // wire.
+        let structural = PayloadManifest::from_yaml(&minimal_data_yaml(
+            "checks:\n  layout:\n    expect:\n      image_files: [/templates/org/cover.adoc, /templates/org/header.html]\n",
+        ))
+        .unwrap();
+        let check = &structural.checks["layout"];
+        assert_eq!(check.entry, None);
+        assert_eq!(
+            check.expect.image_files,
+            vec!["/templates/org/cover.adoc", "/templates/org/header.html"]
+        );
+        let back = PayloadManifest::from_yaml(&structural.to_yaml().unwrap()).unwrap();
+        assert_eq!(back, structural);
+        // An exec check asserting only the default exit carries no
+        // expect block on the wire at all.
+        let smoke = PayloadManifest::from_yaml(&minimal_runtime_yaml(
+            "checks:\n  boot:\n    entry: self\n    argv: [\"-e\", \"puts 1\"]\n",
+        ))
+        .unwrap();
+        assert!(!smoke.to_yaml().unwrap().contains("expect"));
+    }
+
+    #[test]
+    fn checks_entry_self_is_runtime_only() {
+        // spec 26 §1.1: `self` names the runtime exe — legal on kind
+        // runtime only (the ruby runtime's boot-and-stdlib shape).
+        let ok = PayloadManifest::from_yaml(&minimal_runtime_yaml(
+            "checks:\n  boot-and-stdlib:\n    entry: self\n\
+             \x20   argv: [\"-e\", 'require \"json\"; puts JSON.generate({ok: 1})']\n\
+             \x20   expect: {exit: 0, stdout: '\"ok\":1'}\n    timeout: 60\n",
+        ))
+        .unwrap();
+        assert_eq!(
+            ok.checks["boot-and-stdlib"].entry,
+            Some(CheckEntry::SelfExe)
+        );
+        // On any other kind the reserved spelling names nothing — a
+        // named validation error.
+        let err = PayloadManifest::from_yaml(&minimal_app_yaml(
+            "checks:\n  c:\n    entry: self\n",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("self")),
+            "{err}"
+        );
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml(
+            "checks:\n  c:\n    entry: self\n    expect: {image_files: [/x]}\n",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("self")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn checks_structural_rejects_exec_only_keys() {
+        // spec 26 §1.1 (MECE — one key decides the shape): a check with
+        // no entry is structural BY GRAMMAR; argv/fixtures are exec-only.
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml(
+            "checks:\n  layout:\n    argv: [\"-e\", \"puts 1\"]\n    expect: {image_files: [/x]}\n",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("argv")),
+            "{err}"
+        );
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml(
+            "checks:\n  layout:\n    fixtures: /x\n    expect: {image_files: [/x]}\n",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("fixtures")),
+            "{err}"
+        );
+        // A structural check with no image_files asserts nothing at all.
+        let err = PayloadManifest::from_yaml(&minimal_data_yaml("checks:\n  layout: {}\n"))
+            .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("image_files")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn checks_path_rules() {
+        // expect.files are scratch-RELATIVE: never absolute, no '..'.
+        for bad in ["/abs/out.xml", "../escape.xml", "a/../../escape.xml"] {
+            let err = PayloadManifest::from_yaml(&minimal_app_yaml(&format!(
+                "checks:\n  c:\n    entry: /bin/x\n    expect: {{files: ['{bad}']}}\n"
+            )))
+            .unwrap_err();
+            assert!(
+                matches!(err, ManifestError::Invalid(m) if m.contains("files")),
+                "{bad}: {err}"
+            );
+        }
+        // expect.image_files and fixtures are in-image ABSOLUTE, no '..'.
+        for (key, bad) in [("image_files", "rel/x.adoc"), ("image_files", "/a/../b.adoc")] {
+            let err = PayloadManifest::from_yaml(&minimal_data_yaml(&format!(
+                "checks:\n  layout:\n    expect: {{{key}: ['{bad}']}}\n"
+            )))
+            .unwrap_err();
+            assert!(
+                matches!(err, ManifestError::Invalid(m) if m.contains("image_files")),
+                "{bad}: {err}"
+            );
+        }
+        for bad in ["rel/fixtures", "/a/../fixtures"] {
+            let err = PayloadManifest::from_yaml(&minimal_app_yaml(&format!(
+                "checks:\n  c:\n    entry: /bin/x\n    fixtures: '{bad}'\n"
+            )))
+            .unwrap_err();
+            assert!(
+                matches!(err, ManifestError::Invalid(m) if m.contains("fixtures")),
+                "{bad}: {err}"
+            );
+        }
+        // …and entry itself is an in-image absolute path.
+        for bad in ["bin/x", "/a/../x"] {
+            let err = PayloadManifest::from_yaml(&minimal_app_yaml(&format!(
+                "checks:\n  c:\n    entry: '{bad}'\n"
+            )))
+            .unwrap_err();
+            assert!(
+                matches!(err, ManifestError::Invalid(m) if m.contains("entry")),
+                "{bad}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn checks_when_values_come_from_the_platform_family_set() {
+        // A value outside windows/macos/linux is a named structural
+        // error (serde names the variant set).
+        let err = PayloadManifest::from_yaml(&minimal_app_yaml(
+            "checks:\n  c:\n    entry: /bin/x\n    when: [solaris]\n",
+        ))
+        .unwrap_err();
+        assert!(matches!(err, ManifestError::Yaml(_)), "{err}");
+        // The full set round-trips in declaration order.
+        let ok = PayloadManifest::from_yaml(&minimal_app_yaml(
+            "checks:\n  c:\n    entry: /bin/x\n    when: [linux, windows]\n",
+        ))
+        .unwrap();
+        assert_eq!(
+            ok.checks["c"].when,
+            vec![CheckPlatform::Linux, CheckPlatform::Windows]
+        );
+    }
+
+    #[test]
+    fn checks_name_grammar() {
+        // Names surface in report lines and scratch dir names:
+        // [A-Za-z0-9][A-Za-z0-9._-]*.
+        for good in ["html-xml", "boot.v2_ok", "9lives"] {
+            PayloadManifest::from_yaml(&minimal_app_yaml(&format!(
+                "checks:\n  {good}:\n    entry: /bin/x\n"
+            )))
+            .unwrap_or_else(|e| panic!("{good:?} should parse: {e}"));
+        }
+        for bad in ["-lead", ".lead", "has space", "has/slash"] {
+            let err = PayloadManifest::from_yaml(&minimal_app_yaml(&format!(
+                "checks:\n  '{bad}':\n    entry: /bin/x\n"
+            )))
+            .unwrap_err();
+            assert!(
+                matches!(err, ManifestError::Invalid(m) if m.contains("checks[] names")),
+                "{bad}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn checks_timeout_stdout_requires_rules() {
+        // timeout is positive seconds.
+        let err = PayloadManifest::from_yaml(&minimal_app_yaml(
+            "checks:\n  c:\n    entry: /bin/x\n    timeout: 0\n",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("timeout")),
+            "{err}"
+        );
+        // stdout is one non-empty regex (carried uncompiled — the engine
+        // compiles it; tpkg has no regex dependency by design).
+        let err = PayloadManifest::from_yaml(&minimal_app_yaml(
+            "checks:\n  c:\n    entry: /bin/x\n    expect: {stdout: \"\"}\n",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("stdout")),
+            "{err}"
+        );
+        // requires.provides is a non-empty list of non-empty names.
+        for bad in ["{provides: []}", "{provides: [\"\"]}"] {
+            let err = PayloadManifest::from_yaml(&minimal_app_yaml(&format!(
+                "checks:\n  c:\n    entry: /bin/x\n    requires: {bad}\n"
+            )))
+            .unwrap_err();
+            assert!(
+                matches!(err, ManifestError::Invalid(m) if m.contains("provides")),
+                "{bad}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn checks_scratch_token_at_most_once_per_arg() {
+        // `{scratch}` is the ONE argv substitution (spec 26 §1): at most
+        // one occurrence per entry — one per arg across several args is
+        // fine; twice in one arg is a named error.
+        let ok = PayloadManifest::from_yaml(&minimal_app_yaml(
+            "checks:\n  c:\n    entry: /bin/x\n    argv: [\"{scratch}/a.adoc\", \"--out\", \"{scratch}/b\"]\n",
+        ))
+        .unwrap();
+        assert_eq!(ok.checks["c"].argv.len(), 3);
+        let err = PayloadManifest::from_yaml(&minimal_app_yaml(
+            "checks:\n  c:\n    entry: /bin/x\n    argv: [\"{scratch}/a:{scratch}/b\"]\n",
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ManifestError::Invalid(m) if m.contains("{scratch}")),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn checks_tolerate_unknown_keys() {
+        // The crate's forward-compat discipline (spec 18 §3's
+        // unknown-field rule) applies INSIDE the block too: a key the
+        // model does not own changes nothing it does. NOTE: spec 26 §1's
+        // "unknown keys a named error" mis-describes the spec-03
+        // discipline — toleration is what makes the additive MINOR
+        // mechanism work (a schema_minor 4 field must not break a
+        // schema_minor 3 reader).
+        let m = PayloadManifest::from_yaml(&minimal_app_yaml(
+            "checks:\n  c:\n    entry: /bin/x\n    future_key: {x: 1}\n",
+        ))
+        .expect("unknown key inside a check tolerated");
+        assert!(m.checks.contains_key("c"));
+    }
+
+    #[test]
+    fn checks_duplicate_names_are_a_named_error() {
+        // A re-declared check name is an authoring ambiguity — the map's
+        // deserializer refuses it (never a silent winner; serde_yml's
+        // plain map read would be last-wins, cf. the duplicate-alias rule).
+        let err = PayloadManifest::from_yaml(&minimal_app_yaml(
+            "checks:\n  c:\n    entry: /bin/x\n  c:\n    entry: /bin/y\n",
+        ))
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, ManifestError::Yaml(_)) && msg.contains("duplicate check name"),
+            "{msg}"
         );
     }
 }

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -1293,7 +1293,7 @@ fn check_check_name(name: &str) -> Result<(), ManifestError> {
 /// is last-wins, so the refusal lives here, not in `validate`).
 mod checks_map {
     use super::Check;
-    use serde::{Deserializer, de};
+    use serde::{de, Deserializer};
     use std::collections::BTreeMap;
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
@@ -1305,10 +1305,7 @@ mod checks_map {
             fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 f.write_str("a map of check name to check")
             }
-            fn visit_map<A: de::MapAccess<'de>>(
-                self,
-                mut map: A,
-            ) -> Result<Self::Value, A::Error> {
+            fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
                 let mut out = BTreeMap::new();
                 while let Some((name, check)) = map.next_entry::<String, Check>()? {
                     if out.insert(name.clone(), check).is_some() {
@@ -2166,12 +2163,14 @@ mod tests {
         );
         assert_eq!(
             check.argv,
-            vec!["--type", "iso", "{scratch}/test-iso.adoc", "--agree-to-terms"]
+            vec![
+                "--type",
+                "iso",
+                "{scratch}/test-iso.adoc",
+                "--agree-to-terms"
+            ]
         );
-        assert_eq!(
-            check.fixtures.as_deref(),
-            Some("/__tpkg__/check/html-xml")
-        );
+        assert_eq!(check.fixtures.as_deref(), Some("/__tpkg__/check/html-xml"));
         assert_eq!(check.expect.exit, 0);
         assert_eq!(check.expect.files, vec!["test-iso.xml", "test-iso.html"]);
         assert_eq!(check.expect.stdout.as_deref(), Some("\"ok\":1"));
@@ -2242,10 +2241,8 @@ mod tests {
         );
         // On any other kind the reserved spelling names nothing — a
         // named validation error.
-        let err = PayloadManifest::from_yaml(&minimal_app_yaml(
-            "checks:\n  c:\n    entry: self\n",
-        ))
-        .unwrap_err();
+        let err = PayloadManifest::from_yaml(&minimal_app_yaml("checks:\n  c:\n    entry: self\n"))
+            .unwrap_err();
         assert!(
             matches!(err, ManifestError::Invalid(m) if m.contains("self")),
             "{err}"
@@ -2281,8 +2278,8 @@ mod tests {
             "{err}"
         );
         // A structural check with no image_files asserts nothing at all.
-        let err = PayloadManifest::from_yaml(&minimal_data_yaml("checks:\n  layout: {}\n"))
-            .unwrap_err();
+        let err =
+            PayloadManifest::from_yaml(&minimal_data_yaml("checks:\n  layout: {}\n")).unwrap_err();
         assert!(
             matches!(err, ManifestError::Invalid(m) if m.contains("image_files")),
             "{err}"
@@ -2303,7 +2300,10 @@ mod tests {
             );
         }
         // expect.image_files and fixtures are in-image ABSOLUTE, no '..'.
-        for (key, bad) in [("image_files", "rel/x.adoc"), ("image_files", "/a/../b.adoc")] {
+        for (key, bad) in [
+            ("image_files", "rel/x.adoc"),
+            ("image_files", "/a/../b.adoc"),
+        ] {
             let err = PayloadManifest::from_yaml(&minimal_data_yaml(&format!(
                 "checks:\n  layout:\n    expect: {{{key}: ['{bad}']}}\n"
             )))

--- a/crates/tpkg/tests/manifest.rs
+++ b/crates/tpkg/tests/manifest.rs
@@ -302,6 +302,43 @@ fn library_aliases_key_is_schema_legal() {
 }
 
 #[test]
+fn checks_key_is_schema_legal() {
+    // spec 26 §1 (schema_minor 3): the additive `checks:` key — the
+    // versioned JSON Schema admits it and the model round-trips it.
+    // EXEC form (the runtime slice's boot-and-stdlib smoke, §1.1):
+    let exec = "identity:\n  schema_version: 1\n  kind: runtime\n  name: tebako-runtime-ruby\n  version: 4.0.6\n\
+        \x20 producer: {tool: tebako-cli, tool_version: 0.16.0}\n  created: \"2026-08-19T00:00:00Z\"\n\
+        \x20 digest:\n    tree_hash: \"sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\"\n\
+        \x20   blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1\n\
+        \x20 signing: {state: unsigned}\n  encryption: {state: none}\n\
+        provides:\n  provides: {engine: ruby, version: 4.0.6, abi_line: \"4.0\", platform: aarch64-macos}\n\
+        \x20 built_from: {src_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1, patch_set: v0.2.8}\n\
+        \x20 capabilities: {exec: true, read: true, runtime: true}\n\
+        checks:\n  boot-and-stdlib:\n    entry: self\n\
+        \x20   argv: [\"-e\", 'require \"json\"; puts JSON.generate({ok: 1})']\n\
+        \x20   expect: {exit: 0, stdout: '\"ok\":1'}\n    timeout: 60\n";
+    // STRUCTURAL form (the data slice's layout assertions, §1.1):
+    let structural = "identity:\n  schema_version: 1\n  kind: data\n  name: acme-templates\n  version: \"3\"\n\
+        \x20 producer: {tool: tebako-cli, tool_version: 0.16.0}\n  created: \"2026-08-19T00:00:00Z\"\n\
+        \x20 digest:\n    tree_hash: \"sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\"\n\
+        \x20   blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1\n\
+        \x20 signing: {state: unsigned}\n  encryption: {state: none}\n\
+        provides:\n  mount_semantics: {suggested: /templates/acme}\n  capabilities: {exec: false, read: true}\n\
+        checks:\n  layout:\n    expect:\n      image_files: [/templates/acme/cover.adoc, /templates/acme/header.html]\n";
+    let validator = schema_validator();
+    for (text, what) in [(exec, "exec"), (structural, "structural")] {
+        let m = PayloadManifest::from_yaml(text).unwrap_or_else(|e| panic!("{what} checks: {e}"));
+        assert_eq!(m.checks.len(), 1);
+        // …and the schema agrees (MECE cross-check).
+        validator
+            .validate(&yaml_text_to_json(text))
+            .unwrap_or_else(|e| panic!("{what} checks against the JSON schema: {e}"));
+        let back = PayloadManifest::from_yaml(&m.to_yaml().unwrap()).unwrap();
+        assert_eq!(back, m, "{what} checks round-trip");
+    }
+}
+
+#[test]
 fn unknown_keys_are_tolerated_annotations_preserved() {
     let text = read(&fixture_path("data"));
     let with_extras = format!(
@@ -324,7 +361,7 @@ fn unknown_keys_are_tolerated_annotations_preserved() {
 #[test]
 fn model_and_schema_agree_on_rejections() {
     let validator = schema_validator();
-    let cases: [(&str, &str); 4] = [
+    let cases: [(&str, &str); 6] = [
         // kind app with a data-shaped provides
         (
             "identity: {schema_version: 1, kind: app, name: x, version: \"1\", \
@@ -366,6 +403,30 @@ fn model_and_schema_agree_on_rejections() {
              requires: [{kind: toolkit, name: gtk, constraint: \">= 3\", \
              triplets: [aarch64-windows-ucrt]}]\n",
             "reserved triplet",
+        ),
+        // a check name outside the [A-Za-z0-9][A-Za-z0-9._-]* grammar (spec 26 §1)
+        (
+            "identity: {schema_version: 1, kind: app, name: x, version: \"1\", \
+             producer: {tool: t, tool_version: \"1\"}, created: now, \
+             digest: {tree_hash: \"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\", \
+             blob_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}, \
+             signing: {state: unsigned}, encryption: {state: none}}\n\
+             provides: {entrypoints: [{name: x, path: /x}], platforms: universal, \
+             capabilities: {exec: true, read: true}}\n\
+             checks: {\"-lead\": {entry: /bin/x}}\n",
+            "bad check name",
+        ),
+        // a when value outside the windows/macos/linux family set
+        (
+            "identity: {schema_version: 1, kind: app, name: x, version: \"1\", \
+             producer: {tool: t, tool_version: \"1\"}, created: now, \
+             digest: {tree_hash: \"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\", \
+             blob_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}, \
+             signing: {state: unsigned}, encryption: {state: none}}\n\
+             provides: {entrypoints: [{name: x, path: /x}], platforms: universal, \
+             capabilities: {exec: true, read: true}}\n\
+             checks: {c: {entry: /bin/x, when: [solaris]}}\n",
+            "bad when value",
         ),
     ];
     for (text, what) in cases {

--- a/crates/tpkg/tests/manifest_props.rs
+++ b/crates/tpkg/tests/manifest_props.rs
@@ -127,13 +127,25 @@ fn arb_check(kind: PayloadKind) -> impl Strategy<Value = Check> {
         prop::collection::vec(arb_path(), 0..=1),
         prop::collection::vec(need, 0..=1),
         prop::option::of(
-            prop::collection::vec(arb_name(), 1..=2).prop_map(|provides| CheckRequires { provides }),
+            prop::collection::vec(arb_name(), 1..=2)
+                .prop_map(|provides| CheckRequires { provides }),
         ),
         prop::collection::vec(platform, 0..=2),
         prop::option::of(1u64..=600),
     )
         .prop_map(
-            |(entry, argv, fixtures, files, stdout, image_files, needs, requires, when, timeout)| {
+            |(
+                entry,
+                argv,
+                fixtures,
+                files,
+                stdout,
+                image_files,
+                needs,
+                requires,
+                when,
+                timeout,
+            )| {
                 Check {
                     entry: Some(entry),
                     argv,
@@ -392,20 +404,22 @@ fn arb_manifest() -> impl Strategy<Value = PayloadManifest> {
             prop::collection::btree_map(arb_name(), arb_check(kind), 0..=2),
         )
     })
-    .prop_map(|(identity, provides, requires, materialize, aliases, checks)| {
-        let mut library_aliases = aliases;
-        for (i, a) in library_aliases.iter_mut().enumerate() {
-            a.name = format!("{}{i}", a.name);
-        }
-        PayloadManifest {
-            identity,
-            provides,
-            requires,
-            materialize,
-            library_aliases,
-            checks,
-        }
-    })
+    .prop_map(
+        |(identity, provides, requires, materialize, aliases, checks)| {
+            let mut library_aliases = aliases;
+            for (i, a) in library_aliases.iter_mut().enumerate() {
+                a.name = format!("{}{i}", a.name);
+            }
+            PayloadManifest {
+                identity,
+                provides,
+                requires,
+                materialize,
+                library_aliases,
+                checks,
+            }
+        },
+    )
 }
 
 proptest! {

--- a/crates/tpkg/tests/manifest_props.rs
+++ b/crates/tpkg/tests/manifest_props.rs
@@ -72,6 +72,103 @@ fn arb_alias() -> impl Strategy<Value = LibraryAlias> {
     (arb_name(), arb_path()).prop_map(|(name, path)| LibraryAlias { name, path })
 }
 
+/// spec 26 §1: check argv entries carry the `{scratch}` token at most
+/// once each (the engine substitutes; the model only carries).
+fn arb_argv() -> impl Strategy<Value = Vec<String>> {
+    let arg = prop_oneof![
+        arb_name(),
+        arb_name().prop_map(|n| format!("{{scratch}}/{n}")),
+    ];
+    prop::collection::vec(arg, 0..=4)
+}
+
+/// Scratch-relative paths (no leading '/', no '..' components).
+fn arb_rel_files() -> impl Strategy<Value = Vec<String>> {
+    prop::collection::vec(
+        prop::collection::vec(arb_name(), 1..=2).prop_map(|segs| segs.join("/")),
+        0..=2,
+    )
+}
+
+/// spec 26 §1 (schema_minor 3): a valid check for the kind — exec
+/// checks (entry present; `self` only on runtime) or structural checks
+/// (no entry ⇒ no argv/fixtures; a non-empty image_files channel).
+fn arb_check(kind: PayloadKind) -> impl Strategy<Value = Check> {
+    let entry = match kind {
+        PayloadKind::Runtime => prop_oneof![
+            Just(CheckEntry::SelfExe),
+            arb_path().prop_map(CheckEntry::Path),
+        ]
+        .boxed(),
+        _ => arb_path().prop_map(CheckEntry::Path).boxed(),
+    };
+    let need = (
+        arb_path(),
+        prop::sample::select(vec![JailAccess::Ro, JailAccess::Rw]),
+        arb_name(),
+    )
+        .prop_map(|(path, access, why)| CheckNeed {
+            path,
+            access,
+            when: Vec::new(),
+            why: Some(why),
+        });
+    let platform = prop::sample::select(vec![
+        CheckPlatform::Windows,
+        CheckPlatform::Macos,
+        CheckPlatform::Linux,
+    ]);
+    let exec = (
+        entry,
+        arb_argv(),
+        prop::option::of(arb_path()),
+        arb_rel_files(),
+        prop::option::of(arb_name()),
+        prop::collection::vec(arb_path(), 0..=1),
+        prop::collection::vec(need, 0..=1),
+        prop::option::of(
+            prop::collection::vec(arb_name(), 1..=2).prop_map(|provides| CheckRequires { provides }),
+        ),
+        prop::collection::vec(platform, 0..=2),
+        prop::option::of(1u64..=600),
+    )
+        .prop_map(
+            |(entry, argv, fixtures, files, stdout, image_files, needs, requires, when, timeout)| {
+                Check {
+                    entry: Some(entry),
+                    argv,
+                    fixtures,
+                    expect: CheckExpect {
+                        exit: 0,
+                        files,
+                        stdout,
+                        image_files,
+                    },
+                    needs,
+                    requires,
+                    when,
+                    timeout,
+                }
+            },
+        );
+    let structural = prop::collection::vec(arb_path(), 1..=2).prop_map(|image_files| Check {
+        entry: None,
+        argv: Vec::new(),
+        fixtures: None,
+        expect: CheckExpect {
+            exit: 0,
+            files: Vec::new(),
+            stdout: None,
+            image_files,
+        },
+        needs: Vec::new(),
+        requires: None,
+        when: Vec::new(),
+        timeout: None,
+    });
+    prop_oneof![3 => exec.boxed(), 1 => structural.boxed()]
+}
+
 fn arb_signing() -> impl Strategy<Value = Signing> {
     prop_oneof![
         Just(Signing {
@@ -290,9 +387,12 @@ fn arb_manifest() -> impl Strategy<Value = PayloadManifest> {
             prop::collection::vec(arb_path(), 0..=2),
             // spec 03 §2.5: bare names, unique per image (indexed).
             prop::collection::vec(arb_alias(), 0..=2),
+            // spec 26 §1: checks, keyed by name (arb_name satisfies the
+            // check-name grammar).
+            prop::collection::btree_map(arb_name(), arb_check(kind), 0..=2),
         )
     })
-    .prop_map(|(identity, provides, requires, materialize, aliases)| {
+    .prop_map(|(identity, provides, requires, materialize, aliases, checks)| {
         let mut library_aliases = aliases;
         for (i, a) in library_aliases.iter_mut().enumerate() {
             a.name = format!("{}{i}", a.name);
@@ -303,6 +403,7 @@ fn arb_manifest() -> impl Strategy<Value = PayloadManifest> {
             requires,
             materialize,
             library_aliases,
+            checks,
         }
     })
 }

--- a/docs/spec/03-payload-manifest.md
+++ b/docs/spec/03-payload-manifest.md
@@ -174,6 +174,36 @@ winner. No platform filter: native images are triplet-bound (§3), so an
 alias is platform surface by construction. The grammar is registered in
 `docs/spec/schemas/payload-manifest.yaml`.
 
+### 2.6 CHECKS (`checks:`, additive — schema_minor 3)
+
+```yaml
+checks:
+  html-xml:                        # the check name — [A-Za-z0-9][A-Za-z0-9._-]*
+    entry: /bin/metanorma          # in-image executable; "self" on kind
+                                   # runtime only (the runtime exe itself)
+    argv: ["--type", "iso", "{scratch}/test-iso.adoc", "--agree-to-terms"]
+    fixtures: /__tpkg__/check/html-xml   # exec-only; CONTENTS land at the
+                                         # host scratch root
+    expect: {exit: 0, files: ["test-iso.xml", "test-iso.html"]}
+    timeout: 180
+  layout:                          # no entry ⇒ STRUCTURAL (the data-slice
+    expect:                        # shape): the engine mounts and asserts
+      image_files: [/templates/org/cover.adoc]   # in-image, exist + non-empty
+```
+
+A top-level map (any kind may declare checks; old readers ignore it under
+the unknown-field rule) naming the payload's own acceptance contracts —
+"given my declared needs, I do my one real thing". ONE key decides the
+shape (MECE, never a `kind:` flag): `entry` present ⇒ an exec check;
+absent ⇒ a structural check, which declares no `argv`/`fixtures` and
+asserts via `expect.image_files`. `expect.files` are scratch-relative
+existence + non-empty assertions; byte-golden assertions do not exist by
+construction. A malformed block is a named validation error at press /
+`tfs validate` (exit 65), never discovered at run time. The semantics —
+the engine, the three moments, SKIP/FAIL discipline — are spec 26; the
+grammar is registered in
+`docs/spec/schemas/payload-manifest.yaml`.
+
 ## 3. Platform axis (locked, vcpkg-triplet form)
 
 `platforms` is EITHER `"universal"` (pure-ruby/data) OR an explicit list:

--- a/docs/spec/schemas/payload-manifest.yaml
+++ b/docs/spec/schemas/payload-manifest.yaml
@@ -18,7 +18,7 @@
 
 schema: payload-manifest
 schema_version: 1 # MAJOR — breaking changes only
-schema_minor: 2 # MINOR — additive changes only (1: materialize, 2: library_aliases)
+schema_minor: 3 # MINOR — additive changes only (1: materialize, 2: library_aliases, 3: checks)
 status: normative
 owner: crates/tpkg (the model) in tamatebako/tebako
 edge: C7 (driver → payload images), C10 (executable payload → runtime), C11 (feature payload → consumers)
@@ -265,6 +265,49 @@ grammar:
       may declare; no platform filter (native images are triplet-bound,
       so an alias is platform surface by construction). Old readers
       ignore the key (unknown-field rule).
+  checks:
+    type: map of check name → check
+    required: false
+    since: schema_minor 3
+    key: "[A-Za-z0-9][A-Za-z0-9._-]* — names surface in report lines and scratch dir names; unique by the map's construction"
+    entry:
+      entry: {type: "absolute in-image path | the reserved spelling \"self\"", required: false, notes: "PRESENT ⇒ an exec check; ABSENT ⇒ a structural check (MECE — one key decides the shape, never a kind flag). \"self\" is kind-runtime only (spec 26 §1.1: the runtime exe itself, env image mounted)"}
+      argv: {type: list of string, required: false, notes: "exec-only. `{scratch}` (the per-run host scratch dir) at most once per entry; every other spelling is literal passthrough — the engine substitutes, the model carries"}
+      fixtures: {type: absolute in-image path, required: false, notes: "exec-only. The dir whose CONTENTS land at the HOST scratch root — never VFS-spelled (spec 26 §1)"}
+      expect:
+        type: map
+        required: false
+        notes: "absent = the default {exit: 0}; byte-golden assertions do not exist by construction"
+        fields:
+          exit: {type: int, required: false, notes: "default 0"}
+          files: {type: list of scratch-relative paths, required: false, notes: "existence + non-empty after the run; never absolute, no '..' components"}
+          stdout: {type: string, required: false, notes: "one regex the run's stdout must match; carried uncompiled, the engine compiles it"}
+          image_files: {type: list of absolute in-image paths, required: false, notes: "existence + non-empty; the structural check's assertion channel — a structural check requires a non-empty image_files"}
+      needs:
+        type: list
+        required: false
+        notes: additive host needs for the check run ONLY (rare) — a minimal mirror of the spec 23 §2 D1 entry grammar
+        entry:
+          path: {type: string, required: true, notes: absolute host path or a spec 23 §2 symbolic atom}
+          access: {type: enum, values: [ro, rw], required: true}
+          when: {type: "list of enum [windows, macos, linux]", required: false}
+          why: {type: string, required: false}
+      requires:
+        type: map
+        required: false
+        notes: "composition prerequisites; unmet ⇒ SKIP (loud, the capability named), never FAIL (spec 26 §2)"
+        fields:
+          provides: {type: list of string, required: true, notes: non-empty}
+      when: {type: "list of enum [windows, macos, linux]", required: false, notes: "the OS-family axis, NOT the spec 03 §3 triplet axis; absent = every platform"}
+      timeout: {type: int, required: false, notes: positive seconds; expiry is a FAIL}
+    notes: >-
+      spec 26 §1 — the payload's own acceptance contracts, declared
+      in-image: "given my declared needs, I do my one real thing". Any
+      kind may declare checks (exec checks on executable/runtime slices —
+      the latter with entry: self — structural checks on data slices).
+      A malformed block is a named error at press/`tfs validate` (exit
+      65), never discovered at run time (spec 26 §7). Old readers ignore
+      the key (unknown-field rule).
 
 refusals:
   - case: identity.schema_version missing
@@ -285,5 +328,11 @@ refusals:
     behavior: the manifest lies — boot fails with a named error (exit 65), never a skipped entry
   - case: a duplicate alias name within one image, or one alias name declared by two co-mounted images (schema_minor 2)
     behavior: authoring ambiguity — a named error (parse-time, resp. boot-time exit 65), never a silent winner
+  - case: "entry: self on a kind other than runtime (schema_minor 3)"
+    behavior: named validation error at parse (exit 65) — the reserved spelling names the runtime exe, spec 26 §1.1
+  - case: a structural check (no entry) declaring argv/fixtures, or asserting no image_files (schema_minor 3)
+    behavior: named validation error at parse (exit 65) — exec-only keys on a structural check are a grammar violation
+  - case: a malformed checks block otherwise (bad name grammar, relative entry, absolute expect.files, '..' components, non-positive timeout, a when value outside windows/macos/linux) (schema_minor 3)
+    behavior: named validation error at press/`tfs validate` (exit 65), never discovered at run time (spec 26 §7)
 
 deprecated: [] # no field is in a deprecation window

--- a/schema/tpkg-manifest-v1.schema.json
+++ b/schema/tpkg-manifest-v1.schema.json
@@ -27,6 +27,12 @@
         }
       },
       "description": "spec 22 §2.1 windows Class L bare-name rule (payload-manifest schema_minor 2): the ONLY bare library names resolving to the image's own files — a bare name matching no entry is a host reference and passes through untouched. `name` is the exact bare spelling a loader call presents (the no-separator/no-drive refusal is semantic, the tpkg validator); `path` is the absolute in-image file it resolves to. Any kind may declare; old readers ignore the key."
+    },
+    "checks": {
+      "type": "object",
+      "propertyNames": { "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$" },
+      "additionalProperties": { "$ref": "#/$defs/check" },
+      "description": "spec 26 §1 (payload-manifest schema_minor 3): the payload's own acceptance contracts — check name → check. A check WITH `entry` is an exec check; WITHOUT `entry` it is structural (the data-slice shape: asserts expect.image_files, no exec surface). The reserved entry spelling \"self\" is kind-runtime only, the exec/structural key split, the '..' refusals and the {scratch} arity are semantic (the tpkg validator); only shape is checked here. Any kind may declare; old readers ignore the key."
     }
   },
   "allOf": [
@@ -65,6 +71,71 @@
     "absPath": {
       "type": "string",
       "pattern": "^/"
+    },
+    "check": {
+      "type": "object",
+      "description": "One acceptance check (spec 26 §1). Absent `entry` makes the check STRUCTURAL by grammar (MECE — never a kind flag). Byte-golden assertions do not exist by construction: expect carries existence+non-empty channels only.",
+      "properties": {
+        "entry": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The in-image absolute executable path, or the reserved spelling \"self\" (kind runtime only — semantic). Exec checks only."
+        },
+        "argv": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Exec-only. `{scratch}` (the per-run host scratch dir) at most once per entry — semantic; every other spelling is literal passthrough."
+        },
+        "fixtures": {
+          "$ref": "#/$defs/absPath",
+          "description": "Exec-only. The in-image dir whose CONTENTS land at the host scratch root (never VFS-spelled)."
+        },
+        "expect": {
+          "type": "object",
+          "properties": {
+            "exit": { "type": "integer", "minimum": 0, "description": "Expected exit status; absent = 0." },
+            "files": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1, "not": { "pattern": "^/" } },
+              "description": "Scratch-relative paths asserted to exist and be non-empty; the '..' refusal is semantic (the tpkg validator)."
+            },
+            "stdout": { "type": "string", "minLength": 1, "description": "One regex the run's stdout must match; the engine compiles it." },
+            "image_files": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/absPath" },
+              "description": "In-image paths asserted to exist and be non-empty — the structural check's assertion channel."
+            }
+          }
+        },
+        "needs": {
+          "type": "array",
+          "description": "Additive host needs for the check run ONLY (a minimal mirror of the spec 23 §2 entry grammar).",
+          "items": {
+            "type": "object",
+            "required": ["path", "access"],
+            "properties": {
+              "path": { "type": "string", "minLength": 1 },
+              "access": { "enum": ["ro", "rw"] },
+              "when": { "type": "array", "items": { "enum": ["windows", "macos", "linux"] } },
+              "why": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "requires": {
+          "type": "object",
+          "required": ["provides"],
+          "description": "Composition prerequisites; unmet ⇒ SKIP, never FAIL (spec 26 §2).",
+          "properties": {
+            "provides": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+          }
+        },
+        "when": {
+          "type": "array",
+          "items": { "enum": ["windows", "macos", "linux"] },
+          "description": "The OS-family platform filter (NOT the spec 03 §3 triplet axis); absent = every platform."
+        },
+        "timeout": { "type": "integer", "minimum": 1, "description": "Seconds; expiry is a FAIL." }
+      }
     },
     "constraint": {
       "type": "string",


### PR DESCRIPTION
## Summary

The tpkg-side model for spec 26 (payload checks): the additive top-level `checks:` key on `PayloadManifest` — grammar, serde model, parse/validate-time named errors, and the schema registrations. **Scope is §1 + §1.1 + the §7 error discipline only.** The §2 engine (`tebako check`), §2.1 composition checks, and every CLI surface are follow-ups.

Additive as schema_minor 3, following the `materialize` (1) / `library_aliases` (2) discipline: old readers ignore the key, new readers enforce; an absent key never serializes.

Draft — stacks on #420.

## The grammar (spec 26 §1/§1.1)

`checks:` is a map of check-name → `Check`; the name matches `[A-Za-z0-9][A-Za-z0-9._-]*` (report lines, scratch dir names). ONE key decides the shape (MECE, never a `kind:` flag):

- `entry` present ⇒ **exec check**: in-image absolute executable path, or the reserved spelling `self` — legal only on `identity.kind == Runtime` (the runtime exe itself, env image mounted; the factory's `boot-and-stdlib` smoke).
- `entry` absent ⇒ **structural check** (the data-slice shape): no exec surface, asserts `expect.image_files` (in-image absolute paths, existence + non-empty).

A `Check` carries: `entry?`, `argv?` (`{scratch}` at most once per entry, everything else literal passthrough — the engine substitutes, the model carries), `fixtures?` (in-image dir whose CONTENTS land at the host scratch root; exec-only), `expect` (`exit` default 0, `files` scratch-relative exist+non-empty, `stdout` one regex, `image_files` in-image exist+non-empty), `needs?` (minimal mirror of the spec 23 §2 entry grammar: `{path, access, when?, why?}`; `access` reuses the jail model's `ro|rw` axis), `requires?` (`{provides: […]}`, unmet ⇒ SKIP never FAIL), `when?` (the OS-family axis `windows|macos|linux` — NOT the spec 03 §3 triplet axis), `timeout?` (positive seconds). No byte-golden field exists by construction.

## Validation (ManifestError, named, at parse/validate time — §7)

- `entry: self` on a non-runtime kind ⇒ named error.
- Structural check declaring `argv`/`fixtures` ⇒ named error; structural check with empty `expect.image_files` ⇒ named error (its only assertion channel — a vacuous check is caught at parse, never a silent PASS).
- `expect.files` entries non-empty, scratch-relative (never absolute, no `..`); `entry`/`fixtures`/`image_files` absolute in-image, no `..`.
- `when` entries outside `windows|macos|linux` ⇒ named structural error (serde names the variant set).
- `timeout` positive; `requires.provides` a non-empty list of non-empty names; `stdout` non-empty; `needs[].path` non-empty.
- Duplicate check name ⇒ named structural error. **Note:** serde_yml's plain map read is last-wins, so the refusal lives in the map's own deserializer (`checks_map`) — an authoring ambiguity is never a silent winner (the duplicate-alias discipline).

## Judgment calls / deviations from the spec text (flagged for owner review)

1. **Unknown keys inside a check are TOLERATED, not a named error.** Spec 26 §1 says "unknown keys a named error (the spec-03 discipline)", but spec 03's actual discipline — this crate's module docs, the schema registry's `unknown_fields` law (spec 18 §3), and the pinned test `unknown_keys_are_tolerated_annotations_preserved` — is toleration within a MAJOR. Rejecting unknown keys inside `checks:` only would invert the additive-MINOR mechanism it rides (a schema_minor 4 check field must not break a schema_minor 3 reader). Toleration is pinned by the test `checks_tolerate_unknown_keys`. If the owner wants §1's stricter reading, it should be a spec-03-wide decision, not a checks-only exception.
2. **`expect.stdout` is carried UNCOMPILED.** tpkg depends on serde/serde_yml/sha2 only — no regex crate, and none was added. The model validates non-emptiness; the check engine (§2 follow-up) compiles the pattern. Documented on the field.
3. **Structural checks require a non-empty `expect.image_files`** — a structural check without it asserts nothing at all; the model refuses the vacuous shape. (Spec states the channel; the mandate is my reading — a one-line relaxation if the owner disagrees.)
4. **`BTreeMap` storage renders check names sorted on serialize.** Spec 26 §2's "declaration order" run rule is the engine's read of the in-image YAML mapping order, not this model's storage order — noted on the field doc. If the engine must see authored order through the model, that's the engine PR's problem to surface.
5. **No `Needs` model existed in tpkg** (the spec-23 needs model lives in tfs-cli's compose layer), so check needs are a minimal local `{path, access, when?, why?}` struct mirroring spec 23 §2's shape, reusing `JailAccess` for the grant bit.

## Deliberately NOT built (follow-ups)

- The §2 engine (`tebako check`, scratch/fixture materialization, SKIP/FAIL/exit-72).
- §2.1 composition-level checks (D2 `fixtures_inline`/`fixtures_host`).
- `tfs info` surfacing of check names (tebako-info's `manifest_to_json` is hand-written per-field; spec 26 §0's "check names surface through `tfs info`" rides that follow-up).
- The press-time lint WARNING for an executable-kind slice declaring no checks.
- Schema rejection of unknown keys (see deviation 1).

## Files

- `crates/tpkg/src/manifest.rs` — the model (`Check`, `CheckEntry`, `CheckExpect`, `CheckNeed`, `CheckRequires`, `CheckPlatform`, the `checks_map` deserializer), `PayloadManifest.checks`, validation, 10 new unit tests.
- `crates/tpkg/src/lib.rs` — exports.
- `crates/tpkg/tests/manifest.rs` — `checks_key_is_schema_legal` (exec + structural, JSON-Schema MECE cross-check, round-trips) + 2 checks cases in `model_and_schema_agree_on_rejections`.
- `crates/tpkg/tests/manifest_props.rs` — `arb_check(kind)` in the manifest round-trip property.
- `crates/tebako-cli/src/install.rs` — the synthesized manifest mirror declares no checks (the embedded-manifest-wins rule).
- `schema/tpkg-manifest-v1.schema.json` — the structural `check` def + `checks` property (name pattern, shapes; the semantic gates stay in the tpkg validator, per the file's convention).
- `docs/spec/schemas/payload-manifest.yaml` — `schema_minor: 3`, the `checks` grammar block, 3 new refusal entries.
- `docs/spec/03-payload-manifest.md` — the §2.6 amendment subsection.

## Gates (all local runs green)

- `cargo test -p tpkg` — 178 tests across 12 targets (97 lib incl. the new checks tests; 0 failed).
- `cargo clippy -p tpkg` — 0 warnings.
- `cargo check -p tebako-driver -p tebako-shim -p tebako-cli -p tebako-info -p tfs-cli` — clean.
- `cargo test -p tebako-info -p tfs` — 203 passed, 0 failed.
- Registry YAML + schema JSON parse-verified (`payload-manifest.yaml`: schema_minor 3, checks grammar, 12 refusals).
