### PR TITLE
spec 25 phase T1: the interception trace bus + `tebako trace run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ payloads (inkscape & co.) are feedstocks in the
 |---------|--------------|
 | `tebako press` | package an app (lean/fat; `--suite` for multi-command packages; `--jail` presses a host-access policy) |
 | `tebako run <pkg>` | run a pressed package with a user jail tightening (`--jail`/`--mount`/`--no-host`) |
+| `tebako trace run <pkg>` | run under `record` with the trace bus armed; synthesize a suggested manifest (needs/materialize/notes — spec 25 §4) |
 | `tebako install <ref\|name@ver>` | install a payload from a registry + register its shims |
 | `tebako info [topic]` | the store/system surface: system, runtimes, payloads, shims, registries, store (`--remote` adds what the world offers; `--json` everywhere) |
 | `tebako inspect <artifact>` | payload/package introspection: manifest, provides, requires, platforms, verify (strict), JSON |

--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -129,8 +129,10 @@ pub fn vfs_dlmap(path: &str) -> PathRoute<std::ffi::CString> {
 /// (`dlmap2file`, dlmap-prefix redirect included) and the real fopen
 /// opens that copy. Write modes never route here (the caller's real
 /// fopen answers for the host path, policy-gated like any write).
+/// The trace surface is `open` (spec 25 §2: a stdio consumer is the
+/// §4 materialize-candidate signal), never dlopen.
 pub fn vfs_fopen(path: &str) -> PathRoute<std::ffi::CString> {
-    let answer = { context().write().unwrap().dlmap2file(path) };
+    let answer = { context().write().unwrap().dlmap2file_for_open(path) };
     route_answer(answer, path, HostAccess::Ro)
 }
 

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -76,6 +76,7 @@ pub mod scenario;
 pub mod sdk;
 pub mod strip;
 pub mod suite;
+pub mod trace;
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -18,6 +18,9 @@ const USAGE: &str = "Usage:
                one package, N commands (spec 03 §6: per-entry slots + type-2 manifest)
   tebako run <pkg> [--jail <spec>] [--mount <host:mount:ro|rw>]... [--no-host]
                [--] [<args>...]
+  tebako trace run <pkg> [--capture <path>] [--out <path>] [--] [<args>...]
+                                       run under TEBAKO_JAIL=record with the trace bus
+                                       armed; synthesize a suggested manifest (spec 25 §4)
   tebako cache list [--json]
   tebako cache prune [--all] [--older-than Nd]
   tebako add-registry <ref>            register a tpkg-registry.yaml (spec 04 §2)
@@ -115,6 +118,7 @@ fn run(args: &[String]) -> Result<(), CliExit> {
             Ok(())
         }
         "run" => run_package(rest),
+        "trace" => run_trace(rest),
         "cache" => run_cache(rest),
         "add-registry" => run_add_registry(rest),
         "list-registries" => run_list_registries(rest),
@@ -540,6 +544,31 @@ fn run_package(args: &[String]) -> Result<(), CliExit> {
     let plan = tebako_cli::run::plan_run(&parsed).map_err(CliExit::Error)?;
     let err = tebako_cli::run::exec_plan(&plan);
     Err(CliExit::Error(err))
+}
+
+/// `tebako trace run <pkg> [--capture <path>] [--out <path>] [--]
+/// [<args>...]` — spec 25 §4 (phase T1, discovery): run the package under
+/// `TEBAKO_JAIL=record` with the interception bus armed, then synthesize
+/// the capture into a suggested-manifest draft. `explain`/`cover` are
+/// the T2/T3 milestones. Never returns on success (the process exits
+/// with the payload's exit code).
+fn run_trace(args: &[String]) -> Result<(), CliExit> {
+    let Some(action) = args.first() else {
+        return Err(CliExit::Usage(
+            "trace subcommand expected: run (explain | cover are later milestones)".to_string(),
+        ));
+    };
+    match action.as_str() {
+        "run" => {
+            let parsed = tebako_cli::trace::parse_trace_run_args(&args[1..]).map_err(CliExit::Usage)?;
+            tebako_cli::trace::trace_run(&parsed)?;
+            Ok(())
+        }
+        other @ ("explain" | "cover" | "import") => Err(CliExit::Usage(format!(
+            "'tebako trace {other}' is a later tebako-rs milestone (spec 25: explain is T2, cover/import are T3)"
+        ))),
+        other => Err(CliExit::Usage(format!("unknown trace subcommand '{other}'"))),
+    }
 }
 
 fn run_cache(args: &[String]) -> Result<(), CliExit> {

--- a/crates/tebako-cli/src/trace.rs
+++ b/crates/tebako-cli/src/trace.rs
@@ -1,0 +1,693 @@
+//! `tebako trace` — spec 25's observability front-ends. Phase T1 ships
+//! `tebako trace run` (§4, discovery): the package runs under
+//! `TEBAKO_JAIL=record` with the interception bus armed
+//! (`TEBAKO_TRACE=<capture>`), and the capture is synthesized into a
+//! SUGGESTED manifest fragment — commented YAML on stdout (or `--out`),
+//! never applied (spec 25 law 7).
+//!
+//! The bus events come from the runtime driver's `tfs::trace` (the child
+//! inherits both env vars through the bootstrap — no bootstrap or driver
+//! changes); the jail channel feeds spec 23 §8's `needs:` generator
+//! unchanged (`tfs::needs::needs_from_journal`), re-rendered from bus
+//! events into the journal line grammar. The bus extends the draft to
+//! the axes §8 does not cover: `materialize:` candidates (an in-image
+//! file served through a raw host fd — the dlmap redirect and the
+//! preload's fopen routing), closure-covered dlopen NOTEs, and
+//! host-executable entrypoint notes.
+//!
+//! `explain` (§5, T2) and `cover` (§6, T3) are later milestones.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use tebako_json::Value;
+
+use crate::error::{packaging_error, plain_error, TebakoError};
+
+/// The parsed `tebako trace run` argv.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceRunArgs {
+    /// The package file to execute under the trace.
+    pub package: String,
+    /// `--capture <path>`: where the bus writes the JSONL capture.
+    /// Default: a per-run file in the temp dir (kept, named on stderr).
+    pub capture: Option<PathBuf>,
+    /// `--out <path>`: the draft's destination (default: stdout).
+    pub out: Option<PathBuf>,
+    /// Payload args, verbatim.
+    pub args: Vec<String>,
+}
+
+/// Parse the `trace run` argv (the `run.rs` conventions: flags before
+/// `--`, the first non-flag token starts the payload's argv).
+pub fn parse_trace_run_args(args: &[String]) -> Result<TraceRunArgs, String> {
+    const USAGE: &str =
+        "usage: tebako trace run <pkg> [--capture <path>] [--out <path>] [--] [<args>...]";
+    let Some(package) = args.first() else {
+        return Err(USAGE.to_string());
+    };
+    if package.starts_with('-') {
+        return Err(USAGE.to_string());
+    }
+    let mut capture = None;
+    let mut out = None;
+    let mut payload: Vec<String> = Vec::new();
+    let mut i = 1;
+    while i < args.len() {
+        let arg = &args[i];
+        let (flag, inline) = match arg.split_once('=') {
+            Some((f, v)) if f.starts_with("--") => (f, Some(v.to_string())),
+            _ => (arg.as_str(), None),
+        };
+        match flag {
+            "--" => {
+                payload.extend_from_slice(&args[i + 1..]);
+                break;
+            }
+            "--capture" | "--out" => {
+                let value = match inline {
+                    Some(v) => v,
+                    None => {
+                        i += 1;
+                        args.get(i)
+                            .cloned()
+                            .ok_or_else(|| format!("option '{flag}' requires a value"))?
+                    }
+                };
+                if flag == "--capture" {
+                    capture = Some(PathBuf::from(value));
+                } else {
+                    out = Some(PathBuf::from(value));
+                }
+            }
+            _ if flag.starts_with("--") => {
+                return Err(format!(
+                    "unknown trace run option '{flag}' (payload options ride after `--`)"
+                ));
+            }
+            _ => {
+                payload.extend_from_slice(&args[i..]);
+                break;
+            }
+        }
+        i += 1;
+    }
+    Ok(TraceRunArgs {
+        package: package.clone(),
+        capture,
+        out,
+        args: payload,
+    })
+}
+
+/// The default capture path: one JSONL file per run in the temp dir.
+fn default_capture() -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!("tebako-trace-{}-{nanos}.jsonl", std::process::id()))
+}
+
+/// One observation's evidence (spec 25 §4: every draft entry carries its
+/// `why:` — `observed: <n> events, first at <ts>`).
+#[derive(Debug, Clone)]
+pub struct Observation {
+    pub count: u64,
+    pub first_ts: String,
+}
+
+impl Observation {
+    fn record(&mut self, ts: &str) {
+        if self.count == 0 {
+            self.first_ts = ts.to_string();
+        }
+        self.count += 1;
+    }
+
+    fn why(&self) -> String {
+        format!(
+            "observed: {} events, first at {}",
+            self.count, self.first_ts
+        )
+    }
+}
+
+/// The synthesized discovery result.
+#[derive(Debug)]
+pub struct Synthesis {
+    /// Total well-formed events consumed from the capture.
+    pub events: usize,
+    /// The re-rendered §8 journal text fed to the needs generator.
+    pub journal_text: String,
+    /// The §8 needs draft (needs_from_journal's output, unchanged).
+    pub needs_yaml: String,
+    /// `materialize:` candidates: the in-image path → its evidence (an
+    /// open-class event served the file through a raw host fd).
+    pub materialize: BTreeMap<String, Observation>,
+    /// Closure-covered dlopens (every declared dep resolved in-image):
+    /// path → (dep count, evidence).
+    pub closure_covered: BTreeMap<String, (usize, Observation)>,
+    /// Host executables the run routed to: path → evidence.
+    pub host_execs: BTreeMap<String, Observation>,
+}
+
+/// A host path component the exec-cache materialization machinery owns
+/// (spec 25 §4's exclusion law extends §8's: the per-process dl/exec
+/// tmpdirs are tebako's own scratch, never a payload need).
+fn is_exec_cache_noise(path: &str) -> bool {
+    Path::new(path).components().any(|c| {
+        let s = c.as_os_str().to_string_lossy();
+        s.starts_with("tebako-dl-") || s.starts_with("tebako-exec-")
+    })
+}
+
+/// Parse the capture and synthesize the discovery result. Pure: the
+/// §8 substitution atoms, exclusions, and the exists probe are injected
+/// so the unit suite never touches the environment or the filesystem.
+/// Tolerant of the stream's realities (spec 25 §3): a trailing partial
+/// line (a crashed tail) and mid-stream interleave damage are skipped,
+/// never fatal.
+pub fn synthesize(
+    capture_text: &str,
+    substitutions: &[(PathBuf, &str)],
+    exclusions: &[PathBuf],
+    exists: &dyn Fn(&str) -> bool,
+) -> Synthesis {
+    let mut events = 0usize;
+    let mut journal_lines: Vec<String> = Vec::new();
+    let mut materialize: BTreeMap<String, Observation> = BTreeMap::new();
+    let mut closure_covered: BTreeMap<String, (usize, Observation)> = BTreeMap::new();
+    let mut host_execs: BTreeMap<String, Observation> = BTreeMap::new();
+
+    let lines: Vec<&str> = capture_text.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(doc) = tebako_json::parse(line) else {
+            // The trailing line may be a crashed tail's partial write;
+            // anything else is interleave damage. Both are dropped.
+            eprintln!(
+                "tebako: trace: note: capture line {} is not a complete event — skipped",
+                i + 1
+            );
+            continue;
+        };
+        events += 1;
+        let op = doc
+            .find("op")
+            .and_then(Value::as_string)
+            .unwrap_or_default();
+        let path = doc
+            .find("path")
+            .and_then(Value::as_string)
+            .unwrap_or_default();
+        let verdict = doc
+            .find("verdict")
+            .and_then(Value::as_string)
+            .unwrap_or_default();
+        let ts = doc
+            .find("ts")
+            .and_then(Value::as_string)
+            .unwrap_or_default();
+        let detail = doc.find("detail");
+        match op.as_str() {
+            // The jail channel IS the §8 audit journal, formalized (law
+            // 6): re-render the events into the journal line grammar and
+            // feed the needs generator unchanged. A denial is an unmet
+            // need — the generator's own rule.
+            "jail" => {
+                let event = match verdict.as_str() {
+                    "record" => Some("jail-allow"),
+                    v if v.starts_with("allow:") => Some("jail-allow"),
+                    v if v.starts_with("deny:") => Some("jail-deny"),
+                    _ => None,
+                };
+                let access = detail
+                    .and_then(|d| d.find("access"))
+                    .and_then(Value::as_string)
+                    .unwrap_or_default();
+                if let (Some(event), "read" | "write") = (event, access.as_str()) {
+                    if !path.is_empty() && !is_exec_cache_noise(&path) {
+                        journal_lines.push(format!(
+                            "event={event} path={path} op={access} source=record"
+                        ));
+                    }
+                }
+            }
+            // An open-class event that served the file through a raw host
+            // fd (the dlmap redirect, or the preload's fopen routing) is
+            // the §4 materialize-candidate signal: the consumer needed
+            // real host bytes for a VFS-resident file.
+            "open" => {
+                let Some(materialized) = detail.and_then(|d| d.find("materialized")) else {
+                    continue;
+                };
+                if materialized.as_string().is_none() {
+                    continue;
+                }
+                // The in-image path the author declares: the redirect's
+                // tail when the dlmap prefix was spelled, else the path
+                // as dispatched (the fopen surface).
+                let candidate = detail
+                    .and_then(|d| d.find("dlmap_redirect"))
+                    .and_then(Value::as_string)
+                    .unwrap_or(path.clone());
+                materialize
+                    .entry(candidate)
+                    .or_insert(Observation {
+                        count: 0,
+                        first_ts: String::new(),
+                    })
+                    .record(&ts);
+            }
+            // An in-image dlopen whose closure walk resolved every dep
+            // in-image needs no declaration — a NOTE, not an entry.
+            "dlopen" => {
+                if !verdict.starts_with("materialized:") {
+                    continue;
+                }
+                let deps = detail
+                    .and_then(|d| d.find("closure"))
+                    .and_then(|c| c.find("deps"));
+                let Some(Value::Array(deps)) = deps else {
+                    continue;
+                };
+                if deps.is_empty() {
+                    continue;
+                }
+                let all_in_image = deps.iter().all(|dep| {
+                    dep.find("verdict").and_then(Value::as_string).as_deref()
+                        == Some("materialized")
+                });
+                if all_in_image {
+                    let entry = closure_covered.entry(path.clone()).or_insert((
+                        deps.len(),
+                        Observation {
+                            count: 0,
+                            first_ts: String::new(),
+                        },
+                    ));
+                    entry.1.record(&ts);
+                }
+            }
+            // A host-absolute exec the runtime routed OUT of the image:
+            // the entrypoint/runtime-dep note (spawn joins exec here when
+            // its emission lands — the vocabulary is already stable).
+            "exec" | "spawn" => {
+                if verdict == "host" && Path::new(&path).is_absolute() {
+                    host_execs
+                        .entry(path.clone())
+                        .or_insert(Observation {
+                            count: 0,
+                            first_ts: String::new(),
+                        })
+                        .record(&ts);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut journal_text = journal_lines.join("\n");
+    if !journal_text.is_empty() {
+        journal_text.push('\n');
+    }
+    let needs_yaml =
+        tfs::needs::needs_from_journal(&journal_text, substitutions, exclusions, exists);
+    Synthesis {
+        events,
+        journal_text,
+        needs_yaml,
+        materialize,
+        closure_covered,
+        host_execs,
+    }
+}
+
+/// Double-quoted YAML scalar escaping (needs.rs's rule).
+fn yaml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Render the suggested manifest fragment (commented YAML — a draft for
+/// review, never applied, spec 25 law 7).
+pub fn render_draft(package: &str, capture: &Path, synthesis: &Synthesis) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# Suggested manifest additions for {package} — `tebako trace run` (spec 25 §4, discovery).\n\
+         # {} interception event(s) observed; the capture is {}\n\
+         # REVIEW BEFORE MERGING: a generated suggestion never edits a manifest by itself\n\
+         # (spec 25 law 7). Flip ro/rw, delete noise, fill every `why`.\n",
+        synthesis.events,
+        capture.display()
+    ));
+    if synthesis.events == 0 {
+        out.push_str(
+            "# No interception events were captured — the run touched nothing declarable\n\
+             # (or the package is not a tebako v2 composition: nothing mounted the bus).\n",
+        );
+    }
+    out.push_str(&synthesis.needs_yaml);
+    if !synthesis.materialize.is_empty() {
+        out.push_str(
+            "# Files the run consumed through a RAW host fd (a native library's own\n\
+             # stdio/loader read below the interposition — the exec-cache answer):\n\
+             materialize:\n",
+        );
+        for (path, obs) in &synthesis.materialize {
+            out.push_str(&format!(
+                "  - path: \"{}\"\n    why: \"TODO — read through a materialized host copy ({})\"\n",
+                yaml_escape(path),
+                obs.why()
+            ));
+        }
+    }
+    for (path, (deps, obs)) in &synthesis.closure_covered {
+        out.push_str(&format!(
+            "# NOTE: closure-covered — nothing to declare: \"{}\" ({deps} deps, all in-image; {})\n",
+            path,
+            obs.why()
+        ));
+    }
+    for (path, obs) in &synthesis.host_execs {
+        out.push_str(&format!(
+            "# NOTE: host executable observed: \"{}\" — an entrypoint/runtime-dep candidate ({})\n",
+            path,
+            obs.why()
+        ));
+    }
+    out
+}
+
+/// `tebako trace run <pkg> [--capture <path>] [--out <path>] [--] [args...]`.
+///
+/// Runs the package under `TEBAKO_JAIL=record` with the bus armed, then
+/// synthesizes the capture into the suggested-manifest draft. The process
+/// exits with the PAYLOAD's exit code (the run's own verdict is the
+/// payload's — the draft lands either way; spec 25 law 1: observability
+/// never gates).
+pub fn trace_run(parsed: &TraceRunArgs) -> Result<(), TebakoError> {
+    let program = PathBuf::from(&parsed.package);
+    if !program.is_file() {
+        return Err(packaging_error(
+            127,
+            Some(&format!("package not found: {}", parsed.package)),
+        ));
+    }
+    let capture = parsed.capture.clone().unwrap_or_else(default_capture);
+
+    // Spawn + wait on BOTH platforms (the synthesis runs after the
+    // payload, so the unix execve replacement of `tebako run` is not
+    // available here). stdio is inherited: the payload runs as if direct.
+    let status = std::process::Command::new(&program)
+        .args(&parsed.args)
+        .env(tfs::trace::TRACE_ENV, &capture)
+        .env("TEBAKO_JAIL", "record")
+        .status()
+        .map_err(|e| {
+            plain_error(format!(
+                "cannot execute the package {}: {e}",
+                program.display()
+            ))
+        })?;
+    let code = status.code().unwrap_or(1);
+
+    // The capture read is tolerant (law 1): a missing/unreadable channel
+    // degrades to a note and a no-events draft.
+    let capture_text = match std::fs::read_to_string(&capture) {
+        Ok(text) => text,
+        Err(e) => {
+            eprintln!(
+                "tebako: trace: note: no capture at {} ({e}) — drafting with zero events",
+                capture.display()
+            );
+            String::new()
+        }
+    };
+
+    // The §8 generator's inputs (the tfs-cli needs-from-journal set):
+    // $HOME/$TMPDIR substitution atoms, the platform floor + tebako home
+    // + the exec cache as exclusions, canonicalize as the exists probe.
+    let mut substitutions: Vec<(PathBuf, &str)> = Vec::new();
+    for (var, atom) in [("HOME", "$HOME"), ("TMPDIR", "$TMPDIR")] {
+        if let Ok(v) = std::env::var(var) {
+            if !v.is_empty() {
+                substitutions.push((PathBuf::from(v), atom));
+            }
+        }
+    }
+    let mut exclusions = tfs::policy::platform_floor();
+    if let Some(home) = tfs::journal::tebako_home_dir() {
+        exclusions.push(home);
+    }
+    if let Ok(cache) = std::env::var("TEBAKO_EXEC_CACHE") {
+        if !cache.is_empty() {
+            exclusions.push(PathBuf::from(cache));
+        }
+    }
+
+    let synthesis = synthesize(&capture_text, &substitutions, &exclusions, &|p| {
+        std::fs::canonicalize(p).is_ok()
+    });
+    let draft = render_draft(&parsed.package, &capture, &synthesis);
+    match &parsed.out {
+        Some(out) => {
+            std::fs::write(out, &draft)
+                .map_err(|e| plain_error(format!("cannot write {}: {e}", out.display())))?;
+            eprintln!("tebako: trace: draft written to {}", out.display());
+        }
+        None => print!("{draft}"),
+    }
+    eprintln!("tebako: trace: the capture is {}", capture.display());
+    std::process::exit(code);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(tokens: &[&str]) -> Vec<String> {
+        tokens.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_flags_and_payload_split() {
+        let p = parse_trace_run_args(&args(&[
+            "pkg",
+            "--capture",
+            "/tmp/c.jsonl",
+            "--out=/tmp/draft.yaml",
+            "--",
+            "-x",
+            "in.csv",
+        ]))
+        .unwrap();
+        assert_eq!(p.package, "pkg");
+        assert_eq!(p.capture, Some(PathBuf::from("/tmp/c.jsonl")));
+        assert_eq!(p.out, Some(PathBuf::from("/tmp/draft.yaml")));
+        assert_eq!(p.args, vec!["-x".to_string(), "in.csv".to_string()]);
+
+        // No `--`: the first non-flag token starts the payload argv.
+        let p = parse_trace_run_args(&args(&["pkg", "input.csv", "--verbose"])).unwrap();
+        assert!(p.capture.is_none() && p.out.is_none());
+        assert_eq!(
+            p.args,
+            vec!["input.csv".to_string(), "--verbose".to_string()]
+        );
+
+        // Errors.
+        assert!(parse_trace_run_args(&args(&[])).is_err());
+        assert!(parse_trace_run_args(&args(&["--capture", "x"])).is_err());
+        assert!(parse_trace_run_args(&args(&["pkg", "--capture"])).is_err());
+        assert!(parse_trace_run_args(&args(&["pkg", "--frobnicate"])).is_err());
+    }
+
+    /// A bus event line, the tfs::trace render shape.
+    fn event(op: &str, path: &str, verdict: &str, ts: &str, detail: &str) -> String {
+        format!(
+            "{{\"v\":1,\"ts\":\"{ts}\",\"pid\":1,\"tid\":1,\"op\":\"{op}\",\"path\":\"{path}\",\"verdict\":\"{verdict}\",\"detail\":{detail},\"dur_us\":3}}"
+        )
+    }
+
+    /// A host-absolute executable path for the platform (the host_execs
+    /// gate is `Path::is_absolute`; forward slashes keep the JSON simple).
+    const HOST_EXE: &str = if cfg!(windows) {
+        "C:/Windows/system32/findstr.exe"
+    } else {
+        "/usr/bin/git"
+    };
+
+    #[test]
+    fn synthesize_feeds_the_needs_generator_and_names_candidates() {
+        let capture = [
+            // The jail channel: two reads and a write of the same host
+            // path, one read of another, and exec-cache noise to drop.
+            event("jail", "/work/data", "record", "2026-08-19T01:00:01.000000Z", "{\"access\":\"read\"}"),
+            event("jail", "/work/data", "record", "2026-08-19T01:00:02.000000Z", "{\"access\":\"read\"}"),
+            event("jail", "/work/data", "record", "2026-08-19T01:00:03.000000Z", "{\"access\":\"write\"}"),
+            event("jail", "/etc/custom.conf", "record", "2026-08-19T01:00:04.000000Z", "{\"access\":\"read\"}"),
+            event("jail", "/tmp/tebako-dl-abc/tfs/lib/x.so", "record", "2026-08-19T01:00:05.000000Z", "{\"access\":\"read\"}"),
+            // A jail deny is an unmet need (the generator's own rule).
+            event("jail", "/secret", "deny:user", "2026-08-19T01:00:06.000000Z", "{\"access\":\"read\"}"),
+            // The dlmap redirect: an in-image file served via a raw fd.
+            event("open", "/tmp/tebako-dl-abc/tfs/data/font.png", "image:/tfs", "2026-08-19T01:00:07.000000Z",
+                  "{\"dlmap_redirect\":\"/tfs/data/font.png\",\"materialized\":\"/tmp/tebako-dl-abc/tfs/data/font.png\"}"),
+            // The fopen surface: path as dispatched + the host copy.
+            event("open", "/tfs/data/font.png", "image:/tfs", "2026-08-19T01:00:08.000000Z",
+                  "{\"materialized\":\"/tmp/tebako-dl-abc/tfs/data/font.png\"}"),
+            // The closure-covered dlopen (two deps, both in-image).
+            event("dlopen", "/tfs/lib/libsass.so", "materialized:/tmp/tebako-dl-abc/tfs/lib/libsass.so", "2026-08-19T01:00:09.000000Z",
+                  "{\"closure\":{\"format\":\"elf\",\"deps\":[{\"name\":\"libc.so\",\"resolved\":\"/tfs/lib/libc.so\",\"verdict\":\"materialized\"},{\"name\":\"libm.so\",\"resolved\":\"/tfs/lib/libm.so\",\"verdict\":\"materialized\"}]}}"),
+            // A dlopen with a host-system dep: no closure NOTE.
+            event("dlopen", "/tfs/lib/libmixed.so", "materialized:/tmp/tebako-dl-abc/tfs/lib/libmixed.so", "2026-08-19T01:00:10.000000Z",
+                  "{\"closure\":{\"format\":\"elf\",\"deps\":[{\"name\":\"libSystem.dylib\",\"resolved\":null,\"verdict\":\"host-system\"}]}}"),
+            // A host-absolute exec (the entrypoint note) and an in-image
+            // one (no note).
+            event("exec", HOST_EXE, "host", "2026-08-19T01:00:11.000000Z", "{}"),
+            event("exec", "/tfs/bin/tool", "routed:/tmp/tebako-exec-home-1/bin/tool", "2026-08-19T01:00:12.000000Z", "{\"route\":\"home-tree\"}"),
+            // A crashed tail: the partial last line is dropped, not fatal.
+            "{\"v\":1,\"ts\":\"2026-08-19T01:00:13".to_string(),
+        ]
+        .join("\n");
+        let s = synthesize(&capture, &[], &[], &|_| true);
+        assert_eq!(s.events, 12, "12 well-formed events of 13 lines");
+        // The needs feed: /work/data collapses to one rw entry
+        // (strongest-observed-op wins), the deny rides along as ro, the
+        // exec-cache noise never reaches it.
+        assert!(
+            s.journal_text
+                .contains("event=jail-allow path=/work/data op=write"),
+            "{}",
+            s.journal_text
+        );
+        assert!(
+            s.journal_text
+                .contains("event=jail-deny path=/secret op=read"),
+            "{}",
+            s.journal_text
+        );
+        assert!(!s.journal_text.contains("tebako-dl-"), "{}", s.journal_text);
+        assert!(
+            s.needs_yaml.contains("path: \"/work/data\""),
+            "{}",
+            s.needs_yaml
+        );
+        assert!(s.needs_yaml.contains("access: rw"), "{}", s.needs_yaml);
+        assert!(
+            s.needs_yaml.contains("observed: 2 read, 1 write"),
+            "{}",
+            s.needs_yaml
+        );
+        assert!(
+            s.needs_yaml.contains("path: \"/etc/custom.conf\""),
+            "{}",
+            s.needs_yaml
+        );
+        assert!(
+            s.needs_yaml.contains("path: \"/secret\""),
+            "{}",
+            s.needs_yaml
+        );
+        // The materialize candidate is the IN-IMAGE path (the redirect's
+        // tail; the fopen surface's dispatched path names the same file),
+        // deduped with both events as evidence.
+        assert_eq!(s.materialize.len(), 1);
+        let obs = &s.materialize["/tfs/data/font.png"];
+        assert_eq!(obs.count, 2);
+        assert_eq!(obs.first_ts, "2026-08-19T01:00:07.000000Z");
+        // The closure NOTE: only the all-in-image dlopen.
+        assert_eq!(s.closure_covered.len(), 1);
+        let (deps, obs) = &s.closure_covered["/tfs/lib/libsass.so"];
+        assert_eq!(*deps, 2);
+        assert_eq!(obs.count, 1);
+        // The host-exec note.
+        assert_eq!(s.host_execs.len(), 1);
+        assert!(s.host_execs.contains_key(HOST_EXE));
+    }
+
+    #[test]
+    fn synthesize_tolerates_empty_and_substitutes_atoms() {
+        // Empty capture: the needs block keeps the §8 empty spelling.
+        let s = synthesize("", &[], &[], &|_| true);
+        assert_eq!(s.events, 0);
+        assert!(s.needs_yaml.contains("host: []"), "{}", s.needs_yaml);
+
+        // Substitutions re-spell the needs paths; the exclusion drops.
+        let home = PathBuf::from("/home/u");
+        let capture = event(
+            "jail",
+            "/home/u/.config/app",
+            "record",
+            "2026-08-19T01:00:01.000000Z",
+            "{\"access\":\"read\"}",
+        ) + "\n"
+            + &event(
+                "jail",
+                "/sys/kernel",
+                "record",
+                "2026-08-19T01:00:02.000000Z",
+                "{\"access\":\"read\"}",
+            );
+        let s = synthesize(
+            &capture,
+            &[(home, "$HOME")],
+            &[PathBuf::from("/sys")],
+            &|_| true,
+        );
+        assert!(
+            s.needs_yaml.contains("path: \"$HOME/.config/app\""),
+            "{}",
+            s.needs_yaml
+        );
+        assert!(!s.needs_yaml.contains("/sys/kernel"), "{}", s.needs_yaml);
+    }
+
+    #[test]
+    fn render_draft_carries_the_review_contract() {
+        let capture = [
+            event("jail", "/work/data", "record", "2026-08-19T01:00:01.000000Z", "{\"access\":\"read\"}"),
+            event("open", "/tfs/data/font.png", "image:/tfs", "2026-08-19T01:00:02.000000Z",
+                  "{\"materialized\":\"/tmp/tebako-dl-abc/tfs/data/font.png\"}"),
+            event("dlopen", "/tfs/lib/libx.so", "materialized:/tmp/tebako-dl-abc/tfs/lib/libx.so", "2026-08-19T01:00:03.000000Z",
+                  "{\"closure\":{\"format\":\"macho\",\"deps\":[{\"name\":\"liby.dylib\",\"resolved\":\"/tfs/lib/liby.dylib\",\"verdict\":\"materialized\"}]}}"),
+            event("exec", HOST_EXE, "host", "2026-08-19T01:00:04.000000Z", "{}"),
+        ]
+        .join("\n");
+        let s = synthesize(&capture, &[], &[], &|_| true);
+        let draft = render_draft("pkg", Path::new("/tmp/capture.jsonl"), &s);
+        assert!(draft.contains("spec 25 §4"), "{draft}");
+        assert!(
+            draft.contains("never edits a manifest by itself"),
+            "{draft}"
+        );
+        assert!(draft.contains("4 interception event(s)"), "{draft}");
+        assert!(draft.contains("needs:"), "{draft}");
+        assert!(draft.contains("path: \"/work/data\""), "{draft}");
+        assert!(draft.contains("materialize:"), "{draft}");
+        assert!(draft.contains("path: \"/tfs/data/font.png\""), "{draft}");
+        assert!(
+            draft.contains("observed: 1 events, first at 2026-08-19T01:00:02.000000Z"),
+            "{draft}"
+        );
+        assert!(
+            draft.contains("# NOTE: closure-covered — nothing to declare: \"/tfs/lib/libx.so\" (1 deps, all in-image"),
+            "{draft}"
+        );
+        assert!(
+            draft.contains(&format!("# NOTE: host executable observed: \"{HOST_EXE}\"")),
+            "{draft}"
+        );
+
+        // The zero-event capture: the no-events comment, no sections.
+        let s = synthesize("", &[], &[], &|_| true);
+        let draft = render_draft("pkg", Path::new("/tmp/capture.jsonl"), &s);
+        assert!(
+            draft.contains("No interception events were captured"),
+            "{draft}"
+        );
+        assert!(!draft.contains("materialize:"), "{draft}");
+        assert!(!draft.contains("# NOTE:"), "{draft}");
+    }
+}

--- a/crates/tebako-cli/tests/trace_run.rs
+++ b/crates/tebako-cli/tests/trace_run.rs
@@ -1,0 +1,211 @@
+//! `tebako trace run` e2e (spec 25 §4 — the discovery front-end): the
+//! package runs under TEBAKO_JAIL=record with TEBAKO_TRACE naming the
+//! capture, the payload's exit code is the command's exit code, and the
+//! capture synthesizes into the suggested-manifest draft. The fixture
+//! "package" is a shebang script (the kernel execs it; it reports the
+//! env and can hand-write a bus event into the capture). Unix only
+//! (shebang exec), like tests/run.rs.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn tebako_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_tebako"))
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "tebako-trace-e2e-{tag}-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// The probe: report the trace/jail env, echo the payload args, exit 17.
+const PROBE: &str = "#!/bin/sh\n\
+echo \"TRACE=${TEBAKO_TRACE-UNSET}\"\n\
+echo \"JAIL=${TEBAKO_JAIL-UNSET}\"\n\
+echo \"ARGS=$*\"\n\
+exit 17\n";
+
+/// The emitter: one well-formed jail event into the capture (the shape
+/// tfs::trace renders), then exit 0.
+const EMITTER: &str = "#!/bin/sh\n\
+printf '%s\\n' '{\"v\":1,\"ts\":\"2026-08-19T01:02:03.000000Z\",\"pid\":7,\"tid\":1,\"op\":\"jail\",\"path\":\"/etc/hostname\",\"verdict\":\"record\",\"detail\":{\"access\":\"read\"},\"dur_us\":5}' >> \"$TEBAKO_TRACE\"\n\
+exit 0\n";
+
+fn script_pkg(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let pkg = dir.join(name);
+    std::fs::write(&pkg, body).unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&pkg, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    pkg
+}
+
+struct Run {
+    rc: i32,
+    stdout: String,
+    stderr: String,
+}
+
+fn tebako_trace(args: &[&str]) -> Run {
+    let out = Command::new(tebako_bin())
+        .arg("trace")
+        .args(args)
+        .output()
+        .unwrap();
+    Run {
+        rc: out.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+fn line<'a>(stdout: &'a str, key: &str) -> &'a str {
+    stdout
+        .lines()
+        .find_map(|l| l.strip_prefix(key))
+        .unwrap_or_else(|| panic!("{key} missing from stdout:\n{stdout}"))
+}
+
+#[test]
+fn trace_run_arms_the_bus_and_the_record_policy_and_propagates_the_exit_code() {
+    let dir = workdir("env");
+    let pkg = script_pkg(&dir, "pkg", PROBE);
+    let capture = dir.join("capture.jsonl");
+
+    let r = tebako_trace(&[
+        "run",
+        pkg.to_str().unwrap(),
+        "--capture",
+        capture.to_str().unwrap(),
+        "--",
+        "alpha",
+        "--beta",
+    ]);
+    // The payload's exit code IS the command's (17 from the probe).
+    assert_eq!(r.rc, 17, "stdout: {} stderr: {}", r.stdout, r.stderr);
+    // The env reached the payload: the bus channel and the record jail.
+    assert_eq!(line(&r.stdout, "TRACE="), capture.to_string_lossy());
+    assert_eq!(line(&r.stdout, "JAIL="), "record");
+    assert_eq!(line(&r.stdout, "ARGS="), "alpha --beta");
+    // A shell script mounts nothing: no bus, no capture — the draft
+    // degrades to the no-events note (observability never gates).
+    assert!(
+        r.stdout.contains("No interception events were captured"),
+        "stdout: {}",
+        r.stdout
+    );
+    assert!(r.stdout.contains("host: []"), "stdout: {}", r.stdout);
+    assert!(r.stderr.contains("no capture at"), "stderr: {}", r.stderr);
+}
+
+#[test]
+fn trace_run_synthesizes_the_capture_into_the_draft() {
+    let dir = workdir("synthesize");
+    let pkg = script_pkg(&dir, "pkg", EMITTER);
+    let capture = dir.join("capture.jsonl");
+    let out = dir.join("draft.yaml");
+
+    let r = tebako_trace(&[
+        "run",
+        pkg.to_str().unwrap(),
+        "--capture",
+        capture.to_str().unwrap(),
+        "--out",
+        out.to_str().unwrap(),
+    ]);
+    assert_eq!(r.rc, 0, "stdout: {} stderr: {}", r.stdout, r.stderr);
+    // --out: the draft is the file, stdout stays the payload's (empty).
+    assert!(!r.stdout.contains("needs:"), "stdout: {}", r.stdout);
+    let draft = std::fs::read_to_string(&out).unwrap();
+    assert!(draft.contains("1 interception event(s)"), "{draft}");
+    assert!(draft.contains("path: \"/etc/hostname\""), "{draft}");
+    assert!(draft.contains("access: ro"), "{draft}");
+    assert!(draft.contains("observed: 1 read, 0 write"), "{draft}");
+    assert!(
+        draft.contains("never edits a manifest by itself"),
+        "{draft}"
+    );
+    // The capture was left in place and named on stderr.
+    assert!(capture.is_file(), "the capture survives for replay");
+    assert!(
+        r.stderr.contains(&capture.display().to_string()),
+        "stderr: {}",
+        r.stderr
+    );
+}
+
+#[test]
+fn trace_run_defaults_the_capture_into_the_temp_dir() {
+    let dir = workdir("default-capture");
+    let pkg = script_pkg(&dir, "pkg", PROBE);
+
+    let r = tebako_trace(&["run", pkg.to_str().unwrap()]);
+    assert_eq!(r.rc, 17, "stderr: {}", r.stderr);
+    let named = line(&r.stdout, "TRACE=").to_string();
+    assert!(
+        named.contains("tebako-trace-") && named.ends_with(".jsonl"),
+        "the default capture name: {named}"
+    );
+}
+
+#[test]
+fn trace_run_rejects_a_missing_package_and_bad_options() {
+    let dir = workdir("usage");
+    let missing = dir.join("nope");
+
+    let r = tebako_trace(&["run", missing.to_str().unwrap()]);
+    assert_eq!(r.rc, 127, "stdout: {} stderr: {}", r.stdout, r.stderr);
+    assert!(
+        r.stdout.contains("package not found"),
+        "stdout: {}",
+        r.stdout
+    );
+
+    let pkg = script_pkg(&dir, "pkg", PROBE);
+    let r = tebako_trace(&["run", pkg.to_str().unwrap(), "--frobnicate"]);
+    assert_eq!(r.rc, 1);
+    assert!(
+        r.stderr.contains("unknown trace run option"),
+        "stderr: {}",
+        r.stderr
+    );
+
+    let r = tebako_trace(&["run", pkg.to_str().unwrap(), "--capture"]);
+    assert_eq!(r.rc, 1);
+    assert!(
+        r.stderr.contains("requires a value"),
+        "stderr: {}",
+        r.stderr
+    );
+
+    // Bare `trace` and the later-milestone subcommands name themselves.
+    let r = tebako_trace(&[]);
+    assert_eq!(r.rc, 1);
+    assert!(
+        r.stderr.contains("trace subcommand expected"),
+        "stderr: {}",
+        r.stderr
+    );
+    for sub in ["explain", "cover"] {
+        let r = tebako_trace(&[sub]);
+        assert_eq!(r.rc, 1);
+        assert!(
+            r.stderr.contains(&format!(
+                "'tebako trace {sub}' is a later tebako-rs milestone"
+            )),
+            "stderr: {}",
+            r.stderr
+        );
+    }
+}

--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -757,6 +757,18 @@ pub fn boot_with_mount_modes(
     let runtime_root = effective.as_str();
     crate::ffi::set_mount_point(runtime_root);
     let mut h = Handoff::parse(argv)?;
+    // The trace bus (spec 25 §2): --tebako-trace wins over TEBAKO_TRACE.
+    // The channel opens BEFORE any mount — a path op is only safe this
+    // early (the journal/trace fd discipline) — and covers both boot
+    // shapes below. Arming never fails the boot: tfs::trace::arm notes
+    // loudly on stderr and proceeds disarmed (observability never gates).
+    let trace = h
+        .trace
+        .take()
+        .or_else(|| env_var(env, tfs::trace::TRACE_ENV));
+    if let Some(path) = trace {
+        tfs::trace::arm(Path::new(&path));
+    }
     // The exec cache (spec 22 §6) is named before anything can
     // materialize: both boot paths below export it to the handoff env.
     crate::exec_cache::export(env);
@@ -794,9 +806,17 @@ pub fn boot_with_mount_modes(
             // The standalone interpreter spawns too — arm its children
             // the same way (spec 22 §3).
             crate::injection::export(env, declaration.as_ref(), runtime_root)?;
-            Ok(BootOutcome {
-                argv: argv.to_vec(),
-            })
+            // argv[0] + the interpreter's own args — byte-identical to
+            // the incoming argv when no loader flags were present (the
+            // parse then fed every arg to interpreter_args), but the
+            // consumed --tebako-trace never leaks into the interpreter's
+            // argv (the image-boot paths below compose the same way).
+            let mut v = Vec::with_capacity(h.interpreter_args.len() + 1);
+            if let Some(program) = argv.first() {
+                v.push(program.clone());
+            }
+            v.extend(h.interpreter_args.iter().cloned());
+            Ok(BootOutcome { argv: v })
         })();
         if result.is_err() {
             context().write().unwrap().unmount();

--- a/crates/tebako-driver/src/handoff.rs
+++ b/crates/tebako-driver/src/handoff.rs
@@ -2,6 +2,7 @@
 //!
 //! ```text
 //! --tebako-image <self|image-path>:<slot|->:<mount>   (repeatable)
+//! --tebako-trace <path>                               (optional; spec 25 §2)
 //! --tebako-entry <argv0> <user args...>               (terminates scanning)
 //! ```
 //!
@@ -10,7 +11,10 @@
 //! colons so the file component may itself contain colons (Windows drive
 //! prefixes). Anything before the first `--tebako-*` belongs to the
 //! interpreter; everything after `--tebako-entry` belongs to the user,
-//! verbatim.
+//! verbatim. `--tebako-trace` names the spec 25 trace channel (JSONL);
+//! it overrides `TEBAKO_TRACE` when both are set, and the driver opens it
+//! at boot, before any mount (spec 25 §2 — additive by option, the
+//! grammar's contract version never bumps).
 
 use std::path::PathBuf;
 
@@ -61,6 +65,10 @@ pub struct Handoff {
     /// own args) — the bare `--tebako-image` invocation (no entry)
     /// starts the interpreter with exactly these.
     pub interpreter_args: Vec<String>,
+    /// The `--tebako-trace` channel path (spec 25 §2), when given.
+    /// Overrides `TEBAKO_TRACE`; the driver opens it at boot, before any
+    /// mount.
+    pub trace: Option<String>,
 }
 
 fn malformed(value: &str) -> DriverError {
@@ -152,6 +160,19 @@ impl Handoff {
                     // rides the interpreter's own args for the no-entry
                     // boot.
                     h.interpreter_args.push(arg.clone());
+                    i += 1;
+                }
+                "--tebako-trace" => {
+                    // The spec 25 §2 trace channel; opened at boot,
+                    // before any mount; overrides TEBAKO_TRACE.
+                    let value = take_value(flag, inline, argv, &mut i)?;
+                    if value.is_empty() {
+                        return Err(DriverError::new(
+                            EX_TEBAKO_MANIFEST,
+                            "--tebako-trace shall name a channel path".to_string(),
+                        ));
+                    }
+                    h.trace = Some(value);
                     i += 1;
                 }
                 "--tebako-run" => {
@@ -309,6 +330,33 @@ mod tests {
         let err = Handoff::parse(&argv(&["ruby", "--tebako-image"])).unwrap_err();
         assert_eq!(err.code, EX_TEBAKO_MANIFEST);
         let err = Handoff::parse(&argv(&["ruby", "--tebako-entry"])).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_MANIFEST);
+        let err = Handoff::parse(&argv(&["ruby", "--tebako-trace"])).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_MANIFEST);
+    }
+
+    #[test]
+    fn tebako_trace_parses_both_value_forms() {
+        let h = Handoff::parse(&argv(&["ruby", "--tebako-trace", "/tmp/t.jsonl"])).unwrap();
+        assert_eq!(h.trace.as_deref(), Some("/tmp/t.jsonl"));
+        let h = Handoff::parse(&argv(&["ruby", "--tebako-trace=/tmp/t.jsonl"])).unwrap();
+        assert_eq!(h.trace.as_deref(), Some("/tmp/t.jsonl"));
+        // Not consumed as an interpreter arg, and composes with images.
+        assert!(h.interpreter_args.is_empty());
+        let h = Handoff::parse(&argv(&[
+            "ruby",
+            "--tebako-image",
+            "/x.tfs:-:/",
+            "--tebako-trace=/tmp/t.jsonl",
+            "--tebako-entry",
+            "/bin/x",
+        ]))
+        .unwrap();
+        assert_eq!(h.trace.as_deref(), Some("/tmp/t.jsonl"));
+        assert_eq!(h.images.len(), 1);
+        assert_eq!(h.entry.as_deref(), Some("/bin/x"));
+        // An empty channel path is a named error.
+        let err = Handoff::parse(&argv(&["ruby", "--tebako-trace="])).unwrap_err();
         assert_eq!(err.code, EX_TEBAKO_MANIFEST);
     }
 }

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -37,6 +37,7 @@ fn reset() {
         .write()
         .unwrap()
         .set_host_policy(tfs::policy::HostPolicy::open(), None);
+    tfs::trace::disarm();
 }
 
 // ---------------------------------------------------------------------
@@ -215,6 +216,80 @@ fn a_boot_without_the_env_image_is_legal_and_mounts_nothing() {
     let out = boot(&argv(&["ruby", "--version"]), "/__tfs__", &env).unwrap();
     assert_eq!(out.argv, argv(&["ruby", "--version"]));
     assert!(!context().read().unwrap().is_mounted());
+}
+
+// ---------------------------------------------------------------------
+// the trace channel (spec 25 §2, phase T1)
+// ---------------------------------------------------------------------
+
+#[test]
+fn tebako_trace_env_arms_the_bus_before_any_mount() {
+    let g = guard("trace-env");
+    let env_image = write_env_image(g.path());
+    let capture = g.path().join("trace.jsonl");
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+    env.set("TEBAKO_TRACE", capture.display().to_string());
+
+    boot(&argv(&["ruby", "--version"]), "/__tfs__", &env).unwrap();
+
+    // The channel opened at boot, BEFORE the env image mounted — so the
+    // mount decision itself is in the capture.
+    let text = std::fs::read_to_string(&capture).expect("the boot opened the channel");
+    let mount = text
+        .lines()
+        .find(|l| l.contains("\"op\":\"mount\""))
+        .unwrap_or_else(|| panic!("a mount event was traced: {text}"));
+    assert!(mount.contains("\"verdict\":\"ok\""), "{mount}");
+    assert!(mount.contains("/__tfs__"), "{mount}");
+    assert!(tfs::trace::armed(), "the bus stays armed for the run");
+}
+
+#[test]
+fn tebako_trace_argument_wins_over_the_env() {
+    let g = guard("trace-arg");
+    let env_capture = g.path().join("env.jsonl");
+    let arg_capture = g.path().join("arg.jsonl");
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_TRACE", env_capture.display().to_string());
+
+    let out = boot(
+        &argv(&[
+            "ruby",
+            "--tebako-trace",
+            &arg_capture.display().to_string(),
+            "--version",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap();
+
+    assert!(arg_capture.is_file(), "the argument's channel opened");
+    assert!(
+        !env_capture.exists(),
+        "the env channel never opened — the argument wins"
+    );
+    // The consumed loader flag never leaks into the interpreter's argv.
+    assert_eq!(out.argv, argv(&["ruby", "--version"]));
+}
+
+#[test]
+fn a_broken_trace_channel_only_notes_and_the_boot_proceeds() {
+    let g = guard("trace-broken");
+    let blocker = g.path().join("blocker");
+    std::fs::write(&blocker, b"x").unwrap();
+    let mut env = MapEnv::new();
+    // The channel's parent is a regular FILE: arm() cannot open it —
+    // one loud stderr note, the run proceeds (observability never gates).
+    env.set(
+        "TEBAKO_TRACE",
+        blocker.join("t.jsonl").display().to_string(),
+    );
+
+    let out = boot(&argv(&["ruby", "--version"]), "/__tfs__", &env).unwrap();
+    assert_eq!(out.argv, argv(&["ruby", "--version"]));
+    assert!(!tfs::trace::armed(), "the bus stayed disarmed");
 }
 
 #[test]

--- a/crates/tebako-json/src/lib.rs
+++ b/crates/tebako-json/src/lib.rs
@@ -296,6 +296,52 @@ pub fn to_string(v: &Value) -> String {
     out
 }
 
+/// Serialize a [`Value`] in the compact single-line form (no whitespace
+/// anywhere) — the JSONL emission shape (spec 25 §3's event stream: one
+/// JSON object per line). `Number` values are emitted verbatim, strings
+/// through [`escape`].
+pub fn to_line(v: &Value) -> String {
+    let mut out = String::new();
+    write_line(v, &mut out);
+    out
+}
+
+fn write_line(v: &Value, out: &mut String) {
+    match v {
+        Value::Null => out.push_str("null"),
+        Value::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+        Value::Number(n) => out.push_str(n),
+        Value::String(s) => {
+            out.push('"');
+            out.push_str(&escape(s));
+            out.push('"');
+        }
+        Value::Array(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_line(item, out);
+            }
+            out.push(']');
+        }
+        Value::Object(members) => {
+            out.push('{');
+            for (i, (k, val)) in members.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push('"');
+                out.push_str(&escape(k));
+                out.push_str("\":");
+                write_line(val, out);
+            }
+            out.push('}');
+        }
+    }
+}
+
 fn write_value(v: &Value, indent: usize, out: &mut String) {
     match v {
         Value::Null => out.push_str("null"),
@@ -385,5 +431,42 @@ mod tests {
         assert_eq!(to_string(&Value::Object(vec![])), "{}");
         assert_eq!(to_string(&Value::Array(vec![])), "[]");
         assert_eq!(to_string(&Value::Null), "null");
+    }
+
+    #[test]
+    fn line_writer_is_compact_and_round_trips() {
+        // The JSONL emission shape (spec 25 §3): one line, no whitespace,
+        // and the parser accepts exactly what was emitted.
+        let v = Value::Object(vec![
+            ("v".into(), Value::Number("1".into())),
+            (
+                "ts".into(),
+                Value::String("2026-08-19T13:49:20.344211Z".into()),
+            ),
+            ("pid".into(), Value::Number("84213".into())),
+            ("op".into(), Value::String("open".into())),
+            (
+                "path".into(),
+                Value::String("/x/My Docs/quote\"\\\n".into()),
+            ),
+            ("flag".into(), Value::Bool(true)),
+            ("nothing".into(), Value::Null),
+            (
+                "detail".into(),
+                Value::Object(vec![(
+                    "deps".into(),
+                    Value::Array(vec![Value::Object(vec![
+                        ("name".into(), Value::String("libx.so".into())),
+                        ("verdict".into(), Value::String("materialized".into())),
+                    ])]),
+                )]),
+            ),
+        ]);
+        let line = to_line(&v);
+        assert!(!line.contains('\n'), "{line}");
+        assert!(!line.contains(": "), "{line}");
+        assert_eq!(parse(&line).unwrap(), v);
+        assert_eq!(to_line(&Value::Object(vec![])), "{}");
+        assert_eq!(to_line(&Value::Array(vec![])), "[]");
     }
 }

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -19,6 +19,9 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 libc = "0.2"
 # The stack's one logging facility (TEBAKO_DEBUG; zero cost when off).
 tebako-log = { version = "0.1.0", path = "../tebako-log" }
+# The spec 25 trace bus's JSONL emission (spec 25 §7 blesses tebako-json —
+# workspace-internal, zero deps of its own — for event serialization).
+tebako-json = { version = "0.1.0", path = "../tebako-json" }
 # The `zip` crate (pure Rust) rather than libzip-sys: the C ABI contract is
 # behavioral, not library-level; a pure-Rust reader keeps consumers and CI
 # free of a native libzip build, and the v1 scope (read-only, no encryption)

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -9,10 +9,13 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::RwLock;
 
+use tebako_json::Value;
+
 use crate::backend::{Backend, EntryType, RawDirEntry, RawStat, WritableBackend};
 use crate::exec_closure;
 use crate::mount::MountMode;
 use crate::policy::{HostAccess, HostPolicy};
+use crate::trace;
 
 /// Flag bit distinguishing libtfs FDs from host OS FDs.
 pub const TEBAKO_FD_FLAG: i32 = 0x4000_0000;
@@ -117,6 +120,17 @@ struct DlAlias {
     host: std::path::PathBuf,
 }
 
+/// Which interception surface a dlmap2file answer serves — the trace
+/// event's op and shape follow it (spec 25 §2: the `dlopen` op carries
+/// the closure walk; an fopen routing is an `open` event with the
+/// `materialized` detail; internal callers emit their own op events).
+#[derive(Clone, Copy)]
+enum DlSurface {
+    Dlopen,
+    Open,
+    Silent,
+}
+
 /// The process-global context state (behind a lock; see [`context`]).
 pub struct FsContext {
     mounts: BTreeMap<i32, Mount>,
@@ -207,12 +221,19 @@ impl FsContext {
     /// Under the record policy (spec 23 §8) ALLOWS are journaled too
     /// (`event=jail-allow`) — the "perm all and monitor" trail the
     /// `tfs needs` generator turns into a draft `needs:` block.
+    ///
+    /// The trace bus's jail channel (spec 25 §2) is the same decisions,
+    /// formalized: every journaled decision is also a `jail` event
+    /// (`record` / `allow:<source>` / `deny:<source>`). The open default
+    /// stays silent on the bus exactly as on the journal — the open/stat
+    /// events already carry the passthrough.
     pub fn host_check<P: AsRef<std::path::Path>>(
         &self,
         path: P,
         need: HostAccess,
     ) -> Result<(), i32> {
         let path = path.as_ref();
+        let trace_start = trace::Start::now();
         match self.host_policy.check(path, need) {
             Ok(()) => {
                 if self.host_policy.is_record() {
@@ -225,11 +246,39 @@ impl FsContext {
                         );
                     }
                 }
+                if let Some(start) = trace_start {
+                    let verdict = if self.host_policy.is_record() {
+                        Some("record".to_string())
+                    } else if !self.host_policy.never_denies() {
+                        Some(format!("allow:{}", self.host_policy.source()))
+                    } else {
+                        None
+                    };
+                    if let Some(verdict) = verdict {
+                        trace::emit(
+                            trace::Event::new(trace::Op::Jail, path.to_string_lossy(), verdict)
+                                .detail("access", Value::String(need_token(need).to_string()))
+                                .dur(start),
+                        );
+                    }
+                }
                 Ok(())
             }
             Err(e) => {
                 if let Some(journal) = &self.journal {
                     crate::journal::journal_deny(journal, path, need, self.host_policy.source());
+                }
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(
+                            trace::Op::Jail,
+                            path.to_string_lossy(),
+                            format!("deny:{}", self.host_policy.source()),
+                        )
+                        .detail("access", Value::String(need_token(need).to_string()))
+                        .with_errno(e)
+                        .dur(start),
+                    );
                 }
                 Err(e)
             }
@@ -242,12 +291,29 @@ impl FsContext {
 
     /// Legacy single-mount init: fails with EEXIST when anything is mounted.
     pub fn init_mount(&mut self, mount: Mount) -> Result<(), i32> {
-        if !self.mounts.is_empty() {
-            return Err(libc::EEXIST);
+        let trace_start = trace::Start::now();
+        // The event's subjects are captured only when armed — disarmed,
+        // the cost stays the single Start::now() branch (spec 25 §2).
+        let subject = trace_start.map(|_| {
+            (
+                mount.mount_point.clone(),
+                mount
+                    .archive_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().into_owned()),
+            )
+        });
+        let result = if self.mounts.is_empty() {
+            let handle = self.insert_mount(mount);
+            self.compat_handle = Some(handle);
+            Ok(handle)
+        } else {
+            Err(libc::EEXIST)
+        };
+        if let Some((point, image)) = &subject {
+            trace_mount(trace_start, "init", point, image.as_deref(), &result);
         }
-        let handle = self.insert_mount(mount);
-        self.compat_handle = Some(handle);
-        Ok(())
+        result.map(|_| ())
     }
 
     /// Insert a mount; returns its handle.
@@ -262,13 +328,27 @@ impl FsContext {
     /// Multi-mount API: validate + insert, with the C++ errno contract.
     /// `Err` on taken mount point (EEXIST) or empty mount point (EINVAL).
     pub fn mount_checked(&mut self, mount: Mount) -> Result<i32, i32> {
-        if mount.mount_point.is_empty() {
-            return Err(libc::EINVAL);
+        let trace_start = trace::Start::now();
+        let subject = trace_start.map(|_| {
+            (
+                mount.mount_point.clone(),
+                mount
+                    .archive_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().into_owned()),
+            )
+        });
+        let result = if mount.mount_point.is_empty() {
+            Err(libc::EINVAL)
+        } else if self.mount_point_taken(&mount.mount_point) {
+            Err(libc::EEXIST)
+        } else {
+            Ok(self.insert_mount(mount))
+        };
+        if let Some((point, image)) = &subject {
+            trace_mount(trace_start, "insert", point, image.as_deref(), &result);
         }
-        if self.mount_point_taken(&mount.mount_point) {
-            return Err(libc::EEXIST);
-        }
-        Ok(self.insert_mount(mount))
+        result
     }
 
     /// Multi-mount API, union mode (spec 17 §1 / spec 03 §6): `mount`'s
@@ -280,7 +360,26 @@ impl FsContext {
     /// point is free — a union needs an incumbent (a lone image is a
     /// plain exclusive mount).
     pub fn mount_union(&mut self, mount: Mount) -> Result<i32, i32> {
+        let trace_start = trace::Start::now();
+        let subject = trace_start.map(|_| {
+            (
+                mount.mount_point.clone(),
+                mount
+                    .archive_path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().into_owned()),
+            )
+        });
         if mount.mount_point.is_empty() {
+            if let Some((point, image)) = &subject {
+                trace_mount(
+                    trace_start,
+                    "union",
+                    point,
+                    image.as_deref(),
+                    &Err(libc::EINVAL),
+                );
+            }
             return Err(libc::EINVAL);
         }
         let Some(handle) = self
@@ -289,13 +388,35 @@ impl FsContext {
             .find(|m| m.mount_point == mount.mount_point)
             .map(|m| m.handle)
         else {
+            if let Some((point, image)) = &subject {
+                trace_mount(
+                    trace_start,
+                    "union",
+                    point,
+                    image.as_deref(),
+                    &Err(libc::ENODEV),
+                );
+            }
             return Err(libc::ENODEV);
         };
         let mut incumbent = self.mounts.remove(&handle).ok_or(libc::ENODEV)?;
-        let union =
-            crate::backends_union::UnionBackend::new(vec![incumbent.backend, mount.backend])?;
+        let union = match crate::backends_union::UnionBackend::new(vec![
+            incumbent.backend,
+            mount.backend,
+        ]) {
+            Ok(union) => union,
+            Err(e) => {
+                if let Some((point, image)) = &subject {
+                    trace_mount(trace_start, "union", point, image.as_deref(), &Err(e));
+                }
+                return Err(e);
+            }
+        };
         incumbent.backend = Box::new(union);
         self.mounts.insert(handle, incumbent);
+        if let Some((point, image)) = &subject {
+            trace_mount(trace_start, "union", point, image.as_deref(), &Ok(handle));
+        }
         Ok(handle)
     }
 
@@ -311,17 +432,31 @@ impl FsContext {
     /// is flushed whole (entries carry no owner; serving an extraction of
     /// the removed mount's image afterwards would be a stale leak).
     pub fn unmount_handle(&mut self, handle: i32) -> Result<(), i32> {
-        if !self.mounts.contains_key(&handle) {
-            return Err(libc::ENODEV);
+        let trace_start = trace::Start::now();
+        let subject =
+            trace_start.and_then(|_| self.mounts.get(&handle).map(|m| m.mount_point.clone()));
+        let result = if self.mounts.contains_key(&handle) {
+            self.fd_table.retain(|_, e| e.owner != handle);
+            self.dir_table.retain(|_, e| e.owner != handle);
+            self.mounts.remove(&handle);
+            if self.compat_handle == Some(handle) {
+                self.compat_handle = None;
+            }
+            self.dl_cache.clear();
+            Ok(handle)
+        } else {
+            Err(libc::ENODEV)
+        };
+        if trace_start.is_some() {
+            trace_mount(
+                trace_start,
+                "remove",
+                subject.as_deref().unwrap_or(""),
+                None,
+                &result,
+            );
         }
-        self.fd_table.retain(|_, e| e.owner != handle);
-        self.dir_table.retain(|_, e| e.owner != handle);
-        self.mounts.remove(&handle);
-        if self.compat_handle == Some(handle) {
-            self.compat_handle = None;
-        }
-        self.dl_cache.clear();
-        Ok(())
+        result.map(|_| ())
     }
 
     /// Unmount everything; all fds and dir handles become invalid. The
@@ -331,6 +466,14 @@ impl FsContext {
     /// the per-process tmpdir until the exit cleanup — the map is what
     /// must not outlive the mounts).
     pub fn unmount(&mut self) {
+        if let Some(start) = trace::Start::now() {
+            trace::emit(
+                trace::Event::new(trace::Op::Mount, "", "ok")
+                    .detail("action", Value::String("clear".to_string()))
+                    .detail("count", trace::num(self.mounts.len()))
+                    .dur(start),
+            );
+        }
         self.mounts.clear();
         self.fd_table.clear();
         self.dir_table.clear();
@@ -451,13 +594,26 @@ impl FsContext {
     // ---------------------------------------------------------------
 
     /// tebako_fs_open: dispatch + fd allocation. Returns the public fd
-    /// (with TEBAKO_FD_FLAG).
+    /// (with TEBAKO_FD_FLAG). One `open` trace event per call when the
+    /// bus is armed (spec 25 §2): `image:<mount>` (with
+    /// `dlmap_redirect`/`materialized` details when the dlmap-prefix
+    /// redirect served a raw host fd — the §4 materialize-candidate
+    /// signal), `host` (passthrough), `denied:<rule>` (jail source or
+    /// the spec 24 §5 write gate), or `error:<errno>`.
     pub fn open(&mut self, path: &str, flags: i32) -> Result<i32, i32> {
         let path = &Self::normalize(path);
+        let trace_start = trace::Start::now();
         if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
             eprintln!("[tfs] open: {path}");
         }
         if self.mounts.is_empty() {
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(trace::Op::Open, path, "host")
+                        .detail("reason", Value::String("no-mounts".to_string()))
+                        .dur(start),
+                );
+            }
             return Err(libc::ENODEV);
         }
         // dlmap-prefix redirect: a path under the dlmap cache
@@ -473,8 +629,51 @@ impl FsContext {
                 if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
                     eprintln!("[tfs] dlmap redirect: {path} -> {tail}");
                 }
-                let host = self.dlmap2file(&tail)?;
-                return real_open(&host, flags);
+                let host = match self.dlmap2file_inner(&tail) {
+                    Ok(host) => host,
+                    Err(e) => {
+                        if let Some(start) = trace_start {
+                            trace::emit(
+                                trace::Event::new(trace::Op::Open, path, format!("error:{e}"))
+                                    .detail("dlmap_redirect", Value::String(tail.clone()))
+                                    .with_errno(e)
+                                    .dur(start),
+                            );
+                        }
+                        return Err(e);
+                    }
+                };
+                return match real_open(&host, flags) {
+                    Ok(fd) => {
+                        if let Some(start) = trace_start {
+                            let point = self
+                                .find_mount(&tail)
+                                .map(|m| m.mount_point.clone())
+                                .unwrap_or_default();
+                            trace::emit(
+                                trace::Event::new(trace::Op::Open, path, format!("image:{point}"))
+                                    .detail("dlmap_redirect", Value::String(tail))
+                                    .detail(
+                                        "materialized",
+                                        Value::String(host.to_string_lossy().into_owned()),
+                                    )
+                                    .dur(start),
+                            );
+                        }
+                        Ok(fd)
+                    }
+                    Err(e) => {
+                        if let Some(start) = trace_start {
+                            trace::emit(
+                                trace::Event::new(trace::Op::Open, path, format!("error:{e}"))
+                                    .detail("dlmap_redirect", Value::String(tail))
+                                    .with_errno(e)
+                                    .dur(start),
+                            );
+                        }
+                        Err(e)
+                    }
+                };
             }
         }
         let Some(mount) = self.find_mount(path) else {
@@ -488,7 +687,28 @@ impl FsContext {
             } else {
                 HostAccess::Rw
             };
-            self.host_check(path, need)?;
+            if let Err(e) = self.host_check(path, need) {
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(
+                            trace::Op::Open,
+                            path,
+                            format!("denied:{}", self.host_policy.source()),
+                        )
+                        .detail("need", Value::String(need_token(need).to_string()))
+                        .with_errno(e)
+                        .dur(start),
+                    );
+                }
+                return Err(e);
+            }
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(trace::Op::Open, path, "host")
+                        .detail("need", Value::String(need_token(need).to_string()))
+                        .dur(start),
+                );
+            }
             return Err(libc::ENOENT);
         };
         let rel = Self::relative_path(mount, path);
@@ -509,6 +729,13 @@ impl FsContext {
                 if accmode != libc::O_RDONLY && self.path_is_held(path) {
                     // The spec 24 §5 write gate: EROFS, journaled.
                     self.journal_write_denial(path, &mount.mount_point);
+                    if let Some(start) = trace_start {
+                        trace::emit(
+                            trace::Event::new(trace::Op::Open, path, "denied:write-gate")
+                                .with_errno(libc::EROFS)
+                                .dur(start),
+                        );
+                    }
                     return Err(libc::EROFS);
                 }
                 let need = if accmode == libc::O_RDONLY {
@@ -516,10 +743,40 @@ impl FsContext {
                 } else {
                     HostAccess::Rw
                 };
-                self.host_check(path, need)?;
+                if let Err(e) = self.host_check(path, need) {
+                    if let Some(start) = trace_start {
+                        trace::emit(
+                            trace::Event::new(
+                                trace::Op::Open,
+                                path,
+                                format!("denied:{}", self.host_policy.source()),
+                            )
+                            .detail("need", Value::String(need_token(need).to_string()))
+                            .with_errno(e)
+                            .dur(start),
+                        );
+                    }
+                    return Err(e);
+                }
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(trace::Op::Open, path, "host")
+                            .detail("need", Value::String(need_token(need).to_string()))
+                            .dur(start),
+                    );
+                }
                 return Err(libc::ENOENT);
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(trace::Op::Open, path, format!("error:{e}"))
+                            .with_errno(e)
+                            .dur(start),
+                    );
+                }
+                return Err(e);
+            }
         };
         // Only O_RDONLY is supported: mounted content is read-only
         // (fd-based writes land with the spec 11 §7 write family;
@@ -528,16 +785,40 @@ impl FsContext {
         // tree by construction — the spec 24 §5 gate: EROFS, journaled.
         if (flags & O_ACCMODE) != libc::O_RDONLY {
             self.journal_write_denial(path, &mount.mount_point);
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(trace::Op::Open, path, "denied:write-gate")
+                        .with_errno(libc::EROFS)
+                        .dur(start),
+                );
+            }
             return Err(libc::EROFS);
         }
         match st.entry_type {
             EntryType::File => {}
             // C++ maps NotAFile -> EISDIR for any non-regular open.
-            _ => return Err(libc::EISDIR),
+            _ => {
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(trace::Op::Open, path, format!("error:{}", libc::EISDIR))
+                            .with_errno(libc::EISDIR)
+                            .dur(start),
+                    );
+                }
+                return Err(libc::EISDIR);
+            }
         }
         let owner = mount.handle;
