### PR TITLE
deps: limnifs via crates.io 0.2.50 — drop the git-rev pins

### DIFF
--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -41,7 +41,7 @@ serde_yml = "0.0.12"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
 # — pure Rust, no `limni` binary anywhere.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "1bf0c59967e631b6bd970d56505712275768e8f2" }
+limnifs-write = "0.2.50"
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -34,7 +34,7 @@ serde_yaml = "0.9"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
 # §6) — pure Rust, no `limni` binary anywhere.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "1bf0c59967e631b6bd970d56505712275768e8f2" }
+limnifs-write = "0.2.50"
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -46,9 +46,9 @@ dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs", optional = t
 # libsquashfs (squashfs-tools-ng) via vcpkg for the SquashFS backend.
 sqfs-sys = { version = "0.1.0", path = "../sqfs-sys", optional = true }
 # The LimniFS backend (spec 20): the pure-Rust limnifs-core reader — no
-# system dependencies, `#![forbid(unsafe_code)]` upstream. Path dep until
-# limnifs has a release to pin against (same standing as dwarfs-t).
-limnifs-core = { git = "https://github.com/limnifs/limnifs", rev = "1bf0c59967e631b6bd970d56505712275768e8f2", optional = true }
+# system dependencies, `#![forbid(unsafe_code)]` upstream. Registry dep on
+# the published crates.io line (since 0.2.50; same standing as dwarfs-t).
+limnifs-core = { version = "0.2.50", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
@@ -95,5 +95,5 @@ rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
 crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —
 # test-only, never linked into the shipped library.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "1bf0c59967e631b6bd970d56505712275768e8f2" }
+limnifs-write = "0.2.50"
 

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -25,4 +25,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 # The limnifs backend-pair golden class builds its fixture image
 # in-process (spec 20 §8) — never a `limni` binary.
-limnifs-write = { git = "https://github.com/limnifs/limnifs", rev = "1bf0c59967e631b6bd970d56505712275768e8f2" }
+limnifs-write = "0.2.50"


### PR DESCRIPTION
## What

Drop the git-rev pins for the limnifs family and depend on the published crates.io line, **0.2.50**:

- `crates/tfs/Cargo.toml` — `limnifs-core = { version = "0.2.50", optional = true }` (lib) + `limnifs-write = "0.2.50"` (dev)
- `crates/tfs-cli/Cargo.toml`, `crates/tebako-cli/Cargo.toml`, `tests/contract/Cargo.toml` — `limnifs-write = "0.2.50"`

The stale "git pin until crates.io publication" comment is rewritten: registry dep on the published crates.io line since 0.2.50, same standing as dwarfs-t.

## Why

limnifs 0.2.50 is on crates.io — the first release line with blake3 1.8.7 and **no arrayref anywhere** (the yanked-arrayref wall that #425 pinned around at 0.2.44 is gone upstream). #425's pin *form* (git rev) was always temporary; this restores the normal registry flow while keeping its fix.

## Evidence

- Fresh `cargo metadata`: limnifs-{core,format,ocb3,write} all resolve to `registry+https://github.com/rust-lang/crates.io-index` @ 0.2.50; blake3 1.8.7; **arrayref absent** from the graph.
- `cargo check` green: `tfs`, `tfs-cli`, `tebako-cli` (4m43s) and `tebako-contract-tests` (7m43s) — 0.2.44 → 0.2.50 is call-site compatible.

## Notes

- Cargo.lock is gitignored in this workspace (resolutions float) — nothing else to commit.
- Supersedes the pin form of #425 (merged as `c124762e`), not its substance.
