### PR TITLE
spec 26 phase T2: the `tebako check` engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ payloads (inkscape & co.) are feedstocks in the
 | `tebako press` | package an app (lean/fat; `--suite` for multi-command packages; `--jail` presses a host-access policy) |
 | `tebako run <pkg>` | run a pressed package with a user jail tightening (`--jail`/`--mount`/`--no-host`) |
 | `tebako trace run <pkg>` | run under `record` with the trace bus armed; synthesize a suggested manifest (needs/materialize/notes — spec 25 §4) |
+| `tebako check <target>` | run a payload's in-image acceptance checks — a name, a bare `.tfs` (with `--runtime`/`--runtime-image`), a pressed package, or a composition `tebako.yaml`; `--list`/`--check`/`--record`/`--keep-scratch` (spec 26 §2) |
 | `tebako install <ref\|name@ver>` | install a payload from a registry + register its shims |
 | `tebako info [topic]` | the store/system surface: system, runtimes, payloads, shims, registries, store (`--remote` adds what the world offers; `--json` everywhere) |
 | `tebako inspect <artifact>` | payload/package introspection: manifest, provides, requires, platforms, verify (strict), JSON |

--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -51,6 +51,11 @@ flate2 = { version = "1", default-features = false, features = ["rust_backend"] 
 tar = { version = "0.4", default-features = false }
 # Hardlink staging area for manifest tree_hash stamping (spec 03 §7).
 tempfile = "3"
+# spec 26 §2: checks[].expect.stdout is ONE regex the run's stdout must
+# match — tpkg carries it uncompiled by design (no regex dep in the
+# model); the check engine compiles it at run time (pure Rust, no system
+# deps).
+regex = "1"
 
 # The runtime image is extracted in-process through the tfs C ABI
 # (item 30b layout seeding); install reads the embedded payload manifest

--- a/crates/tebako-cli/src/check.rs
+++ b/crates/tebako-cli/src/check.rs
@@ -1,0 +1,2678 @@
+//! `tebako check` — the spec 26 §2 check engine (phase T2): run a
+//! payload's own in-image acceptance contract (`checks:`, spec 26 §1)
+//! against the composition the shim dispatch would mount.
+//!
+//! Four target forms, classified from the argument (MECE):
+//!
+//! - `<name>` — an installed payload (managed mode): the dispatch
+//!   resolution unchanged (`tebako-shim::resolve::resolve_payload` →
+//!   `dispatch::compose_mounts` → per-entrypoint runtime resolution).
+//!   The checks come from the EMBEDDED manifest (in-image is
+//!   authoritative, spec 26 §0); the store mirror supplies deps/policy,
+//!   exactly as dispatch reads it.
+//! - `<image.tfs>` — a bare image (the feedstock's press-time gate):
+//!   exec checks need `--runtime <exe>`; `--runtime-image <env.tfs>` is
+//!   required for non-runtime images and defaults to the checked image
+//!   itself for a runtime slice's `entry: self` checks (spec 26 §1.1).
+//! - `<package>` — a pressed tpkg: per-slot embedded manifests; an exec
+//!   check maps its `entry` (an in-image path) to a `PackageEntry` (the
+//!   slot plus the entrypoint NAME, resolved to the path through the
+//!   owning slot manifest's dispatchables) and execs the package with
+//!   argv0 = the entry name (unix — the bootstrap's argv0 selection,
+//!   spec 07 §2.0).
+//! - `<doc>.yaml` — a spec 23 D2 composition document: the slices and
+//!   runtime it declares, plus its own `checks:` block (spec 26 §2.1).
+//!   Slice checks run before composition checks; the report groups by
+//!   owner (`slice metanorma: html-xml PASS` / `composition: org-compile
+//!   PASS`).
+//!
+//! Per exec check, in declaration order (the model's checks map sorts;
+//! the engine walks the authored YAML mapping for the declared order):
+//!
+//! 1. `when:` platform filter — a non-matching host SKIPs (loud).
+//! 2. `requires: {provides: [...]}` — an unmet capability SKIPs naming it
+//!    (`no jvm in the composition`).
+//! 3. A fresh host-tmp scratch dir, auto-granted `rw` (an engine grant,
+//!    never a declared need); fixtures materialize to the scratch root.
+//! 4. The run: the composition's policy ∪ the check's `needs:` (atoms
+//!    resolved via tpkg::atoms — the SSOT), `{scratch}` argv substituted,
+//!    stdout/stderr captured and teed. `argument_files: auto` resolves
+//!    against the process cwd, which is meaningless for a check run —
+//!    the engine resolves no argument files (the check's argv is the
+//!    author's; the scratch grant covers it).
+//! 5. Assertions (exit → files → stdout) and the verdict line:
+//!    `check html-xml PASS 41s` / `check pdf SKIP (…)` /
+//!    `check html-xml FAIL (expected file missing: test-iso.xml)`.
+//!
+//! Aggregate exit: 0 when every selected check PASSes or SKIPs;
+//! `tpkg::EX_TEBAKO_CHECK` (79 — spec 26 §2/§7 allocated 72, but 72 has
+//! been EX_TEBAKO_TRUST since spec 09; see the constant's doc) when any
+//! FAIL. Timeouts and engine errors mid-check are FAILs with the reason
+//! named; resolution/manifest errors abort with the existing named codes
+//! (64 usage, 65 manifest, 69 unavailable, 127 target not found).
+//! `--record` runs under the bare `record` policy (spec 23 §8 — it
+//! dominates wholesale; grants are inert under allow-all).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{Read, Write as _};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tebako_shim::dispatch::MountSpec;
+use tebako_shim::manifest::Dispatchable;
+use tebako_shim::runtime::{self, RuntimeResolution};
+use tebako_shim::{Ctx, ShimError};
+use tpkg::{
+    Check, CheckEntry, CheckPlatform, Constraint, HostJail, JailAccess, JailMount, PayloadManifest,
+    RuntimeRequirement,
+};
+
+use crate::error::{packaging_error, plain_error, TebakoError};
+
+/// The check-FAIL aggregate exit (spec 26 §2 — re-allocated from the
+/// spec's 72, which collides with EX_TEBAKO_TRUST; tpkg owns the value).
+pub const EX_CHECK: i32 = tpkg::EX_TEBAKO_CHECK;
+
+const EX_USAGE: i32 = tebako_shim::EX_USAGE as i32;
+const EX_MANIFEST: i32 = tebako_shim::EX_TEBAKO_MANIFEST as i32;
+const EX_UNAVAILABLE: i32 = tebako_shim::EX_TEBAKO_UNAVAILABLE as i32;
+
+/// The in-image manifest, backend-relative (tebako-info's constant's
+/// spelling; tpkg::PAYLOAD_MANIFEST_PATH is the absolute form).
+const MANIFEST_BACKEND_PATH: &str = "__tpkg__/manifest.yaml";
+/// tebako-info's cap (1 MiB) — a payload manifest is small by contract.
+const MANIFEST_MAX: u64 = 1 << 20;
+/// The check-run poll interval.
+const POLL: Duration = Duration::from_millis(50);
+
+fn shim_err(e: ShimError) -> TebakoError {
+    TebakoError::new(e.message, i32::from(e.code))
+}
+
+fn errno_text(e: i32) -> String {
+    std::ffi::CStr::from_bytes_until_nul(tfs::errno::strerror(e))
+        .map(|c| c.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| format!("errno {e}"))
+}
+
+// ---------------------------------------------------------------------
+// argv
+// ---------------------------------------------------------------------
+
+/// The parsed `tebako check` argv.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckArgs {
+    /// `<name | image.tfs | package | composition.yaml>`.
+    pub target: String,
+    /// `--check <c>`: run only the check named `<c>`.
+    pub check: Option<String>,
+    /// `--list`: print the selected checks, run none.
+    pub list: bool,
+    /// `--record`: run under the record policy (spec 23 §8).
+    pub record: bool,
+    /// `--keep-scratch`: preserve each check's scratch dir (its path is
+    /// printed) for debugging.
+    pub keep_scratch: bool,
+    /// `--runtime <exe>` (bare-image form).
+    pub runtime: Option<PathBuf>,
+    /// `--runtime-image <env.tfs>` (bare-image form).
+    pub runtime_image: Option<PathBuf>,
+}
+
+/// Parse the `check` argv. Usage errors name the offending token.
+pub fn parse_check_args(args: &[String]) -> Result<CheckArgs, String> {
+    let mut target: Option<String> = None;
+    let mut check: Option<String> = None;
+    let mut list = false;
+    let mut record = false;
+    let mut keep_scratch = false;
+    let mut runtime: Option<PathBuf> = None;
+    let mut runtime_image: Option<PathBuf> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        let (flag, inline) = match arg.split_once('=') {
+            Some((f, v)) if f.starts_with("--") => (f, Some(v.to_string())),
+            _ => (arg.as_str(), None),
+        };
+        let take_value = |i: &mut usize| -> Result<String, String> {
+            if let Some(v) = inline.clone() {
+                return Ok(v);
+            }
+            *i += 1;
+            args.get(*i)
+                .cloned()
+                .ok_or_else(|| format!("option '{flag}' requires a value"))
+        };
+        match flag {
+            "--check" => {
+                let v = take_value(&mut i)?;
+                if check.replace(v).is_some() {
+                    return Err(
+                        "option '--check' selects one check (repeat the command to run another)"
+                            .to_string(),
+                    );
+                }
+            }
+            "--runtime" => runtime = Some(PathBuf::from(take_value(&mut i)?)),
+            "--runtime-image" => runtime_image = Some(PathBuf::from(take_value(&mut i)?)),
+            "--list" => list = true,
+            "--record" => record = true,
+            "--keep-scratch" => keep_scratch = true,
+            _ if flag.starts_with('-') => {
+                return Err(format!("unknown check option '{flag}'"));
+            }
+            _ => {
+                if target.replace(flag.to_string()).is_some() {
+                    return Err(format!(
+                        "unexpected extra argument '{flag}' (one target per run)"
+                    ));
+                }
+            }
+        }
+        i += 1;
+    }
+    if runtime.is_none() && runtime_image.is_some() {
+        return Err(
+            "--runtime-image needs --runtime (the pair names the gate's runtime)".to_string(),
+        );
+    }
+    let target = target.ok_or_else(|| {
+        "usage: tebako check <name | image.tfs | package | composition.yaml> [--check <c>] [--list] [--record] [--keep-scratch] [--runtime <exe> --runtime-image <env.tfs>]".to_string()
+    })?;
+    Ok(CheckArgs {
+        target,
+        check,
+        list,
+        record,
+        keep_scratch,
+        runtime,
+        runtime_image,
+    })
+}
+
+// ---------------------------------------------------------------------
+// Target classification and loading
+// ---------------------------------------------------------------------
+
+/// An image a check reads (fixtures, structural assertions, the manifest):
+/// a whole bare file, or a trailer-described slot region of a package.
+#[derive(Debug, Clone)]
+enum ImageRef {
+    Whole(PathBuf),
+    Region(PathBuf, u64, u64),
+}
+
+impl ImageRef {
+    fn display(&self) -> String {
+        match self {
+            ImageRef::Whole(p) => p.display().to_string(),
+            ImageRef::Region(p, o, s) => format!("{}[slot @{o}+{s}]", p.display()),
+        }
+    }
+
+    /// Mount the image read-only (a Mount value, never the global table).
+    fn mount(&self) -> Result<tfs::context::Mount, String> {
+        let (path, region) = match self {
+            ImageRef::Whole(p) => (p.to_string_lossy().into_owned(), None),
+            ImageRef::Region(p, o, s) => (p.to_string_lossy().into_owned(), Some((*o, *s))),
+        };
+        let mounted = match region {
+            None => tfs::mount::build_from_file(&path, "/mnt"),
+            Some((o, s)) => tfs::mount::build_from_file_at(&path, o, s, "/mnt"),
+        };
+        mounted.map_err(|e| format!("cannot mount {}: {}", self.display(), errno_text(e)))
+    }
+}
+
+/// One report owner: a slice (or the single payload of a bare target) or
+/// the composition document itself. Checks are in DECLARATION order.
+struct OwnerChecks {
+    /// The report prefix: `None` renders the bare form (`check <name> …`),
+    /// `Some("slice metanorma")` / `Some("composition")` the grouped form
+    /// (spec 26 §2.1).
+    label: Option<String>,
+    checks: Vec<(String, Check)>,
+    /// The owner's own image: the fixtures source and the structural
+    /// assertion target. `None` for the composition owner (its checks
+    /// assert the slice union).
+    image: Option<ImageRef>,
+    /// Structural assertions read these (one image for a slice owner; the
+    /// slice union for the composition owner — spec 26 §2.1).
+    structural_images: Vec<ImageRef>,
+    /// The owning slot index (the package form's entry mapping).
+    slot: Option<u32>,
+    /// The owner slice's declared dispatchables (entrypoint name →
+    /// in-image path) — the package form's entry table names PROVIDES
+    /// entrypoints BY NAME; a check's `entry` is the path, resolved
+    /// through this table.
+    dispatchables: Vec<Dispatchable>,
+    /// The composition document's directory — the base of the
+    /// `fixtures_host:` family (spec 26 §2.1). `Some` on the composition
+    /// owner only.
+    doc_dir: Option<PathBuf>,
+}
+
+/// How an exec check's run is planned, per target form.
+enum ExecCtx {
+    /// Managed/store-backed (the name form): per-check runtime resolution
+    /// from the owning dispatchable's `runtime_requirement`; the mounts
+    /// are exactly the dispatch composition (composed lazily — a
+    /// structural-only run never resolves deps, spec 26 §2). The
+    /// resolution is boxed (it dwarfs the other variants).
+    Store {
+        res: Box<tebako_shim::resolve::Resolution>,
+        mounts: Option<Vec<MountSpec>>,
+    },
+    /// The bare-image gate form: the runtime is GIVEN (`--runtime`); the
+    /// env image is `--runtime-image` or, for a runtime slice, the
+    /// checked image itself.
+    Given {
+        exe: Option<PathBuf>,
+        env_image: Option<PathBuf>,
+        checked: PathBuf,
+        kind_is_runtime: bool,
+    },
+    /// A pressed package: exec the package itself; argv0 selects the
+    /// entry (the bootstrap's contract, spec 07 §2.0). The jail the
+    /// engine exports rides the USER-tightening channel — the bootstrap
+    /// re-intersects it with the pressed request (tpkg::jail::effective),
+    /// so under a pressed deny policy the engine's scratch grant is
+    /// bounded by the package's own declaration (the intersection
+    /// ceiling; `--record` dominates wholesale).
+    Package {
+        path: PathBuf,
+        entries: Vec<tpkg::PackageEntry>,
+        has_block: bool,
+        base_jail: Option<HostJail>,
+    },
+    /// A D2 composition document: one runtime for the binding (the doc's
+    /// `runtime:` block, else the entrypoint's requirement), every slice
+    /// mounted, the doc's policy/mounts/needs the base jail. The
+    /// resolution is boxed (it dwarfs the other variants).
+    Composition {
+        requirement: Option<RuntimeRequirement>,
+        runtime: Option<Box<RuntimeResolution>>,
+        mounts: Vec<MountSpec>,
+        base_jail: Option<HostJail>,
+    },
+}
+
+/// The loaded target: owners with their checks (declaration order per
+/// owner, slice owners before the composition owner), the capability set
+/// for `requires:` evaluation, and the exec context.
+struct CheckTarget {
+    owners: Vec<OwnerChecks>,
+    caps: BTreeSet<String>,
+    exec: ExecCtx,
+}
+
+impl CheckTarget {
+    fn total(&self) -> usize {
+        self.owners.iter().map(|o| o.checks.len()).sum()
+    }
+
+    /// Prepare the exec surface: compose the store mounts (and fold the
+    /// dependency images' capabilities in) or resolve the composition's
+    /// runtime. Called once, only when a selected check needs it — a
+    /// structural-only run never resolves anything (spec 26 §2).
+    fn prepare(&mut self, ctx: &Ctx, needs_runtime: bool) -> Result<(), TebakoError> {
+        match &mut self.exec {
+            ExecCtx::Store { res, mounts } => {
+                if mounts.is_none() {
+                    let composed =
+                        tebako_shim::dispatch::compose_mounts(res, ctx).map_err(shim_err)?;
+                    // The composition's capabilities: the payload's own
+                    // (already in `caps`) plus every mounted dependency
+                    // image's embedded manifest. An unreadable/absent dep
+                    // manifest contributes nothing (caps-only read).
+                    for m in composed.iter().skip(1) {
+                        if let Ok(Some((dep, _))) = read_embedded(&ImageRef::Whole(m.image.clone()))
+                        {
+                            collect_caps(&dep, &mut self.caps);
+                        }
+                    }
+                    *mounts = Some(composed);
+                }
+            }
+            ExecCtx::Given {
+                exe,
+                env_image,
+                checked,
+                kind_is_runtime,
+            } => {
+                if !needs_runtime {
+                    return Ok(());
+                }
+                if exe.is_none() {
+                    return Err(TebakoError::new(
+                        format!(
+                            "exec checks on {} need --runtime <exe>{}",
+                            checked.display(),
+                            if *kind_is_runtime {
+                                ""
+                            } else {
+                                " and --runtime-image <env.tfs>"
+                            }
+                        ),
+                        EX_USAGE,
+                    ));
+                }
+                let exe_path = exe.clone().unwrap_or_default();
+                if !exe_path.is_file() {
+                    return Err(packaging_error(
+                        127,
+                        Some(&format!("runtime not found: {}", exe_path.display())),
+                    ));
+                }
+                if env_image.is_none() && *kind_is_runtime {
+                    // spec 26 §1.1: a runtime slice's checks run against
+                    // its own env image by default.
+                    *env_image = Some(checked.clone());
+                }
+                if let Some(image) = env_image {
+                    if !image.is_file() {
+                        return Err(packaging_error(
+                            127,
+                            Some(&format!("runtime image not found: {}", image.display())),
+                        ));
+                    }
+                }
+            }
+            ExecCtx::Package { .. } => {}
+            ExecCtx::Composition {
+                requirement,
+                runtime,
+                ..
+            } => {
+                if needs_runtime && runtime.is_none() {
+                    let req = requirement.as_ref().ok_or_else(|| {
+                        TebakoError::new(
+                            "the composition declares no runtime (add a `runtime:` block) but an exec check needs one",
+                            EX_MANIFEST,
+                        )
+                    })?;
+                    let resolved =
+                        runtime::resolve_runtime(Some(req), true, ctx).map_err(shim_err)?;
+                    if matches!(resolved, RuntimeResolution::Zero) {
+                        return Err(TebakoError::new(
+                            "the composition's runtime resolved to zero runtimes — an exec check needs one",
+                            EX_UNAVAILABLE,
+                        ));
+                    }
+                    *runtime = Some(Box::new(resolved));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+enum TargetKind {
+    Name(String),
+    Image(PathBuf),
+    Package(PathBuf),
+    Composition(PathBuf),
+}
+
+/// Classify the target (MECE): an existing `.yaml`/`.yml` file is a
+/// composition document; another existing file with a tpkg trailer is a
+/// package; any other existing file is a bare image; anything else is a
+/// payload name (managed resolution).
+fn classify(target: &str) -> Result<TargetKind, TebakoError> {
+    let path = Path::new(target);
+    if path.is_file() {
+        let lower = target.to_ascii_lowercase();
+        if lower.ends_with(".yaml") || lower.ends_with(".yml") {
+            return Ok(TargetKind::Composition(path.to_path_buf()));
+        }
+        if crate::install::is_tpkg_package(path) {
+            return Ok(TargetKind::Package(path.to_path_buf()));
+        }
+        return Ok(TargetKind::Image(path.to_path_buf()));
+    }
+    if path.exists() {
+        return Err(packaging_error(
+            127,
+            Some(&format!("check target is not a file: {target}")),
+        ));
+    }
+    Ok(TargetKind::Name(target.to_string()))
+}
+
+/// The entry point: load the target, select, and run. The return is the
+/// process exit code (0, or EX_CHECK when any selected check FAILs);
+/// engine-level failures ride the named codes.
+pub fn run(parsed: &CheckArgs) -> Result<i32, TebakoError> {
+    let ctx = Ctx::from_env().map_err(shim_err)?;
+    let mut target = match classify(&parsed.target)? {
+        TargetKind::Name(name) => load_name(&name, &ctx)?,
+        TargetKind::Image(path) => load_image(&path, parsed)?,
+        TargetKind::Package(path) => load_package(&path)?,
+        TargetKind::Composition(path) => load_composition(&path, &ctx)?,
+    };
+    if target.total() == 0 {
+        eprintln!("tebako check: {} declares no checks", parsed.target);
+        return Ok(0);
+    }
+
+    // Selection: every declared check, or the one --check names (matched
+    // across owners; declaration order preserved).
+    let mut selected: Vec<(usize, usize)> = Vec::new();
+    for (oi, owner) in target.owners.iter().enumerate() {
+        for (ci, (name, _)) in owner.checks.iter().enumerate() {
+            if parsed.check.as_ref().map_or(true, |want| want == name) {
+                selected.push((oi, ci));
+            }
+        }
+    }
+    if let Some(want) = &parsed.check {
+        if selected.is_empty() {
+            let mut names = Vec::new();
+            for owner in &target.owners {
+                for (name, _) in &owner.checks {
+                    names.push(match &owner.label {
+                        Some(label) => format!("{label}: {name}"),
+                        None => name.clone(),
+                    });
+                }
+            }
+            return Err(TebakoError::new(
+                format!(
+                    "no check named {want:?} in {} (declared: {})",
+                    parsed.target,
+                    names.join(", ")
+                ),
+                EX_USAGE,
+            ));
+        }
+    }
+
+    if parsed.list {
+        for (oi, ci) in &selected {
+            let owner = &target.owners[*oi];
+            let (name, check) = &owner.checks[*ci];
+            let shape = if check.entry.is_some() {
+                "exec"
+            } else {
+                "structural"
+            };
+            match &owner.label {
+                Some(label) => println!("{label}: {name} ({shape})"),
+                None => println!("check {name} ({shape})"),
+            }
+        }
+        return Ok(0);
+    }
+
+    let needs_runtime = selected
+        .iter()
+        .any(|(oi, ci)| target.owners[*oi].checks[*ci].1.entry.is_some());
+    let needs_caps = selected
+        .iter()
+        .any(|(oi, ci)| target.owners[*oi].checks[*ci].1.requires.is_some());
+    if needs_runtime || needs_caps {
+        target.prepare(&ctx, needs_runtime)?;
+    }
+
+    let mut any_fail = false;
+    for (oi, ci) in selected {
+        // `target` is borrowed per check; plan_exec needs no mutation
+        // after prepare.
+        let owner = &target.owners[oi];
+        let (name, check) = &owner.checks[ci];
+        let verdict = run_one(&target, owner, name, check, parsed, &ctx)?;
+        if matches!(verdict, Verdict::Fail { .. }) {
+            any_fail = true;
+        }
+        println!("{}", verdict_line(owner.label.as_deref(), name, &verdict));
+    }
+    Ok(if any_fail { EX_CHECK } else { 0 })
+}
+
+// ---------------------------------------------------------------------
+// Per-form loaders
+// ---------------------------------------------------------------------
+
+/// The name form (managed mode): resolve the payload through the dispatch
+/// chain, read the checks from the EMBEDDED manifest (in-image is
+/// authoritative, spec 26 §0), and keep the resolution for the exec
+/// plans. Deps/policy read exactly what dispatch reads (the mirror).
+fn load_name(name: &str, ctx: &Ctx) -> Result<CheckTarget, TebakoError> {
+    let res = tebako_shim::resolve::resolve_payload(name, ctx).map_err(shim_err)?;
+    let image = ImageRef::Whole(res.record.image.clone());
+    let embedded = read_embedded(&image)?;
+    let mut caps = BTreeSet::new();
+    let mut checks = Vec::new();
+    let mut dispatchables = res.manifest.dispatchables();
+    match &embedded {
+        Some((manifest, text)) => {
+            collect_caps(manifest, &mut caps);
+            checks = declaration_order(text, &manifest.checks);
+            dispatchables =
+                tebako_shim::manifest::Manifest::from_payload_manifest(manifest.clone())
+                    .dispatchables();
+        }
+        None => {
+            // No embedded manifest (a pre-checks image): the mirror still
+            // answers the capability question.
+            collect_caps(res.manifest.payload_manifest(), &mut caps);
+        }
+    }
+    let owners = if checks.is_empty() {
+        Vec::new()
+    } else {
+        vec![OwnerChecks {
+            label: None,
+            checks,
+            structural_images: vec![image.clone()],
+            image: Some(image),
+            slot: None,
+            dispatchables,
+            doc_dir: None,
+        }]
+    };
+    Ok(CheckTarget {
+        owners,
+        caps,
+        exec: ExecCtx::Store {
+            res: Box::new(res),
+            mounts: None,
+        },
+    })
+}
+
+/// The bare-image form (the press-time gate, spec 26 §3): the image's own
+/// embedded manifest; exec checks run against the GIVEN runtime.
+fn load_image(path: &Path, parsed: &CheckArgs) -> Result<CheckTarget, TebakoError> {
+    let image = ImageRef::Whole(path.to_path_buf());
+    let embedded = read_embedded(&image)?;
+    let mut caps = BTreeSet::new();
+    let mut checks = Vec::new();
+    let mut dispatchables = Vec::new();
+    let mut kind_is_runtime = false;
+    if let Some((manifest, text)) = &embedded {
+        kind_is_runtime = manifest.identity.kind == tpkg::PayloadKind::Runtime;
+        collect_caps(manifest, &mut caps);
+        checks = declaration_order(text, &manifest.checks);
+        dispatchables = tebako_shim::manifest::Manifest::from_payload_manifest(manifest.clone())
+            .dispatchables();
+    }
+    let owners = if checks.is_empty() {
+        Vec::new()
+    } else {
+        vec![OwnerChecks {
+            label: None,
+            checks,
+            structural_images: vec![image.clone()],
+            image: Some(image),
+            slot: None,
+            dispatchables,
+            doc_dir: None,
+        }]
+    };
+    Ok(CheckTarget {
+        owners,
+        caps,
+        exec: ExecCtx::Given {
+            exe: parsed.runtime.clone(),
+            env_image: parsed.runtime_image.clone(),
+            checked: path.to_path_buf(),
+            kind_is_runtime,
+        },
+    })
+}
+
+/// The package form: every non-runtime slot's embedded manifest (the
+/// runtime slot is never mounted, spec 17 §1 — its checks belong to the
+/// factory/gate, not the package surface). A multi-slice package groups
+/// the report by slice; a single-slice package keeps the bare form.
+fn load_package(path: &Path) -> Result<CheckTarget, TebakoError> {
+    let mut f = std::fs::File::open(path)
+        .map_err(|e| plain_error(format!("cannot open the package {}: {e}", path.display())))?;
+    let m = tpkg::read_from(&mut f).map_err(|e| {
+        plain_error(format!(
+            "corrupt tebako manifest trailer in {} ({})",
+            path.display(),
+            tpkg::strerror(e.code())
+        ))
+    })?;
+    let pm = m.package_manifest().map_err(|e| {
+        plain_error(format!(
+            "invalid package manifest (extension block type 2) in {}: {e}",
+            path.display()
+        ))
+    })?;
+
+    let mut owners = Vec::new();
+    let mut caps = BTreeSet::new();
+    for (index, slot) in m.slots.iter().enumerate() {
+        if slot.format_id == tpkg::TPKG_FORMAT_RUNTIME {
+            continue;
+        }
+        let image = ImageRef::Region(path.to_path_buf(), slot.offset, slot.size);
+        let Some((manifest, text)) = read_embedded(&image)? else {
+            continue;
+        };
+        collect_caps(&manifest, &mut caps);
+        let checks = declaration_order(&text, &manifest.checks);
+        if checks.is_empty() {
+            continue;
+        }
+        owners.push(OwnerChecks {
+            label: Some(format!("slice {}", manifest.identity.name)),
+            checks,
+            structural_images: vec![image.clone()],
+            image: Some(image),
+            slot: Some(index as u32),
+            dispatchables: tebako_shim::manifest::Manifest::from_payload_manifest(manifest.clone())
+                .dispatchables(),
+            doc_dir: None,
+        });
+    }
+    // A single-owner package reads like any single-payload target.
+    if owners.len() == 1 {
+        owners[0].label = None;
+    }
+    let (entries, has_block, base_jail) = match pm {
+        Some(pm) => (pm.entries, true, pm.jail),
+        None => (Vec::new(), false, None),
+    };
+    Ok(CheckTarget {
+        owners,
+        caps,
+        exec: ExecCtx::Package {
+            path: path.to_path_buf(),
+            entries,
+            has_block,
+            base_jail,
+        },
+    })
+}
+
+// ---------------------------------------------------------------------
+// The composition document (spec 23 D2 + spec 26 §2.1)
+// ---------------------------------------------------------------------
+
+/// The D2 document as the check engine reads it. `deny_unknown_fields` is
+/// the spec-03 discipline; `checks:` reuses the payload manifest's own
+/// duplicate-name refusal and validation (the composition grammar is the
+/// slice grammar with the MECE fixture families swapped — tpkg's
+/// [`Check::validate_composition`]).
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompositionDoc {
+    /// The document version (only 1 exists).
+    version: u32,
+    #[serde(default)]
+    runtime: Option<CompositionRuntime>,
+    #[serde(default)]
+    slices: Vec<CompositionSlice>,
+    #[serde(default)]
+    entrypoint: Option<String>,
+    #[serde(default)]
+    policy: Option<String>,
+    #[serde(default)]
+    mounts: Vec<CompositionMount>,
+    #[serde(default)]
+    needs: Option<CompositionNeeds>,
+    #[serde(default, deserialize_with = "tpkg::checks_map::deserialize")]
+    checks: BTreeMap<String, Check>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompositionRuntime {
+    name: String,
+    requirement: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompositionSlice {
+    name: String,
+    #[serde(default)]
+    requirement: Option<String>,
+    /// The mount point (the VFS namespace name). Required for every slice
+    /// except the entrypoint provider (which defaults to `/`).
+    #[serde(default)]
+    mount: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompositionMount {
+    host: String,
+    /// Defaults to the host path itself (the identity mount).
+    #[serde(default)]
+    mount: Option<String>,
+    access: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompositionNeeds {
+    #[serde(default)]
+    host: Vec<CompositionNeed>,
+}
+
+/// A composition-level need: the spec 23 §2 D1 grammar, lowered to a
+/// host-mount grant (identity unless `mount` says otherwise).
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompositionNeed {
+    path: String,
+    access: String,
+    #[serde(default)]
+    mount: Option<String>,
+    #[serde(default)]
+    when: Vec<CheckPlatform>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    why: Option<String>,
+}
+
+fn parse_access_word(word: &str, what: &str) -> Result<JailAccess, TebakoError> {
+    match word {
+        "ro" => Ok(JailAccess::Ro),
+        "rw" => Ok(JailAccess::Rw),
+        other => Err(TebakoError::new(
+            format!("{what}: unknown access {other:?} (want ro|rw)"),
+            EX_MANIFEST,
+        )),
+    }
+}
+
+/// Resolve a slice reference to the newest installed version satisfying
+/// its constraint (spec 05's newest-compatible rule, the dispatch
+/// dependency resolution's own message shape).
+fn resolve_slice(ctx: &Ctx, name: &str, requirement: Option<&str>) -> Result<String, TebakoError> {
+    let installed = tebako_shim::resolve::installed_versions(&ctx.home, name).map_err(shim_err)?;
+    let version = match requirement {
+        Some(req) => {
+            let constraint = Constraint::new(req).map_err(|e| {
+                TebakoError::new(
+                    format!("composition slice {name:?}: invalid requirement {req:?} ({e})"),
+                    EX_MANIFEST,
+                )
+            })?;
+            let constraint = tebako_shim::versions::from_validated(&constraint);
+            installed
+                .iter()
+                .filter(|v| constraint.matches(v))
+                .max_by(|a, b| tebako_shim::versions::compare(a, b))
+                .cloned()
+        }
+        None => installed
+            .iter()
+            .max_by(|a, b| tebako_shim::versions::compare(a, b))
+            .cloned(),
+    };
+    version.ok_or_else(|| {
+        TebakoError::new(
+            format!(
+                "composition slice {name:?}: no satisfying version is installed (installed: {})\n  install the slice with `tebako install {name}`",
+                if installed.is_empty() {
+                    "none".to_string()
+                } else {
+                    installed.join(", ")
+                }
+            ),
+            EX_MANIFEST,
+        )
+    })
+}
+
+/// The engine's atom binding (spec 23 §2's "resolved at bind, per
+/// invocation, per user"): `$HOME`/`%USERPROFILE%` and `$TMPDIR`/`%TEMP%`
+/// from the environment, `$CWD` the invoking cwd, `$TEBAKO_HOME` the
+/// store. The grammar (and the unknown-atom error) is tpkg's.
+fn engine_atom(atom: &str, ctx: &Ctx) -> Option<String> {
+    let env = |key: &str| ctx.env.get(key).filter(|v| !v.is_empty()).cloned();
+    match atom {
+        "HOME" | "USERPROFILE" => env("HOME").or_else(|| env("USERPROFILE")),
+        "TMPDIR" | "TEMP" => env("TMPDIR")
+            .or_else(|| env("TEMP"))
+            .or_else(|| Some(std::env::temp_dir().to_string_lossy().into_owned())),
+        "CWD" => Some(ctx.cwd.to_string_lossy().into_owned()),
+        "TEBAKO_HOME" => Some(ctx.home.to_string_lossy().into_owned()),
+        _ => None,
+    }
+}
+
+fn expand_atom_path(path: &str, ctx: &Ctx) -> Result<String, TebakoError> {
+    tpkg::atoms::expand_symbolic_atoms(path, &|atom| engine_atom(atom, ctx))
+        .map_err(|e| TebakoError::new(e, EX_MANIFEST))
+}
+
+/// Load a D2 composition document: validate, resolve the slices against
+/// the store, read each slice's embedded manifest (checks, capabilities,
+/// the entrypoint provider), and compose the base policy from the doc's
+/// `policy:`/`mounts:`/`needs:` (spec 23 §5 — declarations turn the jail
+/// on, deny by default).
+fn load_composition(path: &Path, ctx: &Ctx) -> Result<CheckTarget, TebakoError> {
+    let text = std::fs::read_to_string(path).map_err(|e| {
+        plain_error(format!(
+            "cannot read the composition document {}: {e}",
+            path.display()
+        ))
+    })?;
+    let doc: CompositionDoc = serde_yml::from_str(&text).map_err(|e| {
+        TebakoError::new(
+            format!("invalid composition document {}: {e}", path.display()),
+            EX_MANIFEST,
+        )
+    })?;
+    let doc_err = |msg: String| TebakoError::new(format!("{}: {msg}", path.display()), EX_MANIFEST);
+    if doc.version != 1 {
+        return Err(doc_err(format!("version must be 1 (got {})", doc.version)));
+    }
+    // The checks block: the slice grammar with the composition fixture
+    // families (the MECE rule is tpkg's validate_composition).
+    for (name, check) in &doc.checks {
+        tpkg::check_check_name(name).map_err(|e| doc_err(format!("checks.{name}: {e}")))?;
+        check
+            .validate_composition()
+            .map_err(|e| doc_err(format!("checks.{name}: {e}")))?;
+    }
+    let mut seen_slices = BTreeSet::new();
+    for slice in &doc.slices {
+        if !seen_slices.insert(slice.name.clone()) {
+            return Err(doc_err(format!(
+                "duplicate slice {:?} — an authoring ambiguity, never a silent winner",
+                slice.name
+            )));
+        }
+    }
+    let policy_open = match doc.policy.as_deref() {
+        None => None,
+        Some("open") => Some(true),
+        Some("deny") => Some(false),
+        Some(other) => {
+            return Err(doc_err(format!(
+                "unknown policy {other:?} (want open|deny — record is the engine's --record, never authored)"
+            )));
+        }
+    };
+
+    // Resolve the slices (newest installed satisfying the requirement)
+    // and read their embedded manifests.
+    let doc_dir = path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    struct ResolvedSlice {
+        name: String,
+        image: ImageRef,
+        manifest: Option<(PayloadManifest, String)>,
+        declared_mount: Option<String>,
+    }
+    let mut slices = Vec::new();
+    for slice in &doc.slices {
+        let version = resolve_slice(ctx, &slice.name, slice.requirement.as_deref())?;
+        let record = tebako_shim::manifest::payload_record(&ctx.home, &slice.name, &version);
+        let image = ImageRef::Whole(record.image);
+        let manifest = read_embedded(&image)?;
+        slices.push(ResolvedSlice {
+            name: slice.name.clone(),
+            image,
+            manifest,
+            declared_mount: slice.mount.clone(),
+        });
+    }
+
+    // The entrypoint provider is the app slice: mounted first, at its
+    // declared mount or `/`. Every other slice (and every slice of an
+    // entrypoint-less document) needs a declared mount — a composition
+    // that would collide at `/` is a named error, never a silent order.
+    let provider = match &doc.entrypoint {
+        Some(entry) => {
+            let providing: Vec<usize> = slices
+                .iter()
+                .enumerate()
+                .filter(|(_, s)| {
+                    s.manifest.as_ref().is_some_and(|(m, _)| {
+                        tebako_shim::manifest::Manifest::from_payload_manifest(m.clone())
+                            .dispatchables()
+                            .iter()
+                            .any(|d| &d.name == entry)
+                    })
+                })
+                .map(|(i, _)| i)
+                .collect();
+            match providing.len() {
+                1 => Some(providing[0]),
+                0 => {
+                    return Err(doc_err(format!(
+                        "entrypoint {entry:?} is not provided by any slice in the composition"
+                    )));
+                }
+                _ => {
+                    return Err(doc_err(format!(
+                        "entrypoint {entry:?} is provided by {} slices — an authoring ambiguity",
+                        providing.len()
+                    )));
+                }
+            }
+        }
+        None => None,
+    };
+    let mut caps = BTreeSet::new();
+    let mut mounts = Vec::new();
+    let mut seen_mounts = BTreeSet::new();
+    let mut owners = Vec::new();
+    for (index, slice) in slices.iter().enumerate() {
+        let mount = if Some(index) == provider {
+            slice
+                .declared_mount
+                .clone()
+                .unwrap_or_else(|| "/".to_string())
+        } else {
+            match &slice.declared_mount {
+                Some(m) => m.clone(),
+                None => {
+                    return Err(doc_err(format!(
+                        "slice {:?} needs a declared mount: (only the entrypoint slice defaults to /)",
+                        slice.name
+                    )));
+                }
+            }
+        };
+        if !seen_mounts.insert(mount.clone()) {
+            return Err(doc_err(format!(
+                "two slices mount at {mount:?} (EEXIST at boot — spec 17 §1)"
+            )));
+        }
+        if let Some((manifest, text)) = &slice.manifest {
+            collect_caps(manifest, &mut caps);
+            let checks = declaration_order(text, &manifest.checks);
+            if !checks.is_empty() {
+                owners.push(OwnerChecks {
+                    label: Some(format!("slice {}", slice.name)),
+                    checks,
+                    structural_images: vec![slice.image.clone()],
+                    image: Some(slice.image.clone()),
+                    slot: None,
+                    dispatchables: tebako_shim::manifest::Manifest::from_payload_manifest(
+                        manifest.clone(),
+                    )
+                    .dispatchables(),
+                    doc_dir: None,
+                });
+            }
+        }
+        let image_path = match &slice.image {
+            ImageRef::Whole(p) => p.clone(),
+            ImageRef::Region(p, ..) => p.clone(),
+        };
+        mounts.push(MountSpec {
+            image: image_path,
+            slot: 0,
+            mount,
+        });
+    }
+    // The entrypoint provider mounts FIRST (the driver resolves the entry
+    // against the first image mount, spec 17 §1).
+    if let Some(provider) = provider {
+        mounts.swap(0, provider);
+    }
+
+    // The runtime requirement: the doc's `runtime:` block, else the
+    // entrypoint's own requirement (the dispatch rule, spec 23 §6).
+    let requirement = match &doc.runtime {
+        Some(rt) => Some(RuntimeRequirement {
+            engine: rt.name.clone(),
+            constraint: Constraint::new(&rt.requirement).map_err(|e| {
+                doc_err(format!(
+                    "runtime requirement {:?} is invalid ({e})",
+                    rt.requirement
+                ))
+            })?,
+            abi: None,
+        }),
+        None => provider.and_then(|p| {
+            slices[p].manifest.as_ref().and_then(|(m, _)| {
+                tebako_shim::manifest::Manifest::from_payload_manifest(m.clone())
+                    .dispatchables()
+                    .into_iter()
+                    .find(|d| Some(&d.name) == doc.entrypoint.as_ref())
+                    .and_then(|d| d.runtime_requirement)
+            })
+        }),
+    };
+    if let Some(req) = &requirement {
+        caps.insert(req.engine.clone());
+    }
+
+    // The base policy: the doc's mounts + needs as grants; deny by
+    // default once anything is declared (spec 23 §5).
+    let mut grants = Vec::new();
+    for m in &doc.mounts {
+        let host = expand_atom_path(&m.host, ctx)?;
+        let host = if Path::new(&host).is_absolute() {
+            host
+        } else {
+            doc_dir.join(host).to_string_lossy().into_owned()
+        };
+        grants.push(JailMount {
+            mount: m.mount.clone().unwrap_or_else(|| host.clone()),
+            host,
+            access: parse_access_word(&m.access, "composition mounts[]")?,
+        });
+    }
+    for n in doc.needs.map(|n| n.host).unwrap_or_default() {
+        if !in_force_on(&n.when, host_platform()) {
+            continue; // a platform-filtered need is inert (spec 23 §2)
+        }
+        let host = expand_atom_path(&n.path, ctx)?;
+        grants.push(JailMount {
+            mount: n.mount.clone().unwrap_or_else(|| host.clone()),
+            host,
+            access: parse_access_word(&n.access, "composition needs[]")?,
+        });
+    }
+    let base_jail = if policy_open.is_some() || !grants.is_empty() {
+        Some(HostJail {
+            default_open: policy_open.unwrap_or(false),
+            record: false,
+            mounts: grants,
+            argument_files: tpkg::ArgumentFiles::default(),
+        })
+    } else {
+        None
+    };
+
+    // The composition owner runs last (slice checks diagnose a broken
+    // slice before the binding that depends on it, spec 26 §2.1).
+    let doc_checks = declaration_order(&text, &doc.checks);
+    if !doc_checks.is_empty() {
+        owners.push(OwnerChecks {
+            label: Some("composition".to_string()),
+            checks: doc_checks,
+            structural_images: slices.iter().map(|s| s.image.clone()).collect(),
+            image: None,
+            slot: None,
+            dispatchables: Vec::new(),
+            doc_dir: Some(doc_dir.clone()),
+        });
+    }
+
+    Ok(CheckTarget {
+        owners,
+        caps,
+        exec: ExecCtx::Composition {
+            requirement,
+            runtime: None,
+            mounts,
+            base_jail,
+        },
+    })
+}
+
+// ---------------------------------------------------------------------
+// Manifest reading + declaration order + capabilities
+// ---------------------------------------------------------------------
+
+/// Read the embedded payload manifest from an image (a Mount value, never
+/// the global table — tebako-info's pattern). `None` = the image carries
+/// no manifest (a legal, if boring, image); a corrupt one is a named 65.
+fn read_embedded(image: &ImageRef) -> Result<Option<(PayloadManifest, String)>, TebakoError> {
+    let mount = image
+        .mount()
+        .map_err(|e| TebakoError::new(e, EX_MANIFEST))?;
+    let backend: &dyn tfs::Backend = &*mount.backend;
+    let st = match backend.stat(MANIFEST_BACKEND_PATH) {
+        Ok(st) => st,
+        Err(_) => return Ok(None), // ENOENT and friends: absent
+    };
+    if st.entry_type != tfs::EntryType::File {
+        return Err(TebakoError::new(
+            format!(
+                "payload manifest {MANIFEST_BACKEND_PATH} in {} is not a regular file",
+                image.display()
+            ),
+            EX_MANIFEST,
+        ));
+    }
+    let size = u64::try_from(st.size)
+        .map_err(|_| TebakoError::new("payload manifest has a negative size", EX_MANIFEST))?;
+    if size > MANIFEST_MAX {
+        return Err(TebakoError::new(
+            format!("payload manifest exceeds {MANIFEST_MAX} bytes"),
+            EX_MANIFEST,
+        ));
+    }
+    let mut buf = vec![0u8; size as usize];
+    let mut off = 0u64;
+    while off < size {
+        let n = backend
+            .pread(MANIFEST_BACKEND_PATH, &mut buf[off as usize..], off)
+            .map_err(|e| {
+                TebakoError::new(
+                    format!("cannot read the payload manifest (errno {e})"),
+                    EX_MANIFEST,
+                )
+            })?;
+        if n == 0 {
+            return Err(TebakoError::new(
+                "short read on the payload manifest",
+                EX_MANIFEST,
+            ));
+        }
+        off += n as u64;
+    }
+    let text = String::from_utf8(buf)
+        .map_err(|_| TebakoError::new("payload manifest is not valid UTF-8", EX_MANIFEST))?;
+    let manifest = PayloadManifest::from_yaml(&text).map_err(|e| {
+        TebakoError::new(
+            format!("corrupt payload manifest in {}: {e}", image.display()),
+            EX_MANIFEST,
+        )
+    })?;
+    Ok(Some((manifest, text)))
+}
+
+/// The checks of one manifest in DECLARATION order (spec 26 §2): the
+/// validated model's map sorts by name, so the engine walks the authored
+/// YAML mapping (serde_yml preserves document order) and looks each key
+/// up in the model. Model entries the mapping did not yield (never
+/// happens — both read the same document) append in map order.
+fn declaration_order(text: &str, checks: &BTreeMap<String, Check>) -> Vec<(String, Check)> {
+    let mut ordered: Vec<(String, Check)> = Vec::new();
+    if let Ok(serde_yml::Value::Mapping(root)) = serde_yml::from_str::<serde_yml::Value>(text) {
+        for (key, value) in &root {
+            let is_checks = matches!(key, serde_yml::Value::String(s) if s == "checks");
+            if !is_checks {
+                continue;
+            }
+            if let serde_yml::Value::Mapping(map) = value {
+                for (name, _) in map {
+                    if let serde_yml::Value::String(name) = name {
+                        if let Some(check) = checks.get(name) {
+                            ordered.push((name.clone(), check.clone()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    for (name, check) in checks {
+        if !ordered.iter().any(|(seen, _)| seen == name) {
+            ordered.push((name.clone(), check.clone()));
+        }
+    }
+    ordered
+}
+
+/// The capability set a `requires:` evaluates against: over the
+/// composition's slices, the union of the slice name, the app
+/// entrypoints, the toolkit executables/libraries, and the runtime
+/// engines (spec 26 §2 step 2 — the spec's `jvm` is the illustrative
+/// case; an openjdk slice provides the `java` executable).
+fn collect_caps(manifest: &PayloadManifest, caps: &mut BTreeSet<String>) {
+    caps.insert(manifest.identity.name.clone());
+    match &manifest.provides {
+        tpkg::Provides::App(app) => {
+            for e in &app.entrypoints {
+                caps.insert(e.name.clone());
+            }
+        }
+        tpkg::Provides::Toolkit(tk) => {
+            for e in &tk.executables {
+                caps.insert(e.name.clone());
+            }
+            for l in &tk.libraries {
+                caps.insert(l.name.clone());
+            }
+        }
+        tpkg::Provides::Runtime(rt) => {
+            for e in &rt.provides {
+                caps.insert(e.engine.clone());
+            }
+        }
+        _ => {}
+    }
+}
+
+// ---------------------------------------------------------------------
+// The per-check pipeline
+// ---------------------------------------------------------------------
+
+/// A check's verdict. FAIL carries the first failing assertion's reason
+/// (or the engine failure's name); SKIP carries the unmet prerequisite.
+enum Verdict {
+    Pass { secs: u64 },
+    Skip { reason: String },
+    Fail { reason: String },
+}
+
+fn verdict_line(label: Option<&str>, name: &str, verdict: &Verdict) -> String {
+    let head = match label {
+        Some(label) => format!("{label}: {name}"),
+        None => format!("check {name}"),
+    };
+    match verdict {
+        Verdict::Pass { secs } => format!("{head} PASS {secs}s"),
+        Verdict::Skip { reason } => format!("{head} SKIP ({reason})"),
+        Verdict::Fail { reason } => format!("{head} FAIL ({reason})"),
+    }
+}
+
+/// The host's OS family (the `when:` axis — spec 26 §1's three names,
+/// matching std::env::consts::OS's spellings on the supported hosts).
+fn host_platform() -> Option<CheckPlatform> {
+    match std::env::consts::OS {
+        "windows" => Some(CheckPlatform::Windows),
+        "macos" => Some(CheckPlatform::Macos),
+        "linux" => Some(CheckPlatform::Linux),
+        _ => None,
+    }
+}
+
+/// A `when:` filter holds: empty = every platform; else the host family
+/// must be listed (an unrecognized host family matches nothing).
+fn in_force_on(when: &[CheckPlatform], host: Option<CheckPlatform>) -> bool {
+    when.is_empty() || host.is_some_and(|h| when.contains(&h))
+}
+
+fn platform_name(p: CheckPlatform) -> &'static str {
+    match p {
+        CheckPlatform::Windows => "windows",
+        CheckPlatform::Macos => "macos",
+        CheckPlatform::Linux => "linux",
+    }
+}
+
+/// The mid-check failure channel: `Fail` is this check's verdict (spec 26
+/// §2 — timeouts and engine errors mid-check are FAILs with the reason
+/// named); `Abort` is a named engine error that ends the run (resolution,
+/// manifest corruption — the existing named codes).
+enum CheckStep {
+    Fail(String),
+    Abort(TebakoError),
+}
+
+impl From<TebakoError> for CheckStep {
+    fn from(e: TebakoError) -> CheckStep {
+        CheckStep::Abort(e)
+    }
+}
+
+fn run_one(
+    target: &CheckTarget,
+    owner: &OwnerChecks,
+    name: &str,
+    check: &Check,
+    parsed: &CheckArgs,
+    ctx: &Ctx,
+) -> Result<Verdict, TebakoError> {
+    let started = Instant::now();
+    // 1. The platform filter.
+    if !in_force_on(&check.when, host_platform()) {
+        return Ok(Verdict::Skip {
+            reason: format!(
+                "not for {} (when: {})",
+                std::env::consts::OS,
+                check
+                    .when
+                    .iter()
+                    .map(|p| platform_name(*p))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        });
+    }
+    // 2. The composition prerequisites — unmet is a SKIP, never a FAIL.
+    if let Some(requires) = &check.requires {
+        for cap in &requires.provides {
+            if !target.caps.contains(cap) {
+                return Ok(Verdict::Skip {
+                    reason: format!("no {cap} in the composition"),
+                });
+            }
+        }
+    }
+    // The structural shape (no entry): mount the image(s) and assert —
+    // no runtime, no scratch, no jail (spec 26 §1.1).
+    if check.entry.is_none() {
+        return Ok(
+            match assert_image_files(&owner.structural_images, &check.expect.image_files) {
+                None => Verdict::Pass {
+                    secs: started.elapsed().as_secs(),
+                },
+                Some(reason) => Verdict::Fail { reason },
+            },
+        );
+    }
+
+    match run_exec(target, owner, name, check, parsed, ctx, started) {
+        Ok(verdict) => Ok(verdict),
+        Err(CheckStep::Fail(reason)) => Ok(Verdict::Fail { reason }),
+        Err(CheckStep::Abort(e)) => Err(e),
+    }
+}
+
+/// The exec path: scratch → fixtures → plan → jail → run → assertions.
+/// Everything that is THIS check's failure returns Fail; only engine-level
+/// named errors abort.
+fn run_exec(
+    target: &CheckTarget,
+    owner: &OwnerChecks,
+    name: &str,
+    check: &Check,
+    parsed: &CheckArgs,
+    ctx: &Ctx,
+    started: Instant,
+) -> Result<Verdict, CheckStep> {
+    // 3. A fresh scratch dir, auto-granted rw for the check's duration.
+    let scratch = Scratch::new(name, parsed.keep_scratch).map_err(CheckStep::Fail)?;
+    // Fixtures materialize into the scratch root (host-spelled, never
+    // VFS — spec 26 §1).
+    materialize_fixtures(owner, check, scratch.path()).map_err(CheckStep::Fail)?;
+    // 4. The run.
+    let mut plan = plan_exec(target, owner, name, check, scratch.path(), ctx)?;
+    let jail_env = check_jail_env(target, check, scratch.path(), parsed.record, ctx)
+        .map_err(CheckStep::Fail)?;
+    plan.env.extend(jail_env);
+    let outcome = run_child(&plan, scratch.path(), check.timeout).map_err(CheckStep::Fail)?;
+    if outcome.timed_out {
+        return Ok(Verdict::Fail {
+            reason: format!("timeout after {}s", check.timeout.unwrap_or(0)),
+        });
+    }
+    // 5. The assertions.
+    Ok(match assert_run(check, &outcome, scratch.path()) {
+        None => Verdict::Pass {
+            secs: started.elapsed().as_secs(),
+        },
+        Some(reason) => Verdict::Fail { reason },
+    })
+}
+
+/// The composed run: program, argv (WITHOUT the program), env on top of
+/// the inherited environment, and the zero-runtime preload scrub.
+struct RunPlan {
+    program: PathBuf,
+    /// unix argv[0] override (the package form's entry selector, spec 07
+    /// §2.0); `None` = the program path itself.
+    argv0: Option<String>,
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    scrub_preload: bool,
+}
+
+/// Plan one exec check's run per target form. Resolution failures abort
+/// (the engine's named codes); per-check mismatches FAIL with the reason
+/// named.
+fn plan_exec(
+    target: &CheckTarget,
+    owner: &OwnerChecks,
+    name: &str,
+    check: &Check,
+    scratch: &Path,
+    ctx: &Ctx,
+) -> Result<RunPlan, CheckStep> {
+    let Some(entry) = &check.entry else {
+        return Err(CheckStep::Fail(
+            "a structural check (no entry) never reaches the exec path".to_string(),
+        ));
+    };
+    let user_args = substitute_argv(&check.argv, scratch);
+    match &target.exec {
+        ExecCtx::Store { res, mounts } => {
+            let entry_path = match entry {
+                CheckEntry::SelfExe => {
+                    return Err(CheckStep::Fail(
+                        "entry: self checks belong to runtime slices — check the bare-image form with --runtime"
+                            .to_string(),
+                    ));
+                }
+                CheckEntry::Path(p) => p,
+            };
+            let dispatchables = res.manifest.dispatchables();
+            let d = match dispatchables.iter().find(|d| &d.path == entry_path) {
+                Some(d) => d,
+                None if dispatchables.len() == 1 => &dispatchables[0],
+                None => {
+                    return Err(CheckStep::Abort(TebakoError::new(
+                        format!(
+                            "check {name:?} entry {entry_path} matches no declared entrypoint of \"{}\" (declared: {})",
+                            res.payload_name,
+                            dispatchables
+                                .iter()
+                                .map(|d| format!("{}={}", d.name, d.path))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ),
+                        EX_MANIFEST,
+                    )));
+                }
+            };
+            plan_store(
+                res,
+                mounts.as_deref().unwrap_or(&[]),
+                d,
+                entry_path,
+                user_args,
+                ctx,
+            )
+        }
+        ExecCtx::Given {
+            exe,
+            env_image,
+            checked,
+            kind_is_runtime,
+        } => {
+            // prepare() guaranteed the pair for exec checks.
+            let exe = exe.clone().unwrap_or_default();
+            let mut args = Vec::new();
+            let mut env = Vec::new();
+            if let Some(image) = env_image {
+                env.push((
+                    "TEBAKO_RUNTIME_IMAGE".to_string(),
+                    image.to_string_lossy().into_owned(),
+                ));
+            }
+            match entry {
+                // spec 17 §1: a bare NAME is the interpreter keyword —
+                // the boot starts the interpreter with the user's args.
+                CheckEntry::SelfExe => {
+                    args.push("--tebako-entry".to_string());
+                    args.push("self".to_string());
+                }
+                CheckEntry::Path(p) => {
+                    if !kind_is_runtime {
+                        args.push("--tebako-image".to_string());
+                        args.push(format!("{}:0:/", checked.display()));
+                    }
+                    // A runtime slice's path entry resolves against the
+                    // runtime root (no image specs, spec 17 §1).
+                    args.push("--tebako-entry".to_string());
+                    args.push(p.clone());
+                }
+            }
+            args.extend(user_args);
+            Ok(RunPlan {
+                program: exe,
+                argv0: None,
+                args,
+                env,
+                scrub_preload: false,
+            })
+        }
+        ExecCtx::Package {
+            path,
+            entries,
+            has_block,
+            ..
+        } => {
+            if !has_block {
+                return Err(CheckStep::Fail(
+                    "the package carries no type-2 manifest — exec checks need its entry table"
+                        .to_string(),
+                ));
+            }
+            let entry_path = match entry {
+                CheckEntry::SelfExe => {
+                    return Err(CheckStep::Fail(
+                        "entry: self belongs to runtime slices — a package's runtime slot is never checked"
+                            .to_string(),
+                    ));
+                }
+                CheckEntry::Path(p) => p,
+            };
+            // The entry table names PROVIDES entrypoints BY NAME; the
+            // check's entry is the in-image path — resolve the name
+            // through the owning slice's own manifest (the name's one
+            // authority), then compare paths.
+            let package_entry = entries.iter().find(|e| {
+                Some(e.slot) == owner.slot
+                    && owner
+                        .dispatchables
+                        .iter()
+                        .any(|d| d.name == e.entrypoint && &d.path == entry_path)
+            });
+            let Some(package_entry) = package_entry else {
+                return Err(CheckStep::Fail(format!(
+                    "check entry {entry_path} matches no declared package entry for slot {} (declared: {})",
+                    owner.slot.unwrap_or(0),
+                    entries
+                        .iter()
+                        .map(|e| format!("{}→slot {}:{}", e.name, e.slot, e.entrypoint))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )));
+            };
+            // argv0 selects the entry (the bootstrap's contract). unix
+            // only — Command has no cross-platform argv0; elsewhere only
+            // the primary entry runs (the basename fallback selects it).
+            #[cfg(unix)]
+            let argv0 = Some(package_entry.name.clone());
+            #[cfg(not(unix))]
+            let argv0 = {
+                if package_entry.name != entries[0].name {
+                    return Err(CheckStep::Fail(format!(
+                        "entry {:?} needs argv0 selection (a unix exec surface); only the primary entry {:?} runs on this platform",
+                        package_entry.name, entries[0].name
+                    )));
+                }
+                None
+            };
+            Ok(RunPlan {
+                program: path.clone(),
+                argv0,
+                args: user_args,
+                env: Vec::new(),
+                scrub_preload: false,
+            })
+        }
+        ExecCtx::Composition {
+            runtime, mounts, ..
+        } => {
+            let entry_path = match entry {
+                CheckEntry::SelfExe => {
+                    return Err(CheckStep::Fail(
+                        "entry: self is reserved for runtime slices — a composition check names a mounted slice's executable"
+                            .to_string(),
+                    ));
+                }
+                CheckEntry::Path(p) => p,
+            };
+            let rt = match runtime.as_deref() {
+                Some(RuntimeResolution::Ready(rt)) => rt,
+                _ => {
+                    return Err(CheckStep::Abort(TebakoError::new(
+                        "the composition's runtime is unresolved (prepare did not run)",
+                        EX_UNAVAILABLE,
+                    )));
+                }
+            };
+            let mut args = Vec::new();
+            let mut env = Vec::new();
+            for m in mounts {
+                args.push("--tebako-image".to_string());
+                args.push(m.triple());
+            }
+            args.push("--tebako-entry".to_string());
+            args.push(entry_path.clone());
+            if let Some(image) = &rt.image {
+                env.push((
+                    "TEBAKO_RUNTIME_IMAGE".to_string(),
+                    image.to_string_lossy().into_owned(),
+                ));
+            }
+            args.extend(user_args);
+            Ok(RunPlan {
+                program: rt.exe.clone(),
+                argv0: None,
+                args,
+                env,
+                scrub_preload: false,
+            })
+        }
+    }
+}
+
+/// The store form's plan: resolve the runtime from the owning
+/// dispatchable's requirement (the dispatch rule), then either the
+/// driver-contract handoff or the zero-runtime materialized exec.
+fn plan_store(
+    res: &tebako_shim::resolve::Resolution,
+    mounts: &[MountSpec],
+    d: &Dispatchable,
+    entry_path: &str,
+    user_args: Vec<String>,
+    ctx: &Ctx,
+) -> Result<RunPlan, CheckStep> {
+    match runtime::resolve_runtime(d.runtime_requirement.as_ref(), true, ctx)
+        .map_err(shim_err)
+        .map_err(CheckStep::Abort)?
+    {
+        RuntimeResolution::Zero => {
+            // Zero-runtime: the install-time materialization is the
+            // program (the dispatch rule — a run never materializes; the
+            // preload shim's env is scrubbed so it cannot intercept the
+            // child's own IO).
+            let host = res.record.tree.join(entry_path.trim_start_matches('/'));
+            if !host.is_file() {
+                return Err(CheckStep::Abort(TebakoError::new(
+                    format!(
+                        "zero-runtime entrypoint {} of \"{}\" {} is not materialized at {}\n  materialize it with `tebako install {}`",
+                        entry_path,
+                        res.payload_name,
+                        res.version,
+                        host.display(),
+                        res.payload_name,
+                    ),
+                    EX_UNAVAILABLE,
+                )));
+            }
+            Ok(RunPlan {
+                program: host,
+                argv0: None,
+                args: user_args,
+                env: Vec::new(),
+                scrub_preload: true,
+            })
+        }
+        RuntimeResolution::Ready(rt) => {
+            let mut args = Vec::new();
+            let mut env = Vec::new();
+            for m in mounts {
+                args.push("--tebako-image".to_string());
+                args.push(m.triple());
+            }
+            args.push("--tebako-entry".to_string());
+            args.push(entry_path.to_string());
+            if let Some(image) = &rt.image {
+                env.push((
+                    "TEBAKO_RUNTIME_IMAGE".to_string(),
+                    image.to_string_lossy().into_owned(),
+                ));
+            }
+            args.extend(user_args);
+            Ok(RunPlan {
+                program: rt.exe,
+                argv0: None,
+                args,
+                env,
+                scrub_preload: false,
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Jail composition (spec 26 §2 steps 3-4)
+// ---------------------------------------------------------------------
+
+/// The check run's jail env: the composition's effective policy ∪ the
+/// engine's scratch grant ∪ the check's in-force `needs:` (identity
+/// mounts, atoms resolved via tpkg::atoms). With NOTHING declared and no
+/// needs, nothing is exported (spec 23 §5's open-with-no-policy rule —
+/// the scratch grant is inert under an open world). Under `--record` the
+/// bare `record` token dominates wholesale (grants are inert under
+/// allow-all; the journal captures the run).
+///
+/// Errors are this check's FAIL reasons, never run-aborting: a need that
+/// does not resolve or bind is the check's own declaration failing, and
+/// sibling checks still run.
+fn check_jail_env(
+    target: &CheckTarget,
+    check: &Check,
+    scratch: &Path,
+    record: bool,
+    ctx: &Ctx,
+) -> Result<Vec<(String, String)>, String> {
+    let journal = ctx.home.join("journal.log").to_string_lossy().into_owned();
+    if record {
+        return Ok(vec![
+            ("TEBAKO_JAIL".to_string(), "record".to_string()),
+            ("TEBAKO_JAIL_SOURCE".to_string(), "user".to_string()),
+            ("TEBAKO_JAIL_JOURNAL".to_string(), journal),
+        ]);
+    }
+    let base = match &target.exec {
+        ExecCtx::Store { res, .. } => res.manifest.host_jail().cloned(),
+        ExecCtx::Given { .. } => None,
+        ExecCtx::Package { base_jail, .. } => base_jail.clone(),
+        ExecCtx::Composition { base_jail, .. } => base_jail.clone(),
+    };
+    let scratch = scratch.to_string_lossy().into_owned();
+    let mut grants = vec![JailMount {
+        host: scratch.clone(),
+        mount: scratch,
+        access: JailAccess::Rw,
+    }];
+    for need in &check.needs {
+        if !in_force_on(&need.when, host_platform()) {
+            continue;
+        }
+        let host = tpkg::atoms::expand_symbolic_atoms(&need.path, &|atom| engine_atom(atom, ctx))
+            .map_err(|e| format!("cannot resolve need {:?}: {e}", need.path))?;
+        grants.push(JailMount {
+            mount: host.clone(),
+            host,
+            access: need.access,
+        });
+    }
+    let needs_in_force = check
+        .needs
+        .iter()
+        .any(|n| in_force_on(&n.when, host_platform()));
+    let jail = match base {
+        // Nothing declared, no needs: the open world needs no export
+        // (the scratch grant exists to OPEN a deny world; under open it
+        // is inert).
+        None if !needs_in_force => return Ok(Vec::new()),
+        None => HostJail {
+            default_open: true,
+            record: false,
+            mounts: grants,
+            argument_files: tpkg::ArgumentFiles::default(),
+        },
+        Some(mut base) => {
+            base.mounts.extend(grants);
+            base
+        }
+    };
+    if jail.is_trivially_open() {
+        return Ok(Vec::new());
+    }
+    // `argument_files` resolves against the process cwd, which is not the
+    // check's scratch — the engine resolves no argument files (the
+    // check's argv is the author's; the scratch grant covers it).
+    let spec = jail.to_env_spec(&[]);
+    bind_check(&spec)?;
+    // The package form's export rides the bootstrap's user-tightening
+    // channel (it re-intersects with the pressed request); every other
+    // form's export IS the driver's policy, labeled by its surface.
+    let source = if matches!(target.exec, ExecCtx::Package { .. }) {
+        "user"
+    } else {
+        "check"
+    };
+    Ok(vec![
+        ("TEBAKO_JAIL".to_string(), spec),
+        ("TEBAKO_JAIL_SOURCE".to_string(), source.to_string()),
+        ("TEBAKO_JAIL_JOURNAL".to_string(), journal),
+    ])
+}
+
+/// Bind-check the composed env spec (grant paths must exist at check
+/// time — run.rs's fail-early contract, degraded to the check's FAIL
+/// reason instead of a dispatch abort).
+#[cfg(unix)]
+fn bind_check(spec: &str) -> Result<(), String> {
+    let parsed =
+        tfs::policy::JailSpec::parse(spec).map_err(|e| format!("invalid jail spec: {e}"))?;
+    tfs::policy::HostPolicy::bind(parsed.default, parsed.mounts, parsed.arg_files)
+        .map_err(|e| format!("cannot bind the check policy: {}", errno_text(e)))?;
+    Ok(())
+}
+
+/// Non-unix platforms skip the eager bind (the driver validates at
+/// install; the preload/exec path is unix-first, spec 07 §8).
+#[cfg(not(unix))]
+fn bind_check(_spec: &str) -> Result<(), String> {
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// Scratch + fixtures
+// ---------------------------------------------------------------------
+
+/// The per-check scratch directory (spec 26 §2 step 3): fresh under the
+/// host tmp, removed at the check's end unless --keep-scratch (then its
+/// path is printed).
+struct Scratch {
+    dir: PathBuf,
+    keep: bool,
+}
+
+impl Scratch {
+    fn new(check_name: &str, keep: bool) -> Result<Scratch, String> {
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "tebako-check-{check_name}-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("cannot create the scratch dir {}: {e}", dir.display()))?;
+        Ok(Scratch { dir, keep })
+    }
+
+    fn path(&self) -> &Path {
+        &self.dir
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        if self.keep {
+            println!("scratch kept: {}", self.dir.display());
+        } else {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+}
+
+/// The `{scratch}` argv substitution (the ONE token, spec 26 §1 — the
+/// model validated at most one occurrence per entry).
+fn substitute_argv(argv: &[String], scratch: &Path) -> Vec<String> {
+    let scratch = scratch.to_string_lossy();
+    argv.iter()
+        .map(|a| a.replace("{scratch}", scratch.as_ref()))
+        .collect()
+}
+
+/// Materialize a check's fixtures into the scratch root: the slice's
+/// in-image `fixtures:` dir CONTENTS (host-spelled, never VFS — the
+/// consumer may be a raw-surface component, spec 26 §1), the composition
+/// family's `fixtures_inline:` files, or the `fixtures_host:` tree
+/// relative to the composition file.
+fn materialize_fixtures(owner: &OwnerChecks, check: &Check, scratch: &Path) -> Result<(), String> {
+    if let Some(fixtures) = &check.fixtures {
+        let image = owner.image.as_ref().ok_or_else(|| {
+            format!("fixtures {fixtures} need the owning slice's image (a composition check speaks fixtures_inline/fixtures_host)")
+        })?;
+        let mount = image.mount()?;
+        let rel = fixtures.trim_start_matches('/');
+        match mount.backend.stat(rel) {
+            Ok(st) if st.entry_type == tfs::EntryType::Directory => {}
+            Ok(_) => {
+                return Err(format!(
+                    "fixtures path is not a directory in the image: {fixtures}"
+                ));
+            }
+            Err(_) => {
+                return Err(format!("fixtures dir missing in the image: {fixtures}"));
+            }
+        }
+        copy_backend_dir(&*mount.backend, rel, scratch, 0)?;
+    }
+    for (name, content) in &check.fixtures_inline {
+        let dest = scratch.join(name);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("cannot create fixture dir for {name}: {e}"))?;
+        }
+        std::fs::write(&dest, content)
+            .map_err(|e| format!("cannot write inline fixture {name}: {e}"))?;
+    }
+    if let Some(host) = &check.fixtures_host {
+        let dir = owner
+            .doc_dir
+            .as_ref()
+            .ok_or_else(|| "internal: fixtures_host outside a composition document".to_string())?;
+        let src = dir.join(host);
+        let meta = std::fs::metadata(&src)
+            .map_err(|_| format!("fixtures host path missing: {}", src.display()))?;
+        if meta.is_dir() {
+            // The CONTENTS land at the scratch root (the in-image
+            // family's semantics, spec 26 §1).
+            copy_host_dir(&src, scratch, 0)?;
+        } else {
+            let name = src
+                .file_name()
+                .ok_or_else(|| format!("fixtures host path has no file name: {}", src.display()))?;
+            std::fs::copy(&src, scratch.join(name))
+                .map_err(|e| format!("cannot copy fixture {}: {e}", src.display()))?;
+        }
+    }
+    Ok(())
+}
+
+/// Copy a host fixtures directory's CONTENTS into `dst` (recursively).
+/// The composition repo's fixtures are trusted checked-in content —
+/// symlinks followed by the metadata walk.
+fn copy_host_dir(src: &Path, dst: &Path, depth: u32) -> Result<(), String> {
+    if depth > 32 {
+        return Err(format!("fixtures nest too deep at {}", src.display()));
+    }
+    for entry in std::fs::read_dir(src)
+        .map_err(|e| format!("cannot list fixtures dir {}: {e}", src.display()))?
+    {
+        let entry = entry.map_err(|e| format!("cannot read a fixture entry: {e}"))?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let meta = std::fs::metadata(&from)
+            .map_err(|e| format!("cannot stat fixture {}: {e}", from.display()))?;
+        if meta.is_dir() {
+            std::fs::create_dir_all(&to)
+                .map_err(|e| format!("cannot create {}: {e}", to.display()))?;
+            copy_host_dir(&from, &to, depth + 1)?;
+        } else {
+            std::fs::copy(&from, &to)
+                .map_err(|e| format!("cannot copy fixture {}: {e}", from.display()))?;
+        }
+    }
+    Ok(())
+}
+
+/// Copy one backend directory's CONTENTS into `out_dir` (recursively,
+/// preserving the relative structure). Entry names are names, never
+/// paths — a `/` or `..` in one is a corrupt image, named.
+fn copy_backend_dir(
+    backend: &dyn tfs::Backend,
+    in_dir: &str,
+    out_dir: &Path,
+    depth: u32,
+) -> Result<(), String> {
+    if depth > 32 {
+        return Err(format!("fixtures nest too deep at {in_dir:?}"));
+    }
+    for entry in backend
+        .read_dir(in_dir)
+        .map_err(|e| format!("cannot list fixtures dir {in_dir:?}: {}", errno_text(e)))?
+    {
+        if entry.name.contains('/') || entry.name == ".." || entry.name == "." {
+            return Err(format!(
+                "corrupt fixtures dir entry {:?} in {in_dir:?}",
+                entry.name
+            ));
+        }
+        let in_path = if in_dir.is_empty() {
+            entry.name.clone()
+        } else {
+            format!("{in_dir}/{}", entry.name)
+        };
+        let out = out_dir.join(&entry.name);
+        if entry.is_dir {
+            std::fs::create_dir_all(&out)
+                .map_err(|e| format!("cannot create {}: {e}", out.display()))?;
+            copy_backend_dir(backend, &in_path, &out, depth + 1)?;
+        } else {
+            let st = backend
+                .stat(&in_path)
+                .map_err(|e| format!("cannot stat fixture {in_path:?}: {}", errno_text(e)))?;
+            let size = u64::try_from(st.size)
+                .map_err(|_| format!("fixture {in_path:?} has a negative size"))?;
+            let mut file = std::fs::File::create(&out)
+                .map_err(|e| format!("cannot create {}: {e}", out.display()))?;
+            let mut off = 0u64;
+            let mut chunk = vec![0u8; 1 << 20];
+            while off < size {
+                let want = chunk.len().min((size - off) as usize);
+                let n = backend
+                    .pread(&in_path, &mut chunk[..want], off)
+                    .map_err(|e| format!("cannot read fixture {in_path:?}: {}", errno_text(e)))?;
+                if n == 0 {
+                    return Err(format!("short read on fixture {in_path:?}"));
+                }
+                file.write_all(&chunk[..n])
+                    .map_err(|e| format!("cannot write {}: {e}", out.display()))?;
+                off += n as u64;
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// The child run + the assertions
+// ---------------------------------------------------------------------
+
+struct RunOutcome {
+    /// The child's exit code; `None` = terminated by signal (unix).
+    exit: Option<i32>,
+    /// The captured stdout (the stdout-regex assertion's input).
+    stdout: String,
+    timed_out: bool,
+}
+
+/// Spawn the plan with cwd = the scratch dir (expect.files are
+/// scratch-relative), stdout/stderr captured and teed live (they are the
+/// payload's, spec 26 §2 step 4), timeout enforced by poll-and-kill.
+fn run_child(plan: &RunPlan, scratch: &Path, timeout: Option<u64>) -> Result<RunOutcome, String> {
+    let mut cmd = Command::new(&plan.program);
+    cmd.args(&plan.args)
+        .current_dir(scratch)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in &plan.env {
+        cmd.env(k, v);
+    }
+    if plan.scrub_preload {
+        // The zero-runtime rule (dispatch.rs): the child runs host paths,
+        // and the inherited preload shim would intercept its IO.
+        cmd.env_remove("LD_PRELOAD");
+        cmd.env_remove("DYLD_INSERT_LIBRARIES");
+        cmd.env_remove("DYLD_PRINT_LIBRARIES");
+        cmd.env_remove("TEBAKO_TFS_MOUNTS");
+    }
+    #[cfg(unix)]
+    if let Some(argv0) = &plan.argv0 {
+        use std::os::unix::process::CommandExt as _;
+        cmd.arg0(argv0);
+    }
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("cannot start {}: {e}", plan.program.display()))?;
+
+    let out_pipe = child.stdout.take().ok_or("stdout was not piped")?;
+    let err_pipe = child.stderr.take().ok_or("stderr was not piped")?;
+    let out_thread = std::thread::spawn(move || pump_stream(out_pipe, true));
+    let err_thread = std::thread::spawn(move || pump_stream(err_pipe, false));
+
+    let started = Instant::now();
+    let deadline = timeout.map(|t| started + Duration::from_secs(t));
+    let mut timed_out = false;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if deadline.is_some_and(|d| Instant::now() >= d) {
+                    timed_out = true;
+                    let _ = child.kill();
+                    match child.wait() {
+                        Ok(status) => break status,
+                        Err(e) => {
+                            return Err(format!(
+                                "cannot reap the timed-out {}: {e}",
+                                plan.program.display()
+                            ));
+                        }
+                    }
+                }
+                std::thread::sleep(POLL);
+            }
+            Err(e) => {
+                let _ = child.kill();
+                return Err(format!("cannot wait on {}: {e}", plan.program.display()));
+            }
+        }
+    };
+    let stdout = out_thread
+        .join()
+        .map(|b| String::from_utf8_lossy(&b).into_owned())
+        .unwrap_or_default();
+    let _ = err_thread.join();
+    Ok(RunOutcome {
+        exit: status.code(),
+        stdout,
+        timed_out,
+    })
+}
+
+/// Read a child stream to EOF, teeing each chunk to the matching report
+/// stream (stdout/stderr are the payload's, spec 26 §2 step 4) while
+/// capturing for the assertions.
+fn pump_stream(mut r: impl Read, tee_out: bool) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        match r.read(&mut chunk) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => {
+                buf.extend_from_slice(&chunk[..n]);
+                let chunk = &chunk[..n];
+                if tee_out {
+                    let _ = std::io::stdout().lock().write_all(chunk);
+                } else {
+                    let _ = std::io::stderr().lock().write_all(chunk);
+                }
+            }
+        }
+    }
+    buf
+}
+
+/// The exec assertions, in order (the first failure names the verdict):
+/// exit code, then `expect.files` (exist + non-empty, scratch-relative),
+/// then the one stdout regex.
+fn assert_run(check: &Check, outcome: &RunOutcome, scratch: &Path) -> Option<String> {
+    let expected = i32::try_from(check.expect.exit).unwrap_or(i32::MAX);
+    match outcome.exit {
+        Some(code) if code == expected => {}
+        Some(code) => return Some(format!("exit code {code} (expected {expected})")),
+        None => return Some(format!("terminated by signal (expected exit {expected})")),
+    }
+    for f in &check.expect.files {
+        let path = scratch.join(f);
+        match std::fs::metadata(&path) {
+            Ok(m) if m.is_file() && m.len() > 0 => {}
+            Ok(m) if m.is_file() => return Some(format!("expected file empty: {f}")),
+            _ => return Some(format!("expected file missing: {f}")),
+        }
+    }
+    if let Some(pattern) = &check.expect.stdout {
+        let re = match regex::Regex::new(pattern) {
+            Ok(re) => re,
+            Err(e) => return Some(format!("invalid stdout pattern: {e}")),
+        };
+        if !re.is_match(&outcome.stdout) {
+            return Some(format!("stdout pattern not matched: {pattern}"));
+        }
+    }
+    None
+}
+
+/// The structural assertion (spec 26 §1.1): each `expect.image_files`
+/// entry must exist as a non-empty regular file in the owner's image —
+/// or, for a composition-level structural check, in ANY of the mounted
+/// slice images (the union: a file empty in one slice fails `empty` only
+/// when no slice carries it non-empty).
+fn assert_image_files(images: &[ImageRef], files: &[String]) -> Option<String> {
+    let mut mounts = Vec::new();
+    for image in images {
+        match image.mount() {
+            Ok(m) => mounts.push(m),
+            Err(e) => return Some(e),
+        }
+    }
+    for f in files {
+        let rel = f.trim_start_matches('/');
+        let mut found = false;
+        let mut max_size = 0i64;
+        for mount in &mounts {
+            if let Ok(st) = mount.backend.stat(rel) {
+                if st.entry_type == tfs::EntryType::File {
+                    found = true;
+                    max_size = max_size.max(st.size);
+                }
+            }
+        }
+        if !found {
+            return Some(format!("expected image file missing: {f}"));
+        }
+        if max_size == 0 {
+            return Some(format!("expected image file empty: {f}"));
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    /// A check with every field defaulted (the model's fields all carry
+    /// serde defaults).
+    fn bare_check() -> Check {
+        serde_yml::from_str::<Check>("{}").expect("the all-default check parses")
+    }
+
+    fn test_ctx(home: &Path) -> Ctx {
+        let mut env = BTreeMap::new();
+        env.insert("HOME".to_string(), "/home/test".to_string());
+        Ctx {
+            home: home.to_path_buf(),
+            cwd: home.to_path_buf(),
+            env,
+        }
+    }
+
+    fn given_target() -> CheckTarget {
+        CheckTarget {
+            owners: Vec::new(),
+            caps: BTreeSet::new(),
+            exec: ExecCtx::Given {
+                exe: None,
+                env_image: None,
+                checked: PathBuf::from("/x.tfs"),
+                kind_is_runtime: false,
+            },
+        }
+    }
+
+    // -- argv ---------------------------------------------------------
+
+    #[test]
+    fn parse_plain_target() {
+        let p = parse_check_args(&args(&["metanorma"])).unwrap();
+        assert_eq!(
+            p,
+            CheckArgs {
+                target: "metanorma".to_string(),
+                check: None,
+                list: false,
+                record: false,
+                keep_scratch: false,
+                runtime: None,
+                runtime_image: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_flags_separate_and_inline() {
+        let p = parse_check_args(&args(&[
+            "img.tfs",
+            "--check",
+            "boot",
+            "--list",
+            "--record",
+            "--keep-scratch",
+            "--runtime=/rt/ruby",
+            "--runtime-image",
+            "/rt/env.tfs",
+        ]))
+        .unwrap();
+        assert_eq!(p.check.as_deref(), Some("boot"));
+        assert!(p.list && p.record && p.keep_scratch);
+        assert_eq!(p.runtime, Some(PathBuf::from("/rt/ruby")));
+        assert_eq!(p.runtime_image, Some(PathBuf::from("/rt/env.tfs")));
+    }
+
+    #[test]
+    fn parse_errors_name_the_token() {
+        let e = parse_check_args(&args(&["t", "--check"])).unwrap_err();
+        assert!(e.contains("option '--check' requires a value"), "{e}");
+        let e = parse_check_args(&args(&["t", "--check", "a", "--check", "b"])).unwrap_err();
+        assert!(e.contains("selects one check"), "{e}");
+        let e = parse_check_args(&args(&["t", "--runtime-image", "x"])).unwrap_err();
+        assert!(e.contains("--runtime-image needs --runtime"), "{e}");
+        let e = parse_check_args(&args(&["a", "b"])).unwrap_err();
+        assert!(e.contains("unexpected extra argument 'b'"), "{e}");
+        let e = parse_check_args(&args(&["t", "--frobnicate"])).unwrap_err();
+        assert!(e.contains("unknown check option '--frobnicate'"), "{e}");
+        let e = parse_check_args(&args(&["--list"])).unwrap_err();
+        assert!(e.contains("usage: tebako check"), "{e}");
+    }
+
+    // -- declaration order + capabilities -----------------------------
+
+    #[test]
+    fn declaration_order_follows_the_text() {
+        let text = "checks:\n  zebra: {}\n  alpha: {}\n";
+        let mut checks = BTreeMap::new();
+        checks.insert("alpha".to_string(), bare_check());
+        checks.insert("extra".to_string(), bare_check());
+        checks.insert("zebra".to_string(), bare_check());
+        let ordered = declaration_order(text, &checks);
+        let names: Vec<&str> = ordered.iter().map(|(n, _)| n.as_str()).collect();
+        // The document's order, not the BTreeMap's; a check the raw scan
+        // missed is appended defensively.
+        assert_eq!(names, vec!["zebra", "alpha", "extra"]);
+    }
+
+    #[test]
+    fn collect_caps_per_kind() {
+        let app = PayloadManifest::from_yaml(
+            "identity:\n  schema_version: 1\n  kind: app\n  name: acme-app\n  version: \"1\"\n\
+            \x20 producer: {tool: t, tool_version: \"1\"}\n  created: \"2026-08-19T00:00:00Z\"\n\
+            \x20 digest:\n    tree_hash: \"sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\"\n\
+            \x20   blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1\n\
+            \x20 signing: {state: unsigned}\n  encryption: {state: none}\n\
+            provides:\n  entrypoints: [{name: acme, path: /bin/acme}, {name: acme-two, path: /bin/acme-two}]\n\
+            \x20 platforms: [aarch64-macos]\n  capabilities: {exec: true, read: true}\n",
+        )
+        .unwrap();
+        let mut caps = BTreeSet::new();
+        collect_caps(&app, &mut caps);
+        assert_eq!(
+            caps.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["acme", "acme-app", "acme-two"]
+        );
+
+        let runtime = PayloadManifest::from_yaml(
+            "identity:\n  schema_version: 1\n  kind: runtime\n  name: tebako-runtime-ruby\n  version: 4.0.6\n\
+            \x20 producer: {tool: t, tool_version: \"1\"}\n  created: \"2026-08-19T00:00:00Z\"\n\
+            \x20 digest:\n    tree_hash: \"sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\"\n\
+            \x20   blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1\n\
+            \x20 signing: {state: unsigned}\n  encryption: {state: none}\n\
+            provides:\n  provides: {engine: ruby, version: 4.0.6, abi_line: \"4.0\", platform: aarch64-macos}\n\
+            \x20 built_from: {src_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1, patch_set: v0.2.8}\n\
+            \x20 capabilities: {exec: true, read: true, runtime: true}\n",
+        )
+        .unwrap();
+        let mut caps = BTreeSet::new();
+        collect_caps(&runtime, &mut caps);
+        assert_eq!(
+            caps.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["ruby", "tebako-runtime-ruby"]
+        );
+
+        let data = PayloadManifest::from_yaml(
+            "identity:\n  schema_version: 1\n  kind: data\n  name: acme-templates\n  version: \"3\"\n\
+            \x20 producer: {tool: t, tool_version: \"1\"}\n  created: \"2026-08-19T00:00:00Z\"\n\
+            \x20 digest:\n    tree_hash: \"sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\"\n\
+            \x20   blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1\n\
+            \x20 signing: {state: unsigned}\n  encryption: {state: none}\n\
+            provides:\n  mount_semantics: {suggested: /templates/acme}\n  capabilities: {exec: false, read: true}\n",
+        )
+        .unwrap();
+        let mut caps = BTreeSet::new();
+        collect_caps(&data, &mut caps);
+        assert_eq!(
+            caps.iter().map(String::as_str).collect::<Vec<_>>(),
+            vec!["acme-templates"]
+        );
+    }
+
+    // -- verdicts + the when filter ------------------------------------
+
+    #[test]
+    fn verdict_line_shapes() {
+        assert_eq!(
+            verdict_line(None, "boot", &Verdict::Pass { secs: 41 }),
+            "check boot PASS 41s"
+        );
+        assert_eq!(
+            verdict_line(
+                None,
+                "pdf",
+                &Verdict::Skip {
+                    reason: "no jvm in the composition".to_string()
+                }
+            ),
+            "check pdf SKIP (no jvm in the composition)"
+        );
+        assert_eq!(
+            verdict_line(
+                Some("slice metanorma"),
+                "layout",
+                &Verdict::Fail {
+                    reason: "expected image file missing: /x".to_string()
+                }
+            ),
+            "slice metanorma: layout FAIL (expected image file missing: /x)"
+        );
+    }
+
+    #[test]
+    fn when_filter_semantics() {
+        assert!(in_force_on(&[], None));
+        assert!(in_force_on(
+            &[CheckPlatform::Linux],
+            Some(CheckPlatform::Linux)
+        ));
+        assert!(!in_force_on(
+            &[CheckPlatform::Macos],
+            Some(CheckPlatform::Linux)
+        ));
+        // An unrecognized host family matches nothing.
+        assert!(!in_force_on(&[CheckPlatform::Macos], None));
+        let expected = match std::env::consts::OS {
+            "windows" => Some(CheckPlatform::Windows),
+            "macos" => Some(CheckPlatform::Macos),
+            "linux" => Some(CheckPlatform::Linux),
+            _ => None,
+        };
+        assert_eq!(host_platform(), expected);
+        assert_eq!(platform_name(CheckPlatform::Windows), "windows");
+        assert_eq!(platform_name(CheckPlatform::Macos), "macos");
+        assert_eq!(platform_name(CheckPlatform::Linux), "linux");
+    }
+
+    // -- the jail env composition --------------------------------------
+
+    #[test]
+    fn jail_env_record_is_the_bare_policy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = test_ctx(tmp.path());
+        let env = check_jail_env(&given_target(), &bare_check(), tmp.path(), true, &ctx).unwrap();
+        let journal = tmp
+            .path()
+            .join("journal.log")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            env,
+            vec![
+                ("TEBAKO_JAIL".to_string(), "record".to_string()),
+                ("TEBAKO_JAIL_SOURCE".to_string(), "user".to_string()),
+                ("TEBAKO_JAIL_JOURNAL".to_string(), journal),
+            ]
+        );
+    }
+
+    #[test]
+    fn jail_env_open_world_exports_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = test_ctx(tmp.path());
+        // The Given form has no declared policy and this check declares
+        // no needs: the open world needs no export (the scratch grant
+        // exists to OPEN a deny world; under open it is inert).
+        let env = check_jail_env(&given_target(), &bare_check(), tmp.path(), false, &ctx).unwrap();
+        assert!(env.is_empty(), "{env:?}");
+    }
+
+    #[test]
+    fn jail_env_needs_open_the_world_with_grants() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = test_ctx(tmp.path());
+        let scratch = tmp.path().join("scratch");
+        std::fs::create_dir(&scratch).unwrap();
+        let mut check = bare_check();
+        check.needs.push(tpkg::CheckNeed {
+            path: tmp.path().to_string_lossy().into_owned(),
+            access: JailAccess::Ro,
+            when: vec![],
+            why: None,
+        });
+        let env = check_jail_env(&given_target(), &check, &scratch, false, &ctx).unwrap();
+        let get = |k: &str| env.iter().find(|(n, _)| n == k).map(|(_, v)| v.as_str());
+        assert_eq!(get("TEBAKO_JAIL_SOURCE"), Some("check"));
+        let spec = get("TEBAKO_JAIL").expect("the jail spec is exported");
+        // The env spec renders the grants as authored (canonicalization
+        // is the driver's bind-time job, not the wire format's).
+        let need = tmp.path().to_string_lossy().into_owned();
+        assert!(spec.contains(&need), "{spec}");
+        assert!(spec.contains("open"), "{spec}");
+    }
+
+    #[test]
+    fn jail_env_when_filtered_needs_are_inert() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = test_ctx(tmp.path());
+        let not_host = match host_platform() {
+            Some(CheckPlatform::Windows) => CheckPlatform::Linux,
+            _ => CheckPlatform::Windows,
+        };
+        let mut check = bare_check();
+        check.needs.push(tpkg::CheckNeed {
+            path: tmp.path().to_string_lossy().into_owned(),
+            access: JailAccess::Ro,
+            when: vec![not_host],
+            why: None,
+        });
+        // The one need is out of force on this host and no base policy is
+        // declared: nothing is exported.
+        let env = check_jail_env(&given_target(), &check, tmp.path(), false, &ctx).unwrap();
+        assert!(env.is_empty(), "{env:?}");
+    }
+
+    #[test]
+    fn jail_env_package_deny_base_is_user_labeled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = test_ctx(tmp.path());
+        let scratch = tmp.path().join("scratch");
+        std::fs::create_dir(&scratch).unwrap();
+        let target = CheckTarget {
+            owners: Vec::new(),
+            caps: BTreeSet::new(),
+            exec: ExecCtx::Package {
+                path: PathBuf::from("/x.tpkg"),
+                entries: Vec::new(),
+                has_block: true,
+                base_jail: Some(HostJail {
+                    default_open: false,
+                    record: false,
+                    mounts: Vec::new(),
+                    argument_files: tpkg::ArgumentFiles::default(),
+                }),
+            },
+        };
+        let env = check_jail_env(&target, &bare_check(), &scratch, false, &ctx).unwrap();
+        let get = |k: &str| env.iter().find(|(n, _)| n == k).map(|(_, v)| v.as_str());
+        // The package form's export rides the bootstrap's user-tightening
+        // channel; the deny base gains the scratch grant.
+        assert_eq!(get("TEBAKO_JAIL_SOURCE"), Some("user"));
+        let spec = get("TEBAKO_JAIL").expect("the jail spec is exported");
+        let raw = scratch.to_string_lossy().into_owned();
+        assert!(spec.contains(&raw), "{spec}");
+        assert!(spec.contains("deny"), "{spec}");
+    }
+
+    // -- atoms ----------------------------------------------------------
+
+    #[test]
+    fn engine_atoms_bind_from_the_ctx() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = test_ctx(tmp.path());
+        assert_eq!(engine_atom("HOME", &ctx).as_deref(), Some("/home/test"));
+        assert_eq!(
+            engine_atom("CWD", &ctx).as_deref(),
+            Some(tmp.path().to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            engine_atom("TEBAKO_HOME", &ctx).as_deref(),
+            Some(tmp.path().to_string_lossy().as_ref())
+        );
+        // TMPDIR/TEMP unset in the fixture env: the host temp dir is the
+        // fallback (spec 23 §2's per-invocation binding).
+        assert!(engine_atom("TMPDIR", &ctx).is_some());
+        assert_eq!(engine_atom("QUX", &ctx), None);
+
+        // HOME falls back to USERPROFILE.
+        let mut env = BTreeMap::new();
+        env.insert("USERPROFILE".to_string(), "C:/Users/test".to_string());
+        let ctx = Ctx {
+            home: tmp.path().to_path_buf(),
+            cwd: tmp.path().to_path_buf(),
+            env,
+        };
+        assert_eq!(engine_atom("HOME", &ctx).as_deref(), Some("C:/Users/test"));
+    }
+
+    #[test]
+    fn expand_atom_path_names_the_unknown_atom() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = test_ctx(tmp.path());
+        let expanded = expand_atom_path("$HOME/docs", &ctx).unwrap();
+        assert_eq!(expanded, "/home/test/docs");
+        let err = expand_atom_path("$QUX/x", &ctx).unwrap_err();
+        assert!(err.message.contains("QUX"), "{err:?}");
+    }
+
+    // -- scratch + argv substitution ------------------------------------
+
+    #[test]
+    fn scratch_lifecycle() {
+        let path;
+        {
+            let scratch = Scratch::new("unit", false).unwrap();
+            path = scratch.path().to_path_buf();
+            assert!(path.is_dir());
+        }
+        assert!(!path.exists(), "dropped scratch is removed: {path:?}");
+
+        let kept = Scratch::new("unit", true).unwrap();
+        let kept_path = kept.path().to_path_buf();
+        drop(kept);
+        assert!(kept_path.is_dir(), "--keep-scratch preserves the dir");
+        std::fs::remove_dir_all(&kept_path).unwrap();
+    }
+
+    #[test]
+    fn substitute_argv_replaces_the_one_token() {
+        let out = substitute_argv(
+            &[
+                "--out".to_string(),
+                "{scratch}/out.txt".to_string(),
+                "literal".to_string(),
+            ],
+            Path::new("/tmp/scr"),
+        );
+        assert_eq!(
+            out,
+            vec![
+                "--out".to_string(),
+                "/tmp/scr/out.txt".to_string(),
+                "literal".to_string()
+            ]
+        );
+    }
+
+    // -- the exec assertions ---------------------------------------------
+
+    fn outcome(exit: Option<i32>, stdout: &str) -> RunOutcome {
+        RunOutcome {
+            exit,
+            stdout: stdout.to_string(),
+            timed_out: false,
+        }
+    }
+
+    #[test]
+    fn assert_run_exit_codes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let check = bare_check();
+        assert_eq!(assert_run(&check, &outcome(Some(0), ""), tmp.path()), None);
+        assert_eq!(
+            assert_run(&check, &outcome(Some(1), ""), tmp.path()),
+            Some("exit code 1 (expected 0)".to_string())
+        );
+        assert_eq!(
+            assert_run(&check, &outcome(None, ""), tmp.path()),
+            Some("terminated by signal (expected exit 0)".to_string())
+        );
+        let mut check = bare_check();
+        check.expect.exit = 3;
+        assert_eq!(assert_run(&check, &outcome(Some(3), ""), tmp.path()), None);
+    }
+
+    #[test]
+    fn assert_run_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut check = bare_check();
+        check.expect.files = vec!["out.txt".to_string()];
+        assert_eq!(
+            assert_run(&check, &outcome(Some(0), ""), tmp.path()),
+            Some("expected file missing: out.txt".to_string())
+        );
+        std::fs::write(tmp.path().join("out.txt"), b"").unwrap();
+        assert_eq!(
+            assert_run(&check, &outcome(Some(0), ""), tmp.path()),
+            Some("expected file empty: out.txt".to_string())
+        );
+        std::fs::write(tmp.path().join("out.txt"), b"x").unwrap();
+        assert_eq!(assert_run(&check, &outcome(Some(0), ""), tmp.path()), None);
+    }
+
+    #[test]
+    fn assert_run_stdout_regex() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut check = bare_check();
+        check.expect.stdout = Some("\"ok\":1".to_string());
+        assert_eq!(
+            assert_run(&check, &outcome(Some(0), "{\"ok\":1}\n"), tmp.path()),
+            None
+        );
+        assert_eq!(
+            assert_run(&check, &outcome(Some(0), "nope\n"), tmp.path()),
+            Some("stdout pattern not matched: \"ok\":1".to_string())
+        );
+        check.expect.stdout = Some("[".to_string());
+        let reason = assert_run(&check, &outcome(Some(0), "x"), tmp.path()).unwrap();
+        assert!(reason.starts_with("invalid stdout pattern: "), "{reason}");
+    }
+
+    // -- the composition document's serde discipline ----------------------
+
+    #[test]
+    fn composition_doc_minimal_parses() {
+        let doc = serde_yml::from_str::<CompositionDoc>("version: 1\n").unwrap();
+        assert_eq!(doc.version, 1);
+        assert!(doc.checks.is_empty());
+        assert!(doc.slices.is_empty());
+    }
+
+    #[test]
+    fn composition_doc_refuses_unknown_fields() {
+        let err = serde_yml::from_str::<CompositionDoc>("version: 1\nbogus: 1\n").unwrap_err();
+        assert!(err.to_string().contains("unknown field"), "{err}");
+    }
+
+    #[test]
+    fn composition_doc_refuses_duplicate_check_names() {
+        let err = serde_yml::from_str::<CompositionDoc>("version: 1\nchecks:\n  a: {}\n  a: {}\n")
+            .unwrap_err();
+        assert!(err.to_string().contains("duplicate check name"), "{err}");
+    }
+
+    #[test]
+    fn access_words() {
+        assert_eq!(parse_access_word("ro", "t").unwrap(), JailAccess::Ro);
+        assert_eq!(parse_access_word("rw", "t").unwrap(), JailAccess::Rw);
+        let err = parse_access_word("xx", "mounts[0]").unwrap_err();
+        assert!(
+            err.message
+                .contains("mounts[0]: unknown access \"xx\" (want ro|rw)"),
+            "{err:?}"
+        );
+    }
+}

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -15,6 +15,10 @@
 //!   tebako update-registries
 //!   tebako install <ref | name[@version]>
 //!   tebako uninstall <name>
+//!   tebako check <name | image.tfs | package | tebako.yaml>
+//!                [--check <c>] [--list] [--record] [--keep-scratch]
+//!                [--runtime <exe> --runtime-image <env.tfs>]
+//!                (the payload's in-image acceptance contract, spec 26 §2)
 //!
 //! Lean press flow (gem's do_press_three_part): resolve the runtime into
 //! the shared cache (in-process HTTPS via crates/tebako-http) → seed the
@@ -57,6 +61,7 @@
 //!   gem's 8-byte padding is cosmetic);
 //! - .tebako.yml is not read.
 
+pub mod check;
 pub mod contract;
 pub mod deploy;
 pub mod error;

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -21,6 +21,10 @@ const USAGE: &str = "Usage:
   tebako trace run <pkg> [--capture <path>] [--out <path>] [--] [<args>...]
                                        run under TEBAKO_JAIL=record with the trace bus
                                        armed; synthesize a suggested manifest (spec 25 §4)
+  tebako check <name | image.tfs | package | tebako.yaml>
+               [--check <c>] [--list] [--record] [--keep-scratch]
+               [--runtime <exe> --runtime-image <env.tfs>]
+                                       the payload's in-image acceptance checks (spec 26 §2)
   tebako cache list [--json]
   tebako cache prune [--all] [--older-than Nd]
   tebako add-registry <ref>            register a tpkg-registry.yaml (spec 04 §2)
@@ -119,6 +123,7 @@ fn run(args: &[String]) -> Result<(), CliExit> {
         }
         "run" => run_package(rest),
         "trace" => run_trace(rest),
+        "check" => run_check(rest),
         "cache" => run_cache(rest),
         "add-registry" => run_add_registry(rest),
         "list-registries" => run_list_registries(rest),
@@ -569,6 +574,18 @@ fn run_trace(args: &[String]) -> Result<(), CliExit> {
         ))),
         other => Err(CliExit::Usage(format!("unknown trace subcommand '{other}'"))),
     }
+}
+
+/// `tebako check <target> [flags]` — the spec 26 §2 check engine. The
+/// verdict lines print as checks run; the engine's return is the process
+/// exit code (0, or EX_TEBAKO_CHECK when any check FAILs).
+fn run_check(args: &[String]) -> Result<(), CliExit> {
+    let parsed = tebako_cli::check::parse_check_args(args).map_err(CliExit::Usage)?;
+    let code = tebako_cli::check::run(&parsed)?;
+    if code != 0 {
+        std::process::exit(code);
+    }
+    Ok(())
 }
 
 fn run_cache(args: &[String]) -> Result<(), CliExit> {

--- a/crates/tebako-cli/tests/check.rs
+++ b/crates/tebako-cli/tests/check.rs
@@ -1,0 +1,782 @@
+//! `tebako check` e2e (spec 26 §2 — the check engine): structural checks
+//! against bare images, exec checks against a GIVEN runtime (the
+//! press-time gate) with the driver-contract argv/env observed end to
+//! end, the store-backed name form (zero-runtime materialized exec), the
+//! pressed-package form (argv0 entry selection against the type-2 entry
+//! table), and the composition-document form (the slice union). The
+//! fixture "runtimes"/"packages" are shebang scripts — the kernel execs
+//! them and they report what they saw. Unix only (shebang exec), like
+//! tests/run.rs and tests/trace_run.rs.
+
+#![cfg(unix)]
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn tebako_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_tebako"))
+}
+
+fn workdir(tag: &str) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "tebako-check-e2e-{tag}-{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+struct Run {
+    rc: i32,
+    stdout: String,
+    stderr: String,
+}
+
+/// `tebako check <args>` with TEBAko_HOME pinned at `home` (never the
+/// operator's real store) plus any per-leg env.
+fn tebako_check(home: &Path, args: &[&Path], env: &[(&str, String)]) -> Run {
+    let mut cmd = Command::new(tebako_bin());
+    cmd.arg("check")
+        .args(args)
+        .env("TEBAKO_HOME", home)
+        .env("TEBAKO_OFFLINE", "1");
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().unwrap();
+    Run {
+        rc: out.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+fn script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, body).unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    path
+}
+
+/// A mountable payload image (the tfs ZIP backend is pure Rust) with
+/// explicit directory entries, so a backend `stat` on a directory sees
+/// one.
+fn zip_image(files: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let options = zip::write::SimpleFileOptions::default();
+    let mut dirs = std::collections::BTreeSet::new();
+    for (name, _) in files {
+        let mut prefix = String::new();
+        for component in Path::new(name).parent().into_iter().flat_map(|p| p.iter()) {
+            if !prefix.is_empty() {
+                prefix.push('/');
+            }
+            prefix.push_str(&component.to_string_lossy());
+            dirs.insert(format!("{prefix}/"));
+        }
+    }
+    for dir in dirs {
+        writer.add_directory(dir, options).unwrap();
+    }
+    for (name, bytes) in files {
+        writer.start_file(name, options).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}
+
+const TREE_HASH: &str = "sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3";
+const BLOB: &str = "7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1";
+
+fn identity(kind: &str, name: &str, version: &str) -> String {
+    [
+        "identity:\n  schema_version: 1\n  kind: ",
+        kind,
+        "\n  name: ",
+        name,
+        "\n  version: \"",
+        version,
+        "\"\n  producer: {tool: t, tool_version: \"1\"}\n  created: \"2026-08-19T00:00:00Z\"\n",
+        "  digest:\n    tree_hash: \"",
+        TREE_HASH,
+        "\"\n    blob_sha256: ",
+        BLOB,
+        "\n  signing: {state: unsigned}\n  encryption: {state: none}\n",
+    ]
+    .concat()
+}
+
+/// A kind:app manifest for payload `name` with one entrypoint
+/// `acme` → `/bin/acme` and the given checks block.
+fn app_manifest(name: &str, checks: &str) -> String {
+    [
+        identity("app", name, "1.0"),
+        "provides:\n  entrypoints: [{name: acme, path: /bin/acme}]\n  platforms: [aarch64-macos]\n  capabilities: {exec: true, read: true}\nchecks:\n"
+            .to_string(),
+        checks.to_string(),
+    ]
+    .concat()
+}
+
+/// A kind:data manifest with the given checks block.
+fn data_manifest(name: &str, suggested: &str, checks: &str) -> String {
+    [
+        identity("data", name, "1.0"),
+        "provides:\n  mount_semantics: {suggested: ".to_string(),
+        suggested.to_string(),
+        "}\n  capabilities: {exec: false, read: true}\nchecks:\n".to_string(),
+        checks.to_string(),
+    ]
+    .concat()
+}
+
+/// The fixture app image: an entrypoint, a fixtures dir, a data file,
+/// and the six-check block the Given-form legs select from.
+fn app_image(dir: &Path) -> PathBuf {
+    let checks = "  layout:\n    expect: {image_files: [/data/file.txt]}\n\
+        \x20 boot:\n    entry: /bin/acme\n    argv: [\"{scratch}/made.txt\"]\n    fixtures: /fixtures\n    expect: {exit: 0, files: [made.txt], stdout: \"CONTRACT OK\"}\n\
+        \x20 bail:\n    entry: /bin/acme\n\
+        \x20 slow:\n    entry: /bin/acme\n    timeout: 1\n\
+        \x20 win-only:\n    entry: /bin/acme\n    when: [windows]\n\
+        \x20 needs-jvm:\n    entry: /bin/acme\n    requires: {provides: [jvm]}\n";
+    let manifest = app_manifest("acme-app", checks);
+    let bytes = zip_image(&[
+        ("__tpkg__/manifest.yaml", manifest.as_bytes()),
+        ("bin/acme", b"#!/bin/sh\n"),
+        ("fixtures/hello.txt", b"hello fixture\n"),
+        ("data/file.txt", b"x"),
+    ]);
+    let path = dir.join("acme-app.tfs");
+    std::fs::write(&path, bytes).unwrap();
+    path
+}
+
+/// The contract probe: report the driver-contract argv/env (spec 17 §1),
+/// prove the fixtures landed at the scratch root (the cwd), write the
+/// `{scratch}`-named file, and print the regex anchor.
+const CONTRACT: &str = "#!/bin/sh\n\
+echo \"IMG=$2\"\n\
+echo \"ENTRY=$4\"\n\
+echo \"RTIMG=${TEBAKO_RUNTIME_IMAGE:-UNSET}\"\n\
+cat hello.txt\n\
+echo data > \"$5\"\n\
+echo \"CONTRACT OK\"\n";
+
+/// A bare "env image" stand-in (the engine only hands its path to the
+/// runtime as TEBAKO_RUNTIME_IMAGE).
+fn env_image(dir: &Path) -> PathBuf {
+    let bytes = zip_image(&[("lib/stub", b"x")]);
+    let path = dir.join("env.tfs");
+    std::fs::write(&path, bytes).unwrap();
+    path
+}
+
+#[test]
+fn structural_checks_pass_and_fail_on_bare_images() {
+    let dir = workdir("structural");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+
+    // PASS: the asserted file exists and is non-empty.
+    let pass = dir.join("data-pass.tfs");
+    std::fs::write(
+        &pass,
+        zip_image(&[
+            (
+                "__tpkg__/manifest.yaml",
+                data_manifest(
+                    "acme-templates",
+                    "/templates/acme",
+                    "  layout:\n    expect: {image_files: [/templates/acme/cover.adoc]}\n",
+                )
+                .as_bytes(),
+            ),
+            ("templates/acme/cover.adoc", b"= Cover\n"),
+        ]),
+    )
+    .unwrap();
+    let run = tebako_check(&home, &[&pass], &[]);
+    assert_eq!(
+        run.rc, 0,
+        "stdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+    assert!(run.stdout.contains("check layout PASS"), "{}", run.stdout);
+
+    // FAIL: the asserted file is absent — the aggregate exit is
+    // EX_TEBAKO_CHECK (79; spec 26 §2's 72 collides with EX_TEBAKO_TRUST).
+    let fail = dir.join("data-fail.tfs");
+    std::fs::write(
+        &fail,
+        zip_image(&[
+            (
+                "__tpkg__/manifest.yaml",
+                data_manifest(
+                    "acme-templates",
+                    "/templates/acme",
+                    "  layout:\n    expect: {image_files: [/templates/acme/cover.adoc, /templates/acme/missing.html]}\n",
+                )
+                .as_bytes(),
+            ),
+            ("templates/acme/cover.adoc", b"= Cover\n"),
+        ]),
+    )
+    .unwrap();
+    let run = tebako_check(&home, &[&fail], &[]);
+    assert_eq!(
+        run.rc, 79,
+        "stdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+    assert!(
+        run.stdout.contains(
+            "check layout FAIL (expected image file missing: /templates/acme/missing.html)"
+        ),
+        "{}",
+        run.stdout
+    );
+}
+
+#[test]
+fn exec_check_against_a_given_runtime_observes_the_driver_contract() {
+    let dir = workdir("given");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+    let image = app_image(&dir);
+    let runtime = script(&dir, "fake-ruby", CONTRACT);
+    let env = env_image(&dir);
+
+    let run = tebako_check(
+        &home,
+        &[
+            &image,
+            &PathBuf::from("--check"),
+            &PathBuf::from("boot"),
+            &PathBuf::from("--runtime"),
+            &runtime,
+            &PathBuf::from("--runtime-image"),
+            &env,
+        ],
+        &[],
+    );
+    assert_eq!(
+        run.rc, 0,
+        "stdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+    // The driver contract, observed by the payload side: the checked
+    // image mounted whole at /, the entry path, the env image.
+    assert!(
+        run.stdout.contains(&format!("IMG={}:0:/", image.display())),
+        "{}",
+        run.stdout
+    );
+    assert!(run.stdout.contains("ENTRY=/bin/acme"), "{}", run.stdout);
+    assert!(
+        run.stdout.contains(&format!("RTIMG={}", env.display())),
+        "{}",
+        run.stdout
+    );
+    // The in-image fixtures materialized at the scratch root (the cwd)…
+    assert!(run.stdout.contains("hello fixture"), "{}", run.stdout);
+    // …and the verdict line.
+    assert!(run.stdout.contains("check boot PASS"), "{}", run.stdout);
+}
+
+#[test]
+fn exec_check_fail_exit_mismatch_and_timeout() {
+    let dir = workdir("givenfail");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+    let image = app_image(&dir);
+    let env = env_image(&dir);
+
+    // exit mismatch → FAIL with the reason named, aggregate 79
+    let bail = script(&dir, "bail-ruby", "#!/bin/sh\nexit 3\n");
+    let run = tebako_check(
+        &home,
+        &[
+            &image,
+            &PathBuf::from("--check"),
+            &PathBuf::from("bail"),
+            &PathBuf::from("--runtime"),
+            &bail,
+            &PathBuf::from("--runtime-image"),
+            &env,
+        ],
+        &[],
+    );
+    assert_eq!(run.rc, 79, "stdout:\n{}", run.stdout);
+    assert!(
+        run.stdout
+            .contains("check bail FAIL (exit code 3 (expected 0))"),
+        "{}",
+        run.stdout
+    );
+
+    // timeout → FAIL naming the timeout
+    let sleepy = script(&dir, "sleepy-ruby", "#!/bin/sh\nsleep 30\n");
+    let run = tebako_check(
+        &home,
+        &[
+            &image,
+            &PathBuf::from("--check"),
+            &PathBuf::from("slow"),
+            &PathBuf::from("--runtime"),
+            &sleepy,
+            &PathBuf::from("--runtime-image"),
+            &env,
+        ],
+        &[],
+    );
+    assert_eq!(run.rc, 79, "stdout:\n{}", run.stdout);
+    assert!(
+        run.stdout.contains("check slow FAIL (timeout after 1s)"),
+        "{}",
+        run.stdout
+    );
+}
+
+#[test]
+fn skips_are_loud_and_exit_zero() {
+    let dir = workdir("skips");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+    let image = app_image(&dir);
+    let runtime = script(&dir, "fake-ruby", CONTRACT);
+    let env = env_image(&dir);
+
+    // The platform filter: this host is never `windows` (the file is
+    // unix-only), so win-only SKIPs.
+    let run = tebako_check(
+        &home,
+        &[
+            &image,
+            &PathBuf::from("--check"),
+            &PathBuf::from("win-only"),
+            &PathBuf::from("--runtime"),
+            &runtime,
+            &PathBuf::from("--runtime-image"),
+            &env,
+        ],
+        &[],
+    );
+    assert_eq!(run.rc, 0, "stdout:\n{}", run.stdout);
+    assert!(
+        run.stdout.contains("check win-only SKIP (not for "),
+        "{}",
+        run.stdout
+    );
+    assert!(run.stdout.contains("(when: windows))"), "{}", run.stdout);
+
+    // An unmet composition prerequisite SKIPs, never FAILs.
+    let run = tebako_check(
+        &home,
+        &[
+            &image,
+            &PathBuf::from("--check"),
+            &PathBuf::from("needs-jvm"),
+            &PathBuf::from("--runtime"),
+            &runtime,
+            &PathBuf::from("--runtime-image"),
+            &env,
+        ],
+        &[],
+    );
+    assert_eq!(run.rc, 0, "stdout:\n{}", run.stdout);
+    assert!(
+        run.stdout
+            .contains("check needs-jvm SKIP (no jvm in the composition)"),
+        "{}",
+        run.stdout
+    );
+}
+
+#[test]
+fn list_prints_declaration_order_and_shape() {
+    let dir = workdir("list");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+    let image = app_image(&dir);
+
+    let run = tebako_check(&home, &[&image, &PathBuf::from("--list")], &[]);
+    assert_eq!(run.rc, 0, "stdout:\n{}", run.stdout);
+    let lines: Vec<&str> = run
+        .stdout
+        .lines()
+        .filter(|l| l.starts_with("check "))
+        .collect();
+    assert_eq!(
+        lines,
+        vec![
+            "check layout (structural)",
+            "check boot (exec)",
+            "check bail (exec)",
+            "check slow (exec)",
+            "check win-only (exec)",
+            "check needs-jvm (exec)",
+        ],
+        "{}",
+        run.stdout
+    );
+}
+
+#[test]
+fn unknown_check_name_is_a_named_usage_error() {
+    let dir = workdir("unknown");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+    let image = app_image(&dir);
+
+    let run = tebako_check(
+        &home,
+        &[&image, &PathBuf::from("--check"), &PathBuf::from("nope")],
+        &[],
+    );
+    assert_eq!(run.rc, 64, "stdout:\n{}", run.stdout);
+    assert!(
+        run.stdout.contains("no check named \"nope\""),
+        "{}",
+        run.stdout
+    );
+    assert!(run.stdout.contains("declared:"), "{}", run.stdout);
+}
+
+#[test]
+fn keep_scratch_preserves_and_names_the_dir() {
+    let dir = workdir("keep");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+    let image = app_image(&dir);
+    let runtime = script(&dir, "fake-ruby", CONTRACT);
+    let env = env_image(&dir);
+
+    let run = tebako_check(
+        &home,
+        &[
+            &image,
+            &PathBuf::from("--check"),
+            &PathBuf::from("boot"),
+            &PathBuf::from("--runtime"),
+            &runtime,
+            &PathBuf::from("--runtime-image"),
+            &env,
+            &PathBuf::from("--keep-scratch"),
+        ],
+        &[],
+    );
+    assert_eq!(run.rc, 0, "stdout:\n{}", run.stdout);
+    let path = run
+        .stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("scratch kept: "))
+        .unwrap_or_else(|| panic!("scratch kept: missing from stdout:\n{}", run.stdout));
+    assert!(Path::new(path).is_dir(), "--keep-scratch preserves {path}");
+    std::fs::remove_dir_all(path).unwrap();
+}
+
+#[test]
+fn usage_errors_exit_1() {
+    let dir = workdir("usage");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+
+    // no target
+    let run = tebako_check(&home, &[], &[]);
+    assert_eq!(
+        run.rc, 1,
+        "stdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+    assert!(run.stderr.contains("usage: tebako check"), "{}", run.stderr);
+
+    // --runtime-image without --runtime
+    let run = tebako_check(
+        &home,
+        &[
+            &PathBuf::from("x.tfs"),
+            &PathBuf::from("--runtime-image"),
+            &PathBuf::from("y"),
+        ],
+        &[],
+    );
+    assert_eq!(run.rc, 1, "stderr:\n{}", run.stderr);
+    assert!(
+        run.stderr.contains("--runtime-image needs --runtime"),
+        "{}",
+        run.stderr
+    );
+}
+
+// ---------------------------------------------------------------------
+// The pressed-package form
+// ---------------------------------------------------------------------
+
+/// A "package": a probe script + one zip slot carrying the checks-bearing
+/// payload manifest + the tpkg trailer with a type-2 package manifest
+/// (tests/run.rs's fixture shape).
+fn package_with_checks(dir: &Path) -> PathBuf {
+    let pkg = dir.join("acme-pkg");
+    std::fs::write(&pkg, "#!/bin/sh\necho \"ARGS=$*\"\nexit 0\n").unwrap();
+
+    let checks = "  boot:\n    entry: /bin/acme\n    argv: [hello]\n    expect: {exit: 0, stdout: \"ARGS=hello\"}\n\
+        \x20 layout:\n    expect: {image_files: [/data/file.txt]}\n\
+        \x20 nope:\n    entry: /bin/other\n";
+    let slot = zip_image(&[
+        (
+            "__tpkg__/manifest.yaml",
+            app_manifest("acme-app", checks).as_bytes(),
+        ),
+        ("data/file.txt", b"x"),
+    ]);
+    let payload = dir.join("acme-pkg.payload");
+    std::fs::write(&payload, &slot).unwrap();
+
+    let mut m = tpkg::Manifest {
+        package_flags: 0,
+        launcher_abi: 0,
+        ..Default::default()
+    };
+    m.set_runtime_ref(b"ruby@9.9.9;tebako=9.9.9");
+    let base = std::fs::metadata(&pkg).unwrap().len();
+    let size = std::fs::metadata(&payload).unwrap().len();
+    m.slots.push(tpkg::Slot::new(
+        base,
+        size,
+        tpkg::TPKG_FORMAT_DWARFS,
+        "/__tfs__",
+    ));
+    m.set_package_manifest(&tpkg::PackageManifest {
+        schema_version: tpkg::PACKAGE_SCHEMA_VERSION,
+        package: tpkg::PackageIdentity {
+            name: "acme-pkg".to_string(),
+            version: "1.0.0".to_string(),
+            producer: tpkg::Producer {
+                tool: "tebako-cli".to_string(),
+                tool_version: "0.16.0".to_string(),
+            },
+            created: "2026-08-20T00:00:00Z".to_string(),
+        },
+        entries: vec![tpkg::PackageEntry {
+            name: "acme".to_string(),
+            slot: 0,
+            // The entry table names the PROVIDES entrypoint BY NAME; the
+            // engine resolves it to the in-image path through the slot
+            // manifest.
+            entrypoint: "acme".to_string(),
+            runtime_ref: "ruby@9.9.9;tebako=9.9.9".to_string(),
+        }],
+        jail: None,
+        env: Default::default(),
+        mounts: Vec::new(),
+    })
+    .unwrap();
+    {
+        let mut f = std::fs::OpenOptions::new().append(true).open(&pkg).unwrap();
+        f.write_all(&std::fs::read(&payload).unwrap()).unwrap();
+        tpkg::write_to(&mut f, &m).unwrap();
+    }
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&pkg, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    pkg
+}
+
+#[test]
+fn package_form_runs_slot_checks_and_names_entry_mismatches() {
+    let dir = workdir("package");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+    let pkg = package_with_checks(&dir);
+
+    let run = tebako_check(&home, &[&pkg], &[]);
+    assert_eq!(
+        run.rc, 79,
+        "stdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+    // exec: the package itself runs with the check's argv…
+    assert!(run.stdout.contains("check boot PASS"), "{}", run.stdout);
+    // …structural reads the slot region…
+    assert!(run.stdout.contains("check layout PASS"), "{}", run.stdout);
+    // …and an entry path no package entry maps to is a named FAIL (the
+    // declared table is listed).
+    assert!(
+        run.stdout.contains(
+            "check nope FAIL (check entry /bin/other matches no declared package entry for slot 0"
+        ),
+        "{}",
+        run.stdout
+    );
+    assert!(run.stdout.contains("acme→slot 0:acme"), "{}", run.stdout);
+}
+
+// ---------------------------------------------------------------------
+// The store-backed name form
+// ---------------------------------------------------------------------
+
+/// Install a fake payload record: the image, its manifest mirror, and
+/// (for the zero-runtime exec leg) the materialized tree.
+fn store_payload(home: &Path, name: &str, version: &str, manifest: &str, files: &[(&str, &[u8])]) {
+    let dir = home.join("payloads").join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut image_files = vec![("__tpkg__/manifest.yaml", manifest.as_bytes())];
+    image_files.extend_from_slice(files);
+    std::fs::write(dir.join(format!("{version}.tfs")), zip_image(&image_files)).unwrap();
+    std::fs::write(dir.join(format!("{version}.manifest.yaml")), manifest).unwrap();
+}
+
+#[test]
+fn name_form_resolves_the_store_and_execs_zero_runtime() {
+    let dir = workdir("name");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+
+    let checks = "  boot:\n    entry: /bin/acme\n    argv: [--out, \"{scratch}/made.txt\"]\n    expect: {exit: 0, files: [made.txt], stdout: \"ZERO OK\"}\n";
+    let manifest = app_manifest("acme-tool", checks);
+    store_payload(
+        &home,
+        "acme-tool",
+        "1.0",
+        &manifest,
+        &[("bin/acme", b"#!/bin/sh\n")],
+    );
+
+    // The zero-runtime entrypoint's install-time materialization (the
+    // dispatch rule — a run never materializes): a probe script that
+    // writes the {scratch}-named file ($1 = --out, $2 = the path).
+    let tree = home.join("payloads/acme-tool/1.0.tree");
+    std::fs::create_dir_all(tree.join("bin")).unwrap();
+    script(
+        &tree,
+        "bin/acme",
+        "#!/bin/sh\necho \"ZERO OK\"\necho x > \"$2\"\n",
+    );
+
+    let run = tebako_check(
+        &home,
+        &[&PathBuf::from("acme-tool")],
+        &[("TEBAKO_ACME_TOOL_VERSION", "1.0".to_string())],
+    );
+    assert_eq!(
+        run.rc, 0,
+        "stdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+    assert!(run.stdout.contains("ZERO OK"), "{}", run.stdout);
+    assert!(run.stdout.contains("check boot PASS"), "{}", run.stdout);
+}
+
+// ---------------------------------------------------------------------
+// The composition-document form (spec 26 §2.1)
+// ---------------------------------------------------------------------
+
+#[test]
+fn composition_checks_assert_the_slice_union() {
+    let dir = workdir("composition");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+    store_payload(
+        &home,
+        "acme-data",
+        "1.0",
+        &data_manifest("acme-data", "/data", ""),
+        &[("templates/acme/cover.adoc", b"= Cover\n")],
+    );
+
+    // PASS: the asserted file is in the mounted slice union.
+    let doc = dir.join("tebako.yaml");
+    std::fs::write(
+        &doc,
+        "version: 1\nslices:\n  - {name: acme-data, mount: /data}\nchecks:\n  layout:\n    expect: {image_files: [/templates/acme/cover.adoc]}\n",
+    )
+    .unwrap();
+    let run = tebako_check(&home, &[&doc], &[]);
+    assert_eq!(
+        run.rc, 0,
+        "stdout:\n{}\nstderr:\n{}",
+        run.stdout, run.stderr
+    );
+    assert!(
+        run.stdout.contains("composition: layout PASS"),
+        "{}",
+        run.stdout
+    );
+
+    // FAIL: absent from every slice — the union misses.
+    std::fs::write(
+        &doc,
+        "version: 1\nslices:\n  - {name: acme-data, mount: /data}\nchecks:\n  layout:\n    expect: {image_files: [/templates/acme/missing.html]}\n",
+    )
+    .unwrap();
+    let run = tebako_check(&home, &[&doc], &[]);
+    assert_eq!(run.rc, 79, "stdout:\n{}", run.stdout);
+    assert!(
+        run.stdout.contains(
+            "composition: layout FAIL (expected image file missing: /templates/acme/missing.html)"
+        ),
+        "{}",
+        run.stdout
+    );
+}
+
+#[test]
+fn composition_documents_are_validated_with_named_errors() {
+    let dir = workdir("composition-invalid");
+    let home = dir.join("home");
+    std::fs::create_dir(&home).unwrap();
+    store_payload(
+        &home,
+        "acme-data",
+        "1.0",
+        &data_manifest("acme-data", "/data", ""),
+        &[("templates/acme/cover.adoc", b"= Cover\n")],
+    );
+    let doc = dir.join("tebako.yaml");
+
+    // Only version 1 exists.
+    std::fs::write(&doc, "version: 2\n").unwrap();
+    let run = tebako_check(&home, &[&doc], &[]);
+    assert_eq!(run.rc, 65, "stdout:\n{}", run.stdout);
+    assert!(
+        run.stdout.contains("version must be 1 (got 2)"),
+        "{}",
+        run.stdout
+    );
+
+    // An entrypoint-less composition's slices must declare their mounts
+    // (a collision at / would be a silent order — refused).
+    std::fs::write(&doc, "version: 1\nslices:\n  - {name: acme-data}\n").unwrap();
+    let run = tebako_check(&home, &[&doc], &[]);
+    assert_eq!(run.rc, 65, "stdout:\n{}", run.stdout);
+    assert!(
+        run.stdout.contains("needs a declared mount"),
+        "{}",
+        run.stdout
+    );
+
+    // An unknown policy word is named (record is the engine's --record,
+    // never authored).
+    std::fs::write(
+        &doc,
+        "version: 1\npolicy: record\nslices:\n  - {name: acme-data, mount: /data}\n",
+    )
+    .unwrap();
+    let run = tebako_check(&home, &[&doc], &[]);
+    assert_eq!(run.rc, 65, "stdout:\n{}", run.stdout);
+    assert!(
+        run.stdout
+            .contains("unknown policy \"record\" (want open|deny"),
+        "{}",
+        run.stdout
+    );
+}

--- a/crates/tebako-shim/src/dispatch.rs
+++ b/crates/tebako-shim/src/dispatch.rs
@@ -54,7 +54,9 @@ pub struct ExecPlan {
 
 /// Compose the mount set: the payload image at `/`, then each declared
 /// dependency (spec 03 §2.3) resolved against the payload cache.
-fn compose_mounts(res: &Resolution, ctx: &Ctx) -> Result<Vec<MountSpec>, ShimError> {
+/// Public for the spec 26 §2 check engine (tebako-cli): a check run
+/// mounts exactly the composition dispatch would.
+pub fn compose_mounts(res: &Resolution, ctx: &Ctx) -> Result<Vec<MountSpec>, ShimError> {
     let mut mounts = vec![MountSpec {
         image: res.record.image.clone(),
         slot: 0,

--- a/crates/tebako-shim/src/resolve.rs
+++ b/crates/tebako-shim/src/resolve.rs
@@ -188,14 +188,45 @@ fn project_pin(start: &Path, tool: &str) -> Result<Option<(String, PathBuf)>, Sh
 /// Resolve the dispatch target for `tool` through the full chain.
 pub fn resolve(tool: &str, ctx: &Ctx) -> Result<Resolution, ShimError> {
     let payload_name = providing_payload(&ctx.home, tool)?;
-    manifest::check_path_component("payload name", &payload_name)?;
-    let installed = installed_versions(&ctx.home, &payload_name)?;
+    let res = resolve_named(tool, &payload_name, ctx)?;
+    if res.manifest.entrypoint(tool).is_none() {
+        return fail(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "payload \"{payload_name}\" {version} declares no entrypoint \"{tool}\" in {mirror}\n  the shim link is stale; run `tebako-shim doctor`",
+                version = res.version,
+                mirror = res.record.manifest_mirror.display()
+            ),
+        );
+    }
+    Ok(res)
+}
+
+/// The payload-addressed resolution (spec 26 §2's check engine): the name
+/// IS the payload (never the suite scan — a check target names its slice
+/// directly), the version chain / record / mirror load are dispatch's
+/// own, and there is NO entrypoint gate (a data slice declares none —
+/// structural checks resolve exactly this far).
+pub fn resolve_payload(payload_name: &str, ctx: &Ctx) -> Result<Resolution, ShimError> {
+    manifest::check_path_component("payload name", payload_name)?;
+    if !ctx.home.join("payloads").join(payload_name).is_dir() {
+        return Err(no_provider(&ctx.home, payload_name));
+    }
+    resolve_named(payload_name, payload_name, ctx)
+}
+
+/// The shared resolution tail: version chain → disabled gate → record →
+/// mirror load. `tool` keys the version chain (env var, project pin,
+/// defaults); `payload_name` keys the store record.
+fn resolve_named(tool: &str, payload_name: &str, ctx: &Ctx) -> Result<Resolution, ShimError> {
+    manifest::check_path_component("payload name", payload_name)?;
+    let installed = installed_versions(&ctx.home, payload_name)?;
     if installed.is_empty() {
         return fail(
             EX_TEBAKO_MANIFEST,
             format!(
                 "payload \"{payload_name}\" (providing \"{tool}\") has no installed versions under {}\n  run `tebako-shim doctor` to diagnose",
-                ctx.home.join("payloads").join(&payload_name).display()
+                ctx.home.join("payloads").join(payload_name).display()
             ),
         );
     }
@@ -224,7 +255,7 @@ pub fn resolve(tool: &str, ctx: &Ctx) -> Result<Resolution, ShimError> {
     }
     // 4. registry default
     if picked.is_none() {
-        if let Some((version, reg)) = config::registry_default(&ctx.home, &cfg, &payload_name, ctx)?
+        if let Some((version, reg)) = config::registry_default(&ctx.home, &cfg, payload_name, ctx)?
         {
             picked = Some((version, VersionSource::RegistryDefault(reg)));
         }
@@ -264,7 +295,7 @@ pub fn resolve(tool: &str, ctx: &Ctx) -> Result<Resolution, ShimError> {
         );
     }
 
-    let record = manifest::payload_record(&ctx.home, &payload_name, &version);
+    let record = manifest::payload_record(&ctx.home, payload_name, &version);
     if !record.installed() {
         return fail(
             EX_TEBAKO_MANIFEST,
@@ -275,19 +306,10 @@ pub fn resolve(tool: &str, ctx: &Ctx) -> Result<Resolution, ShimError> {
         );
     }
     let manifest = Manifest::load(&record.manifest_mirror)?;
-    if manifest.entrypoint(tool).is_none() {
-        return fail(
-            EX_TEBAKO_MANIFEST,
-            format!(
-                "payload \"{payload_name}\" {version} declares no entrypoint \"{tool}\" in {}\n  the shim link is stale; run `tebako-shim doctor`",
-                record.manifest_mirror.display()
-            ),
-        );
-    }
 
     Ok(Resolution {
         tool: tool.to_string(),
-        payload_name,
+        payload_name: payload_name.to_string(),
         version,
         source,
         record,

--- a/crates/tfs-cli/src/compose.rs
+++ b/crates/tfs-cli/src/compose.rs
@@ -24,11 +24,12 @@
 //! MECE at this layer: only `images`, `policy`, `mounts`, `needs` are
 //! known keys — slice NAMES and entrypoints resolve at the shim layer, so
 //! a compose file naming `runtime:`, `slices:`, or `entrypoint:` earns a
-//! named error pointing there. `$HOME`/`$TMPDIR`/`$CWD` atoms in host and
-//! image paths expand at compose time. Needs entries lower to identity
-//! host-mount grants (the host path exposed at itself). `record` carries
-//! no grants (the same rule as the env grammar — inert configuration is a
-//! named error).
+//! named error pointing there. Symbolic atoms in host and image paths
+//! expand at compose time (the grammar is tpkg::atoms — the SSOT; the CLI
+//! binds `$HOME`/`$TMPDIR`/`$CWD` from the process environment). Needs
+//! entries lower to identity host-mount grants (the host path exposed at
+//! itself). `record` carries no grants (the same rule as the env grammar
+//! — inert configuration is a named error).
 //!
 //! The compose file is the whole composition: combining `--compose` with
 //! `--image`/`--jail` is a named error (one source of truth per run).
@@ -99,10 +100,11 @@ struct NeedEntry {
 }
 
 /// Parse a compose file. `expand` resolves the symbolic atoms (`$HOME`,
-/// `$TMPDIR`, `$CWD`) — the caller binds it to the process environment so
-/// tests never mutate it. `exists` probes the host at compose time (the
-/// CLI binds it to canonicalize): absent hosts named by `optional: true`
-/// needs are skipped; absent hosts otherwise are named errors.
+/// `$TMPDIR`, `$CWD`, … — the grammar is tpkg::atoms, the SSOT) — the
+/// caller binds it to the process environment so tests never mutate it.
+/// `exists` probes the host at compose time (the CLI binds it to
+/// canonicalize): absent hosts named by `optional: true` needs are
+/// skipped; absent hosts otherwise are named errors.
 pub fn parse_compose(
     yaml: &str,
     expand: &dyn Fn(&str) -> Option<String>,
@@ -196,23 +198,11 @@ pub fn parse_compose(
     Ok(ComposeSpec { images, jail })
 }
 
-/// Expand a leading `$ATOM` (the manifest grammar's atoms, spec 23 §4)
-/// using `expand`; an unknown atom is a named error. Atoms are path
-/// prefixes: bare `$HOME` or `$HOME/…`.
+/// Expand a leading symbolic atom (`$HOME/…`, `%TEMP%\…`) — the grammar
+/// lives in tpkg (spec 00 invariant 10); this is the compose file's
+/// binding of it.
 fn expand_atoms(path: &str, expand: &dyn Fn(&str) -> Option<String>) -> Result<String, String> {
-    let Some(rest) = path.strip_prefix('$') else {
-        return Ok(path.to_string());
-    };
-    let (atom, tail) = match rest.find('/') {
-        Some(i) => (&rest[..i], &rest[i..]),
-        None => (rest, ""),
-    };
-    match expand(atom) {
-        Some(base) => Ok(format!("{base}{tail}")),
-        None => Err(format!(
-            "unknown atom ${atom} in {path:?} (the compose file speaks $HOME, $TMPDIR, $CWD)"
-        )),
-    }
+    tpkg::atoms::expand_symbolic_atoms(path, expand)
 }
 
 /// The `ro|rw` grant bit, as the compose file spells it.

--- a/crates/tpkg/src/atoms.rs
+++ b/crates/tpkg/src/atoms.rs
@@ -1,0 +1,139 @@
+//! The symbolic path atoms of the needs/mounts grammar (spec 23 §2) — the
+//! ONE home of the atom set and its expansion rule (spec 00 invariant 10:
+//! the grammar is a contract value; consumers FLOW it from here).
+//!
+//! Manifests and composition documents write host paths as `$HOME/…`,
+//! `$TMPDIR`, `$CWD`, `$TEBAKO_HOME` (windows spellings `%USERPROFILE%`,
+//! `%TEMP%`); atoms resolve at bind time, per invocation, per user —
+//! never baked. The VALUES come from the caller's environment (the lookup
+//! closure); this module owns the GRAMMAR: which atoms exist, where in a
+//! path they may appear (a leading prefix), and the named errors.
+
+/// The atom names the grammar speaks (spec 23 §2), sigil-agnostic: the
+/// lookup is tried with the bare name (`HOME`, `TEMP`, …). `$HOME` ≡
+/// `%USERPROFILE%` and `$TMPDIR` ≡ `%TEMP%` are the same axis spelled per
+/// platform family; the caller binds whichever its environment carries.
+pub const SYMBOLIC_ATOMS: &[&str] = &[
+    "HOME",
+    "USERPROFILE",
+    "TMPDIR",
+    "TEMP",
+    "CWD",
+    "TEBAKO_HOME",
+];
+
+/// Expand a leading symbolic atom using `lookup`. Atoms are path
+/// prefixes: bare `$HOME` or `$HOME/…`; `%USERPROFILE%`,
+/// `%USERPROFILE%/…`, `%USERPROFILE%\…`. A path without a leading atom is
+/// returned unchanged; a lone `%` without its closing sigil is not an
+/// atom (literal passthrough).
+///
+/// Errors are named and distinguish the two failure classes: an atom the
+/// grammar does not speak (a typo the author fixes) vs an atom the
+/// grammar speaks that does not resolve in this environment (spec 23 §2:
+/// "an atom that does not resolve fails the bind only when the need is
+/// otherwise in force" — resolution is the caller's moment, the naming is
+/// the grammar's).
+pub fn expand_symbolic_atoms(
+    path: &str,
+    lookup: &dyn Fn(&str) -> Option<String>,
+) -> Result<String, String> {
+    // `$ATOM`, bare or `/`-tailed.
+    if let Some(rest) = path.strip_prefix('$') {
+        let (atom, tail) = match rest.find('/') {
+            Some(i) => (&rest[..i], &rest[i..]),
+            None => (rest, ""),
+        };
+        return bind_atom(atom, tail, path, lookup);
+    }
+    // `%ATOM%`, bare or `/`- / `\`-tailed (the windows spellings).
+    if let Some(rest) = path.strip_prefix('%') {
+        if let Some(i) = rest.find('%') {
+            let atom = &rest[..i];
+            let tail = &rest[i + 1..];
+            return bind_atom(atom, tail, path, lookup);
+        }
+    }
+    Ok(path.to_string())
+}
+
+fn bind_atom(
+    atom: &str,
+    tail: &str,
+    path: &str,
+    lookup: &dyn Fn(&str) -> Option<String>,
+) -> Result<String, String> {
+    if !SYMBOLIC_ATOMS.contains(&atom) {
+        return Err(format!(
+            "unknown atom in {path:?} (the needs/mounts grammar speaks {})",
+            SYMBOLIC_ATOMS
+                .iter()
+                .map(|a| format!("${a}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    match lookup(atom) {
+        Some(base) if !base.is_empty() => Ok(format!("{base}{tail}")),
+        _ => Err(format!(
+            "atom ${atom} in {path:?} does not resolve in this environment"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lookup(atom: &str) -> Option<String> {
+        match atom {
+            "HOME" => Some("/Users/u".to_string()),
+            "TMPDIR" => Some("/tmp/x".to_string()),
+            "CWD" => Some("/work/dir".to_string()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn expands_the_dollar_spellings() {
+        let e = |p: &str| expand_symbolic_atoms(p, &lookup);
+        assert_eq!(e("$HOME").unwrap(), "/Users/u");
+        assert_eq!(e("$HOME/.config/app").unwrap(), "/Users/u/.config/app");
+        assert_eq!(e("$TMPDIR/scratch").unwrap(), "/tmp/x/scratch");
+        assert_eq!(e("$CWD").unwrap(), "/work/dir");
+    }
+
+    #[test]
+    fn expands_the_percent_spellings() {
+        let e = |p: &str| expand_symbolic_atoms(p, &lookup);
+        assert_eq!(e("%TMPDIR%").unwrap(), "/tmp/x");
+        assert_eq!(e("%TMPDIR%/scratch").unwrap(), "/tmp/x/scratch");
+        assert_eq!(e("%TMPDIR%\\scratch").unwrap(), "/tmp/x\\scratch");
+    }
+
+    #[test]
+    fn paths_without_atoms_pass_through() {
+        let e = |p: &str| expand_symbolic_atoms(p, &lookup);
+        assert_eq!(e("/opt/vendor").unwrap(), "/opt/vendor");
+        assert_eq!(e("relative/dir").unwrap(), "relative/dir");
+        // A lone `%` without the closing sigil is not an atom.
+        assert_eq!(e("%per_cent").unwrap(), "%per_cent");
+        // An atom mid-path is not a prefix — never rewritten.
+        assert_eq!(e("/opt/$HOME").unwrap(), "/opt/$HOME");
+    }
+
+    #[test]
+    fn unknown_and_unresolvable_atoms_are_named_errors() {
+        let unknown = expand_symbolic_atoms("$QUX/x", &lookup).unwrap_err();
+        assert!(unknown.contains("$QUX"), "{unknown}");
+        assert!(unknown.contains("unknown atom"), "{unknown}");
+        assert!(unknown.contains("$TEBAKO_HOME"), "{unknown}");
+
+        let unresolved = expand_symbolic_atoms("$TEBAKO_HOME/x", &lookup).unwrap_err();
+        assert!(unresolved.contains("$TEBAKO_HOME"), "{unresolved}");
+        assert!(unresolved.contains("does not resolve"), "{unresolved}");
+
+        let empty = expand_symbolic_atoms("$/x", &lookup).unwrap_err();
+        assert!(empty.contains("unknown atom"), "{empty}");
+    }
+}

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -140,6 +140,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod atoms;
 mod codec;
 mod contract;
 mod crc32;
@@ -168,12 +169,13 @@ pub use ext::{ExtBlock, ExtError};
 pub use io::{read_from, write_to};
 pub use jail::{ArgumentFiles, HostJail, JailAccess, JailError, JailMount};
 pub use manifest::{
-    AppProvides, BuiltFrom, Capabilities, Check, CheckEntry, CheckExpect, CheckNeed, CheckPlatform,
-    CheckRequires, Constraint, DataProvides, Digest, Encryption, EncryptionPart, EncryptionState,
-    EngineProvides, Entrypoint, Identity, LibraryAlias, ManifestError, MountSemantics, PayloadKind,
-    PayloadManifest, Platform, Platforms, Producer, Provides, Requirement, RuntimeProvides,
-    RuntimeRequirement, Sbom, Signing, SigningMechanism, SigningState, Source, ToolkitExecutable,
-    ToolkitLibrary, ToolkitProvides, PAYLOAD_MANIFEST_PATH, PAYLOAD_SCHEMA_VERSION,
+    check_check_name, checks_map, AppProvides, BuiltFrom, Capabilities, Check, CheckEntry,
+    CheckExpect, CheckNeed, CheckPlatform, CheckRequires, Constraint, DataProvides, Digest,
+    Encryption, EncryptionPart, EncryptionState, EngineProvides, Entrypoint, Identity,
+    LibraryAlias, ManifestError, MountSemantics, PayloadKind, PayloadManifest, Platform, Platforms,
+    Producer, Provides, Requirement, RuntimeProvides, RuntimeRequirement, Sbom, Signing,
+    SigningMechanism, SigningState, Source, ToolkitExecutable, ToolkitLibrary, ToolkitProvides,
+    PAYLOAD_MANIFEST_PATH, PAYLOAD_SCHEMA_VERSION,
 };
 pub use merkle::{
     render_tree_hash, tree_digest, Child, FileHasher, MerkleDigest, NodeKind, TreeWalk,
@@ -278,6 +280,15 @@ pub const EX_TEBAKO_CONTRACT_ERA: i32 = 77;
 /// env form. Loader-side; raised by the resolver and the driver's mount
 /// path — run-time errnos (EROFS, ENOKEY) stay the syscalls' own.
 pub const EX_TEBAKO_OVERLAY: i32 = 68;
+/// The spec-26 §2/§7 exit code (spec 06 §4 table row) for a payload
+/// CHECK failure: any selected check FAILed (a failed expectation, a
+/// timeout, or an engine error mid-check — the verdict line names it).
+/// SKIP never fails the aggregate. **79, not 72**: spec 26's draft text
+/// allocated 72, but 72 has been `EX_TEBAKO_TRUST` since spec 09 (the
+/// signer-key-not-trusted refusal, shipped in the bootstrap and the
+/// install path) — one code, one class; the check class takes the next
+/// free code in the loader block.
+pub const EX_TEBAKO_CHECK: i32 = 79;
 
 // ---------------------------------------------------------------------
 // v2 chain-of-trust extension (all v2-extension numerics BIG-ENDIAN;

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -1237,6 +1237,13 @@ fn u32_is_zero(v: &u32) -> bool {
 /// under the resolved composition); a check WITHOUT `entry` is a
 /// STRUCTURAL check (the data-slice shape — the engine mounts the image
 /// and asserts `expect.image_files`, no runtime, no composition).
+///
+/// The fixture families are MECE across the two `checks:` contexts
+/// (spec 26 §2.1): a SLICE manifest speaks the in-image `fixtures`; a
+/// COMPOSITION document (which has no image of its own) speaks
+/// `fixtures_inline`/`fixtures_host`. Each family is a named validation
+/// error in the other's context ([`Check::validate`] vs
+/// [`Check::validate_composition`]).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Check {
     /// Exec checks: the in-image executable — or `self` on a runtime
@@ -1254,6 +1261,19 @@ pub struct Check {
     /// payload's own raw-surface component, spec 26 §1). Exec-only.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fixtures: Option<String>,
+    /// Composition-check fixture source (spec 26 §2.1): fixture name →
+    /// content, written into the scratch root. Valid ONLY in a
+    /// composition document's `checks:` block (a composition has no
+    /// image of its own); a slice manifest declaring it is a named
+    /// validation error — the fixture families are MECE.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub fixtures_inline: BTreeMap<String, String>,
+    /// Composition-check fixture source (spec 26 §2.1): a path relative
+    /// to the composition FILE (the org repo's checked-in fixtures),
+    /// copied to scratch. Valid ONLY in a composition document (the same
+    /// MECE rule as [`Check::fixtures_inline`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixtures_host: Option<String>,
     /// The assertions (absent = the default `exit: 0`).
     #[serde(default, skip_serializing_if = "CheckExpect::is_default")]
     pub expect: CheckExpect,
@@ -1273,8 +1293,10 @@ pub struct Check {
 
 /// The check-name grammar (spec 26 §1): names appear in report lines
 /// and scratch dir names — `[A-Za-z0-9][A-Za-z0-9._-]*`. Uniqueness is
-/// enforced by the map's own deserializer (see `checks_map`).
-fn check_check_name(name: &str) -> Result<(), ManifestError> {
+/// enforced by the map's own deserializer (see `checks_map`). Public so
+/// the composition-document model (spec 26 §2.1) validates its own
+/// check blocks with the same rule.
+pub fn check_check_name(name: &str) -> Result<(), ManifestError> {
     let ok = matches!(name.bytes().next(), Some(b) if b.is_ascii_alphanumeric())
         && name
             .bytes()
@@ -1291,7 +1313,10 @@ fn check_check_name(name: &str) -> Result<(), ManifestError> {
 /// authoring ambiguity is a named structural error, never a silent
 /// winner (the duplicate-alias discipline; serde_yml's plain map read
 /// is last-wins, so the refusal lives here, not in `validate`).
-mod checks_map {
+/// Public for the other `checks:`-block surface — the spec 26 §2.1
+/// composition document (tebako-cli's check engine) deserializes its
+/// map through the same refusal.
+pub mod checks_map {
     use super::Check;
     use serde::{de, Deserializer};
     use std::collections::BTreeMap;
@@ -1322,7 +1347,12 @@ mod checks_map {
 }
 
 impl Check {
-    fn validate(&self, kind: PayloadKind) -> Result<(), ManifestError> {
+    /// The check context the grammar is validated under (spec 26 §2.1's
+    /// MECE fixture rule): a SLICE check speaks the in-image `fixtures`;
+    /// a COMPOSITION check speaks `fixtures_inline`/`fixtures_host` (the
+    /// composition has no image of its own). Each family is a named
+    /// error in the other's context.
+    fn validate_in(&self, kind: PayloadKind, composition: bool) -> Result<(), ManifestError> {
         match &self.entry {
             Some(CheckEntry::SelfExe) => {
                 // §1.1: the reserved spelling names the runtime exe — a
@@ -1351,9 +1381,12 @@ impl Check {
                         "checks[].argv is exec-only — a structural check (no entry) declares none",
                     ));
                 }
-                if self.fixtures.is_some() {
+                if self.fixtures.is_some()
+                    || !self.fixtures_inline.is_empty()
+                    || self.fixtures_host.is_some()
+                {
                     return Err(ManifestError::Invalid(
-                        "checks[].fixtures is exec-only — a structural check (no entry) declares none",
+                        "checks[].fixtures/fixtures_inline/fixtures_host are exec-only — a structural check (no entry) declares none",
                     ));
                 }
                 if self.expect.image_files.is_empty() {
@@ -1378,6 +1411,55 @@ impl Check {
             if fixtures.split('/').any(|component| component == "..") {
                 return Err(ManifestError::Invalid(
                     "checks[].fixtures must not contain '..' components",
+                ));
+            }
+        }
+        // The fixture-family rule (spec 26 §2.1, MECE): `fixtures` is the
+        // slice family's in-image source; `fixtures_inline`/`fixtures_host`
+        // are the composition family's. Each is a named error in the
+        // other's context (never a silent ignore under the unknown-field
+        // rule — these keys are KNOWN, and refused here).
+        if composition {
+            if self.fixtures.is_some() {
+                return Err(ManifestError::Invalid(
+                    "checks[].fixtures names an in-image dir a composition does not have — a composition check declares fixtures_inline or fixtures_host (spec 26 §2.1)",
+                ));
+            }
+        } else if !self.fixtures_inline.is_empty() || self.fixtures_host.is_some() {
+            return Err(ManifestError::Invalid(
+                "checks[].fixtures_inline/fixtures_host belong to composition checks (spec 26 §2.1) — a slice check's fixtures are in-image (fixtures:)",
+            ));
+        }
+        for name in self.fixtures_inline.keys() {
+            if name.is_empty()
+                || name.starts_with('/')
+                || name.split('/').any(|c| c == "..")
+                || name.split('/').any(|c| c.is_empty())
+            {
+                return Err(ManifestError::Invalid(
+                    "checks[].fixtures_inline names must be non-empty scratch-relative file paths (never absolute, no '..' components)",
+                ));
+            }
+        }
+        if let Some(host) = &self.fixtures_host {
+            check_non_empty(
+                host,
+                "checks[].fixtures_host must not be empty (a path relative to the composition file)",
+            )?;
+            // The absolute spellings of EITHER platform family (POSIX
+            // `/…`, windows `X:…`/`\\…`) are refused everywhere — the
+            // path is relative to the composition file by contract, and
+            // a validator's answer never depends on the host OS.
+            let drive_qualified = host.len() >= 2
+                && host.as_bytes()[0].is_ascii_alphabetic()
+                && host.as_bytes()[1] == b':';
+            if host.starts_with('/')
+                || host.starts_with('\\')
+                || drive_qualified
+                || host.split(['/', '\\']).any(|c| c == "..")
+            {
+                return Err(ManifestError::Invalid(
+                    "checks[].fixtures_host must be relative to the composition file (never absolute, no '..' components)",
                 ));
             }
         }
@@ -1426,6 +1508,26 @@ impl Check {
             }
         }
         Ok(())
+    }
+
+    /// Slice-context validation (spec 26 §1 — the in-image manifest's
+    /// `checks:` block): the grammar with the in-image fixture family.
+    fn validate(&self, kind: PayloadKind) -> Result<(), ManifestError> {
+        self.validate_in(kind, false)
+    }
+
+    /// Composition-context validation (spec 26 §2.1 — a composition
+    /// document's `checks:` block): the slice grammar minus the in-image
+    /// `fixtures` (the composition has no image), with `entry: self`
+    /// still reserved for runtime slices (a composition check names a
+    /// mounted slice's executable). Structural composition checks are
+    /// legal: the engine asserts `expect.image_files` against the
+    /// mounted slice set.
+    pub fn validate_composition(&self) -> Result<(), ManifestError> {
+        // Any non-runtime kind keeps `self` reserved — the composition
+        // document is kind-less, so the runtime-only spelling never
+        // binds here.
+        self.validate_in(PayloadKind::App, true)
     }
 }
 

--- a/crates/tpkg/tests/manifest.rs
+++ b/crates/tpkg/tests/manifest.rs
@@ -338,6 +338,135 @@ fn checks_key_is_schema_legal() {
     }
 }
 
+/// A minimal kind:app manifest base for checks-validation tests (an exec
+/// check needs an exec-capable kind).
+fn app_manifest_with_checks(checks: &str) -> String {
+    format!(
+        "identity:\n  schema_version: 1\n  kind: app\n  name: acme-app\n  version: \"1\"\n\
+        \x20 producer: {{tool: t, tool_version: \"1\"}}\n  created: \"2026-08-19T00:00:00Z\"\n\
+        \x20 digest:\n    tree_hash: \"sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\"\n\
+        \x20   blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1\n\
+        \x20 signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+        provides:\n  entrypoints: [{{name: acme, path: /bin/acme}}]\n  platforms: [aarch64-macos]\n  capabilities: {{exec: true, read: true}}\n\
+        checks:\n{checks}"
+    )
+}
+
+#[test]
+fn checks_fixture_families_are_mece() {
+    // spec 26 §2.1: `fixtures` is the slice family's (in-image) source;
+    // `fixtures_inline`/`fixtures_host` are the composition family's.
+    // Each is a named error in the other's context.
+    let err = PayloadManifest::from_yaml(&app_manifest_with_checks(
+        "  c1:\n    entry: /bin/acme\n    fixtures_inline: {a.txt: hi}\n",
+    ))
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("fixtures_inline/fixtures_host belong to composition checks"),
+        "{err}"
+    );
+    let err = PayloadManifest::from_yaml(&app_manifest_with_checks(
+        "  c1:\n    entry: /bin/acme\n    fixtures_host: fixtures\n",
+    ))
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("fixtures_inline/fixtures_host belong to composition checks"),
+        "{err}"
+    );
+    // …and the composition context refuses the slice family.
+    let check: Check = serde_yml::from_str("entry: /bin/acme\nfixtures: /fixtures\n").unwrap();
+    let err = check.validate_composition().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("a composition check declares fixtures_inline or fixtures_host"),
+        "{err}"
+    );
+    // Both composition families validate in their own context.
+    let check: Check =
+        serde_yml::from_str("entry: /bin/acme\nfixtures_inline: {a.txt: hi, sub/b.txt: bye}\n")
+            .unwrap();
+    check.validate_composition().unwrap();
+    let check: Check =
+        serde_yml::from_str("entry: /bin/acme\nfixtures_host: fixtures/iso\n").unwrap();
+    check.validate_composition().unwrap();
+}
+
+#[test]
+fn checks_fixtures_host_path_rules() {
+    // fixtures_host is relative to the composition FILE — the absolute
+    // spellings of EITHER platform family are refused everywhere (the
+    // validator's answer never depends on the host OS).
+    for bad in [
+        "/abs/fixtures",
+        "\\\\share\\\\fixtures",
+        "C:/fixtures",
+        "../up",
+        "a/../b",
+    ] {
+        let check: Check =
+            serde_yml::from_str(&format!("entry: /bin/acme\nfixtures_host: \"{bad}\"\n")).unwrap();
+        let err = check.validate_composition().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("fixtures_host must be relative to the composition file"),
+            "{bad}: {err}"
+        );
+    }
+    let check: Check = serde_yml::from_str("entry: /bin/acme\nfixtures_host: \"\"\n").unwrap();
+    let err = check.validate_composition().unwrap_err();
+    assert!(
+        err.to_string().contains("fixtures_host must not be empty"),
+        "{err}"
+    );
+}
+
+#[test]
+fn checks_fixtures_inline_name_rules() {
+    for bad in ["/abs.txt", "../up.txt", "a//b.txt"] {
+        let check: Check = serde_yml::from_str(&format!(
+            "entry: /bin/acme\nfixtures_inline: {{\"{bad}\": x}}\n"
+        ))
+        .unwrap();
+        let err = check.validate_composition().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("fixtures_inline names must be non-empty scratch-relative file paths"),
+            "{bad}: {err}"
+        );
+    }
+}
+
+#[test]
+fn structural_checks_refuse_every_fixture_key() {
+    // A structural check (no entry) has no exec surface at all: every
+    // fixture key is a named error, in either context.
+    let err = PayloadManifest::from_yaml(&app_manifest_with_checks(
+        "  c1:\n    fixtures: /fixtures\n    expect: {image_files: [/a]}\n",
+    ))
+    .unwrap_err();
+    assert!(err.to_string().contains("are exec-only"), "{err}");
+    let check: Check =
+        serde_yml::from_str("fixtures_inline: {a.txt: hi}\nexpect: {image_files: [/a]}\n").unwrap();
+    let err = check.validate_composition().unwrap_err();
+    assert!(err.to_string().contains("are exec-only"), "{err}");
+}
+
+#[test]
+fn duplicate_check_names_are_refused() {
+    // The checks map's own deserializer refuses a re-declared name — an
+    // authoring ambiguity is a named structural error, never last-wins.
+    let err = PayloadManifest::from_yaml(&app_manifest_with_checks(
+        "  c1:\n    entry: /bin/acme\n  c1:\n    entry: /bin/acme\n",
+    ))
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("duplicate check name \"c1\""),
+        "{err}"
+    );
+}
+
 #[test]
 fn unknown_keys_are_tolerated_annotations_preserved() {
     let text = read(&fixture_path("data"));

--- a/crates/tpkg/tests/manifest_props.rs
+++ b/crates/tpkg/tests/manifest_props.rs
@@ -150,6 +150,8 @@ fn arb_check(kind: PayloadKind) -> impl Strategy<Value = Check> {
                     entry: Some(entry),
                     argv,
                     fixtures,
+                    fixtures_inline: std::collections::BTreeMap::new(),
+                    fixtures_host: None,
                     expect: CheckExpect {
                         exit: 0,
                         files,
@@ -167,6 +169,8 @@ fn arb_check(kind: PayloadKind) -> impl Strategy<Value = Check> {
         entry: None,
         argv: Vec::new(),
         fixtures: None,
+        fixtures_inline: std::collections::BTreeMap::new(),
+        fixtures_host: None,
         expect: CheckExpect {
             exit: 0,
             files: Vec::new(),

--- a/docs/spec/00-INDEX.md
+++ b/docs/spec/00-INDEX.md
@@ -56,7 +56,7 @@ spec 02 §6).
 23. [23 — Declarative composition and needs resolution](23-declarative-composition.md) — the fully declarative slice stack: D1 needs / D2 composition doc / D3 press-baked union / D4-D5 operator surfaces; deny-safe by default, the needs-check law (PLANNED)
 24. [24 — Declarative overlays](24-declarative-overlays.md) — write areas and key bindings: the gated COW write gate, `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT`, the record-mode fold-in, exit 68 (PARTIAL)
 25. [25 — Trace observability](25-trace-observability.md) — the interception bus, `tebako trace run|explain|cover`, the escapes correlation (PARTIAL)
-26. [26 — Payload checks](26-payload-checks.md) — the in-image self-validation contract: the `checks:` manifest block, `tebako check` at press/install/discovery moments, SKIP discipline, exit 72 (PLANNED)
+26. [26 — Payload checks](26-payload-checks.md) — the in-image self-validation contract: the `checks:` manifest block, `tebako check` at press/install/discovery moments, SKIP discipline, exit 79 (PARTIAL — the block + the engine shipped; the §3 press/install gate wiring remains)
 
 ## Locked invariants (all specs subordinate to these)
 

--- a/docs/spec/06-launcher-abi.md
+++ b/docs/spec/06-launcher-abi.md
@@ -78,6 +78,7 @@ republish of v1-era runtimes needed.
 | 74 | `EX_TEBAKO_IO` | filesystem/lock/install failure |
 | 75 | `EX_TEBAKO_CONTRACT` | runtime declares an unsupported `contract_version` (§6) |
 | 76 | `EX_TEBAKO_INSTALL` | `--tebako-install` refused (`TPKG_FLAG_NO_INSTALL`) or needs the CLI |
+| 79 | `EX_TEBAKO_CHECK` | a payload check FAILed — the `tebako check` aggregate (spec 26 §2; code constant `tpkg::EX_TEBAKO_CHECK`) |
 
 stderr body: `tebako-bootstrap: <message>\n` — message bodies match the
 C++ reference bootstrap 1:1 (golden parity).

--- a/docs/spec/26-payload-checks.md
+++ b/docs/spec/26-payload-checks.md
@@ -1,6 +1,11 @@
 # Spec 26 — Payload checks: the in-image self-validation contract
 
-Status: PLANNED (draft for owner review)
+Status: PARTIAL (§1's `checks:` manifest block (schema_minor 3) and
+§2/§2.1's `tebako check` engine shipped 2026-08-20 — the four target
+forms (name / bare image / package / composition document), the SKIP
+discipline, and the jail composition; §3's press/install gate wiring
+remains. Note the §2 aggregate exit is 79, not this draft's original
+72 — 72 has been `EX_TEBAKO_TRUST` since spec 09)
 Depends on: 03 (payload manifest), 08 (jails), 17 (driver contract),
 22 (runtime-native interposition), 23 (declarative composition),
 24 (overlays), 25 (trace observability)
@@ -144,8 +149,11 @@ in declaration order (slice checks before composition checks, §2.1):
 1. `when:` filter — a non-matching platform SKIPs (loud).
 2. `requires:` — the resolved composition must provide every listed
    capability; an unmet prerequisite SKIPs with the missing capability
-   named. A check fails ONLY when its prerequisites are present and its
-   behavior is wrong.
+   named. The capability set is the union, over the composition's
+   slices, of the slice name, the app `entrypoints[].name`, the toolkit
+   `executables[].name`/`libraries[].name`, and the runtime
+   `provides.engine` (an openjdk slice provides `java`). A check fails
+   ONLY when its prerequisites are present and its behavior is wrong.
 3. A fresh scratch dir (host tmp) is created, auto-granted `rw` for the
    check's duration — an engine grant, never a declared need; fixtures
    materialize into it.
@@ -158,9 +166,12 @@ in declaration order (slice checks before composition checks, §2.1):
    test-iso.xml)`.
 
 Aggregate exit: `0` when every selected check PASSes or SKIPs;
-**exit 72 (`EX_TEBAKO_CHECK`)** when any FAILs (the code is allocated
-here; 65 keeps malformed-`checks:`-block, caught at press/validate time
-by the schema). Timeout and engine errors are FAILs with the reason
+**exit 79 (`EX_TEBAKO_CHECK`)** when any FAILs (the code is allocated
+here — this spec's draft said 72, but 72 has been `EX_TEBAKO_TRUST`
+since spec 09's trust chain; 79 is the allocation, owned by
+`tpkg::EX_TEBAKO_CHECK` and listed in spec 06 §4; 65 keeps
+malformed-`checks:`-block, caught at press/validate time by the
+schema). Timeout and engine errors are FAILs with the reason
 named. `--keep-scratch` preserves the dir for debugging (its path is
 printed); otherwise it is removed.
 
@@ -321,7 +332,9 @@ boot_smoke/smoke_verdict on every platform.
 - Malformed `checks:` block: schema error at press/`tfs validate` for a
   slice, at composition load for a D2 document, exit 65 — never
   discovered at run time.
-- Check FAIL: exit 72, the check name and the failed expectation named
+- Check FAIL: exit 79 (`EX_TEBAKO_CHECK` — re-allocated from this
+  spec's draft 72, which has been `EX_TEBAKO_TRUST` since spec 09),
+  the check name and the failed expectation named
   (missing file, exit code, stdout pattern, timeout) — never a bare
   nonzero.
 - SKIP is loud and always names the unmet prerequisite; a SKIP never

--- a/docs/spec/schemas/payload-manifest.yaml
+++ b/docs/spec/schemas/payload-manifest.yaml
@@ -274,6 +274,8 @@ grammar:
       entry: {type: "absolute in-image path | the reserved spelling \"self\"", required: false, notes: "PRESENT ⇒ an exec check; ABSENT ⇒ a structural check (MECE — one key decides the shape, never a kind flag). \"self\" is kind-runtime only (spec 26 §1.1: the runtime exe itself, env image mounted)"}
       argv: {type: list of string, required: false, notes: "exec-only. `{scratch}` (the per-run host scratch dir) at most once per entry; every other spelling is literal passthrough — the engine substitutes, the model carries"}
       fixtures: {type: absolute in-image path, required: false, notes: "exec-only. The dir whose CONTENTS land at the HOST scratch root — never VFS-spelled (spec 26 §1)"}
+      fixtures_inline: {type: map of fixture name → content, required: false, notes: "COMPOSITION-ONLY (spec 26 §2.1) — a composition document's checks: block speaks this family (a composition has no image); REFUSED in a slice manifest with a named validation error (the fixture families are MECE). Names are non-empty scratch-relative paths (never absolute, no '..' components)"}
+      fixtures_host: {type: path relative to the composition file, required: false, notes: "COMPOSITION-ONLY (spec 26 §2.1) — the org repo's checked-in fixture tree, copied to scratch; refused in a slice manifest. Never absolute (either platform family's spellings), no '..' components — validated platform-neutrally"}
       expect:
         type: map
         required: false
@@ -332,6 +334,10 @@ refusals:
     behavior: named validation error at parse (exit 65) — the reserved spelling names the runtime exe, spec 26 §1.1
   - case: a structural check (no entry) declaring argv/fixtures, or asserting no image_files (schema_minor 3)
     behavior: named validation error at parse (exit 65) — exec-only keys on a structural check are a grammar violation
+  - case: a slice manifest declaring fixtures_inline/fixtures_host, or a composition check declaring fixtures (schema_minor 3)
+    behavior: named validation error at parse (exit 65) — the fixture families are MECE per context (spec 26 §2.1); a composition check is validated by the engine at document load, a slice check at press/`tfs validate`
+  - case: a duplicate check name within one checks: block (schema_minor 3)
+    behavior: named structural error at parse — an authoring ambiguity, never a silent winner (the map's own deserializer refuses)
   - case: a malformed checks block otherwise (bad name grammar, relative entry, absolute expect.files, '..' components, non-positive timeout, a when value outside windows/macos/linux) (schema_minor 3)
     behavior: named validation error at press/`tfs validate` (exit 65), never discovered at run time (spec 26 §7)
 


### PR DESCRIPTION
## ⚠️ Deviations / decisions needing owner review (read first)

1. **Exit-code re-allocation: 72 → 79.** Spec 26 §2/§7's draft allocates
   exit **72** to `EX_TEBAKO_CHECK`, but 72 has been `EX_TEBAKO_TRUST`
   since spec 09 (signer-key-not-trusted, shipped in the bootstrap and
   the install path). This PR allocates **79** (`tpkg::EX_TEBAKO_CHECK`,
   with a doc comment explaining the collision) and amends the specs in
   the same PR: spec 26 §2/§7 (72→79 with the collision note) and the
   spec 06 §4 table (new 79 row). If the owner prefers a different code,
   the constant + the two spec edits are the only touchpoints.
2. **New dependency: `regex = "1"` in tebako-cli.** Spec 26 §1 assigns
   regex compilation to the engine — `checks[].expect.stdout` is carried
   UNCOMPILED by tpkg (the model has no regex dep by design). Pure Rust,
   no system deps; law 1/5 clean.
3. **`tpkg::atoms` SSOT lift.** The spec 23 §2 symbolic-atom grammar
   (`$HOME`/`%USERPROFILE%`/`$TMPDIR`/`%TEMP`/`$CWD`/`$TEBAKO_HOME`)
   existed as a private copy inside tfs-cli's compose. The check engine
   needs the same grammar for `needs:` paths and composition
   `mounts:`/`needs.host`. Per invariant 10 the grammar now has exactly
   one home — `tpkg::atoms` (`SYMBOLIC_ATOMS` + `expand_symbolic_atoms`)
   — and tfs-cli's compose delegates to it (behavior unchanged; its 15
   lib compose tests pass).
4. **Composition target interpretation: slice checks run with the FULL
   composition mounted.** For a `tebako.yaml` target, a slice's own
   `checks:` run against the composition the document assembles (every
   slice mounted, the doc's policy/mounts/needs the base jail) — not
   against the slice alone. A slice's checks diagnose a broken slice in
   situ, before the binding that depends on it (the composition owner's
   checks run last). Flagging because §2.1's prose can be read either
   way; the report groups by owner (`slice X: <name> …`,
   `composition: <name> …`).
5. **Package form: the scratch grant is bounded by the pressed policy.**
   The engine's `TEBAKO_JAIL` export for a pressed-package target rides
   the bootstrap's user-tightening channel (`TEBAKO_JAIL_SOURCE=user`),
   which the bootstrap RE-INTERSECTS with the package's pressed request
   (`tpkg::jail::effective`). Under a pressed deny policy the engine's
   scratch `rw` grant is therefore bounded by the package's own
   declaration (the intersection ceiling) — a check that needs scratch
   writes under a pressed deny jail must declare them via `needs:`…
   except that `needs:` grants are intersected too. `--record`
   dominates wholesale. This is the correct conservative reading (the
   engine never WIDENS a pressed policy), flagged so the owner can
   confirm the ceiling is intended rather than an engine-side escape.
6. **`argument_files` is NOT resolved for check runs.** A pressed/base
   jail's `argument_files:` resolve against the process cwd, which is
   not the check's scratch; the check's argv is the author's and the
   scratch grant covers it. Documented in the module header.
7. **Package entry matching resolves names through the slot manifest.**
   The type-2 entry table names PROVIDES entrypoints BY NAME
   (`entries[].entrypoint`); a check's `entry` is the in-image PATH. The
   engine resolves the name through the owning slot's embedded
   manifest's dispatchables (the name's one authority) and compares
   paths; a mismatch FAILs listing the declared table
   (`name→slot:entrypoint`).

## What this is

Spec 26 phase T2: the `tebako check` engine (`crates/tebako-cli/src/check.rs`,
~2 700 lines with tests). `tebako check <name | image.tfs | package |
tebako.yaml> [--check <c>] [--list] [--record] [--keep-scratch]
[--runtime <exe> --runtime-image <env.tfs>]` runs the in-image `checks:`
block (§1, shipped in 84e89a46) at the spec's moments:

- **name** (managed): `tebako_shim::resolve::resolve_payload` — the
  dispatch chain minus the entrypoint gate (a data slice declares none);
  checks read from the EMBEDDED manifest (in-image is authoritative);
  exec plans per dispatchable: zero-runtime → the install-time
  materialized tree (preload env scrubbed), runtime-bound → the spec-17
  handoff (`--tebako-image` triples + `--tebako-entry` +
  `TEBAKO_RUNTIME_IMAGE`).
- **bare image** (the press-time gate): the GIVEN runtime pair;
  `entry: self` maps to the spec-17 bare-name keyword; a runtime-kind
  image defaults `--runtime-image` to itself.
- **package**: every non-runtime slot's embedded manifest; exec runs the
  package itself with unix argv0 = the entry-table name (the bootstrap's
  selection contract); a package with no type-2 block FAILs exec checks
  with the reason named.
- **composition document** (§2.1): the D2 model (`version: 1`,
  `runtime:`/`slices:`/`entrypoint:`/`policy:`/`mounts:`/`needs.host:`/
  `checks:`) with tpkg's duplicate-name refusal and the MECE fixture
  families (`fixtures` in-image for slices; `fixtures_inline`/
  `fixtures_host` for composition checks); slices resolved
  newest-installed-satisfying; the entrypoint provider mounts first at
  `/`, every other slice requires a declared mount, duplicate mounts
  refused; the base jail is the doc's policy/mounts/needs (deny by
  default once anything is declared).

The per-check pipeline: `when:` filter and `requires:` capabilities SKIP
(loud, the platform/capability named) — never FAIL; scratch dir per
check (removed unless `--keep-scratch`, which prints the path);
fixtures materialized host-spelled; the jail env = base ∪ scratch rw ∪
in-force `needs:` (atoms via `tpkg::atoms`), nothing exported under an
open world, bare `record` under `--record`, unix bind-check degraded to
the check's FAIL reason; the child runs with cwd = scratch, stdout/
stderr teed live and captured; assertions in order — exit code,
`expect.files` (exist + non-empty), the one stdout regex; timeout is a
FAIL (`timeout after Ns`). Verdict lines `check <name> PASS 41s` /
`SKIP (…)` / `FAIL (…)`, grouped `slice X: …` / `composition: …` for
multi-owner targets. Aggregate 0 or 79; resolution/manifest errors ride
the existing named codes (64/65/69/127).

## Supporting moves

- `tpkg::EX_TEBAKO_CHECK = 79` (deviation 1).
- tpkg `Check` gains the composition-only `fixtures_inline`/
  `fixtures_host` keys with the MECE context rule: `Check::validate`
  (slice context) refuses them, the new pub `Check::validate_composition`
  refuses `fixtures`, and a structural check refuses all three
  (exec-only). `checks_map` (duplicate-name refusal deserializer) and
  `check_check_name` are pub for the composition model.
- `tpkg::atoms` (deviation 3); tfs-cli compose delegates.
- `tebako-shim`: `resolve::resolve_payload` (payload-addressed
  resolution without the suite scan or the entrypoint gate — the
  structural-check path) and `dispatch::compose_mounts` made pub.

## Doc sync (same PR)

- spec 26: status PLANNED → PARTIAL; §2/§7 exit 72→79 with the
  collision note; §2 step 2 names the capability set.
- spec 06 §4: the 79 row.
- spec 00-INDEX: the spec 26 line (exit 79, PARTIAL).
- README commands table: the `tebako check` row.
- `docs/spec/schemas/payload-manifest.yaml`: the composition-only
  fixture keys documented as refused in slice context + the refusal rows
  (MECE families, duplicate check names).

## Verification

- `cargo fmt` clean; `cargo clippy --all-targets -D warnings` on
  tpkg/tebako-shim/tebako-cli/tfs-cli clean.
- tpkg: 6 new validation tests (MECE families, fixtures_host/fixtures_inline
  path rules, structural refusals, duplicate names) — full tpkg suite
  green.
- tebako-cli lib: 23 new check-engine unit tests (argv parse, declaration
  order, capability sets per kind, verdict lines, when-filter, jail-env
  composition incl. record/open-world/deny-base, atoms, scratch
  lifecycle, exec assertions, composition-doc serde discipline).
- tebako-cli e2e `tests/check.rs` (unix): 12 legs — structural PASS/FAIL
  on bare images; the Given-form exec PASS observing the driver contract
  (`--tebako-image <img>:0:/`, `--tebako-entry`, `TEBAKO_RUNTIME_IMAGE`,
  fixtures at the scratch root, `{scratch}` argv); exit-mismatch and
  timeout FAILs at 79; both SKIP shapes at 0; `--list` in declaration
  order; unknown `--check` at 64; `--keep-scratch`; usage at 1; the
  pressed-package form (argv0 entry selection + the named
  entry-mismatch FAIL); the store-backed name form (zero-runtime
  materialized exec); the composition form (union structural PASS/FAIL,
  document validation at 65).
- `cli_e2e` and `tfs-cli --lib` suites green (no regressions).

**Do not merge** — owner gate per the ecosystem rule (the whole chain
validated end-to-end before anything lands on main).