+        let trace_point = trace_start.map(|_| mount.mount_point.clone());
         let fd = self.next_fd;
         if fd > TEBAKO_FD_MAX {
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(trace::Op::Open, path, format!("error:{}", libc::EMFILE))
+                        .with_errno(libc::EMFILE)
+                        .dur(start),
+                );
+            }
             return Err(libc::EMFILE);
         }
         self.next_fd += 1;
@@ -550,6 +831,11 @@ impl FsContext {
                 owner,
             },
         );
+        if let (Some(start), Some(point)) = (trace_start, trace_point) {
+            trace::emit(
+                trace::Event::new(trace::Op::Open, path, format!("image:{point}")).dur(start),
+            );
+        }
         Ok(fd | TEBAKO_FD_FLAG)
     }
 
@@ -749,7 +1035,15 @@ impl FsContext {
     /// tebako_fs_stat.
     pub fn stat(&self, path: &str) -> Result<RawStat, i32> {
         let path = &Self::normalize(path);
+        let trace_start = trace::Start::now();
         if self.mounts.is_empty() {
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(trace::Op::Stat, path, "host")
+                        .detail("reason", Value::String("no-mounts".to_string()))
+                        .dur(start),
+                );
+            }
             return Err(libc::ENODEV);
         }
         // dlmap-prefix redirect (see open()): answer with the memfs
