### PR TITLE
deps: limnifs 0.2.44 — blake3 1.8.7 floor, off yanked arrayref

### DIFF
--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -41,7 +41,7 @@ serde_yml = "0.0.12"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
 # — pure Rust, no `limni` binary anywhere.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "eddaea404b7686c4f22462c366065a3a35bf9b43" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "1bf0c59967e631b6bd970d56505712275768e8f2" }
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -34,7 +34,7 @@ serde_yaml = "0.9"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
 # §6) — pure Rust, no `limni` binary anywhere.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "eddaea404b7686c4f22462c366065a3a35bf9b43" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "1bf0c59967e631b6bd970d56505712275768e8f2" }
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -48,7 +48,7 @@ sqfs-sys = { version = "0.1.0", path = "../sqfs-sys", optional = true }
 # The LimniFS backend (spec 20): the pure-Rust limnifs-core reader — no
 # system dependencies, `#![forbid(unsafe_code)]` upstream. Path dep until
 # limnifs has a release to pin against (same standing as dwarfs-t).
-limnifs-core = { git = "https://github.com/limnifs/limnifs", rev = "eddaea404b7686c4f22462c366065a3a35bf9b43", optional = true }
+limnifs-core = { git = "https://github.com/limnifs/limnifs", rev = "1bf0c59967e631b6bd970d56505712275768e8f2", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
@@ -95,5 +95,5 @@ rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
 crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —
 # test-only, never linked into the shipped library.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "eddaea404b7686c4f22462c366065a3a35bf9b43" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "1bf0c59967e631b6bd970d56505712275768e8f2" }
 

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -25,4 +25,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 # The limnifs backend-pair golden class builds its fixture image
 # in-process (spec 20 §8) — never a `limni` binary.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "eddaea404b7686c4f22462c366065a3a35bf9b43" }
+limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "1bf0c59967e631b6bd970d56505712275768e8f2" }


### PR DESCRIPTION
## What

Bumps the limnifs git pin `eddaea40…` → `1bf0c599…` (limnifs 0.2.44) in all four manifests that carry it:

- `crates/tfs/Cargo.toml` (`limnifs-core` + the `limnifs-write` dev-dep)
- `crates/tfs-cli/Cargo.toml`
- `crates/tebako-cli/Cargo.toml`
- `tests/contract/Cargo.toml`

## Why

The 2026-08-20 arrayref mass-yank (0.3.5–0.3.9 yanked, `droundy/arrayref` deleted) broke every fresh resolution that still named blake3 1.5.x. blake3 dropped arrayref only in 1.8.7; limnifs 0.2.44 raises its blake3 floor to exactly 1.8.7, so a fresh resolution never names arrayref at all — stale crates.io edges now fail closed instead of resolving onto yanked arrayref `^0.3.5`.

This unblocks the factory runtime re-cut (tebako-runtime-ruby run 32346716268, whose link-unit legs check out tebako `main`) without vendoring anything. Supersedes the closed vendor-patch approach in #424.

## Evidence

`cargo metadata` on this branch (fresh resolve, no lockfile):

- blake3 → 1.8.7
- arrayref → absent from the dependency graph
- limnifs-core / limnifs-format / limnifs-ocb3 / limnifs-write → all 0.2.44
