### PR TITLE
spec 25 phase T2: spawn/resolve trace emission + tebako trace spawn join

### DIFF
--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -283,7 +283,27 @@ pub fn vfs_rewinddir(id: usize) -> Result<(), i32> {
 /// host copy; host-or-denied → the route's answer (an allowed host path
 /// execs the original, a denied one fails EPERM/EROFS).
 pub fn vfs_materialize_exec(path: &str) -> PathRoute<std::ffi::CString> {
-    let answer = { context().write().unwrap().exec_materialize(path) };
+    materialize_exec_route(path, false)
+}
+
+/// The posix_spawn/posix_spawnp surface (spec 25 §2, phase T2): the same
+/// routing, emitted as a `spawn` trace event — the op token marks the
+/// child-creating surface for the stream's process-tree regrouping.
+pub fn vfs_materialize_spawn(path: &str) -> PathRoute<std::ffi::CString> {
+    materialize_exec_route(path, true)
+}
+
+/// The shared exec/spawn route: the engine answers with the trace op the
+/// syscall surface owns (`exec` for execve, `spawn` for posix_spawn).
+fn materialize_exec_route(path: &str, spawn: bool) -> PathRoute<std::ffi::CString> {
+    let answer = {
+        let mut ctx = context().write().unwrap();
+        if spawn {
+            ctx.exec_materialize_for_spawn(path)
+        } else {
+            ctx.exec_materialize(path)
+        }
+    };
     match answer {
         Ok(host) => match ensure_exec_bit(&host) {
             Ok(()) => PathRoute::Vfs(host),
@@ -502,6 +522,48 @@ mod tests {
             "a mount-claimed path absent from the image keeps the ENOENT pass-through"
         );
         assert_eq!(vfs_write_path("/tmp/libtfs-preload-route-write"), Ok(()));
+
+        // ---- exec/spawn trace surfaces (spec 25 §2, phase T2) ----
+        // execve and posix_spawn share the engine's routing answer; the
+        // trace op names the syscall surface. The bus is process-global:
+        // armed for this block only, disarmed right after.
+        let capture = dir.join("trace.jsonl");
+        assert!(tfs::trace::arm(&capture), "the bus arms");
+        let PathRoute::Vfs(exec_host) = vfs_materialize_exec(&tool) else {
+            panic!("memfs exec should route Vfs");
+        };
+        let PathRoute::Vfs(spawn_host) = vfs_materialize_spawn(&tool) else {
+            panic!("memfs spawn should route Vfs");
+        };
+        assert_eq!(exec_host, spawn_host, "one routing answer, two surfaces");
+        assert_eq!(
+            vfs_materialize_spawn("/etc/definitely-host"),
+            PathRoute::Host
+        );
+        tfs::trace::disarm();
+        let text = std::fs::read_to_string(&capture).unwrap();
+        let exec_line = text
+            .lines()
+            .find(|l| l.contains("\"op\":\"exec\""))
+            .unwrap_or_else(|| panic!("an exec event was traced: {text}"));
+        assert!(exec_line.contains("\"verdict\":\"routed:"), "{exec_line}");
+        let spawn_lines: Vec<&str> = text
+            .lines()
+            .filter(|l| l.contains("\"op\":\"spawn\""))
+            .collect();
+        assert_eq!(
+            spawn_lines.len(),
+            2,
+            "the memfs spawn and the host-passthrough spawn: {text}"
+        );
+        assert!(
+            spawn_lines[0].contains("\"verdict\":\"routed:"),
+            "{spawn_lines:?}"
+        );
+        assert!(
+            spawn_lines[1].contains("\"verdict\":\"host\""),
+            "the host fallthrough carries the exec row's host verdict: {spawn_lines:?}"
+        );
 
         // ---- write-class gating: memfs is EROFS ----
         assert_eq!(vfs_write_path(&secret), Err(libc::EROFS));

--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -529,15 +529,24 @@ mod tests {
         // armed for this block only, disarmed right after.
         let capture = dir.join("trace.jsonl");
         assert!(tfs::trace::arm(&capture), "the bus arms");
-        let PathRoute::Vfs(exec_host) = vfs_materialize_exec(&tool) else {
+        // Enter through the production seam (engine_call — the shims'
+        // re-entrancy guard): a direct unguarded route call leaves
+        // IN_ENGINE unset, and the extraction's host writes then
+        // re-enter the shims and deadlock the context lock on glibc
+        // (the 2026-08-21 ubuntu CI hang of this test).
+        let PathRoute::Vfs(exec_host) =
+            crate::sys::engine_call(|| vfs_materialize_exec(&tool)).unwrap()
+        else {
             panic!("memfs exec should route Vfs");
         };
-        let PathRoute::Vfs(spawn_host) = vfs_materialize_spawn(&tool) else {
+        let PathRoute::Vfs(spawn_host) =
+            crate::sys::engine_call(|| vfs_materialize_spawn(&tool)).unwrap()
+        else {
             panic!("memfs spawn should route Vfs");
         };
         assert_eq!(exec_host, spawn_host, "one routing answer, two surfaces");
         assert_eq!(
-            vfs_materialize_spawn("/etc/definitely-host"),
+            crate::sys::engine_call(|| vfs_materialize_spawn("/etc/definitely-host")).unwrap(),
             PathRoute::Host
         );
         tfs::trace::disarm();

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -1348,7 +1348,9 @@ pub unsafe extern "C" fn execve(
 }
 
 /// Interposed `posix_spawn` (roadmap 39): the execve routing with the
-/// spawn contract — the return IS the errno (never -1).
+/// spawn contract — the return IS the errno (never -1). The trace op is
+/// `spawn` (spec 25 §2: a child is created — the stream's process-tree
+/// signal), never `exec`.
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn posix_spawn(
     pid: *mut libc::pid_t,
@@ -1361,7 +1363,7 @@ pub unsafe extern "C" fn posix_spawn(
     let Some(p) = (unsafe { c_path(path) }) else {
         return unsafe { plat::real_posix_spawn()(pid, path, file_actions, attrp, argv, envp) };
     };
-    match engine_call(|| route::vfs_materialize_exec(p)) {
+    match engine_call(|| route::vfs_materialize_spawn(p)) {
         Some(PathRoute::Vfs(host)) => unsafe {
             plat::real_posix_spawn()(pid, host.as_ptr(), file_actions, attrp, argv, envp)
         },
@@ -1373,8 +1375,10 @@ pub unsafe extern "C" fn posix_spawn(
 }
 
 /// Interposed `posix_spawnp` (roadmap 39): an explicit path routes like
-/// posix_spawn; a bare name is a host PATH search (memfs dirs are not in
-/// the host PATH — pass through, stated honestly in the crate docs).
+/// posix_spawn (the `spawn` trace op, spec 25 §2); a bare name is a host
+/// PATH search (memfs dirs are not in the host PATH — pass through,
+/// stated honestly in the crate docs; no VFS decision exists, so no
+/// trace event).
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn posix_spawnp(
     pid: *mut libc::pid_t,
@@ -1390,7 +1394,7 @@ pub unsafe extern "C" fn posix_spawnp(
     if !p.contains('/') {
         return unsafe { plat::real_posix_spawnp()(pid, file, file_actions, attrp, argv, envp) };
     }
-    match engine_call(|| route::vfs_materialize_exec(p)) {
+    match engine_call(|| route::vfs_materialize_spawn(p)) {
         Some(PathRoute::Vfs(host)) => unsafe {
             plat::real_posix_spawnp()(pid, host.as_ptr(), file_actions, attrp, argv, envp)
         },

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -74,7 +74,15 @@ thread_local! {
 /// Run `f` (a route-layer engine call) unless this thread is already
 /// inside the engine: re-entrant calls (the engine's own host IO) get
 /// `None` and the shim passes them straight to the real implementation.
-fn engine_call<T>(f: impl FnOnce() -> T) -> Option<T> {
+///
+/// pub(crate) for the TEST seam: a test that calls the route layer
+/// directly must enter through this guard exactly like the shims do.
+/// Unguarded direct entry leaves IN_ENGINE unset, so the engine's own
+/// host IO (the extraction writes under the context lock) re-enters the
+/// shims and deadlocks the context lock on glibc (the 2026-08-21
+/// route_matrix ubuntu hang; macOS test binaries do not interpose
+/// in-process, so only Linux CI saw it).
+pub(crate) fn engine_call<T>(f: impl FnOnce() -> T) -> Option<T> {
     IN_ENGINE.with(|c| {
         if c.get() {
             return None;

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -554,8 +554,9 @@ fn run_package(args: &[String]) -> Result<(), CliExit> {
 /// `tebako trace run <pkg> [--capture <path>] [--out <path>] [--]
 /// [<args>...]` — spec 25 §4 (phase T1, discovery): run the package under
 /// `TEBAKO_JAIL=record` with the interception bus armed, then synthesize
-/// the capture into a suggested-manifest draft. `explain`/`cover` are
-/// the T2/T3 milestones. Never returns on success (the process exits
+/// the capture into a suggested-manifest draft. The spawn/resolve
+/// emission is T2 (bus-side, landed); `cover`/`import` are T3 and
+/// `explain` T4. Never returns on success (the process exits
 /// with the payload's exit code).
 fn run_trace(args: &[String]) -> Result<(), CliExit> {
     let Some(action) = args.first() else {
@@ -570,7 +571,7 @@ fn run_trace(args: &[String]) -> Result<(), CliExit> {
             Ok(())
         }
         other @ ("explain" | "cover" | "import") => Err(CliExit::Usage(format!(
-            "'tebako trace {other}' is a later tebako-rs milestone (spec 25: explain is T2, cover/import are T3)"
+            "'tebako trace {other}' is a later tebako-rs milestone (spec 25: cover/import are T3, explain is T4)"
         ))),
         other => Err(CliExit::Usage(format!("unknown trace subcommand '{other}'"))),
     }

--- a/crates/tebako-cli/src/trace.rs
+++ b/crates/tebako-cli/src/trace.rs
@@ -15,7 +15,11 @@
 //! preload's fopen routing), closure-covered dlopen NOTEs, and
 //! host-executable entrypoint notes.
 //!
-//! `explain` (§5, T2) and `cover` (§6, T3) are later milestones.
+//! `explain` (§5, phase T4) and `cover` (§6, phase T3) are later
+//! milestones; phase T2 was the spawn/resolve emission (the preload's
+//! posix_spawn surface and the driver's image-triple resolution — pure
+//! bus-side work, no consumer change needed here beyond the pinned
+//! spawn grammar below).
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -293,8 +297,9 @@ pub fn synthesize(
                 }
             }
             // A host-absolute exec the runtime routed OUT of the image:
-            // the entrypoint/runtime-dep note (spawn joins exec here when
-            // its emission lands — the vocabulary is already stable).
+            // the entrypoint/runtime-dep note. The spawn surface (T2:
+            // the preload's posix_spawn path) reports the same grammar
+            // and joins exec here.
             "exec" | "spawn" => {
                 if verdict == "host" && Path::new(&path).is_absolute() {
                     host_execs
@@ -519,6 +524,13 @@ mod tests {
         "/usr/bin/git"
     };
 
+    /// A second host executable, reached via the spawn surface (T2).
+    const HOST_SPAWN: &str = if cfg!(windows) {
+        "C:/Windows/system32/where.exe"
+    } else {
+        "/usr/bin/curl"
+    };
+
     #[test]
     fn synthesize_feeds_the_needs_generator_and_names_candidates() {
         let capture = [
@@ -544,15 +556,18 @@ mod tests {
             event("dlopen", "/tfs/lib/libmixed.so", "materialized:/tmp/tebako-dl-abc/tfs/lib/libmixed.so", "2026-08-19T01:00:10.000000Z",
                   "{\"closure\":{\"format\":\"elf\",\"deps\":[{\"name\":\"libSystem.dylib\",\"resolved\":null,\"verdict\":\"host-system\"}]}}"),
             // A host-absolute exec (the entrypoint note) and an in-image
-            // one (no note).
+            // one (no note). The T2 spawn surface joins exec here: same
+            // grammar, same note.
             event("exec", HOST_EXE, "host", "2026-08-19T01:00:11.000000Z", "{}"),
             event("exec", "/tfs/bin/tool", "routed:/tmp/tebako-exec-home-1/bin/tool", "2026-08-19T01:00:12.000000Z", "{\"route\":\"home-tree\"}"),
+            event("spawn", HOST_SPAWN, "host", "2026-08-19T01:00:13.000000Z", "{}"),
+            event("spawn", "/tfs/bin/tool", "routed:/tmp/tebako-exec-home-1/bin/tool", "2026-08-19T01:00:14.000000Z", "{\"route\":\"home-tree\"}"),
             // A crashed tail: the partial last line is dropped, not fatal.
-            "{\"v\":1,\"ts\":\"2026-08-19T01:00:13".to_string(),
+            "{\"v\":1,\"ts\":\"2026-08-19T01:00:15".to_string(),
         ]
         .join("\n");
         let s = synthesize(&capture, &[], &[], &|_| true);
-        assert_eq!(s.events, 12, "12 well-formed events of 13 lines");
+        assert_eq!(s.events, 14, "14 well-formed events of 15 lines");
         // The needs feed: /work/data collapses to one rw entry
         // (strongest-observed-op wins), the deny rides along as ro, the
         // exec-cache noise never reaches it.
@@ -602,9 +617,11 @@ mod tests {
         let (deps, obs) = &s.closure_covered["/tfs/lib/libsass.so"];
         assert_eq!(*deps, 2);
         assert_eq!(obs.count, 1);
-        // The host-exec note.
-        assert_eq!(s.host_execs.len(), 1);
+        // The host-exec notes: the exec surface and the spawn surface
+        // each contributed one.
+        assert_eq!(s.host_execs.len(), 2);
         assert!(s.host_execs.contains_key(HOST_EXE));
+        assert!(s.host_execs.contains_key(HOST_SPAWN));
     }
 
     #[test]

--- a/crates/tebako-driver/Cargo.toml
+++ b/crates/tebako-driver/Cargo.toml
@@ -20,6 +20,9 @@ crate-type = ["staticlib", "rlib"]
 tebako-log = { version = "0.1.0", path = "../tebako-log" }
 # Trailer probing for `<self|package>:<slot>` resolution (spec 02).
 tpkg = { version = "0.1.0", path = "../tpkg" }
+# The resolve trace events' detail values (spec 25 §7 blesses tebako-json
+# for trace emission; the envelope renderer lives in tfs::trace).
+tebako-json = { version = "0.1.0", path = "../tebako-json" }
 # The env-image layout declaration (spec 18 C3) is authored YAML.
 serde = { version = "1", features = ["derive"] }
 serde_yml = "0.0.12"

--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -198,39 +198,194 @@ enum ResolvedRegion {
     Region(u64, u64),
 }
 
-/// Probe a file's tpkg trailer and resolve the slot reference.
-fn resolve_image(path: &Path, slot: SlotRef, display: &str) -> Result<ResolvedImage, DriverError> {
-    let mut file = std::fs::File::open(path)
-        .map_err(|e| unavailable(format!("cannot open image file '{display}': {e}")))?;
+/// The failure half of a resolve decision: the named boot error (the
+/// exit-code path, unchanged) plus the errno-level fact and class token
+/// the `resolve` trace event carries (spec 25 §2, phase T2 — the schema's
+/// `reason` key).
+struct ResolveFailure {
+    errno: i32,
+    reason: &'static str,
+    error: DriverError,
+}
+
+impl ResolveFailure {
+    fn new(errno: i32, reason: &'static str, error: DriverError) -> ResolveFailure {
+        ResolveFailure {
+            errno,
+            reason,
+            error,
+        }
+    }
+}
+
+/// The slot reference as spelled in the triple (the schema's `slot`
+/// detail): `-` for the whole-file form, the number otherwise.
+fn slot_spelled(slot: &SlotRef) -> String {
+    match slot {
+        SlotRef::Whole => "-".to_string(),
+        SlotRef::Slot(n) => n.to_string(),
+    }
+}
+
+/// Emit the `resolve` event for one triple's resolution (spec 25 §2,
+/// phase T2): `whole` for a bare image, `slot:<n>` with the region +
+/// slot-count details for a package, `error:<errno>` with the `reason`
+/// class on failure. `path` is the host file actually probed (a `<self>`
+/// triple names the running executable) — the value the §6 correlator
+/// matches the outside capture's reads against.
+fn trace_resolve(
+    start: tfs::trace::Start,
+    slot: &SlotRef,
+    mount: &str,
+    display: &str,
+    result: &Result<ResolvedImage, ResolveFailure>,
+) {
+    use tebako_json::Value;
+    let event = match result {
+        Ok(resolved) => match resolved.region {
+            ResolvedRegion::Whole => {
+                tfs::trace::Event::new(tfs::trace::Op::Resolve, display, "whole")
+                    .detail("slot", Value::String(slot_spelled(slot)))
+            }
+            // A Region answer always comes from a trailer probe that
+            // succeeded — the slots count rides along as the package's
+            // slot-table size. The slot number is the ref's (only a
+            // numeric ref resolves to a region); the Whole pairing is
+            // unreachable by construction, and the bus's law is that a
+            // trace-side surprise drops the event, never disturbs the
+            // run — so no unreachable!() panic here.
+            ResolvedRegion::Region(offset, size) => {
+                let slots = resolved
+                    .trailer
+                    .as_ref()
+                    .map_or(0, |t| t.slots.len() as u64);
+                let SlotRef::Slot(n) = slot else {
+                    return;
+                };
+                tfs::trace::Event::new(tfs::trace::Op::Resolve, display, format!("slot:{n}"))
+                    .detail("offset", tfs::trace::num(offset))
+                    .detail("size", tfs::trace::num(size))
+                    .detail("slots", tfs::trace::num(slots))
+            }
+        },
+        Err(f) => tfs::trace::Event::new(
+            tfs::trace::Op::Resolve,
+            display,
+            format!("error:{}", f.errno),
+        )
+        .detail("slot", Value::String(slot_spelled(slot)))
+        .detail("reason", Value::String(f.reason.to_string()))
+        .with_errno(f.errno),
+    };
+    tfs::trace::emit(
+        event
+            .detail("mount", Value::String(mount.to_string()))
+            .dur(start),
+    );
+}
+
+/// Emit the resolve failure that is decided ABOVE resolve_image: a
+/// `<self>` triple whose own executable carries no trailer probed clean
+/// (a `whole` answer) but is refused by the self-slot rule.
+fn trace_resolve_self_not_packaged(slot: &SlotRef, mount: &str, display: &str) {
+    let Some(start) = tfs::trace::Start::now() else {
+        return;
+    };
+    use tebako_json::Value;
+    tfs::trace::emit(
+        tfs::trace::Event::new(
+            tfs::trace::Op::Resolve,
+            display,
+            format!("error:{}", libc::EINVAL),
+        )
+        .detail("slot", Value::String(slot_spelled(slot)))
+        .detail("reason", Value::String("self-not-packaged".to_string()))
+        .detail("mount", Value::String(mount.to_string()))
+        .with_errno(libc::EINVAL)
+        .dur(start),
+    );
+}
+
+/// Probe a file's tpkg trailer and resolve the slot reference, tracing
+/// the decision (one `resolve` event per triple, BEFORE the mount it
+/// feeds — spec 25 §2). The disarmed cost is one relaxed atomic load.
+fn resolve_image(
+    path: &Path,
+    slot: SlotRef,
+    display: &str,
+    mount: &str,
+) -> Result<ResolvedImage, DriverError> {
+    let start = tfs::trace::Start::now();
+    let result = resolve_image_inner(path, slot, display);
+    if let Some(start) = start {
+        trace_resolve(start, &slot, mount, display, &result);
+    }
+    result.map_err(|f| f.error)
+}
+
+/// The trailer probe itself (the untraced core of [`resolve_image`]).
+fn resolve_image_inner(
+    path: &Path,
+    slot: SlotRef,
+    display: &str,
+) -> Result<ResolvedImage, ResolveFailure> {
+    let mut file = std::fs::File::open(path).map_err(|e| {
+        let errno = e.raw_os_error().unwrap_or(libc::EIO);
+        ResolveFailure::new(
+            errno,
+            "open",
+            unavailable(format!("cannot open image file '{display}': {e}")),
+        )
+    })?;
     match tpkg::read_from(&mut file) {
         Err(tpkg::TpkgError::NoTrailer) => match slot {
             SlotRef::Whole | SlotRef::Slot(0) => Ok(ResolvedImage {
                 region: ResolvedRegion::Whole,
                 trailer: None,
             }),
-            SlotRef::Slot(n) => Err(manifest(format!(
-                "--tebako-image slot {n} is out of range for '{display}' (a bare image file — no slot table; use slot 0 or -)"
-            ))),
+            SlotRef::Slot(n) => Err(ResolveFailure::new(
+                libc::EINVAL,
+                "no-trailer",
+                manifest(format!(
+                    "--tebako-image slot {n} is out of range for '{display}' (a bare image file — no slot table; use slot 0 or -)"
+                )),
+            )),
         },
-        Err(e) => Err(manifest(format!(
-            "corrupt tpkg manifest trailer in '{display}' ({e}) — re-stitch the package"
-        ))),
+        Err(e) => Err(ResolveFailure::new(
+            libc::EINVAL,
+            "corrupt-trailer",
+            manifest(format!(
+                "corrupt tpkg manifest trailer in '{display}' ({e}) — re-stitch the package"
+            )),
+        )),
         Ok(m) => match slot {
-            SlotRef::Whole => Err(manifest(format!(
-                "--tebako-image slot - names a whole bare image, but '{display}' is a package ({} slot(s)) — use a numeric slot",
-                m.slots.len()
-            ))),
+            SlotRef::Whole => Err(ResolveFailure::new(
+                libc::EINVAL,
+                "whole-on-package",
+                manifest(format!(
+                    "--tebako-image slot - names a whole bare image, but '{display}' is a package ({} slot(s)) — use a numeric slot",
+                    m.slots.len()
+                )),
+            )),
             SlotRef::Slot(n) => {
                 let Some(s) = m.slots.get(n as usize) else {
-                    return Err(manifest(format!(
-                        "--tebako-image slot {n} is out of range for '{display}' ({} slot(s) in its manifest)",
-                        m.slots.len()
-                    )));
+                    return Err(ResolveFailure::new(
+                        libc::ERANGE,
+                        "slot-out-of-range",
+                        manifest(format!(
+                            "--tebako-image slot {n} is out of range for '{display}' ({} slot(s) in its manifest)",
+                            m.slots.len()
+                        )),
+                    ));
                 };
                 if s.format_id == tpkg::TPKG_FORMAT_RUNTIME {
-                    return Err(manifest(format!(
-                        "--tebako-image slot {n} of '{display}' is a runtime payload slot — payload slots are never mounted"
-                    )));
+                    return Err(ResolveFailure::new(
+                        libc::EINVAL,
+                        "runtime-slot",
+                        manifest(format!(
+                            "--tebako-image slot {n} of '{display}' is a runtime payload slot — payload slots are never mounted"
+                        )),
+                    ));
                 }
                 Ok(ResolvedImage {
                     region: ResolvedRegion::Region(s.offset, s.size),
@@ -500,11 +655,18 @@ fn mount_image(
             let exe = std::env::current_exe()
                 .map_err(|e| io(format!("cannot determine own executable path: {e}")))?;
             let display = exe.display().to_string();
-            let resolved = resolve_image(&exe, SlotRef::Slot(*n), &display)?;
+            let resolved = resolve_image(&exe, SlotRef::Slot(*n), &display, &spec.mount)?;
             match resolved.region {
-                ResolvedRegion::Whole => Err(manifest(
-                    "the running executable carries no tpkg trailer — <self> slots require a stitched package",
-                )),
+                ResolvedRegion::Whole => {
+                    // The probe answered clean (a bare exe mounts whole
+                    // for a FILE triple) — but a <self> triple requires
+                    // the slot table. The refusal is the resolve
+                    // decision's own event (spec 25 §2).
+                    trace_resolve_self_not_packaged(&SlotRef::Slot(*n), &spec.mount, &display);
+                    Err(manifest(
+                        "the running executable carries no tpkg trailer — <self> slots require a stitched package",
+                    ))
+                }
                 ResolvedRegion::Region(offset, size) => {
                     let what = format!("failed to mount own slot {n} at '{}'", spec.mount);
                     let mount = build_error(
@@ -525,7 +687,7 @@ fn mount_image(
         }
         ImageSource::File(path, slot) => {
             let display = path.display().to_string();
-            let resolved = resolve_image(path, *slot, &display)?;
+            let resolved = resolve_image(path, *slot, &display, &spec.mount)?;
             let what = format!("failed to mount image '{display}' at '{}'", spec.mount);
             let mount = match resolved.region {
                 ResolvedRegion::Whole => {

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -292,6 +292,271 @@ fn a_broken_trace_channel_only_notes_and_the_boot_proceeds() {
     assert!(!tfs::trace::armed(), "the bus stayed disarmed");
 }
 
+// ---------------------------------------------------------------------
+// the resolve channel (spec 25 §2, phase T2): one `resolve` event per
+// --tebako-image triple, emitted BEFORE the mount it feeds. The env
+// image has no slot decision — it emits no resolve event.
+// ---------------------------------------------------------------------
+
+/// The capture's `resolve` events, parsed (the bus render shape).
+fn resolve_events(capture: &Path) -> Vec<tebako_json::Value> {
+    let text = std::fs::read_to_string(capture).expect("read the capture");
+    text.lines()
+        .map(|l| tebako_json::parse(l).expect("each capture line parses"))
+        .filter(|d| {
+            d.find("op")
+                .and_then(tebako_json::Value::as_string)
+                .as_deref()
+                == Some("resolve")
+        })
+        .collect()
+}
+
+fn field<'v>(doc: &'v tebako_json::Value, key: &str) -> &'v tebako_json::Value {
+    doc.find(key)
+        .unwrap_or_else(|| panic!("`{key}` present in {doc:?}"))
+}
+
+fn detail<'v>(doc: &'v tebako_json::Value, key: &str) -> &'v tebako_json::Value {
+    field(doc, "detail")
+        .find(key)
+        .unwrap_or_else(|| panic!("detail `{key}` present in {doc:?}"))
+}
+
+#[test]
+fn resolve_events_cover_the_whole_and_slot_decisions() {
+    let g = guard("resolve-ok");
+    let env_image = write_env_image(g.path());
+    let bare = write_payload_image(g.path());
+    let packaged = g.path().join("packaged.tfs");
+    build_zip(&packaged, &["tools/"], &[("tools/x", b"x\n".as_slice())]);
+    package_in_place(&packaged, tpkg::TPKG_FORMAT_ZIP);
+    let capture = g.path().join("trace.jsonl");
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+    env.set("TEBAKO_TRACE", capture.display().to_string());
+
+    boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:0:/", bare.display()),
+            "--tebako-image",
+            &format!("{}:0:/opt/tool", packaged.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap();
+
+    let events = resolve_events(&capture);
+    assert_eq!(
+        events.len(),
+        2,
+        "one resolve event per triple — the env image has no slot decision: {events:?}"
+    );
+
+    // The bare image: the whole-file decision, slot as spelled.
+    let whole = &events[0];
+    assert_eq!(
+        field(whole, "path").as_string().as_deref(),
+        Some(bare.to_str().unwrap())
+    );
+    assert_eq!(
+        field(whole, "verdict").as_string().as_deref(),
+        Some("whole")
+    );
+    assert_eq!(detail(whole, "slot").as_string().as_deref(), Some("0"));
+    assert_eq!(detail(whole, "mount").as_string().as_deref(), Some("/"));
+    assert_eq!(
+        field(whole, "pid").as_u64(),
+        Some(u64::from(std::process::id())),
+        "the resolve event rides the envelope's pid"
+    );
+
+    // The package: the slot region — the payload/slot identity the
+    // correlator matches the outside capture's byte-range reads against.
+    let slot = &events[1];
+    assert_eq!(
+        field(slot, "path").as_string().as_deref(),
+        Some(packaged.to_str().unwrap())
+    );
+    assert_eq!(
+        field(slot, "verdict").as_string().as_deref(),
+        Some("slot:0")
+    );
+    assert_eq!(detail(slot, "offset").as_u64(), Some(0));
+    assert!(
+        detail(slot, "size").as_u64().unwrap_or(0) > 0,
+        "the region's byte size: {slot:?}"
+    );
+    assert_eq!(detail(slot, "slots").as_u64(), Some(1));
+    assert_eq!(
+        detail(slot, "mount").as_string().as_deref(),
+        Some("/opt/tool")
+    );
+
+    // Each triple's resolve decision precedes the mount it feeds (the
+    // schema's ordering note): the resolve event naming the image lands
+    // before the mount event whose image detail names it. (The env
+    // image's mount comes first overall — it has no resolve event.)
+    let text = std::fs::read_to_string(&capture).unwrap();
+    let lines: Vec<&str> = text.lines().collect();
+    let at = |op: &str, image: &str| {
+        lines
+            .iter()
+            .position(|l| l.contains(&format!("\"op\":\"{op}\"")) && l.contains(image))
+            .unwrap_or_else(|| panic!("a {op} event naming {image}: {text}"))
+    };
+    for image in [bare.display().to_string(), packaged.display().to_string()] {
+        assert!(
+            at("resolve", &image) < at("mount", &image),
+            "resolve precedes the mount for {image}: {text}"
+        );
+    }
+}
+
+/// One failing boot with the bus armed; returns the resolve events.
+fn resolve_failure_capture(
+    g: &Guard,
+    tag: &str,
+    triple: &str,
+) -> (tebako_driver::DriverError, Vec<tebako_json::Value>) {
+    let capture = g.path().join(format!("{tag}.jsonl"));
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_TRACE", capture.display().to_string());
+    let err = boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            triple,
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap_err();
+    (err, resolve_events(&capture))
+}
+
+#[test]
+fn resolve_errors_carry_the_errno_and_the_failure_class() {
+    let g = guard("resolve-err");
+    let bare = write_payload_image(g.path());
+    let packaged = g.path().join("packaged.tfs");
+    build_zip(&packaged, &["tools/"], &[("tools/x", b"x\n".as_slice())]);
+    package_in_place(&packaged, tpkg::TPKG_FORMAT_ZIP);
+    let runtime_slotted = g.path().join("runtime.tfs");
+    build_zip(
+        &runtime_slotted,
+        &["tools/"],
+        &[("tools/x", b"x\n".as_slice())],
+    );
+    package_in_place(&runtime_slotted, tpkg::TPKG_FORMAT_RUNTIME);
+
+    // (triple, boot exit code, errno, reason): the named boot errors are
+    // unchanged (65 manifest / 69 unavailable); the event carries the
+    // errno-level fact and the class.
+    let cases: Vec<(String, i32, i32, &str)> = vec![
+        (
+            format!("{}:3:/", bare.display()),
+            65,
+            libc::EINVAL,
+            "no-trailer",
+        ),
+        (
+            format!("{}:3:/", packaged.display()),
+            65,
+            libc::ERANGE,
+            "slot-out-of-range",
+        ),
+        (
+            format!("{}:-:/", packaged.display()),
+            65,
+            libc::EINVAL,
+            "whole-on-package",
+        ),
+        (
+            format!("{}:0:/", runtime_slotted.display()),
+            65,
+            libc::EINVAL,
+            "runtime-slot",
+        ),
+        (
+            format!("{}:0:/", g.path().join("nope.tfs").display()),
+            69,
+            libc::ENOENT,
+            "open",
+        ),
+    ];
+    for (i, (triple, code, errno, reason)) in cases.iter().enumerate() {
+        let (err, events) = resolve_failure_capture(&g, &format!("case{i}"), triple);
+        assert_eq!(err.code, *code, "{triple}: {}", err.message);
+        assert_eq!(events.len(), 1, "{triple}: one resolve event: {events:?}");
+        let event = &events[0];
+        let verdict = format!("error:{errno}");
+        assert_eq!(
+            field(event, "verdict").as_string().as_deref(),
+            Some(verdict.as_str()),
+            "{triple}"
+        );
+        // The schema's typed-duplicate rule: the errno field IS the
+        // verdict suffix.
+        assert_eq!(
+            field(event, "errno").as_u64(),
+            Some(*errno as u64),
+            "{triple}"
+        );
+        assert_eq!(
+            detail(event, "reason").as_string().as_deref(),
+            Some(*reason),
+            "{triple}"
+        );
+        assert_eq!(detail(event, "mount").as_string().as_deref(), Some("/"));
+        assert!(
+            !context().read().unwrap().is_mounted(),
+            "{triple}: a refused boot leaves nothing mounted"
+        );
+    }
+}
+
+#[test]
+fn a_self_triple_without_a_trailer_traces_the_probe_and_the_refusal() {
+    let g = guard("resolve-self");
+    // The test executable carries no tpkg trailer: `self:0` probes clean
+    // (a bare file mounts whole for a FILE triple) and the self-slot
+    // rule then refuses — two resolve events, one decision each.
+    let (err, events) = resolve_failure_capture(&g, "self", "self:0:/");
+    assert_eq!(err.code, 65, "{}", err.message);
+    assert!(
+        err.message.contains("carries no tpkg trailer"),
+        "{}",
+        err.message
+    );
+    assert_eq!(events.len(), 2, "the probe + the refusal: {events:?}");
+    assert_eq!(
+        field(&events[0], "verdict").as_string().as_deref(),
+        Some("whole")
+    );
+    assert_eq!(
+        field(&events[1], "verdict").as_string().as_deref(),
+        Some(format!("error:{}", libc::EINVAL).as_str())
+    );
+    assert_eq!(
+        detail(&events[1], "reason").as_string().as_deref(),
+        Some("self-not-packaged")
+    );
+    // The event's path is the file actually probed: the running exe.
+    let exe = std::env::current_exe().unwrap();
+    assert_eq!(
+        field(&events[0], "path").as_string().as_deref(),
+        Some(exe.to_str().unwrap())
+    );
+}
+
 #[test]
 fn bare_payload_mounts_whole_with_slot_0() {
     let g = guard("bare-0");

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -1589,7 +1589,7 @@ impl FsContext {
     }
 
     /// The exec surface's answer for a memfs path (the preload's
-    /// execve/posix_spawn routing): a mount whose in-image manifest
+    /// execve routing): a mount whose in-image manifest
     /// declares the home annotation (`identity.annotations.java_home` —
     /// the payload root IS a tool home, spec 03's free-form annotations)
     /// materializes WHOLE once per process and the answer is the host
@@ -1603,6 +1603,20 @@ impl FsContext {
     /// ENOENT fallthrough (the §4 entrypoint-note signal), or
     /// `error:<errno>`.
     pub fn exec_materialize(&mut self, path: &str) -> Result<std::ffi::CString, i32> {
+        self.exec_materialize_op(path, trace::Op::Exec)
+    }
+
+    /// The posix_spawn surface's answer (spec 25 §2, phase T2): the
+    /// identical routing decision, emitted as `spawn` — the op token is
+    /// the process-tree signal (execve replaces the process, a spawn
+    /// creates a child whose events carry a new pid).
+    pub fn exec_materialize_for_spawn(&mut self, path: &str) -> Result<std::ffi::CString, i32> {
+        self.exec_materialize_op(path, trace::Op::Spawn)
+    }
+
+    /// The shared exec/spawn routing: one decision, the op naming the
+    /// syscall surface it serves (the §2 table's single exec/spawn row).
+    fn exec_materialize_op(&mut self, path: &str, op: trace::Op) -> Result<std::ffi::CString, i32> {
         let normalized = Self::normalize(path);
         let trace_start = trace::Start::now();
         if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
@@ -1627,18 +1641,17 @@ impl FsContext {
             if let Some(start) = trace_start {
                 let event = match &result {
                     Ok(host) => trace::Event::new(
-                        trace::Op::Exec,
+                        op,
                         &normalized,
                         format!("routed:{}", host.to_string_lossy()),
                     )
                     .detail("route", Value::String("dlmap-closure".to_string())),
                     // ENOENT: nothing held — the consumer execs the host
                     // path (the §4 entrypoint/runtime-dep note signal).
-                    Err(e) if *e == libc::ENOENT => {
-                        trace::Event::new(trace::Op::Exec, &normalized, "host")
+                    Err(e) if *e == libc::ENOENT => trace::Event::new(op, &normalized, "host"),
+                    Err(e) => {
+                        trace::Event::new(op, &normalized, format!("error:{e}")).with_errno(*e)
                     }
-                    Err(e) => trace::Event::new(trace::Op::Exec, &normalized, format!("error:{e}"))
-                        .with_errno(*e),
                 };
                 trace::emit(event.dur(start));
             }
@@ -1647,13 +1660,9 @@ impl FsContext {
         if rel.is_empty() {
             if let Some(start) = trace_start {
                 trace::emit(
-                    trace::Event::new(
-                        trace::Op::Exec,
-                        &normalized,
-                        format!("error:{}", libc::EISDIR),
-                    )
-                    .with_errno(libc::EISDIR)
-                    .dur(start),
+                    trace::Event::new(op, &normalized, format!("error:{}", libc::EISDIR))
+                        .with_errno(libc::EISDIR)
+                        .dur(start),
                 );
             }
             return Err(libc::EISDIR);
@@ -1663,7 +1672,7 @@ impl FsContext {
             Err(e) => {
                 if let Some(start) = trace_start {
                     trace::emit(
-                        trace::Event::new(trace::Op::Exec, &normalized, format!("error:{e}"))
+                        trace::Event::new(op, &normalized, format!("error:{e}"))
                             .with_errno(e)
                             .dur(start),
                     );
@@ -1675,13 +1684,9 @@ impl FsContext {
             let Some(mount) = self.mounts.get(&handle) else {
                 if let Some(start) = trace_start {
                     trace::emit(
-                        trace::Event::new(
-                            trace::Op::Exec,
-                            &normalized,
-                            format!("error:{}", libc::ENODEV),
-                        )
-                        .with_errno(libc::ENODEV)
-                        .dur(start),
+                        trace::Event::new(op, &normalized, format!("error:{}", libc::ENODEV))
+                            .with_errno(libc::ENODEV)
+                            .dur(start),
                     );
                 }
                 return Err(libc::ENODEV);
@@ -1690,7 +1695,7 @@ impl FsContext {
             if let Err(e) = extract_dir_recursive(mount.backend.as_ref(), "", &root, &mut skipped) {
                 if let Some(start) = trace_start {
                     trace::emit(
-                        trace::Event::new(trace::Op::Exec, &normalized, format!("error:{e}"))
+                        trace::Event::new(op, &normalized, format!("error:{e}"))
                             .with_errno(e)
                             .dur(start),
                     );
@@ -1703,14 +1708,9 @@ impl FsContext {
             std::ffi::CString::new(host.to_string_lossy().into_owned()).map_err(|_| libc::EIO);
         if let Some(start) = trace_start {
             let event = match &result {
-                Ok(_) => trace::Event::new(
-                    trace::Op::Exec,
-                    &normalized,
-                    format!("routed:{}", host.display()),
-                )
-                .detail("route", Value::String("home-tree".to_string())),
-                Err(e) => trace::Event::new(trace::Op::Exec, &normalized, format!("error:{e}"))
-                    .with_errno(*e),
+                Ok(_) => trace::Event::new(op, &normalized, format!("routed:{}", host.display()))
+                    .detail("route", Value::String("home-tree".to_string())),
+                Err(e) => trace::Event::new(op, &normalized, format!("error:{e}")).with_errno(*e),
             };
             trace::emit(event.dur(start));
         }

--- a/crates/tfs/src/trace.rs
+++ b/crates/tfs/src/trace.rs
@@ -48,11 +48,12 @@
 //!
 //! ## Op vocabulary
 //!
-//! [`Op`] is the full §2 table. `Spawn` and `Resolve` are defined now so
-//! the vocabulary is stable, but their emission points are later
-//! integration (the preload's posix_spawn path and tebako-resolve — T2+);
-//! T1 emits mount/open/stat/dlopen/exec/materialize/jail from
-//! [`crate::context`].
+//! [`Op`] is the full §2 table. T1 emits mount/open/stat/dlopen/exec/
+//! materialize/jail from [`crate::context`]; T2 adds `Spawn` (the same
+//! context routing, selected by the preload's posix_spawn surface) and
+//! `Resolve` (emitted by the tebako-driver's image-triple resolution —
+//! the bus itself stays emitter-agnostic: anything linked against tfs
+//! appends through [`emit`]).
 
 use std::fmt;
 use std::fs::{File, OpenOptions};
@@ -90,13 +91,16 @@ pub enum Op {
     Stat,
     Dlopen,
     Exec,
-    /// Later integration (T2: the preload's posix_spawn path). Defined
-    /// now so the vocabulary is stable.
+    /// The posix_spawn surface's routing decision (T2: the preload's
+    /// posix_spawn/posix_spawnp path — same grammar as `Exec`, the op
+    /// token marking that a child process is created).
     Spawn,
     Materialize,
     Jail,
-    /// Later integration (T2+: tebako-resolve is L3, outside this
-    /// crate). Defined now so the vocabulary is stable.
+    /// The driver's `--tebako-image` triple resolution (T2:
+    /// tebako-driver's resolve_image — whole / slot:<n> / error:<errno>).
+    /// The PLANNED L3 cache resolution (cache/fetched) rides the same op
+    /// when its loader-side channel story lands.
     Resolve,
 }
 
@@ -692,6 +696,14 @@ mod tests {
             materialized = ctx.dlmap2file("/tfs/data/secret.txt").unwrap();
             assert_eq!(routed, materialized);
 
+            // The spawn surface (spec 25 §2's shared exec/spawn row, phase
+            // T2): the same routing decision, emitted as `spawn` — the
+            // preload's posix_spawn path's op.
+            let spawned = ctx
+                .exec_materialize_for_spawn("/tfs/data/secret.txt")
+                .unwrap();
+            assert_eq!(materialized, spawned);
+
             // The dlmap-prefix redirect (the §4 class-R materialize
             // signal): opening the materialized copy's path serves a raw
             // host fd under the `image:<mount>` verdict. The fd is left
@@ -764,9 +776,23 @@ mod tests {
                         || verdict.starts_with("allow:")
                         || verdict.starts_with("deny:")
                 }
-                // T1 never emits these (the vocabulary is stable, the
-                // emission points are T2+).
-                "spawn" | "resolve" => false,
+                // T2: the spawn surface shares the exec row's grammar
+                // (the preload's posix_spawn path routes here).
+                "spawn" => {
+                    verdict == "host"
+                        || verdict.starts_with("routed:")
+                        || verdict.starts_with("error:")
+                }
+                // T2: the driver's image-triple resolution (whole /
+                // slot:<n> / error:<errno>); the L3 cache/fetched half is
+                // PLANNED — listed so a stream carrying it validates.
+                "resolve" => {
+                    verdict == "whole"
+                        || verdict.starts_with("slot:")
+                        || verdict == "cache"
+                        || verdict == "fetched"
+                        || verdict.starts_with("error:")
+                }
                 _ => false,
             }
         };
@@ -858,6 +884,7 @@ mod tests {
         assert!(has("jail", "deny:"), "jail deny: {seen:?}");
         assert!(has("dlopen", "materialized:"), "dlopen: {seen:?}");
         assert!(has("exec", "routed:"), "exec routed: {seen:?}");
+        assert!(has("spawn", "routed:"), "spawn routed: {seen:?}");
         assert!(has("materialize", "ok:"), "materialize ok: {seen:?}");
         assert!(has("materialize", "cache-hit"), "materialize hit: {seen:?}");
 
@@ -918,6 +945,13 @@ mod tests {
         let exec = detail_of("exec", "routed:");
         assert_eq!(
             exec.find("route").and_then(Value::as_string).as_deref(),
+            Some("dlmap-closure")
+        );
+        // The spawn event is the exec row's grammar on the child-creating
+        // surface — the op token is the only difference.
+        let spawn = detail_of("spawn", "routed:");
+        assert_eq!(
+            spawn.find("route").and_then(Value::as_string).as_deref(),
             Some("dlmap-closure")
         );
         // The dlopen event carries the closure walk (schema §2): a

--- a/docs/spec/00-INDEX.md
+++ b/docs/spec/00-INDEX.md
@@ -55,7 +55,7 @@ spec 02 §6).
 22. [22 — Runtime-native interposition](22-runtime-native-interposition.md) — the generalized hooks: loader/exec/resource interposition inside the runtime, the documented interface, and the death of per-gem adapters (the spec-18 contract's runtime-internal half)
 23. [23 — Declarative composition and needs resolution](23-declarative-composition.md) — the fully declarative slice stack: D1 needs / D2 composition doc / D3 press-baked union / D4-D5 operator surfaces; deny-safe by default, the needs-check law (PLANNED)
 24. [24 — Declarative overlays](24-declarative-overlays.md) — write areas and key bindings: the gated COW write gate, `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT`, the record-mode fold-in, exit 68 (PARTIAL)
-25. [25 — Trace observability](25-trace-observability.md) — the interception bus, `tebako trace run|explain|cover`, the escapes correlation (PARTIAL)
+25. [25 — Trace observability](25-trace-observability.md) — the interception bus, `tebako trace run|explain|cover`, the escapes correlation (PARTIAL — the bus + `trace run` + the spawn/resolve emission shipped; `cover` + the procmon converter are T3, `explain` T4)
 26. [26 — Payload checks](26-payload-checks.md) — the in-image self-validation contract: the `checks:` manifest block, `tebako check` at press/install/discovery moments, SKIP discipline, exit 79 (PARTIAL — the block + the engine shipped; the §3 press/install gate wiring remains)
 
 ## Locked invariants (all specs subordinate to these)

--- a/docs/spec/25-trace-observability.md
+++ b/docs/spec/25-trace-observability.md
@@ -2,8 +2,11 @@
 
 **Status: PARTIAL (phase T1 shipped 2026-08-19: the `tfs::trace`
 interception bus + `docs/spec/schemas/trace-event.yaml` + `tebako trace
-run`; `explain` is T2, `cover` + the procmon converter are T3.
-Owner-signed 2026-08-19 — architecture A: the in-tfs
+run`; phase T2 shipped 2026-08-20: the `spawn`/`resolve` emission — the
+preload's posix_spawn surface and the driver's image-triple resolution;
+`cover` + the procmon converter are T3, `explain` is T4 — re-phased
+2026-08-20: emission completeness precedes the replay/correlation
+front-ends. Owner-signed 2026-08-19 — architecture A: the in-tfs
 event bus + `tebako trace` front-ends; outside capture rides the
 three-layer producer model of §6.1, with retrace as the libc-boundary
 layer on BOTH platforms).**
@@ -81,10 +84,10 @@ already implements, one event per decision:
 | `mount` | mount table insert/remove | `ok` / `error:<errno>` |
 | `open` / `stat` | path dispatch (spec 11) | `image:<mount>` / `host` / `denied:<rule>` / `error:<errno>` |
 | `dlopen` | `dlmap2file` / `dlalias2file` | `materialized:<host-path>` / `host` / `error:<errno>` |
-| `exec` / `spawn` | exec routing (spec 17/22) | `routed:<entry>` / `host` / `error:<errno>` |
+| `exec` / `spawn` | exec routing (spec 17/22) — one routing decision, two syscall surfaces: `exec` is the execve surface (process replacement), `spawn` the posix_spawn surface (a child is created — the correlator's process-tree signal) | `routed:<entry>` / `host` / `error:<errno>` |
 | `materialize` | exec-cache extraction | `ok:<host-path>` / `cache-hit` / `error:<errno>` |
 | `jail` | policy bind / check (spec 08, 23 §8) | `allow:<rule>` / `deny:<rule>` / `record` |
-| `resolve` | runtime/payload resolution (L3) | `cache` / `fetched` / `error` |
+| `resolve` | the driver's `--tebako-image <path>:<slot>:<mount>` resolution (trailer probe → whole file or slot region — the payload/slot identity the correlator matches outside reads against). **PLANNED:** the L3 runtime/payload cache resolution (tebako-resolve — loader-side, outside the runtime process; its channel story lands with the phase that needs it) | `whole` / `slot:<n>` / `error:<errno>` — PLANNED L3 half: `cache` / `fetched` / `error` |
 
 The `dlopen` event's `detail` carries the closure walk as structure —
 the parsed format, the dep list, each dep's resolve verdict
@@ -287,8 +290,14 @@ coverage features as these land upstream; none block T1/T2:
 | phase | contents | dogfood |
 |-------|----------|---------|
 | T1 | the bus + schema + `run` (discovery) | the msys dogfood rides the bus; a payload author onboards a fresh gem without hand diagnostics |
-| T2 | `explain` (diagnosis) | replay the incident-13 captures; the named hop matches history |
+| T2 | the `spawn`/`resolve` emission: the preload's posix_spawn surface reports `spawn` (a child-process decision — the correlator's process-tree signal), and the driver emits one `resolve` event per `--tebako-image` triple (the payload/slot identity: whole / `slot:<n>` + offset/size/mount, or the named failure class) | a traced boot of a broken composition names the failing triple in the capture itself — no stderr spelunking; a traced run's spawns regroup by pid |
 | T3 | `cover` (certification) + the procmon converter | a dogfood leg under retrace on both platforms (libc layer); a kernel-layer leg (ptrace/eBPF on linux, procmon-converter on windows) as the §6.4 prerequisites land; escapes report in CI |
+| T4 | `explain` (diagnosis) | replay the incident-13 captures; the named hop matches history |
+
+(Re-phased 2026-08-20: emission completeness precedes the front-ends —
+the original T2 (`explain`) is T4, the original T3 (`cover` + the
+converter) stays T3, and T2 is the spawn/resolve emission the
+correlator's inputs depend on.)
 
 Each phase ships behind its own PR chain against this spec; the spec
 moves PLANNED → PARTIAL → SHIPPED per phase (spec 00's status law).

--- a/docs/spec/schemas/trace-event.yaml
+++ b/docs/spec/schemas/trace-event.yaml
@@ -6,9 +6,10 @@
 # owns the wire grammar: the envelope fields, the op vocabulary, and the
 # per-op verdict/detail keys.
 #
-# SSOT: this file owns the grammar; crates/tfs/src/trace.rs (the emitter)
-# and crates/tebako-cli/src/trace.rs (the `tebako trace run` consumer)
-# mirror it — keep the three in sync in the same PR. The property test in
+# SSOT: this file owns the grammar; crates/tfs/src/trace.rs (the emitter),
+# crates/tebako-driver/src/driver.rs (the resolve emitter), and
+# crates/tebako-cli/src/trace.rs (the `tebako trace run` consumer)
+# mirror it — keep the four in sync in the same PR. The property test in
 # crates/tfs/src/trace.rs drives the op matrix against a mounted fixture
 # and validates every emitted event against this grammar.
 # =============================================================================
@@ -18,7 +19,7 @@ schema_version: 1 # MAJOR — the envelope's `v` field; additive-only, NEVER bum
 schema_minor: 0 # MINOR — additive counter (unused while v1 grows by ops/keys)
 status: normative
 owner: crates/tfs (tfs::trace, the bus) in tamatebako/tebako
-edge: T1 (driver/context → trace channel), T1' (channel → tebako trace run generator)
+edge: T1 (driver/context → trace channel), T1' (channel → tebako trace run generator), T2 (preload posix_spawn surface → spawn; driver resolve_image → resolve)
 
 # The schema evolution law (spec 18 §3), specialized for an append-only
 # event stream: events are never re-read by their emitter, so evolution
@@ -147,14 +148,57 @@ grammar:
         reports an empty walk (format: null, deps: []) — the walk did not
         re-run; the paired materialize event carries cache-hit.
     exec:
-      emitter: crates/tfs/src/context.rs (exec_materialize — the preload's execve/posix_spawn routing)
+      emitter: crates/tfs/src/context.rs (exec_materialize — the execve-surface routing; the preload's execve and the C ABI's tebako_fs_exec_materialize)
       verdicts: ["routed:<host-path>", "host", "error:<errno>"]
       detail_keys:
         route: "home-tree | dlmap-closure"
       notes: >-
         verdict `host` on the ENOENT fallthrough is the spec 25 §4
         entrypoint/runtime-dep note signal (a spawned host-absolute
-        executable).
+        executable). The interpreter's own spawn hook (spec 22 rule E1)
+        rides the C ABI's exec surface — splitting it onto the spawn
+        vocabulary is factory-side follow-up, not a bus change.
+    spawn:
+      emitter: crates/tfs/src/context.rs (exec_materialize_for_spawn — the preload's posix_spawn/posix_spawnp routing; phase T2)
+      verdicts: ["routed:<host-path>", "host", "error:<errno>"]
+      detail_keys:
+        route: "home-tree | dlmap-closure"
+      notes: >-
+        The exec row's grammar on the child-creating surface (spec 25 §2):
+        same routing decision, same details — the op token is the
+        process-tree signal (a spawn means later events may carry a NEW
+        pid: the child's re-derived channel). A bare-name posix_spawnp
+        (no '/' in the file argument) is a host PATH search that never
+        consults the VFS — no routing decision exists, so no event; the
+        correlator treats it as a KNOWN-UNSERVED passthrough (§6.3).
+        Emitted at the routing decision, BEFORE the real spawn runs: the
+        child pid is not the event's to carry (the child's own events
+        report their own pid).
+    resolve:
+      emitter: crates/tebako-driver/src/driver.rs (resolve_image — the --tebako-image <path>:<slot>:<mount> triple → mount-region decision; phase T2)
+      verdicts: [whole, "slot:<n>", "error:<errno>"]
+      detail_keys:
+        slot: "the slot reference as spelled (`0`…`n` or `-`) — on whole and error verdicts (a slot:<n> verdict carries n itself)"
+        mount: "the triple's mount point (the physical, drive-qualified point on windows)"
+        offset: "int — the slot region's byte offset in the image file, on slot:<n>"
+        size: "int — the slot region's byte size, on slot:<n>"
+        slots: "int — the package's slot count, on slot:<n>"
+        reason: "open | no-trailer | corrupt-trailer | whole-on-package | slot-out-of-range | runtime-slot | self-not-packaged — the failure class, on error:<errno>"
+      notes: >-
+        One event per --tebako-image triple, BEFORE the mount it feeds:
+        path is the host file actually probed (a `<self>` triple names
+        the running executable), the verdict is the resolution class, and
+        the slot:<n> details are the payload/slot identity the §6
+        correlator matches the outside capture's byte-range reads
+        against. The env image (TEBAKO_RUNTIME_IMAGE) emits NO resolve
+        event — it is bare by construction (no slot decision); its mount
+        event covers it. Failures carry the closest errno-level fact
+        (the open's raw errno; EINVAL for the grammar refusals; ERANGE
+        for slot-out-of-range) with the named class in `reason`; the
+        boot's named-error path (exit codes 65/69) is unchanged.
+        PLANNED: the L3 runtime/payload cache resolution (tebako-resolve
+        — loader-side, outside the runtime process) adds verdicts
+        `cache` / `fetched` / `error` when its channel story lands.
     materialize:
       emitter: crates/tfs/src/context.rs (extract_for_exec — dlopen/exec extractions and tebako install's store-side pass)
       verdicts: ["ok:<host-path>", "cache-hit", "error:<errno>"]
@@ -179,20 +223,14 @@ grammar:
         (never under the open default — the op events carry those
         passthroughs). A policy-gated decision yields BOTH its op event
         and the jail event: two layers of one decision, by design.
-    spawn:
-      emitter: "none in phase T1 (T2: libtfs-preload's posix_spawn path)"
-      verdicts: ["routed:<entry>", "host", "error:<errno>"]
-      notes: Defined now so the vocabulary is stable; unemitted in T1.
-    resolve:
-      emitter: "none in phase T1 (T2+: tebako-resolve, the L3 layer)"
-      verdicts: [cache, fetched, "error:<errno>"]
-      notes: Defined now so the vocabulary is stable; unemitted in T1.
 
 notes: >-
   Phase T1 emits mount/open/stat/dlopen/exec/materialize/jail from the
-  tfs context. The driver's class-R boot materialization
+  tfs context; phase T2 adds spawn (the same context routing, the
+  preload's posix_spawn surface) and resolve (the driver's image-triple
+  resolution). The driver's class-R boot materialization
   (crates/tebako-driver/src/materialize.rs — declared-manifest
-  resources, merkle-verified) is deliberately NOT instrumented in T1: it
+  resources, merkle-verified) is deliberately NOT instrumented: it
   is boot work outside the interception surface, and its failures already
   abort the boot loudly. The TEBAKO_DEBUG_TFS eprintln gates remain as
   the human-readable degraded view over the same emission points.


### PR DESCRIPTION
## What — spec 25 phase T2: spawn/resolve trace emission

Second phase of the trace-observability toolkit (spec 25; T1 = #422, merged). Extends the T1 interception bus with the two remaining producer families:

- **Spawn emission** — `tfs::context::exec_materialize_for_spawn` routes through the preload `posix_spawn`/`posix_spawnp` shims so host-exec spawns land on the trace bus. Bare-name `spawnp` (PATH search, no file touch) passes through event-free, per `trace-event.yaml`.
- **Resolve emission** — the driver emits one resolve event per image argument: `whole` (bare file, slot `-`/`0`), `slot:<n>` (trailer-described region), or `error:<errno>`, carrying the seven `reason` classes from the schema. The env image (`TEBAKO_RUNTIME_IMAGE`) is excluded by design; resolve-before-mount ordering is pinned by the boot tests.
- **CLI** — `tebako trace` joins `spawn` events into the host-exec note so a trace reads as one causal chain.
- Spec 25 + `docs/spec/schemas/trace-event.yaml` + the spec index are updated to the shipped semantics. Named errors and exit codes are unchanged (bus is observability-only).

Out of scope (T3): the correlator against the retrace `06-libsass` golden fixture.

## Evidence

- `cargo fmt --check` clean.
- Code reviewed against spec 25 + the schema: spawn routing, resolve outcome classes, env-image exclusion, resolve-before-mount ordering, CLI join — all coherent.
- Local gates on `8c90ab3f` (rebased onto `5f0d7176` post-#426): clippy `-D warnings` clean on tfs / libtfs-preload / tebako-driver / tebako-cli (`--all-targets`); tests green — tebako-driver 62 + 6 + 2 (incl. the new resolve-outcome and resolve-before-mount boot tests), tfs 178, tebako-cli 16, 0 failed; `tebako-bootstrap` pre-build OK. `cargo fmt --check` clean.

## Notes

- Stacks on main `3c6d3c60` (spec 26 T2, #423). No manifest overlap with the concurrent limnifs registry PR (`deps/limnifs-crates-io`) — this touches `tebako-driver/Cargo.toml` only, that one touches tfs/tfs-cli/tebako-cli/tests-contract manifests.


## Postmortem — the ubuntu CI hang (fixed in `c60ff20b`)

The first push's ubuntu leg hung ~5h in `cargo test` (baseline: 15 min on main). Cancelled for its logs, which named the hung test: `route::tests::route_matrix` (libtfs-preload unit binary). Root cause: the new T2 assertions called the route layer **directly**, leaving the shims' `IN_ENGINE` re-entrancy guard unset — the extraction's host writes then re-entered the in-process-interposed `open` shim under the held context write lock → same-thread deadlock. glibc-only: macOS test binaries never interpose their own calls (two-level namespace), so all local gates were green. Production was never affected — real entries come through the shims, which set the guard.

Fix: `engine_call` is now `pub(crate)` and documented as the test seam; the block enters through it (the production shape). Verified locally: route_matrix 4/4, integration 16/16, clippy `-D warnings` clean. The fresh CI run on `c60ff20b` is the authoritative glibc verdict.