@@ -759,23 +1053,88 @@ impl FsContext {
             if let Some(mount) = self.find_mount(&tail) {
                 let rel = Self::relative_path(mount, &tail);
                 if let Ok(st) = mount.backend.stat(rel) {
+                    if let Some(start) = trace_start {
+                        trace::emit(
+                            trace::Event::new(
+                                trace::Op::Stat,
+                                path,
+                                format!("image:{}", mount.mount_point),
+                            )
+                            .detail("dlmap_redirect", Value::String(tail))
+                            .dur(start),
+                        );
+                    }
                     return Ok(st);
                 }
             }
         }
         let Some(mount) = self.find_mount(path) else {
             // Host-passthrough decision (spec 08), see open().
-            self.host_check(path, HostAccess::Ro)?;
+            if let Err(e) = self.host_check(path, HostAccess::Ro) {
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(
+                            trace::Op::Stat,
+                            path,
+                            format!("denied:{}", self.host_policy.source()),
+                        )
+                        .with_errno(e)
+                        .dur(start),
+                    );
+                }
+                return Err(e);
+            }
+            if let Some(start) = trace_start {
+                trace::emit(trace::Event::new(trace::Op::Stat, path, "host").dur(start));
+            }
             return Err(libc::ENOENT);
         };
         let rel = Self::relative_path(mount, path);
         match mount.backend.stat(rel) {
             // Covered but not held: a host path (see open()).
             Err(e) if e == libc::ENOENT => {
-                self.host_check(path, HostAccess::Ro)?;
+                if let Err(e) = self.host_check(path, HostAccess::Ro) {
+                    if let Some(start) = trace_start {
+                        trace::emit(
+                            trace::Event::new(
+                                trace::Op::Stat,
+                                path,
+                                format!("denied:{}", self.host_policy.source()),
+                            )
+                            .with_errno(e)
+                            .dur(start),
+                        );
+                    }
+                    return Err(e);
+                }
+                if let Some(start) = trace_start {
+                    trace::emit(trace::Event::new(trace::Op::Stat, path, "host").dur(start));
+                }
                 Err(libc::ENOENT)
             }
-            other => other,
+            Err(e) => {
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(trace::Op::Stat, path, format!("error:{e}"))
+                            .with_errno(e)
+                            .dur(start),
+                    );
+                }
+                Err(e)
+            }
+            Ok(st) => {
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(
+                            trace::Op::Stat,
+                            path,
+                            format!("image:{}", mount.mount_point),
+                        )
+                        .dur(start),
+                    );
+                }
+                Ok(st)
+            }
         }
     }
 
@@ -1042,22 +1401,54 @@ impl FsContext {
     pub fn dlalias2file(&self, name: &str) -> Result<std::ffi::CString, i32> {
         if name.bytes().any(|b| b == b'/' || b == b'\\' || b == b':') {
             // Not a bare name — the alias rule never engages; no
-            // bare-name verdict exists, so nothing is journaled.
+            // bare-name verdict exists, so nothing is journaled (and no
+            // dlopen event either — the same bare-name-only rule).
             return Err(libc::ENOENT);
         }
+        let trace_start = trace::Start::now();
         let Some(alias) = self
             .dlaliases
             .iter()
             .find(|a| a.name.eq_ignore_ascii_case(name))
         else {
             self.journal_lib_load(name, "host");
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(trace::Op::Dlopen, name, "host")
+                        .detail("alias", Value::Bool(false))
+                        .dur(start),
+                );
+            }
             return Err(libc::ENOENT);
         };
         self.journal_lib_load(name, "alias");
         if !alias.host.exists() {
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(trace::Op::Dlopen, name, format!("error:{}", libc::EIO))
+                        .detail("alias", Value::Bool(true))
+                        .with_errno(libc::EIO)
+                        .dur(start),
+                );
+            }
             return Err(libc::EIO);
         }
-        std::ffi::CString::new(alias.host.to_string_lossy().into_owned()).map_err(|_| libc::EIO)
+        let result = std::ffi::CString::new(alias.host.to_string_lossy().into_owned())
+            .map_err(|_| libc::EIO);
+        if let Some(start) = trace_start {
+            let event = match &result {
+                Ok(_) => trace::Event::new(
+                    trace::Op::Dlopen,
+                    name,
+                    format!("materialized:{}", alias.host.display()),
+                ),
+                Err(e) => {
+                    trace::Event::new(trace::Op::Dlopen, name, format!("error:{e}")).with_errno(*e)
+                }
+            };
+            trace::emit(event.detail("alias", Value::Bool(true)).dur(start));
+        }
+        result
     }
 
     /// One lib-load verdict line on the audit journal, under the record
@@ -1085,8 +1476,38 @@ impl FsContext {
     /// originals. A drive-letter memfs root (msys `A:/t`) flattens its
     /// colon in the tail (`host_tail`) so the host join stays relative —
     /// the redirect inverse degrades to host-serve there.
+    ///
+    /// The dlopen surface's trace event (spec 25 §2): verdict
+    /// `materialized:<host>` / `host` / `error:<errno>`, the closure
+    /// walk's format + per-dep verdicts in the detail.
     pub fn dlmap2file(&mut self, path: &str) -> Result<std::ffi::CString, i32> {
+        self.dlmap2file_traced(path, DlSurface::Dlopen)
+    }
+
+    /// The preload's fopen routing (libtfs-preload `vfs_fopen`): the same
+    /// engine answer, but the surface is stdio — the event is the `open`
+    /// op carrying the `materialized` detail (the §4 materialize-
+    /// candidate signal), never a dlopen event.
+    pub fn dlmap2file_for_open(&mut self, path: &str) -> Result<std::ffi::CString, i32> {
+        self.dlmap2file_traced(path, DlSurface::Open)
+    }
+
+    /// open()'s dlmap-prefix redirect and exec_materialize's fallback:
+    /// the caller emits its own op event — no surface event here.
+    fn dlmap2file_inner(&mut self, path: &str) -> Result<std::ffi::CString, i32> {
+        self.dlmap2file_traced(path, DlSurface::Silent)
+    }
+
+    fn dlmap2file_traced(
+        &mut self,
+        path: &str,
+        surface: DlSurface,
+    ) -> Result<std::ffi::CString, i32> {
         let path = &Self::normalize(path);
+        let trace_start = trace::Start::now();
+        // The closure walk's trace record, filled by the top
+        // extract_for_exec frame only (recursion passes None).
+        let mut closure = trace_start.map(|_| trace::ClosureTrace::default());
         // dlmap-prefix redirect (see open()): the dlmap spelling of a
         // memfs path materializes the original — stdio (`fopen`) and
         // dlopen consumers of loader-computed paths land here.
@@ -1096,18 +1517,66 @@ impl FsContext {
             eprintln!("[tfs] dlmap2file: {path} (effective {effective})");
         }
         let mut visited = std::collections::HashSet::new();
-        let host = self.extract_for_exec(
+        let result = self.extract_for_exec(
             effective,
             effective,
             &ClosureDest::Dlcache,
             &[],
             &mut visited,
-        )?;
-        if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
-            eprintln!("[tfs] dlmap2file: {effective} -> {}", host.display());
+            closure.as_mut(),
+        );
+        if let Ok(host) = &result {
+            if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+                eprintln!("[tfs] dlmap2file: {effective} -> {}", host.display());
+            }
         }
-        let s = host.to_string_lossy().into_owned();
-        std::ffi::CString::new(s).map_err(|_| libc::EIO)
+        let result = result.and_then(|host| {
+            std::ffi::CString::new(host.to_string_lossy().into_owned()).map_err(|_| libc::EIO)
+        });
+        if let (Some(start), Some(closure)) = (trace_start, closure) {
+            let event = match (surface, &result) {
+                // No surface event — the caller emits its own op event.
+                (DlSurface::Silent, _) => None,
+                (DlSurface::Dlopen, Ok(host)) => Some(trace::Event::new(
+                    trace::Op::Dlopen,
+                    path,
+                    format!("materialized:{}", host.to_string_lossy()),
+                )),
+                (DlSurface::Dlopen, Err(e)) if *e == libc::ENOENT => {
+                    Some(trace::Event::new(trace::Op::Dlopen, path, "host"))
+                }
+                (DlSurface::Dlopen, Err(e)) => Some(
+                    trace::Event::new(trace::Op::Dlopen, path, format!("error:{e}")).with_errno(*e),
+                ),
+                (DlSurface::Open, Ok(host)) => {
+                    let point = self
+                        .find_mount(effective)
+                        .map(|m| m.mount_point.clone())
+                        .unwrap_or_default();
+                    Some(
+                        trace::Event::new(trace::Op::Open, path, format!("image:{point}")).detail(
+                            "materialized",
+                            Value::String(host.to_string_lossy().into_owned()),
+                        ),
+                    )
+                }
+                (DlSurface::Open, Err(e)) if *e == libc::ENOENT => {
+                    Some(trace::Event::new(trace::Op::Open, path, "host"))
+                }
+                (DlSurface::Open, Err(e)) => Some(
+                    trace::Event::new(trace::Op::Open, path, format!("error:{e}")).with_errno(*e),
+                ),
+            };
+            if let Some(event) = event {
+                let event = if effective == path.as_str() {
+                    event
+                } else {
+                    event.detail("effective", Value::String(effective.to_string()))
+                };
+                trace::emit(event.detail("closure", closure.into_value()).dur(start));
+            }
+        }
+        result
     }
 
     /// The per-process dl tmpdir, created and cleanup-registered on
@@ -1129,8 +1598,13 @@ impl FsContext {
     /// so the closure walk's answer boots a java that cannot find its
     /// boot class path (the metanorma dogfood's jing failure). Any
     /// other mount answers via dlmap2file's closure walk, unchanged.
+    /// The `exec` trace event (spec 25 §2): `routed:<host>` with the
+    /// `route` detail (`home-tree` | `dlmap-closure`), `host` on the
+    /// ENOENT fallthrough (the §4 entrypoint-note signal), or
+    /// `error:<errno>`.
     pub fn exec_materialize(&mut self, path: &str) -> Result<std::ffi::CString, i32> {
         let normalized = Self::normalize(path);
+        let trace_start = trace::Start::now();
         if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
             eprintln!("[tfs] exec_materialize: path={path} normalized={normalized}");
         }
@@ -1149,19 +1623,98 @@ impl FsContext {
                     "[tfs] exec_materialize: path={path} -> dlmap2file fallback (no home mount)"
                 );
             }
-            return self.dlmap2file(path);
+            let result = self.dlmap2file_inner(path);
+            if let Some(start) = trace_start {
+                let event = match &result {
+                    Ok(host) => trace::Event::new(
+                        trace::Op::Exec,
+                        &normalized,
+                        format!("routed:{}", host.to_string_lossy()),
+                    )
+                    .detail("route", Value::String("dlmap-closure".to_string())),
+                    // ENOENT: nothing held — the consumer execs the host
+                    // path (the §4 entrypoint/runtime-dep note signal).
+                    Err(e) if *e == libc::ENOENT => {
+                        trace::Event::new(trace::Op::Exec, &normalized, "host")
+                    }
+                    Err(e) => trace::Event::new(trace::Op::Exec, &normalized, format!("error:{e}"))
+                        .with_errno(*e),
+                };
+                trace::emit(event.dur(start));
+            }
+            return result;
         };
         if rel.is_empty() {
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(
+                        trace::Op::Exec,
+                        &normalized,
+                        format!("error:{}", libc::EISDIR),
+                    )
+                    .with_errno(libc::EISDIR)
+                    .dur(start),
+                );
+            }
             return Err(libc::EISDIR);
         }
-        let root = self.home_tree_root(handle)?;
+        let root = match self.home_tree_root(handle) {
+            Ok(root) => root,
+            Err(e) => {
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(trace::Op::Exec, &normalized, format!("error:{e}"))
+                            .with_errno(e)
+                            .dur(start),
+                    );
+                }
+                return Err(e);
+            }
+        };
         if self.home_trees.insert(handle) {
-            let mount = self.mounts.get(&handle).ok_or(libc::ENODEV)?;
+            let Some(mount) = self.mounts.get(&handle) else {
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(
+                            trace::Op::Exec,
+                            &normalized,
+                            format!("error:{}", libc::ENODEV),
+                        )
+                        .with_errno(libc::ENODEV)
+                        .dur(start),
+                    );
+                }
+                return Err(libc::ENODEV);
+            };
             let mut skipped = 0usize;
-            extract_dir_recursive(mount.backend.as_ref(), "", &root, &mut skipped)?;
+            if let Err(e) = extract_dir_recursive(mount.backend.as_ref(), "", &root, &mut skipped) {
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(trace::Op::Exec, &normalized, format!("error:{e}"))
+                            .with_errno(e)
+                            .dur(start),
+                    );
+                }
+                return Err(e);
+            }
         }
         let host = root.join(&rel);
-        std::ffi::CString::new(host.to_string_lossy().into_owned()).map_err(|_| libc::EIO)
+        let result =
+            std::ffi::CString::new(host.to_string_lossy().into_owned()).map_err(|_| libc::EIO);
+        if let Some(start) = trace_start {
+            let event = match &result {
+                Ok(_) => trace::Event::new(
+                    trace::Op::Exec,
+                    &normalized,
+                    format!("routed:{}", host.display()),
+                )
+                .detail("route", Value::String("home-tree".to_string())),
+                Err(e) => trace::Event::new(trace::Op::Exec, &normalized, format!("error:{e}"))
+                    .with_errno(*e),
+            };
+            trace::emit(event.dur(start));
+        }
+        result
     }
 
     /// The mount's home-layout verdict, memoized per handle: the
@@ -1264,6 +1817,7 @@ impl FsContext {
             &ClosureDest::Store(dest.to_path_buf()),
             &[],
             &mut visited,
+            None,
         )
     }
 
@@ -1273,6 +1827,14 @@ impl FsContext {
     /// (`@executable_path` anchor), `chain_rpaths` the rpaths
     /// accumulated down the load chain, `visited` the cycle-breaking
     /// set of memfs paths already extracted in this walk.
+    ///
+    /// The `materialize` trace event (spec 25 §2): `ok:<host>` after the
+    /// write, `cache-hit` off the dl cache, `error:<errno>` on a real
+    /// failure. The ENOENT host-passthrough answers stay silent (the
+    /// caller's dlopen/exec event carries the `host` verdict — no
+    /// materialization was decided). `closure_trace`, when Some, records
+    /// the walk — format + per-dep verdicts — for the top frame's
+    /// dlopen event (recursion passes None; only the top frame records).
     fn extract_for_exec(
         &mut self,
         path: &str,
@@ -1280,13 +1842,29 @@ impl FsContext {
         dest: &ClosureDest,
         chain_rpaths: &[String],
         visited: &mut std::collections::HashSet<String>,
+        mut closure_trace: Option<&mut trace::ClosureTrace>,
     ) -> Result<std::path::PathBuf, i32> {
         let path = &Self::normalize(path);
+        let trace_start = trace::Start::now();
+        let dest_token = match dest {
+            ClosureDest::Dlcache => "dlcache",
+            ClosureDest::Store(_) => "store",
+        };
         let Some(mount) = self.find_mount(path) else {
             // Host-passthrough decision (spec 08), see open(). The
             // extraction writes themselves are process-internal and
             // not policy-gated.
-            self.host_check(path, HostAccess::Ro)?;
+            if let Err(e) = self.host_check(path, HostAccess::Ro) {
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(trace::Op::Materialize, path, format!("error:{e}"))
+                            .detail("dest", Value::String(dest_token.to_string()))
+                            .with_errno(e)
+                            .dur(start),
+                    );
+                }
+                return Err(e);
+            }
             return Err(libc::ENOENT);
         };
         let owner = mount.handle;
@@ -1295,51 +1873,115 @@ impl FsContext {
 
         if matches!(dest, ClosureDest::Dlcache) {
             if let Some(cached) = self.dl_cache.get(path) {
-                return Ok(cached.clone());
+                let cached = cached.clone();
+                if let Some(start) = trace_start {
+                    trace::emit(
+                        trace::Event::new(trace::Op::Materialize, path, "cache-hit")
+                            .detail("dest", Value::String(dest_token.to_string()))
+                            .detail("host", Value::String(cached.display().to_string()))
+                            .dur(start),
+                    );
+                }
+                return Ok(cached);
             }
         }
 
         if rel_owned.is_empty() {
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(
+                        trace::Op::Materialize,
+                        path,
+                        format!("error:{}", libc::EISDIR),
+                    )
+                    .detail("dest", Value::String(dest_token.to_string()))
+                    .with_errno(libc::EISDIR)
+                    .dur(start),
+                );
+            }
             return Err(libc::EISDIR);
         }
+        // The error-verdict one-liner: the gate stays the Start token —
+        // disarmed, the closure body costs one branch and no builds.
+        let trace_err = |e: i32| {
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(trace::Op::Materialize, path, format!("error:{e}"))
+                        .detail("dest", Value::String(dest_token.to_string()))
+                        .with_errno(e)
+                        .dur(start),
+                );
+            }
+        };
         let st = match mount.backend.stat(&rel_owned) {
             Ok(st) => st,
             // Covered but not held: a host path (see open()) — the
             // consumer falls back to the host answer.
             Err(e) if e == libc::ENOENT => {
-                self.host_check(path, HostAccess::Ro)?;
+                if let Err(e) = self.host_check(path, HostAccess::Ro) {
+                    trace_err(e);
+                    return Err(e);
+                }
                 return Err(libc::ENOENT);
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                trace_err(e);
+                return Err(e);
+            }
         };
         if st.entry_type != EntryType::File {
+            trace_err(libc::EISDIR);
             return Err(libc::EISDIR);
         }
 
         let root = match dest {
-            ClosureDest::Dlcache => ensure_dl_tmpdir(&mut self.dl_tmpdir)?,
+            ClosureDest::Dlcache => match ensure_dl_tmpdir(&mut self.dl_tmpdir) {
+                Ok(root) => root,
+                Err(e) => {
+                    trace_err(e);
+                    return Err(e);
+                }
+            },
             ClosureDest::Store(root) => root.clone(),
         };
 
         let host_path = root.join(Self::host_tail(path));
         if let Some(parent) = host_path.parent() {
-            std::fs::create_dir_all(parent).map_err(|_| libc::EIO)?;
+            if std::fs::create_dir_all(parent).is_err() {
+                trace_err(libc::EIO);
+                return Err(libc::EIO);
+            }
         }
 
         // Stream the file out in chunks.
-        let mut out = std::fs::File::create(&host_path).map_err(|_| libc::EIO)?;
+        let mut out = match std::fs::File::create(&host_path) {
+            Ok(out) => out,
+            Err(_) => {
+                trace_err(libc::EIO);
+                return Err(libc::EIO);
+            }
+        };
         let mut offset = 0u64;
         let mut buf = vec![0u8; 8192];
         loop {
-            let n = mount.backend.pread(&rel_owned, &mut buf, offset)?;
+            let n = match mount.backend.pread(&rel_owned, &mut buf, offset) {
+                Ok(n) => n,
+                Err(e) => {
+                    trace_err(e);
+                    return Err(e);
+                }
+            };
             if n == 0 {
                 break;
             }
             use std::io::Write as _;
-            out.write_all(&buf[..n]).map_err(|_| {
+            if let Err(e) = out.write_all(&buf[..n]).map_err(|_| {
                 let _ = std::fs::remove_file(&host_path);
                 libc::EIO
-            })?;
+            }) {
+                trace_err(e);
+                return Err(e);
+            }
             offset += n as u64;
         }
         drop(out);
@@ -1353,6 +1995,18 @@ impl FsContext {
 
         if matches!(dest, ClosureDest::Dlcache) {
             self.dl_cache.insert(path.to_string(), host_path.clone());
+        }
+        if let Some(start) = trace_start {
+            trace::emit(
+                trace::Event::new(
+                    trace::Op::Materialize,
+                    path,
+                    format!("ok:{}", host_path.display()),
+                )
+                .detail("dest", Value::String(dest_token.to_string()))
+                .detail("bytes", trace::num(offset))
+                .dur(start),
+            );
         }
         // Eager dependency closure: the platform loader's probes are
         // raw syscalls no userland hook can serve (dyld proven on
@@ -1396,6 +2050,16 @@ impl FsContext {
                 parsed.format, parsed.deps
             );
         }
+        if let Some(ct) = closure_trace.as_deref_mut() {
+            ct.format = Some(
+                match parsed.format {
+                    exec_closure::ImageFormat::MachO => "macho",
+                    exec_closure::ImageFormat::Elf => "elf",
+                    exec_closure::ImageFormat::Pe => "pe",
+                }
+                .to_string(),
+            );
+        }
         let referrer_dir = memfs_dirname(path);
         let exe_dir = memfs_dirname(exe);
         let mut chain: Vec<String> = chain_rpaths.to_vec();
@@ -1417,21 +2081,52 @@ impl FsContext {
                         "[tfs] closure dep: {dep} — not held at the importer's dir (host/system)"
                     );
                 }
+                if let Some(ct) = closure_trace.as_deref_mut() {
+                    ct.deps.push(trace::ClosureDep {
+                        name: dep.clone(),
+                        resolved: None,
+                        verdict: "host-system".to_string(),
+                    });
+                }
                 continue;
             };
             if visited.contains(&memfs) {
+                // Already extracted earlier in this walk — materialized.
+                if let Some(ct) = closure_trace.as_deref_mut() {
+                    ct.deps.push(trace::ClosureDep {
+                        name: dep.clone(),
+                        resolved: Some(memfs),
+                        verdict: "materialized".to_string(),
+                    });
+                }
                 continue;
             }
             // The dep's own closure rides its extraction (same exe,
             // same destination).
-            if let Err(e) = self.extract_for_exec(&memfs, exe, dest, &chain, visited) {
+            if let Err(e) = self.extract_for_exec(&memfs, exe, dest, &chain, visited, None) {
                 // The OS load fails on its own with the loader's error;
                 // the trace names the dep the walk could not serve.
                 if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
                     eprintln!("[tfs] closure dep: {dep} -> {memfs} — extraction failed errno={e}");
                 }
-            } else if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
-                eprintln!("[tfs] closure dep: {dep} -> {memfs} materialized");
+                if let Some(ct) = closure_trace.as_deref_mut() {
+                    ct.deps.push(trace::ClosureDep {
+                        name: dep.clone(),
+                        resolved: Some(memfs),
+                        verdict: format!("error:{e}"),
+                    });
+                }
+            } else {
+                if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+                    eprintln!("[tfs] closure dep: {dep} -> {memfs} materialized");
+                }
+                if let Some(ct) = closure_trace.as_deref_mut() {
+                    ct.deps.push(trace::ClosureDep {
+                        name: dep.clone(),
+                        resolved: Some(memfs),
+                        verdict: "materialized".to_string(),
+                    });
+                }
             }
         }
         Ok(host_path)
@@ -1625,6 +2320,42 @@ fn runtime_dll_name() -> Option<String> {
         .ok()
         .filter(|v| !v.is_empty())
         .map(|v| v.to_ascii_lowercase())
+}
+
+/// The trace detail's read/write token for a [`HostAccess`].
+fn need_token(need: HostAccess) -> &'static str {
+    match need {
+        HostAccess::Ro => "read",
+        HostAccess::Rw => "write",
+    }
+}
+
+/// Emit one `mount` event (spec 25 §2) when the bus is armed — the
+/// shared shape for init/insert/union/remove: the mount point is the
+/// event's path; `action`, the Ok handle, and the image path ride the
+/// detail. Errors render `error:<errno>` with the errno field set.
+fn trace_mount(
+    start: Option<trace::Start>,
+    action: &str,
+    mount_point: &str,
+    image: Option<&str>,
+    result: &Result<i32, i32>,
+) {
+    let Some(start) = start else {
+        return;
+    };
+    let mut event = match result {
+        Ok(handle) => trace::Event::new(trace::Op::Mount, mount_point, "ok")
+            .detail("action", Value::String(action.to_string()))
+            .detail("handle", trace::num(handle)),
+        Err(e) => trace::Event::new(trace::Op::Mount, mount_point, format!("error:{e}"))
+            .detail("action", Value::String(action.to_string()))
+            .with_errno(*e),
+    };
+    if let Some(image) = image {
+        event = event.detail("image", Value::String(image.to_string()));
+    }
+    trace::emit(event.dur(start));
 }
 
 /// Open a materialized dlmap copy for real (no TEBAKO_FD_FLAG): the

--- a/crates/tfs/src/lib.rs
+++ b/crates/tfs/src/lib.rs
@@ -67,6 +67,12 @@
 //! against an ro grant EROFS, allowed paths keep today's ENOENT
 //! pass-through, and every denial is journaled to the tebako audit
 //! journal (`crates/tfs/src/journal.rs` — path, op class, policy source).
+//! The spec 25 trace bus (`crates/tfs/src/trace.rs`, phase T1) emits one
+//! structured JSONL event per interception decision — mount, open, stat,
+//! dlopen, exec, materialize, jail — to the channel named by
+//! `TEBAKO_TRACE` / the driver's `--tebako-trace` argument; disarmed it
+//! costs one branch, and the envelope grammar lives in
+//! `docs/spec/schemas/trace-event.yaml`.
 //!
 //! ## PLANNED (next milestones)
 //!
@@ -100,6 +106,7 @@ pub mod overlay_spec;
 pub mod policy;
 #[cfg(feature = "enc")]
 pub mod secure_buf;
+pub mod trace;
 pub mod tree_walk;
 
 pub use backend::{Backend, EntryType, RawDirEntry, RawStat, WritableBackend};

--- a/crates/tfs/src/needs.rs
+++ b/crates/tfs/src/needs.rs
@@ -99,7 +99,7 @@ pub fn needs_from_journal(
         let Some((path, write)) = parse_event_line(line) else {
             continue;
         };
-        if path.is_empty() || !std::path::Path::new(path).is_absolute() {
+        if path.is_empty() || !recorded_is_absolute(path) {
             omitted += 1;
             continue;
         }
@@ -212,6 +212,19 @@ fn parse_event_line(line: &str) -> Option<(&str, bool)> {
     Some((path, write))
 }
 
+/// A recorded journal path counts as absolute when it is `/`-rooted,
+/// drive-rooted (`C:/…`, `C:\…`), or UNC-rooted (`\\…`). Never the host's
+/// `Path::is_absolute`: on Windows that demands a drive prefix and
+/// rejects every `/`-spelled entry, silently dropping the whole journal
+/// (the tebako-cli trace tests exposed this on the windows-gnu leg).
+fn recorded_is_absolute(path: &str) -> bool {
+    if path.starts_with('/') || path.starts_with("\\\\") {
+        return true;
+    }
+    let b = path.as_bytes();
+    b.len() >= 3 && b[0].is_ascii_alphabetic() && b[1] == b':' && (b[2] == b'/' || b[2] == b'\\')
+}
+
 /// Re-spell a recorded path with the longest matching (prefix, atom)
 /// substitution; identity when none matches.
 fn substitute(path: &str, substitutions: &[(PathBuf, &str)]) -> String {
@@ -225,7 +238,14 @@ fn substitute(path: &str, substitutions: &[(PathBuf, &str)]) -> String {
             out = if rest.as_os_str().is_empty() {
                 atom.to_string()
             } else {
-                format!("{atom}/{}", rest.display())
+                // Manifest paths join with `/` always (the MECE grammar);
+                // rest.display() would backslash the tail on Windows.
+                let tail = rest
+                    .iter()
+                    .map(|c| c.to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join("/");
+                format!("{atom}/{tail}")
             };
         }
     }
@@ -478,6 +498,38 @@ mod tests {
         assert_eq!(yaml.match_indices("$TMPDIR/data").count(), 1, "{yaml}");
         assert!(yaml.contains("access: rw"), "{yaml}");
         assert!(yaml.contains("observed: 1 read, 1 write"), "{yaml}");
+    }
+
+    #[test]
+    fn recorded_paths_are_absolute_by_spelling_not_host_platform() {
+        // The journal is written by the traced process, which may spell
+        // paths the other platform's way (an msys runtime on Windows
+        // records `/work/data`). Host `Path::is_absolute` would drop
+        // those on Windows; the spelling check keeps them everywhere.
+        for p in [
+            "/work/data",
+            "C:/work/data",
+            "C:\\work\\data",
+            "\\\\share\\x",
+        ] {
+            assert!(super::recorded_is_absolute(p), "{p}");
+        }
+        for p in ["", "rel/dir", "C:", "C:rel"] {
+            assert!(!super::recorded_is_absolute(p), "{p}");
+        }
+    }
+
+    #[test]
+    fn substitution_joins_with_forward_slashes_on_every_platform() {
+        // Manifest paths are `/`-joined by grammar (spec 23); the tail
+        // must never pick up the host separator.
+        let subs = [(PathBuf::from("/home/u"), "$HOME")];
+        assert_eq!(
+            super::substitute("/home/u/.config/app", &subs),
+            "$HOME/.config/app"
+        );
+        assert_eq!(super::substitute("/home/u", &subs), "$HOME");
+        assert_eq!(super::substitute("/other/place", &subs), "/other/place");
     }
 
     #[test]

--- a/crates/tfs/src/trace.rs
+++ b/crates/tfs/src/trace.rs
@@ -1,0 +1,959 @@
+//! The spec 25 interception trace bus (phase T1).
+//!
+//! One structured event per interception decision, appended as one JSONL
+//! line per event to the channel named by `TEBAKO_TRACE` (or the driver's
+//! `--tebako-trace` argument, which wins when both are set — spec 25 §2).
+//! The envelope grammar is owned by `docs/spec/schemas/trace-event.yaml`;
+//! this module mirrors it field-for-field (`v:1`).
+//!
+//! The bus's laws (spec 25 §1/§2, restated where they bind the code):
+//!
+//! - **Observability never gates.** [`arm`] failure leaves the bus
+//!   disarmed with one loud stderr note; the run proceeds. A poisoned
+//!   channel lock or a failed write drops the event silently — the trace
+//!   channel never fails, blocks, or alters the run it observes.
+//! - **Disarmed cost is one branch.** [`Start::now`] is the single gate:
+//!   one relaxed atomic load returning `None` when disarmed. Call sites
+//!   build events only behind `if let Some(start) = Start::now()`.
+//! - **Journal fd discipline.** The channel file is opened once at arm
+//!   time (driver boot, before any mount — a path operation, which is
+//!   exactly when it is safe: [`crate::journal`]'s rule is that path ops
+//!   under the preload's context lock self-deadlock); [`emit`] only ever
+//!   issues a bare `write(2)` on the open fd. Append-only, never
+//!   policy-gated.
+//! - **No unsafe, no shell-outs.** Pure safe Rust; serialization via the
+//!   workspace's `tebako-json` (spec 25 §7's blessed dependency).
+//!
+//! ## pid / tid
+//!
+//! Every event carries `pid` (the OS process id, re-read per event so
+//! forked children report their own) and `tid`. **`tid` is the bus's
+//! per-process thread ordinal** — the first thread to emit is 1, then 2,
+//! 3, … — not an OS thread id: stable Rust exposes no OS tid and the bus
+//! forbids `unsafe` (which rules out the libc call). Grouping by
+//! (pid, tid) regroups events by thread identically, which is all the
+//! schema contract requires of the pair.
+//!
+//! ## Children
+//!
+//! A spawned/exec'd child re-derives the channel at its own driver boot:
+//! `TEBAKO_TRACE` is in the inherited environment, the child's driver
+//! calls [`arm`], and its events append to the same file. This is the
+//! §2 "children re-derive" clause. The POSIX fd-inheritance spelling it
+//! also mentions is not the mechanism (dup/CLOEXEC games would need
+//! `unsafe`); env re-derivation covers both platforms uniformly. On
+//! fork, the already-open fd IS inherited until the child's own [`arm`],
+//! so pre-arm child events still land in the same channel — same
+//! observable effect, zero unsafe.
+//!
+//! ## Op vocabulary
+//!
+//! [`Op`] is the full §2 table. `Spawn` and `Resolve` are defined now so
+//! the vocabulary is stable, but their emission points are later
+//! integration (the preload's posix_spawn path and tebako-resolve — T2+);
+//! T1 emits mount/open/stat/dlopen/exec/materialize/jail from
+//! [`crate::context`].
+
+use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use tebako_json::Value;
+
+/// The environment variable naming the trace channel (spec 25 §2). The
+/// driver's `--tebako-trace` argument overrides it when both are set.
+pub const TRACE_ENV: &str = "TEBAKO_TRACE";
+
+/// The wire envelope version — the schema's `v` field. Additive-only,
+/// never bumped (spec 25 §3's evolution rule).
+pub const ENVELOPE_VERSION: u32 = 1;
+
+static CHANNEL: Mutex<Option<File>> = Mutex::new(None);
+static ARMED: AtomicBool = AtomicBool::new(false);
+static TID_NEXT: AtomicU64 = AtomicU64::new(1);
+
+thread_local! {
+    /// The thread's cached bus ordinal (0 = not yet assigned).
+    static TID: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// The §2 op table. Wire tokens are the snake_case names; the vocabulary
+/// is the schema's, additive-only.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Op {
+    Mount,
+    Open,
+    Stat,
+    Dlopen,
+    Exec,
+    /// Later integration (T2: the preload's posix_spawn path). Defined
+    /// now so the vocabulary is stable.
+    Spawn,
+    Materialize,
+    Jail,
+    /// Later integration (T2+: tebako-resolve is L3, outside this
+    /// crate). Defined now so the vocabulary is stable.
+    Resolve,
+}
+
+impl Op {
+    /// The wire token (schema's `op` field).
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Op::Mount => "mount",
+            Op::Open => "open",
+            Op::Stat => "stat",
+            Op::Dlopen => "dlopen",
+            Op::Exec => "exec",
+            Op::Spawn => "spawn",
+            Op::Materialize => "materialize",
+            Op::Jail => "jail",
+            Op::Resolve => "resolve",
+        }
+    }
+}
+
+/// One interception decision — one JSONL line. Rendered in schema field
+/// order: v, ts, pid, tid, op, path, verdict, detail, dur_us, errno.
+pub struct Event {
+    op: Op,
+    path: String,
+    verdict: String,
+    detail: Vec<(String, Value)>,
+    errno: Option<i32>,
+    dur_us: u64,
+}
+
+impl Event {
+    /// A fresh event with `dur_us: 0` — set the measured duration with
+    /// [`Event::dur`] from the [`Start`] token the call site gated on.
+    pub fn new(op: Op, path: impl Into<String>, verdict: impl Into<String>) -> Self {
+        Event {
+            op,
+            path: path.into(),
+            verdict: verdict.into(),
+            detail: Vec::new(),
+            errno: None,
+            dur_us: 0,
+        }
+    }
+
+    /// Append one detail key (schema: per-op keys, insertion-ordered).
+    pub fn detail(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.detail.push((key.into(), value));
+        self
+    }
+
+    /// Attach the errno of a failed decision (schema: optional int).
+    pub fn with_errno(mut self, errno: i32) -> Self {
+        self.errno = Some(errno);
+        self
+    }
+
+    /// Record the decision's wall time from the gating token.
+    pub fn dur(mut self, start: Start) -> Self {
+        self.dur_us = start.elapsed_us();
+        self
+    }
+
+    /// The JSONL line (no trailing newline) in schema field order.
+    fn render(&self) -> String {
+        let mut fields = Vec::with_capacity(10);
+        fields.push(("v".to_string(), num(ENVELOPE_VERSION)));
+        fields.push(("ts".to_string(), Value::String(rfc3339_now())));
+        fields.push(("pid".to_string(), num(std::process::id())));
+        fields.push(("tid".to_string(), num(tid())));
+        fields.push((
+            "op".to_string(),
+            Value::String(self.op.as_str().to_string()),
+        ));
+        fields.push(("path".to_string(), Value::String(self.path.clone())));
+        fields.push(("verdict".to_string(), Value::String(self.verdict.clone())));
+        fields.push(("detail".to_string(), Value::Object(self.detail.clone())));
+        fields.push(("dur_us".to_string(), num(self.dur_us)));
+        if let Some(errno) = self.errno {
+            fields.push(("errno".to_string(), num(errno)));
+        }
+        tebako_json::to_line(&Value::Object(fields))
+    }
+}
+
+/// The gating token and the disarmed-cost law in one: `Some` only when
+/// the bus is armed, so call sites write
+/// `if let Some(start) = Start::now() { …build + emit… }` and the
+/// disarmed run costs one relaxed load + branch.
+#[derive(Clone, Copy)]
+pub struct Start(Instant);
+
+impl Start {
+    /// `Some` (and a timestamp) only while the bus is armed.
+    pub fn now() -> Option<Start> {
+        if ARMED.load(Ordering::Relaxed) {
+            Some(Start(Instant::now()))
+        } else {
+            None
+        }
+    }
+
+    /// Microseconds since the token was taken (saturating cast).
+    pub fn elapsed_us(self) -> u64 {
+        u64::try_from(self.0.elapsed().as_micros()).unwrap_or(u64::MAX)
+    }
+}
+
+/// Open the channel at `path` (creating parent directories) and arm the
+/// bus. Called once per process at driver boot, BEFORE any mount — the
+/// open is a path operation, which is exactly when it is safe
+/// (journal.rs's discipline). Failure is one loud stderr note and a
+/// disarmed bus: the run proceeds (observability never gates). Returns
+/// whether the bus armed.
+pub fn arm(path: &Path) -> bool {
+    match open_channel(path) {
+        Ok(file) => {
+            // A poisoned lock means a previous emitter panicked
+            // mid-write; recover the channel — law 1 says trace trouble
+            // never fails the run, arming included.
+            let mut guard = CHANNEL.lock().unwrap_or_else(|p| p.into_inner());
+            *guard = Some(file);
+            ARMED.store(true, Ordering::SeqCst);
+            true
+        }
+        Err(note) => {
+            eprintln!("tebako: trace: {note} — trace disabled, the run proceeds");
+            false
+        }
+    }
+}
+
+/// Disarm and close the channel. The test/reset seam — production never
+/// disarms; the channel lives for the process's life.
+pub fn disarm() {
+    ARMED.store(false, Ordering::SeqCst);
+    let mut guard = CHANNEL.lock().unwrap_or_else(|p| p.into_inner());
+    *guard = None;
+}
+
+/// Whether the bus is armed (one relaxed load).
+pub fn armed() -> bool {
+    ARMED.load(Ordering::Relaxed)
+}
+
+/// Append one event as one JSONL line. The disarmed fast path is one
+/// relaxed load; when armed, one mutex hold around one bare `write(2)`
+/// on the channel fd (never a path op — the journal discipline). A
+/// poisoned lock or a failed write drops the event: the trace never
+/// disturbs the run it observes.
+pub fn emit(event: Event) {
+    if !ARMED.load(Ordering::Relaxed) {
+        return;
+    }
+    let mut line = event.render();
+    line.push('\n');
+    if let Ok(mut guard) = CHANNEL.lock() {
+        if let Some(file) = guard.as_mut() {
+            let _ = file.write_all(line.as_bytes());
+        }
+    }
+}
+
+/// The bus's per-process thread ordinal (see the module docs): 1 for
+/// the first thread to emit, then sequential. Cached thread-locally;
+/// the counter costs one atomic fetch-add per NEW thread.
+pub fn tid() -> u64 {
+    TID.with(|cell| {
+        let cached = cell.get();
+        if cached != 0 {
+            cached
+        } else {
+            let ordinal = TID_NEXT.fetch_add(1, Ordering::Relaxed);
+            cell.set(ordinal);
+            ordinal
+        }
+    })
+}
+
+/// Envelope/detail shorthand: a JSON number from anything displayable
+/// (tebako-json's `Number` carries the literal string).
+pub fn num(v: impl fmt::Display) -> Value {
+    Value::Number(v.to_string())
+}
+
+/// The dlopen event's closure-walk record (spec 25 §2: the dlopen detail
+/// carries the closure walk — image format, dep list, per-dep verdict).
+/// The top `extract_for_exec` frame fills it; rendered as the detail's
+/// `closure` object: `{"format": <token|null>, "deps": [...]}`.
+#[derive(Default)]
+pub struct ClosureTrace {
+    /// The parsed image format token (`macho`/`elf`/`pe`); None when the
+    /// header parse was unsupported (or the answer came off the dl
+    /// cache) — no dep walk ran.
+    pub format: Option<String>,
+    /// One entry per declared dependency, in declaration order.
+    pub deps: Vec<ClosureDep>,
+}
+
+/// One dependency's walk verdict.
+pub struct ClosureDep {
+    /// The dependency name as the image declares it.
+    pub name: String,
+    /// The in-image path it resolved to; None for a host/system name.
+    pub resolved: Option<String>,
+    /// `materialized` | `host-system` | `error:<errno>`.
+    pub verdict: String,
+}
+
+impl ClosureTrace {
+    /// The detail value: `{"format":…, "deps":[{name,resolved,verdict}]}`.
+    pub fn into_value(self) -> Value {
+        let format = match self.format {
+            Some(f) => Value::String(f),
+            None => Value::Null,
+        };
+        let deps = self
+            .deps
+            .into_iter()
+            .map(|dep| {
+                let resolved = match dep.resolved {
+                    Some(r) => Value::String(r),
+                    None => Value::Null,
+                };
+                Value::Object(vec![
+                    ("name".to_string(), Value::String(dep.name)),
+                    ("resolved".to_string(), resolved),
+                    ("verdict".to_string(), Value::String(dep.verdict)),
+                ])
+            })
+            .collect();
+        Value::Object(vec![
+            ("format".to_string(), format),
+            ("deps".to_string(), Value::Array(deps)),
+        ])
+    }
+}
+
+fn open_channel(path: &Path) -> Result<File, String> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("cannot create {}: {e}", parent.display()))?;
+        }
+    }
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| format!("cannot open {}: {e}", path.display()))
+}
+
+/// Current UTC time as the schema's `ts`: RFC 3339 with microsecond
+/// precision (`2026-08-19T13:49:20.344123Z`).
+fn rfc3339_now() -> String {
+    let since = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO);
+    format_ts(since.as_secs() as i64, since.subsec_micros())
+}
+
+/// Pure formatting core (testable): epoch seconds + microseconds →
+/// `YYYY-MM-DDTHH:MM:SS.ffffffZ`. Civil date via Hinnant's
+/// civil_from_days — no chrono, no tz database (spec 25 §7: no new
+/// dependencies outside the workspace).
+fn format_ts(secs: i64, micros: u32) -> String {
+    let days = secs.div_euclid(86_400);
+    let tod = secs.rem_euclid(86_400);
+    let (y, mo, d) = civil_from_days(days);
+    format!(
+        "{y:04}-{mo:02}-{d:02}T{:02}:{:02}:{:02}.{micros:06}Z",
+        tod / 3600,
+        (tod % 3600) / 60,
+        tod % 60,
+    )
+}
+
+/// Howard Hinnant's civil_from_days: days since 1970-01-01 → (year,
+/// month, day), proleptic Gregorian, correct for negative days.
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::lock_global_context;
+
+    /// Disarm on drop even when a test panics mid-assertion, so armed
+    /// state never leaks into the next test on this process-wide bus.
+    struct ArmedGuard;
+    impl ArmedGuard {
+        /// Arm at `path` after clearing any leftover state; the caller
+        /// must already hold the crate-wide global-context lock so no
+        /// concurrent context test can interleave its events into this
+        /// test's capture file.
+        fn arm(path: &Path) -> (ArmedGuard, bool) {
+            disarm();
+            let armed = arm(path);
+            (ArmedGuard, armed)
+        }
+    }
+    impl Drop for ArmedGuard {
+        fn drop(&mut self) {
+            disarm();
+        }
+    }
+
+    #[test]
+    fn format_ts_golden() {
+        assert_eq!(format_ts(0, 0), "1970-01-01T00:00:00.000000Z");
+        assert_eq!(format_ts(1_700_000_000, 0), "2023-11-14T22:13:20.000000Z");
+        assert_eq!(format_ts(1_700_000_000, 42), "2023-11-14T22:13:20.000042Z");
+        // Negative seconds: the civil math is proleptic, not clamped.
+        assert_eq!(format_ts(-1, 0), "1969-12-31T23:59:59.000000Z");
+    }
+
+    #[test]
+    fn op_wire_tokens_are_the_schema_vocabulary() {
+        let tokens: Vec<&str> = [
+            Op::Mount,
+            Op::Open,
+            Op::Stat,
+            Op::Dlopen,
+            Op::Exec,
+            Op::Spawn,
+            Op::Materialize,
+            Op::Jail,
+            Op::Resolve,
+        ]
+        .iter()
+        .map(|op| op.as_str())
+        .collect();
+        assert_eq!(
+            tokens,
+            vec![
+                "mount",
+                "open",
+                "stat",
+                "dlopen",
+                "exec",
+                "spawn",
+                "materialize",
+                "jail",
+                "resolve"
+            ]
+        );
+    }
+
+    #[test]
+    fn tid_is_stable_per_thread_and_distinct_across_threads() {
+        let mine = tid();
+        assert_eq!(mine, tid());
+        assert_ne!(mine, 0);
+        let theirs = std::thread::spawn(tid).join().expect("spawn tid");
+        assert_ne!(mine, theirs);
+    }
+
+    #[test]
+    fn disarmed_start_is_none() {
+        let _lock = lock_global_context();
+        disarm();
+        assert!(!armed());
+        assert!(Start::now().is_none());
+    }
+
+    #[test]
+    fn arm_failure_stays_disarmed_and_returns_false() {
+        let _lock = lock_global_context();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // A path whose parent component is a regular FILE: neither
+        // create_dir_all nor open can succeed.
+        let blocker = tmp.path().join("blocker");
+        std::fs::write(&blocker, b"x").expect("write blocker");
+        let (_guard, armed) = ArmedGuard::arm(&blocker.join("child.jsonl"));
+        assert!(!armed);
+        assert!(!super::armed());
+        assert!(Start::now().is_none());
+    }
+
+    #[test]
+    fn armed_emit_writes_schema_ordered_jsonl() {
+        let _lock = lock_global_context();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let capture = tmp.path().join("nested").join("trace.jsonl");
+        let (_guard, armed) = ArmedGuard::arm(&capture);
+        assert!(armed, "arm creates parent directories");
+
+        let start = Start::now().expect("armed start");
+        emit(
+            Event::new(Op::Open, "/__tfs__/app.rb", "image:/app")
+                .detail("need", Value::String("read".to_string()))
+                .dur(start),
+        );
+        emit(Event::new(Op::Open, "/etc/passwd", "denied:user").with_errno(libc::EPERM));
+        drop(_guard);
+
+        let text = std::fs::read_to_string(&capture).expect("read capture");
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 2, "one JSONL line per event");
+
+        let first = tebako_json::parse(lines[0]).expect("first line parses");
+        let get = |key: &str| first.find(key).unwrap_or_else(|| panic!("{key} present"));
+        assert_eq!(get("v").as_u64(), Some(1));
+        assert_eq!(
+            get("pid").as_u64(),
+            Some(u64::from(std::process::id())),
+            "pid is the emitting process"
+        );
+        assert!(get("tid").as_u64().expect("tid int") >= 1);
+        assert_eq!(get("op").as_string().as_deref(), Some("open"));
+        assert_eq!(get("path").as_string().as_deref(), Some("/__tfs__/app.rb"));
+        assert_eq!(get("verdict").as_string().as_deref(), Some("image:/app"));
+        let ts = get("ts").as_string().expect("ts string");
+        assert!(
+            ts.ends_with('Z') && ts.contains('T') && ts.contains('.'),
+            "rfc3339µs: {ts}"
+        );
+        assert!(get("dur_us").as_u64().is_some(), "dur_us int");
+        assert!(first.find("errno").is_none(), "errno omitted when unset");
+        let detail = get("detail");
+        assert_eq!(
+            detail.find("need").and_then(Value::as_string).as_deref(),
+            Some("read")
+        );
+
+        // Schema field order on the wire: v, ts, pid, tid, op, path,
+        // verdict, detail, dur_us, (errno).
+        let order = [
+            "\"v\":",
+            "\"ts\":",
+            "\"pid\":",
+            "\"tid\":",
+            "\"op\":",
+            "\"path\":",
+            "\"verdict\":",
+            "\"detail\":",
+            "\"dur_us\":",
+        ];
+        let mut at = 0;
+        for key in order {
+            let found = lines[0][at..]
+                .find(key)
+                .unwrap_or_else(|| panic!("{key} after offset {at} in {}", lines[0]));
+            at += found + key.len();
+        }
+
+        let second = tebako_json::parse(lines[1]).expect("second line parses");
+        assert_eq!(
+            second.find("errno").and_then(Value::as_u64),
+            Some(libc::EPERM as u64),
+            "errno present when set"
+        );
+        assert_eq!(
+            second.find("verdict").and_then(Value::as_string).as_deref(),
+            Some("denied:user")
+        );
+
+        // Compact JSONL: no pretty whitespace, no embedded newlines.
+        assert!(!lines[0].contains(": "), "compact emission");
+    }
+
+    #[test]
+    fn closure_trace_renders_the_schema_shape() {
+        let ct = ClosureTrace {
+            format: Some("macho".to_string()),
+            deps: vec![
+                ClosureDep {
+                    name: "@rpath/libx.dylib".to_string(),
+                    resolved: Some("/__tfs__/lib/libx.dylib".to_string()),
+                    verdict: "materialized".to_string(),
+                },
+                ClosureDep {
+                    name: "/usr/lib/libSystem.B.dylib".to_string(),
+                    resolved: None,
+                    verdict: "host-system".to_string(),
+                },
+            ],
+        };
+        let line = tebako_json::to_line(&ct.into_value());
+        assert_eq!(
+            line,
+            "{\"format\":\"macho\",\"deps\":[\
+{\"name\":\"@rpath/libx.dylib\",\"resolved\":\"/__tfs__/lib/libx.dylib\",\"verdict\":\"materialized\"},\
+{\"name\":\"/usr/lib/libSystem.B.dylib\",\"resolved\":null,\"verdict\":\"host-system\"}]}"
+        );
+        // The empty walk (unsupported header / cache hit): null + [].
+        let empty = tebako_json::to_line(&ClosureTrace::default().into_value());
+        assert_eq!(empty, "{\"format\":null,\"deps\":[]}");
+    }
+
+    #[test]
+    fn emit_after_disarm_is_a_no_op() {
+        let _lock = lock_global_context();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let capture = tmp.path().join("trace.jsonl");
+        {
+            let (_guard, armed) = ArmedGuard::arm(&capture);
+            assert!(armed);
+            emit(Event::new(Op::Stat, "/x", "host"));
+        } // guard drops → disarmed
+        emit(Event::new(Op::Stat, "/y", "host"));
+        let text = std::fs::read_to_string(&capture).expect("read capture");
+        assert_eq!(text.lines().count(), 1, "the disarmed emit never lands");
+    }
+
+    /// The spec 25 §3/§7 property: driving the public tfs op matrix
+    /// through the process-global context emits exactly one schema-valid
+    /// event per decision. Every line of the capture is validated against
+    /// the trace-event.yaml contract (required keys and types, the op
+    /// vocabulary, the per-op verdict grammar, errno present exactly when
+    /// the verdict names one); the expected (op, verdict) decisions are
+    /// then asserted present. The grammar owner is
+    /// `docs/spec/schemas/trace-event.yaml`; this test is the CI gate
+    /// that document names.
+    #[test]
+    fn the_op_matrix_emits_one_schema_valid_event_per_decision() {
+        use std::io::Write as _;
+
+        let _lock = lock_global_context();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let capture = tmp.path().join("nested").join("capture.jsonl");
+        let (_guard, armed) = ArmedGuard::arm(&capture);
+        assert!(armed);
+
+        // The one-file zip fixture (context.rs's shape).
+        let image = tmp.path().join("img.zip");
+        {
+            let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+            let options = zip::write::SimpleFileOptions::default();
+            writer.start_file("data/secret.txt", options).unwrap();
+            writer.write_all(b"hush").unwrap();
+            let bytes = writer.finish().unwrap().into_inner();
+            std::fs::write(&image, bytes).unwrap();
+        }
+        let journal_file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(tmp.path().join("journal.log"))
+            .unwrap();
+        // A host file outside every mount, for the passthrough decisions.
+        let host_file = tmp.path().join("host.txt");
+        std::fs::write(&host_file, b"host").unwrap();
+        let host_path = host_file.to_string_lossy().into_owned();
+
+        // Hoisted out of the context block: the redirect assertion below
+        // compares against the materialized host path (deferred init —
+        // assigned once inside, read after).
+        let materialized: std::ffi::CString;
+        {
+            let mut ctx = crate::context::context().write().unwrap();
+            ctx.set_host_policy(
+                crate::policy::HostPolicy::bind(
+                    crate::policy::PolicyDefault::Record,
+                    vec![],
+                    vec![],
+                )
+                .unwrap(),
+                Some(journal_file),
+            );
+            let mount = crate::mount::build_from_file(image.to_str().unwrap(), "/tfs").unwrap();
+            ctx.mount_checked(mount).unwrap(); // mount ok (insert)
+
+            let fd = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+            let _ = ctx.close(fd);
+            ctx.stat("/tfs/data/secret.txt").unwrap(); // stat image:/tfs
+
+            // Host passthroughs under the record policy: the op event
+            // (`host`) AND the jail event (`record`) — two layers, spec
+            // 25 §2's stacked-decision rule.
+            assert_eq!(ctx.open(&host_path, libc::O_RDONLY), Err(libc::ENOENT));
+            assert_eq!(ctx.stat(&host_path).map(|_| ()), Err(libc::ENOENT));
+
+            // The spec 24 §5 write gate.
+            assert_eq!(
+                ctx.open("/tfs/data/secret.txt", libc::O_WRONLY),
+                Err(libc::EROFS)
+            );
+
+            // The exec surface (closure route) extracts first…
+            let routed = ctx.exec_materialize("/tfs/data/secret.txt").unwrap();
+            assert!(std::path::Path::new(&routed.to_string_lossy().into_owned()).is_file());
+            // …then the dlopen surface answers from the dl cache.
+            materialized = ctx.dlmap2file("/tfs/data/secret.txt").unwrap();
+            assert_eq!(routed, materialized);
+
+            // The dlmap-prefix redirect (the §4 class-R materialize
+            // signal): opening the materialized copy's path serves a raw
+            // host fd under the `image:<mount>` verdict. The fd is left
+            // to process exit — closing it would need unsafe, which the
+            // bus forbids, tests included.
+            let raw = ctx
+                .open(materialized.to_str().unwrap(), libc::O_RDONLY)
+                .unwrap();
+            assert_eq!(raw & crate::context::TEBAKO_FD_FLAG, 0, "a raw host fd");
+
+            // The deny half of the jail channel.
+            ctx.set_host_policy(
+                crate::policy::HostPolicy::bind(crate::policy::PolicyDefault::Deny, vec![], vec![])
+                    .unwrap(),
+                None,
+            );
+            assert_eq!(ctx.open(&host_path, libc::O_RDONLY), Err(libc::EPERM));
+
+            // Reset the shared context for the next test on this process,
+            // then the clear-all unmount event.
+            ctx.set_host_policy(crate::policy::HostPolicy::open(), None);
+            ctx.unmount();
+        }
+        drop(_guard);
+
+        let text = std::fs::read_to_string(&capture).expect("read capture");
+        let lines: Vec<&str> = text.lines().collect();
+        assert!(lines.len() >= 15, "the matrix's decisions: {text}");
+
+        // -----------------------------------------------------------
+        // Every line validates against the schema contract.
+        // -----------------------------------------------------------
+        const OPS: [&str; 9] = [
+            "mount",
+            "open",
+            "stat",
+            "dlopen",
+            "exec",
+            "spawn",
+            "materialize",
+            "jail",
+            "resolve",
+        ];
+        let verdict_ok = |op: &str, verdict: &str| -> bool {
+            match op {
+                "mount" => verdict == "ok" || verdict.starts_with("error:"),
+                "open" | "stat" => {
+                    verdict == "host"
+                        || verdict.starts_with("image:")
+                        || verdict.starts_with("denied:")
+                        || verdict.starts_with("error:")
+                }
+                "dlopen" => {
+                    verdict == "host"
+                        || verdict.starts_with("materialized:")
+                        || verdict.starts_with("error:")
+                }
+                "exec" => {
+                    verdict == "host"
+                        || verdict.starts_with("routed:")
+                        || verdict.starts_with("error:")
+                }
+                "materialize" => {
+                    verdict == "cache-hit"
+                        || verdict.starts_with("ok:")
+                        || verdict.starts_with("error:")
+                }
+                "jail" => {
+                    verdict == "record"
+                        || verdict.starts_with("allow:")
+                        || verdict.starts_with("deny:")
+                }
+                // T1 never emits these (the vocabulary is stable, the
+                // emission points are T2+).
+                "spawn" | "resolve" => false,
+                _ => false,
+            }
+        };
+        let mut seen: Vec<(String, String)> = Vec::new();
+        for (i, line) in lines.iter().enumerate() {
+            let doc = tebako_json::parse(line)
+                .unwrap_or_else(|e| panic!("line {} parses as JSON: {e}: {line}", i + 1));
+            let get = |key: &str| {
+                doc.find(key)
+                    .unwrap_or_else(|| panic!("line {}: `{key}` present: {line}", i + 1))
+            };
+            assert_eq!(get("v").as_u64(), Some(1), "line {}", i + 1);
+            let ts = get("ts").as_string().expect("ts string");
+            assert!(
+                ts.ends_with('Z') && ts.contains('T') && ts.contains('.'),
+                "line {}: rfc3339µs ts: {ts}",
+                i + 1
+            );
+            assert_eq!(get("pid").as_u64(), Some(u64::from(std::process::id())));
+            assert!(
+                get("tid").as_u64().is_some_and(|t| t >= 1),
+                "line {}",
+                i + 1
+            );
+            let op = get("op").as_string().expect("op string");
+            assert!(
+                OPS.contains(&op.as_str()),
+                "line {}: op in the vocabulary",
+                i + 1
+            );
+            assert!(get("path").as_string().is_some(), "line {}", i + 1);
+            let verdict = get("verdict").as_string().expect("verdict string");
+            assert!(
+                verdict_ok(&op, &verdict),
+                "line {}: `{verdict}` is a {op} verdict: {line}",
+                i + 1
+            );
+            assert!(
+                matches!(get("detail"), Value::Object(_)),
+                "line {}: detail is an object",
+                i + 1
+            );
+            assert!(get("dur_us").as_u64().is_some(), "line {}", i + 1);
+            match doc.find("errno") {
+                Some(errno) => {
+                    let n = errno.as_u64().expect("errno int");
+                    assert!(
+                        verdict.starts_with("error:")
+                            || verdict.starts_with("denied:")
+                            || verdict.starts_with("deny:"),
+                        "line {}: errno rides a failing verdict: {line}",
+                        i + 1
+                    );
+                    if let Some(suffix) = verdict.strip_prefix("error:") {
+                        assert_eq!(
+                            suffix.parse::<u64>().ok(),
+                            Some(n),
+                            "line {}: the verdict's errno IS the field: {line}",
+                            i + 1
+                        );
+                    }
+                }
+                None => assert!(
+                    !verdict.starts_with("error:")
+                        && !verdict.starts_with("denied:")
+                        && !verdict.starts_with("deny:"),
+                    "line {}: a failing verdict carries errno: {line}",
+                    i + 1
+                ),
+            }
+            seen.push((op, verdict));
+        }
+
+        // -----------------------------------------------------------
+        // The expected decisions are all present.
+        // -----------------------------------------------------------
+        let has = |op: &str, prefix: &str| {
+            seen.iter()
+                .any(|(o, v)| o == op && (prefix.is_empty() || v.starts_with(prefix)))
+        };
+        assert!(has("mount", "ok"), "mount ok: {seen:?}");
+        assert!(has("open", "image:/tfs"), "open image: {seen:?}");
+        assert!(has("stat", "image:/tfs"), "stat image: {seen:?}");
+        assert!(has("open", "host"), "open host: {seen:?}");
+        assert!(has("stat", "host"), "stat host: {seen:?}");
+        assert!(has("jail", "record"), "jail record: {seen:?}");
+        assert!(has("open", "denied:write-gate"), "write gate: {seen:?}");
+        assert!(has("open", "denied:"), "open denied: {seen:?}");
+        assert!(has("jail", "deny:"), "jail deny: {seen:?}");
+        assert!(has("dlopen", "materialized:"), "dlopen: {seen:?}");
+        assert!(has("exec", "routed:"), "exec routed: {seen:?}");
+        assert!(has("materialize", "ok:"), "materialize ok: {seen:?}");
+        assert!(has("materialize", "cache-hit"), "materialize hit: {seen:?}");
+
+        // The decision-level details (schema's per-op detail grammar).
+        let detail_of = |op: &str, prefix: &str| {
+            let line = lines[seen
+                .iter()
+                .position(|(o, v)| o == op && v.starts_with(prefix))
+                .unwrap_or_else(|| panic!("a {op} {prefix} event in {seen:?}"))];
+            let doc = tebako_json::parse(line).unwrap();
+            doc.find("detail").unwrap().clone()
+        };
+        let insert = detail_of("mount", "ok");
+        assert_eq!(
+            insert.find("action").and_then(Value::as_string).as_deref(),
+            Some("insert")
+        );
+        assert_eq!(
+            insert.find("image").and_then(Value::as_string).as_deref(),
+            Some(image.to_str().unwrap())
+        );
+        let clear = lines
+            .iter()
+            .map(|l| tebako_json::parse(l).unwrap())
+            .find(|d| {
+                d.find("detail")
+                    .and_then(|dt| dt.find("action"))
+                    .and_then(Value::as_string)
+                    .as_deref()
+                    == Some("clear")
+            })
+            .expect("the clear-all unmount event");
+        assert_eq!(
+            clear.find("path").and_then(Value::as_string).as_deref(),
+            Some("")
+        );
+        assert!(
+            clear
+                .find("detail")
+                .and_then(|d| d.find("count"))
+                .and_then(Value::as_u64)
+                == Some(1),
+            "the clear reports its mount count: {clear:?}"
+        );
+        let passthrough = detail_of("open", "host");
+        assert_eq!(
+            passthrough
+                .find("need")
+                .and_then(Value::as_string)
+                .as_deref(),
+            Some("read")
+        );
+        let jail = detail_of("jail", "record");
+        assert_eq!(
+            jail.find("access").and_then(Value::as_string).as_deref(),
+            Some("read")
+        );
+        let exec = detail_of("exec", "routed:");
+        assert_eq!(
+            exec.find("route").and_then(Value::as_string).as_deref(),
+            Some("dlmap-closure")
+        );
+        // The dlopen event carries the closure walk (schema §2): a
+        // non-binary fixture parses no header — format null, deps [].
+        let dl = detail_of("dlopen", "materialized:");
+        let closure = dl.find("closure").expect("closure detail");
+        assert!(matches!(closure.find("format"), Some(Value::Null)));
+        assert!(matches!(closure.find("deps"), Some(Value::Array(d)) if d.is_empty()));
+        // The dlmap redirect: the open verdict names the mount and the
+        // details carry the tail + the materialized host path.
+        let redirect = lines
+            .iter()
+            .map(|l| tebako_json::parse(l).unwrap())
+            .find(|d| {
+                d.find("op").and_then(Value::as_string).as_deref() == Some("open")
+                    && d.find("detail")
+                        .and_then(|dt| dt.find("dlmap_redirect"))
+                        .and_then(Value::as_string)
+                        .as_deref()
+                        == Some("/tfs/data/secret.txt")
+            })
+            .expect("the dlmap-redirect open event");
+        assert_eq!(
+            redirect
+                .find("verdict")
+                .and_then(Value::as_string)
+                .as_deref(),
+            Some("image:/tfs")
+        );
+        assert_eq!(
+            redirect
+                .find("detail")
+                .and_then(|d| d.find("materialized"))
+                .and_then(Value::as_string)
+                .as_deref(),
+            Some(materialized.to_str().unwrap())
+        );
+    }
+}

--- a/crates/tpkg/src/jail.rs
+++ b/crates/tpkg/src/jail.rs
@@ -164,6 +164,13 @@ pub struct HostJail {
         default = "default_open_true"
     )]
     pub default_open: bool,
+    /// The spec 23 §8 `record` policy (allow-all + audit) — the discovery
+    /// instrument behind `tebako trace run`. **Env-grammar only**: a
+    /// manifest cannot ask to be observed, so serde skips the field and
+    /// the YAML block grammar stays byte-identical. Carries no grants
+    /// (inert under allow-all — `parse_env_spec` rejects them).
+    #[serde(skip)]
+    pub record: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mounts: Vec<JailMount>,
     #[serde(default, skip_serializing_if = "ArgumentFiles::is_empty")]
@@ -246,6 +253,7 @@ impl HostJail {
     pub const fn open() -> HostJail {
         HostJail {
             default_open: true,
+            record: false,
             mounts: Vec::new(),
             argument_files: ArgumentFiles {
                 auto: false,
@@ -258,6 +266,7 @@ impl HostJail {
     pub const fn deny() -> HostJail {
         HostJail {
             default_open: false,
+            record: false,
             mounts: Vec::new(),
             argument_files: ArgumentFiles {
                 auto: false,
@@ -272,9 +281,26 @@ impl HostJail {
     pub const fn deny_with_arg_files() -> HostJail {
         HostJail {
             default_open: false,
+            record: false,
             mounts: Vec::new(),
             argument_files: ArgumentFiles {
                 auto: true,
+                files: Vec::new(),
+            },
+        }
+    }
+
+    /// `record` (spec 23 §8): allow everything and journal each host
+    /// access — the observation mode `tebako trace run` drives. No
+    /// grants (inert under allow-all); the engine maps it to
+    /// `PolicyDefault::Record` at bind.
+    pub const fn record() -> HostJail {
+        HostJail {
+            default_open: true,
+            record: true,
+            mounts: Vec::new(),
+            argument_files: ArgumentFiles {
+                auto: false,
                 files: Vec::new(),
             },
         }
@@ -284,8 +310,13 @@ impl HostJail {
     /// (open default, no grants — `auto-allowed` under an open default
     /// grants nothing the default does not already allow). Surfaces skip
     /// exporting such a policy, keeping the no-policy path byte-identical.
+    /// `record` is NEVER trivially open: it must export so the engine
+    /// journals.
     pub fn is_trivially_open(&self) -> bool {
-        self.default_open && self.mounts.is_empty() && self.argument_files.files.is_empty()
+        !self.record
+            && self.default_open
+            && self.mounts.is_empty()
+            && self.argument_files.files.is_empty()
     }
 
     /// Parse and validate the YAML block form.
@@ -341,7 +372,9 @@ impl HostJail {
 
     /// Parse a `--jail` spec (press/run/shim surfaces): the profiles
     /// `open` | `deny` | `deny:arg`, a YAML file carrying the block form,
-    /// or the `TEBAKO_JAIL` env grammar itself (spec 08 §1).
+    /// or the `TEBAKO_JAIL` env grammar itself (spec 08 §1) — which
+    /// includes the spec 23 §8 `record` token, so `--jail record` works
+    /// on every surface that takes `--jail`.
     pub fn from_cli_spec(spec: &str) -> Result<HostJail, JailError> {
         match spec {
             "open" => return Ok(HostJail::open()),
@@ -382,27 +415,35 @@ impl HostJail {
         Ok(user)
     }
 
-    /// Parse the `TEBAKO_JAIL` env form (spec 08 §1):
+    /// Parse the `TEBAKO_JAIL` env form (spec 08 §1, extended by exactly
+    /// one token per spec 23 §8's last bullet: `record`):
     ///
     /// ```text
     /// jail      = directive *( ";" directive )
-    /// directive = "open" | "deny"          # namespace default (default: open)
-    ///           | host ":" mount ":" mode  # docker -v grant; mount absolute
-    ///           | "@" path                 # argument file (read-only grant)
+    /// directive = "open" | "deny" | "record" # namespace default (default: open)
+    ///           | host ":" mount ":" mode    # docker -v grant; mount absolute
+    ///           | "@" path                   # argument file (read-only grant)
     /// mode      = "ro" | "rw"
     /// ```
     ///
-    /// Errors on: empty spec, conflicting or duplicated `open`/`deny`,
-    /// unknown access modes, non-absolute mount points, empty
-    /// hosts/mounts/argument files, and unrecognised directive shapes. The
-    /// messages mirror the engine's `tfs::policy::JailSpec` parser — one
-    /// grammar, one message set.
+    /// `record` (spec 23 §8) is allow-all + audit: it journals every host
+    /// access so `tebako trace run` can draft a `needs:` block, so it takes
+    /// no grants — a spec mixing `record` with mounts or argument files is
+    /// a named error, not a silently inert combination.
+    ///
+    /// Errors on: empty spec, conflicting or duplicated
+    /// `open`/`deny`/`record`, unknown access modes, non-absolute mount
+    /// points, empty hosts/mounts/argument files, a `record` default
+    /// carrying grants, and unrecognised directive shapes. The messages
+    /// mirror the engine's `tfs::policy::JailSpec` parser — one grammar,
+    /// one message set.
     pub fn parse_env_spec(spec: &str) -> Result<HostJail, JailError> {
         let err = |msg: String| JailError::Spec(format!("{msg} in {spec:?}"));
         if spec.trim().is_empty() {
             return Err(JailError::Spec("empty spec".to_string()));
         }
         let mut default_open: Option<bool> = None;
+        let mut record = false;
         let mut mounts = Vec::new();
         let mut files = Vec::new();
         for token in spec.split(';') {
@@ -410,14 +451,17 @@ impl HostJail {
                 return Err(err("empty directive (stray ';')".to_string()));
             }
             match token {
-                "open" | "deny" => {
-                    let value = token == "open";
-                    if default_open.is_some() {
+                "open" | "deny" | "record" => {
+                    if default_open.is_some() || record {
                         return Err(err(format!(
                             "duplicate/conflicting default directive {token:?}"
                         )));
                     }
-                    default_open = Some(value);
+                    if token == "record" {
+                        record = true;
+                    } else {
+                        default_open = Some(token == "open");
+                    }
                 }
                 _ if token.starts_with('@') => {
                     let path = &token[1..];
@@ -431,8 +475,15 @@ impl HostJail {
                 }
             }
         }
+        if record && (!mounts.is_empty() || !files.is_empty()) {
+            return Err(err(
+                "record carries no grants: mounts and argument files are inert under it — drop them"
+                    .to_string(),
+            ));
+        }
         Ok(HostJail {
             default_open: default_open.unwrap_or(true),
+            record,
             mounts,
             argument_files: ArgumentFiles { auto: false, files },
         }
@@ -443,7 +494,13 @@ impl HostJail {
     /// the dispatch surface's resolution of `auto-allowed` (argv entries
     /// naming existing files — see [`resolve_argument_files`]); they are
     /// unioned with the explicit list, deduplicated, in first-seen order.
+    /// A `record` jail renders as the bare `record` token: grants and
+    /// argument files are inert under allow-all (parse rejects the mix,
+    /// so rendering them would produce a spec that cannot round-trip).
     pub fn to_env_spec(&self, resolved_arg_files: &[PathBuf]) -> String {
+        if self.record {
+            return "record".to_string();
+        }
         let mut out = String::from(if self.default_open { "open" } else { "deny" });
         for m in &self.mounts {
             out.push(';');
@@ -548,6 +605,11 @@ fn tighten_mount(m: &JailMount, q: &HostJail) -> Option<JailMount> {
 /// coalesce to the tighter access; argument files union and `auto-allowed`
 /// is honored when either side asks. Associative and idempotent, so a
 /// surface and the bootstrap may compose in sequence with no drift.
+///
+/// `record` never survives the intersection (`record: false` in the
+/// result): observation is not a policy a package's request can tighten
+/// into, and a record TIGHTENING dominates wholesale in [`effective`]
+/// instead — the request's grants are inert under allow-all.
 pub fn intersect(request: &HostJail, tightening: &HostJail) -> HostJail {
     let mut mounts: Vec<JailMount> = Vec::new();
     for m in &tightening.mounts {
@@ -575,6 +637,7 @@ pub fn intersect(request: &HostJail, tightening: &HostJail) -> HostJail {
     }
     HostJail {
         default_open: request.default_open && tightening.default_open,
+        record: false,
         mounts: coalesced,
         argument_files: ArgumentFiles {
             auto: request.argument_files.auto || tightening.argument_files.auto,
@@ -587,6 +650,11 @@ pub fn intersect(request: &HostJail, tightening: &HostJail) -> HostJail {
 /// package's manifest REQUEST and the user's tightening. Returns the
 /// effective jail and the audit source label (`manifest` / `user` /
 /// `manifest+user`) recorded as `TEBAKO_JAIL_SOURCE` and in the journal.
+///
+/// A `record` tightening dominates wholesale (spec 23 §8): the request's
+/// grants are inert under allow-all, so the composition IS the record
+/// policy, sourced `user` — never `manifest+user`, as nothing of the
+/// request survives to compose.
 pub fn effective(
     request: Option<&HostJail>,
     tightening: Option<&HostJail>,
@@ -595,6 +663,7 @@ pub fn effective(
         (None, None) => None,
         (Some(r), None) => Some((r.clone(), "manifest")),
         (None, Some(t)) => Some((t.clone(), "user")),
+        (Some(_), Some(t)) if t.record => Some((t.clone(), "user")),
         (Some(r), Some(t)) => Some((intersect(r, t), "manifest+user")),
     }
 }
@@ -808,6 +877,71 @@ mod tests {
         let j = HostJail::from_cli_spec("deny;/data:/data:ro").unwrap();
         assert_eq!(j.mounts, vec![mount("/data", "/data", JailAccess::Ro)]);
         assert!(HostJail::from_cli_spec("frob").is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // The record token (spec 23 §8; the policy spec 25 T1's
+    // `tebako trace run` exports)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn env_spec_parses_record_and_renders_it_back() {
+        let j = HostJail::parse_env_spec("record").unwrap();
+        assert_eq!(j, HostJail::record());
+        assert!(j.record);
+        assert!(j.default_open, "record is allow-all underneath");
+        assert!(!j.is_trivially_open(), "record must export to journal");
+        assert_eq!(j.to_env_spec(&[]), "record");
+        // `--jail record` rides the same grammar on every cli surface.
+        assert_eq!(
+            HostJail::from_cli_spec("record").unwrap(),
+            HostJail::record()
+        );
+    }
+
+    #[test]
+    fn env_spec_record_rejections_mirror_the_engine() {
+        for (spec, frag) in [
+            ("record;record", "duplicate/conflicting"),
+            ("open;record", "duplicate/conflicting"),
+            ("record;deny", "duplicate/conflicting"),
+            ("record;/h:/w:ro", "record carries no grants"),
+            ("record;@/f", "record carries no grants"),
+        ] {
+            let e = HostJail::parse_env_spec(spec).unwrap_err();
+            assert!(
+                e.to_string().contains(frag),
+                "spec {spec:?}: error {e} should mention {frag:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn record_dominates_a_manifest_request_wholesale() {
+        // spec 23 §8: the package's grants are inert under allow-all, so
+        // the composition IS the record policy, sourced `user`.
+        let mut request = HostJail::deny();
+        request.mounts = vec![mount("/a", "/a", JailAccess::Ro)];
+        let (eff, source) = effective(Some(&request), Some(&HostJail::record())).unwrap();
+        assert_eq!(eff, HostJail::record());
+        assert_eq!(source, "user");
+        // Alone on the user side it flows unchanged; intersect never
+        // manufactures it.
+        let (eff, source) = effective(None, Some(&HostJail::record())).unwrap();
+        assert_eq!(eff, HostJail::record());
+        assert_eq!(source, "user");
+        assert!(!intersect(&request, &HostJail::record()).record);
+    }
+
+    #[test]
+    fn record_never_enters_the_yaml_block() {
+        // Serde skips the field: the block grammar is byte-identical, and
+        // a `record:` key in YAML is an unknown key — tolerated, inert
+        // (the manifest convention), never honored.
+        let yaml = HostJail::record().to_yaml().unwrap();
+        assert!(!yaml.contains("record"), "{yaml}");
+        let parsed = HostJail::from_yaml("default: open\nrecord: true\n").unwrap();
+        assert!(!parsed.record, "a manifest cannot ask to record");
     }
 
     // ---------------------------------------------------------------

--- a/docs/spec/00-INDEX.md
+++ b/docs/spec/00-INDEX.md
@@ -55,7 +55,7 @@ spec 02 §6).
 22. [22 — Runtime-native interposition](22-runtime-native-interposition.md) — the generalized hooks: loader/exec/resource interposition inside the runtime, the documented interface, and the death of per-gem adapters (the spec-18 contract's runtime-internal half)
 23. [23 — Declarative composition and needs resolution](23-declarative-composition.md) — the fully declarative slice stack: D1 needs / D2 composition doc / D3 press-baked union / D4-D5 operator surfaces; deny-safe by default, the needs-check law (PLANNED)
 24. [24 — Declarative overlays](24-declarative-overlays.md) — write areas and key bindings: the gated COW write gate, `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT`, the record-mode fold-in, exit 68 (PARTIAL)
-25. [25 — Trace observability](25-trace-observability.md) — the interception bus, `tebako trace run|explain|cover`, the escapes correlation (PLANNED)
+25. [25 — Trace observability](25-trace-observability.md) — the interception bus, `tebako trace run|explain|cover`, the escapes correlation (PARTIAL)
 26. [26 — Payload checks](26-payload-checks.md) — the in-image self-validation contract: the `checks:` manifest block, `tebako check` at press/install/discovery moments, SKIP discipline, exit 72 (PLANNED)
 
 ## Locked invariants (all specs subordinate to these)

--- a/docs/spec/17-runtime-driver-contract.md
+++ b/docs/spec/17-runtime-driver-contract.md
@@ -9,6 +9,7 @@ exact contract (roadmap 22's "add a language" playbook).
 
 ```
 <runtime> --tebako-image <self|image-path>:<slot|->:<mount> ...
+          [--tebako-trace <host-path>]
           --tebako-entry <argv0> <user args...>
 ```
 
@@ -80,6 +81,13 @@ exact contract (roadmap 22's "add a language" playbook).
   and drops the keyword (the deploy shims' re-entry form). With images
   but NO `--tebako-entry` at all, the boot mounts and starts the
   interpreter with its own args (the smoke form).
+- `--tebako-trace <host-path>` (spec 25 §2, additive): arm the
+  interception trace bus at boot, BEFORE any mount — the channel file is
+  opened once and appended for the process's life. The `TEBAKO_TRACE`
+  env names the same channel; the argument wins when both are set. A
+  channel that cannot be opened is a loud stderr note and a disarmed
+  bus, never a boot failure (spec 25 law 1: observability never gates).
+  The consumed flag never reaches the interpreter's argv.
 - The interpreter's own args are skipped (and `--tebako-extract` stays
   theirs); an unknown `--tebako-*` flag is a named error, never silently
   ignored.
@@ -99,6 +107,7 @@ exact contract (roadmap 22's "add a language" playbook).
 | `TEBAKO_JAIL` | jail policy env form (spec 08) — the driver/preload enforces it |
 | `TEBAKO_JAIL_SOURCE` | audit label of the policy's origin (`manifest` / `user` / `manifest+user`, or the exporting surface) — journaled with every denial (spec 08 §2) |
 | `TEBAKO_JAIL_JOURNAL` | explicit audit-journal path (default: `$TEBAKO_HOME/journal.log`) |
+| `TEBAKO_TRACE` | spec 25 §2: the interception trace bus's channel file (JSONL). Opened at boot before any mount, appended for the process's life, never policy-gated; children re-derive it from the inherited env. `--tebako-trace` wins when both are set |
 | `TEBAKO_EXEC_CACHE` | spec 22 §6: the boot's exec-cache root — materialized binaries/libraries live under it (per-process on POSIX; leave-in-place and content-keyed on windows, spec 22 §2.1); read-only to payloads |
 | `TEBAKO_RUNTIME_DLL` | spec 22 §2.1 (windows only): the runtime's own PE module basename (e.g. `x64-ucrt-ruby340.dll`), flowed from the factory record — the single owner — and exported by the driver at boot. The tfs PE closure walk excludes a bare import name matching it (case-insensitive, bare names only); POSIX legs never read it |
 | `TEBAKO_PRELOAD_SHIM` | spec 22 §3: the preload shim's in-VFS path, flowed from the env image's `preload_shim` layout grant — the interpreter's spawn hook reads it (never a hand-written copy); the driver additionally arms `LD_PRELOAD` (ELF) / `DYLD_INSERT_LIBRARIES` (macOS) with the materialized host copy |

--- a/docs/spec/25-trace-observability.md
+++ b/docs/spec/25-trace-observability.md
@@ -1,6 +1,9 @@
 # Spec 25 — Trace observability: the interception bus, diagnosis, and coverage
 
-**Status: PLANNED (owner-signed 2026-08-19 — architecture A: the in-tfs
+**Status: PARTIAL (phase T1 shipped 2026-08-19: the `tfs::trace`
+interception bus + `docs/spec/schemas/trace-event.yaml` + `tebako trace
+run`; `explain` is T2, `cover` + the procmon converter are T3.
+Owner-signed 2026-08-19 — architecture A: the in-tfs
 event bus + `tebako trace` front-ends; outside capture rides the
 three-layer producer model of §6.1, with retrace as the libc-boundary
 layer on BOTH platforms).**

--- a/docs/spec/schemas/trace-event.yaml
+++ b/docs/spec/schemas/trace-event.yaml
@@ -1,0 +1,198 @@
+# =============================================================================
+# trace-event.yaml — the trace bus event envelope (spec 25 §3, phase T1)
+#
+# One structured event per interception decision, one JSONL line per event,
+# appended to the channel named by TEBAKO_TRACE / --tebako-trace. This file
+# owns the wire grammar: the envelope fields, the op vocabulary, and the
+# per-op verdict/detail keys.
+#
+# SSOT: this file owns the grammar; crates/tfs/src/trace.rs (the emitter)
+# and crates/tebako-cli/src/trace.rs (the `tebako trace run` consumer)
+# mirror it — keep the three in sync in the same PR. The property test in
+# crates/tfs/src/trace.rs drives the op matrix against a mounted fixture
+# and validates every emitted event against this grammar.
+# =============================================================================
+
+schema: trace-event
+schema_version: 1 # MAJOR — the envelope's `v` field; additive-only, NEVER bumps
+schema_minor: 0 # MINOR — additive counter (unused while v1 grows by ops/keys)
+status: normative
+owner: crates/tfs (tfs::trace, the bus) in tamatebako/tebako
+edge: T1 (driver/context → trace channel), T1' (channel → tebako trace run generator)
+
+# The schema evolution law (spec 18 §3), specialized for an append-only
+# event stream: events are never re-read by their emitter, so evolution
+# serves DOWNSTREAM readers (trace explain/cover, external tooling).
+evolution:
+  major_minor: >-
+    The envelope's `v` is 1 forever. Extensions ride NEW ops and NEW detail
+    keys — never retyped fields, never renamed keys, never a version bump
+    (spec 25 §3: a consumer that understands v1 today understands every
+    future v1 event; one it doesn't recognize costs it exactly that event's
+    detail).
+  unknown_fields: >-
+    Readers ignore unknown detail keys and unknown ops within v1. A writer
+    never invents semantics a reader must know to parse the envelope.
+  unknown_major: >-
+    Not reachable: `v` never bumps. A consumer meeting v != 1 is reading a
+    non-tebako file and names that, never guesses.
+  type_changes: >-
+    Forbidden within v1. New shapes arrive as new keys.
+  lists_stay_lists: >-
+    Ordered/multiplicity data (the closure walk's deps) is a list of
+    entries carrying their identity fields — never keyed maps.
+
+channel:
+  named_by: TEBAKO_TRACE (env) or --tebako-trace <path> (driver argument wins)
+  opened: >-
+    At driver boot, BEFORE any mount (a path op is only safe that early —
+    the journal fd discipline, crates/tfs/src/journal.rs). Append-only,
+    never policy-gated.
+  children: >-
+    Re-derived at each child's own driver boot on both platforms —
+    TEBAKO_TRACE inherits across spawn/exec and the child re-opens for
+    append. (Spec 25 §2's POSIX fd-inheritance spelling is not the
+    mechanism: the bus forbids unsafe, and env re-derivation is uniform.)
+  failure: >-
+    Observability never gates: an unopenable channel is one loud stderr
+    note and a disarmed bus; the run proceeds. A dropped write drops the
+    event, never the run.
+  disarmed_cost: >-
+    One relaxed atomic load per interception point (tfs::trace::Start::now
+    returns None; no event is built).
+
+grammar:
+  envelope:
+    type: map
+    required: true
+    serialization: one JSON object per line (JSONL), keys in the listed order
+    fields:
+      v: {type: int, required: true, notes: "== 1; the envelope version"}
+      ts: {type: string, required: true, notes: "RFC 3339 UTC, microsecond precision: 2026-08-19T13:49:20.344123Z"}
+      pid: {type: int, required: true, notes: "the emitting OS process id (re-read per event — a forked child reports its own)"}
+      tid:
+        type: int
+        required: true
+        notes: >-
+          The bus's PER-PROCESS thread ordinal (1 for the first thread to
+          emit, then sequential) — deliberately not an OS thread id: the
+          bus is pure safe Rust and stable Rust exposes no OS tid. Grouping
+          by (pid, tid) regroups events by thread identically.
+      op: {type: string, required: true, notes: "one of the op vocabulary below"}
+      path:
+        type: string
+        required: true
+        notes: >-
+          The decision's subject: the normalized VFS path (open/stat/
+          dlopen/exec/materialize), the mount point (mount), the bare
+          library name (dlopen's alias surface), the host path (jail).
+          Empty for the whole-table mount clear.
+      verdict: {type: string, required: true, notes: "<word> or <word>:<payload>, per op below"}
+      detail: {type: map, required: true, notes: "per-op keys below; empty when none"}
+      dur_us: {type: int, required: true, notes: "the decision's wall time, microseconds"}
+      errno:
+        type: int
+        required: false
+        notes: >-
+          Present when the verdict carries an errno (error:<errno>,
+          denied:<rule>, deny:<rule>). The typed duplicate of the verdict
+          suffix, for filtering.
+
+  ops:
+    mount:
+      emitter: crates/tfs/src/context.rs (mount table decisions)
+      verdicts: [ok, "error:<errno>"]
+      detail_keys:
+        action: "init | insert | union | remove | clear"
+        handle: "int — the mount handle, on a successful init/insert/union/remove"
+        image: "string — the host image path, when file-backed"
+        count: "int — mounts cleared, on action: clear only"
+    open:
+      emitter: crates/tfs/src/context.rs (open; the fopen routing via dlmap2file_for_open)
+      verdicts: ["image:<mount>", "host", "denied:<rule>", "error:<errno>"]
+      detail_keys:
+        need: "read | write — on passthrough/denial decisions"
+        dlmap_redirect: "the memfs original, when the dlmap-prefix redirect served"
+        materialized: >-
+          The host path of the materialized copy a raw host fd answered
+          from (dlmap-prefix redirect; the preload's fopen routing) — the
+          spec 25 §4 materialize-candidate signal.
+        effective: "the memfs path, when the presented spelling was a dlmap-prefix path"
+        reason: "no-mounts — the degenerate passthrough with an empty mount table"
+        closure: "the closure-walk record (see dlopen), on the fopen surface"
+      notes: >-
+        denied:<rule> carries the policy source label, or `write-gate`
+        for the spec 24 §5 held-tree EROFS.
+    stat:
+      emitter: crates/tfs/src/context.rs (stat/fstat)
+      verdicts: ["image:<mount>", "host", "denied:<rule>", "error:<errno>"]
+      detail_keys:
+        dlmap_redirect: "as open's"
+        reason: "as open's"
+    dlopen:
+      emitter: crates/tfs/src/context.rs (dlmap2file, dlalias2file)
+      verdicts: ["materialized:<host-path>", "host", "error:<errno>"]
+      detail_keys:
+        closure:
+          format: "macho | elf | pe, or null when the header parse was unsupported (no dep walk ran)"
+          deps:
+            - name: "the dependency name as the image declares it"
+              resolved: "the in-image path it resolved to, or null for a host/system name"
+              verdict: "materialized | host-system | error:<errno>"
+        effective: "as open's"
+        alias: "bool — the windows bare-name surface (dlalias2file)"
+      notes: >-
+        The closure key is present on the dlopen surface (dlmap2file);
+        the alias surface carries `alias` instead. A cache-hit answer
+        reports an empty walk (format: null, deps: []) — the walk did not
+        re-run; the paired materialize event carries cache-hit.
+    exec:
+      emitter: crates/tfs/src/context.rs (exec_materialize — the preload's execve/posix_spawn routing)
+      verdicts: ["routed:<host-path>", "host", "error:<errno>"]
+      detail_keys:
+        route: "home-tree | dlmap-closure"
+      notes: >-
+        verdict `host` on the ENOENT fallthrough is the spec 25 §4
+        entrypoint/runtime-dep note signal (a spawned host-absolute
+        executable).
+    materialize:
+      emitter: crates/tfs/src/context.rs (extract_for_exec — dlopen/exec extractions and tebako install's store-side pass)
+      verdicts: ["ok:<host-path>", "cache-hit", "error:<errno>"]
+      detail_keys:
+        dest: "dlcache | store"
+        bytes: "int — bytes written, on ok"
+        host: "the cached host path, on cache-hit"
+      notes: >-
+        The ENOENT host-passthrough answers emit nothing here (no
+        materialization was decided); the caller's dlopen/exec event
+        carries the `host` verdict.
+    jail:
+      emitter: crates/tfs/src/context.rs (host_check — spec 23 §8's journal, formalized)
+      verdicts: ["allow:<rule>", "deny:<rule>", "record"]
+      detail_keys:
+        access: "read | write"
+      notes: >-
+        <rule> is the policy's source label (manifest / user /
+        manifest+user / TEBAKO_JAIL / …). `record` is the record-policy
+        allow (the observation trail `tebako trace run` turns into a
+        needs: draft); plain allows emit only when the policy can deny
+        (never under the open default — the op events carry those
+        passthroughs). A policy-gated decision yields BOTH its op event
+        and the jail event: two layers of one decision, by design.
+    spawn:
+      emitter: "none in phase T1 (T2: libtfs-preload's posix_spawn path)"
+      verdicts: ["routed:<entry>", "host", "error:<errno>"]
+      notes: Defined now so the vocabulary is stable; unemitted in T1.
+    resolve:
+      emitter: "none in phase T1 (T2+: tebako-resolve, the L3 layer)"
+      verdicts: [cache, fetched, "error:<errno>"]
+      notes: Defined now so the vocabulary is stable; unemitted in T1.
+
+notes: >-
+  Phase T1 emits mount/open/stat/dlopen/exec/materialize/jail from the
+  tfs context. The driver's class-R boot materialization
+  (crates/tebako-driver/src/materialize.rs — declared-manifest
+  resources, merkle-verified) is deliberately NOT instrumented in T1: it
+  is boot work outside the interception surface, and its failures already
+  abort the boot loudly. The TEBAKO_DEBUG_TFS eprintln gates remain as
+  the human-readable degraded view over the same emission points.


### PR DESCRIPTION
spec 25 phase T1: the interception trace bus + `tebako trace run`

The bus (crates/tfs/src/trace.rs): one structured JSONL event per
interception decision (mount/open/stat/dlopen/exec/materialize/jail —
spawn/resolve defined, emitted T2+), armed by TEBAKO_TRACE or the
driver's additive --tebako-trace argument (argument wins; the channel
opens at boot BEFORE any mount and is appended for the process's life —
the journal fd discipline: bare writes only, never policy-gated).
Disarmed, an emission point is one Option::is_none() branch; an arm
failure is one loud stderr note and the run proceeds (law 1:
observability never gates). No unsafe anywhere in the module. The
envelope grammar's owner is docs/spec/schemas/trace-event.yaml (v1,
additive-only, never bumped); the §3/§7 property test drives the whole
public op matrix through the process-global context and validates every
captured line against the schema contract.

Emission points (crates/tfs/src/context.rs): the mount table
(init/insert/union/remove/clear), path dispatch per open/stat branch
(the dlmap-prefix redirect carrying the §4 materialize-candidate
details), dlmap2file/dlalias2file (the dlopen surface — the closure
walk rides the detail as structure: format + per-dep verdicts, incident
13's round-4 eprintln gates formalized), exec_materialize (the exec
route), extract_for_exec (the materialize surface), host_check (the
jail channel — spec 23 §8's journaled decisions as events). The
TEBAKO_DEBUG_TFS eprintln gates REMAIN as the human-readable degraded
view over the same points (§2).

`tebako trace run <pkg>` (crates/tebako-cli/src/trace.rs, §4): runs the
package under TEBAKO_JAIL=record with the bus armed (both ride the
inherited env through the bootstrap — zero bootstrap changes), then
synthesizes the capture into a SUGGESTED manifest fragment — commented
YAML, never applied (law 7): the §8 needs generator fed by jail events
re-rendered into the journal grammar (unchanged, exec-cache noise
pre-filtered), materialize: candidates from raw-host-fd opens (the
sassc class-R case), closure-covered dlopen NOTEs, host-executable
entrypoint notes; every entry carries its `why:` evidence. The command
exits with the payload's exit code; a missing capture degrades to a
note + a no-events draft. explain/cover/import name their milestones.

Supporting moves: tpkg's TEBAKO_JAIL env grammar gains the bare
`record` token (spec 23 §8's mode reaching the bootstrap compose — a
user record tightening wins the effective policy; serde-skipped, YAML
byte-identical); the driver parses --tebako-trace (both value forms,
empty is 65) and arms right after Handoff::parse — the plain-boot argv
now composes argv0+interpreter_args so the consumed loader flag never
reaches the interpreter (byte-identical when no loader flags ride);
libtfs-preload's vfs_fopen routes through dlmap2file_for_open (the
fopen surface traces as `open`, the §4 signal); tebako-json gains
to_line (the compact writer the bus serializes with — §7's blessed
workspace-internal dep).

Documented deviations (module docs + schema): tid is the bus's
per-process thread ordinal (stable Rust exposes no OS tid, unsafe is
forbidden); children re-derive the channel from the inherited env at
their own boot on both platforms (the §2 fd-inheritance spelling would
need unsafe).

Doc sync in the same commit: spec 25 → PARTIAL (T1 shipped), spec
00-INDEX, spec 17 §1 grammar + §2 env table, README commands table.


---

Local gates (this worktree, vcpkg env): fmt ✓ · clippy --all-targets -D warnings (six touched crates) ✓ · cli_e2e 13/13 ✓ (tebako-bootstrap dogfooded from target/debug).
