### PR TITLE
spec 25: trace import procmon (rest of T3) + trace explain (T4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ payloads (inkscape & co.) are feedstocks in the
 | `tebako run <pkg>` | run a pressed package with a user jail tightening (`--jail`/`--mount`/`--no-host`) |
 | `tebako trace run <pkg>` | run under `record` with the trace bus armed; synthesize a suggested manifest (needs/materialize/notes — spec 25 §4) |
 | `tebako trace cover` | the escapes report: correlate an inside capture against an outside retrace capture under `--prefix` (golden-parity with retrace-correlate — spec 25 §6) |
+| `tebako trace import procmon <csv>` | convert a procmon CSV export into the retrace-shaped JSON outside stream `cover` consumes (byte-parity with procmon2retrace — spec 25 §6.2) |
+| `tebako trace explain <capture>` | replay a capture into the hop chain and name the first red hop (the signature table lives in data — spec 25 §5) |
 | `tebako check <target>` | run a payload's in-image acceptance checks — a name, a bare `.tfs` (with `--runtime`/`--runtime-image`), a pressed package, or a composition `tebako.yaml`; `--list`/`--check`/`--record`/`--keep-scratch` (spec 26 §2) |
 | `tebako install <ref\|name@ver>` | install a payload from a registry + register its shims |
 | `tebako info [topic]` | the store/system surface: system, runtimes, payloads, shims, registries, store (`--remote` adds what the world offers; `--json` everywhere) |

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -587,7 +587,8 @@ fn run_trace(args: &[String]) -> Result<(), CliExit> {
     };
     match action.as_str() {
         "run" => {
-            let parsed = tebako_cli::trace::parse_trace_run_args(&args[1..]).map_err(CliExit::Usage)?;
+            let parsed =
+                tebako_cli::trace::parse_trace_run_args(&args[1..]).map_err(CliExit::Usage)?;
             tebako_cli::trace::trace_run(&parsed)?;
             Ok(())
         }
@@ -596,7 +597,9 @@ fn run_trace(args: &[String]) -> Result<(), CliExit> {
         other @ "explain" => Err(CliExit::Usage(format!(
             "'tebako trace {other}' is a later tebako-rs milestone (spec 25: explain is T4)"
         ))),
-        other => Err(CliExit::Usage(format!("unknown trace subcommand '{other}'"))),
+        other => Err(CliExit::Usage(format!(
+            "unknown trace subcommand '{other}'"
+        ))),
     }
 }
 

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -26,6 +26,11 @@ const USAGE: &str = "Usage:
                                        the escapes report (spec 25 §6, phase T3): outside
                                        touches under the prefix the inside stream never saw
                                        (exit 0 clean / 1 escapes / 2 error)
+  tebako trace import procmon <capture.csv>
+                                       the spec 25 §6.2 offline converter: a procmon CSV
+                                       export becomes the retrace-shaped JSON outside
+                                       stream cover consumes (exit 0 converted /
+                                       1 zero entries / 2 error)
   tebako check <name | image.tfs | package | tebako.yaml>
                [--check <c>] [--list] [--record] [--keep-scratch]
                [--runtime <exe> --runtime-image <env.tfs>]
@@ -92,11 +97,13 @@ fn run(args: &[String]) -> Result<(), CliExit> {
     // stderr so stdout is the document alone. Every other call keeps the
     // banner on stdout (unchanged). `trace cover` is a machine contract
     // too: its stdout byte-compares against the retrace golden fixtures
-    // (spec 25 §6.3's parity clause).
+    // (spec 25 §6.3's parity clause). `trace import` likewise: its
+    // stdout is the converted retrace JSON document (spec 25 §6.2).
     let machine_stdout = (subcommand == "cache"
         && rest.first().map(|a| a.as_str()) == Some("list")
         && rest.iter().any(|a| a == "--json"))
-        || (subcommand == "trace" && rest.first().map(|a| a.as_str()) == Some("cover"));
+        || (subcommand == "trace"
+            && matches!(rest.first().map(|a| a.as_str()), Some("cover" | "import")));
     if machine_stdout {
         eprintln!("{VERSION_BANNER}");
     } else {
@@ -559,20 +566,22 @@ fn run_package(args: &[String]) -> Result<(), CliExit> {
     Err(CliExit::Error(err))
 }
 
-/// `tebako trace <run|cover> ...` — the spec 25 front-ends. `run` (§4,
-/// phase T1, discovery) runs the package under `TEBAKO_JAIL=record` with
-/// the interception bus armed, then synthesizes the capture into a
+/// `tebako trace <run|cover|import> ...` — the spec 25 front-ends. `run`
+/// (§4, phase T1, discovery) runs the package under `TEBAKO_JAIL=record`
+/// with the interception bus armed, then synthesizes the capture into a
 /// suggested-manifest draft; it never returns on success (the process
 /// exits with the payload's exit code). `cover` (§6, phase T3) is the
 /// escapes correlator; it never returns either (the exit code is the
 /// coverage verdict: 0 clean / 1 escapes / 2 usage-or-IO, the
-/// retrace-correlate parity codes). The spawn/resolve emission is T2
-/// (bus-side, landed); `import` (the procmon converter, the rest of T3)
-/// and `explain` (§5, T4) are later milestones.
+/// retrace-correlate parity codes). `import` (§6.2, the rest of T3) is
+/// the procmon converter; it never returns (0 converted / 1 zero
+/// entries / 2 usage-or-IO, procmon2retrace's codes). The spawn/resolve
+/// emission is T2 (bus-side, landed); `explain` (§5, T4) is a later
+/// milestone.
 fn run_trace(args: &[String]) -> Result<(), CliExit> {
     let Some(action) = args.first() else {
         return Err(CliExit::Usage(
-            "trace subcommand expected: run | cover (explain | import are later milestones)"
+            "trace subcommand expected: run | cover | import (explain is a later milestone)"
                 .to_string(),
         ));
     };
@@ -583,8 +592,9 @@ fn run_trace(args: &[String]) -> Result<(), CliExit> {
             Ok(())
         }
         "cover" => tebako_cli::trace::cover::trace_cover(&args[1..]),
-        other @ ("explain" | "import") => Err(CliExit::Usage(format!(
-            "'tebako trace {other}' is a later tebako-rs milestone (spec 25: import is the rest of T3, explain is T4)"
+        "import" => tebako_cli::trace::import::trace_import(&args[1..]),
+        other @ "explain" => Err(CliExit::Usage(format!(
+            "'tebako trace {other}' is a later tebako-rs milestone (spec 25: explain is T4)"
         ))),
         other => Err(CliExit::Usage(format!("unknown trace subcommand '{other}'"))),
     }

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -31,6 +31,10 @@ const USAGE: &str = "Usage:
                                        export becomes the retrace-shaped JSON outside
                                        stream cover consumes (exit 0 converted /
                                        1 zero entries / 2 error)
+  tebako trace explain <capture.jsonl>
+                                       diagnosis (spec 25 §5, phase T4): replay the
+                                       capture into the hop chain and name the first
+                                       red hop (exit 0 clean / 1 red hop / 2 error)
   tebako check <name | image.tfs | package | tebako.yaml>
                [--check <c>] [--list] [--record] [--keep-scratch]
                [--runtime <exe> --runtime-image <env.tfs>]
@@ -98,12 +102,16 @@ fn run(args: &[String]) -> Result<(), CliExit> {
     // banner on stdout (unchanged). `trace cover` is a machine contract
     // too: its stdout byte-compares against the retrace golden fixtures
     // (spec 25 §6.3's parity clause). `trace import` likewise: its
-    // stdout is the converted retrace JSON document (spec 25 §6.2).
+    // stdout is the converted retrace JSON document (spec 25 §6.2); and
+    // `trace explain`'s stdout is the diagnosis report alone (§5).
     let machine_stdout = (subcommand == "cache"
         && rest.first().map(|a| a.as_str()) == Some("list")
         && rest.iter().any(|a| a == "--json"))
         || (subcommand == "trace"
-            && matches!(rest.first().map(|a| a.as_str()), Some("cover" | "import")));
+            && matches!(
+                rest.first().map(|a| a.as_str()),
+                Some("cover" | "import" | "explain")
+            ));
     if machine_stdout {
         eprintln!("{VERSION_BANNER}");
     } else {
@@ -566,23 +574,23 @@ fn run_package(args: &[String]) -> Result<(), CliExit> {
     Err(CliExit::Error(err))
 }
 
-/// `tebako trace <run|cover|import> ...` — the spec 25 front-ends. `run`
-/// (§4, phase T1, discovery) runs the package under `TEBAKO_JAIL=record`
-/// with the interception bus armed, then synthesizes the capture into a
-/// suggested-manifest draft; it never returns on success (the process
-/// exits with the payload's exit code). `cover` (§6, phase T3) is the
-/// escapes correlator; it never returns either (the exit code is the
-/// coverage verdict: 0 clean / 1 escapes / 2 usage-or-IO, the
-/// retrace-correlate parity codes). `import` (§6.2, the rest of T3) is
-/// the procmon converter; it never returns (0 converted / 1 zero
-/// entries / 2 usage-or-IO, procmon2retrace's codes). The spawn/resolve
-/// emission is T2 (bus-side, landed); `explain` (§5, T4) is a later
-/// milestone.
+/// `tebako trace <run|cover|import|explain> ...` — the spec 25
+/// front-ends. `run` (§4, phase T1, discovery) runs the package under
+/// `TEBAKO_JAIL=record` with the interception bus armed, then
+/// synthesizes the capture into a suggested-manifest draft; it never
+/// returns on success (the process exits with the payload's exit code).
+/// `cover` (§6, phase T3) is the escapes correlator; it never returns
+/// either (the exit code is the coverage verdict: 0 clean / 1 escapes /
+/// 2 usage-or-IO, the retrace-correlate parity codes). `import` (§6.2,
+/// the rest of T3) is the procmon converter; it never returns (0
+/// converted / 1 zero entries / 2 usage-or-IO, procmon2retrace's codes).
+/// `explain` (§5, phase T4) is the diagnosis replay; it never returns
+/// (0 clean / 1 red hop / 2 usage-or-IO). The spawn/resolve emission is
+/// T2 (bus-side, landed).
 fn run_trace(args: &[String]) -> Result<(), CliExit> {
     let Some(action) = args.first() else {
         return Err(CliExit::Usage(
-            "trace subcommand expected: run | cover | import (explain is a later milestone)"
-                .to_string(),
+            "trace subcommand expected: run | cover | import | explain".to_string(),
         ));
     };
     match action.as_str() {
@@ -594,9 +602,7 @@ fn run_trace(args: &[String]) -> Result<(), CliExit> {
         }
         "cover" => tebako_cli::trace::cover::trace_cover(&args[1..]),
         "import" => tebako_cli::trace::import::trace_import(&args[1..]),
-        other @ "explain" => Err(CliExit::Usage(format!(
-            "'tebako trace {other}' is a later tebako-rs milestone (spec 25: explain is T4)"
-        ))),
+        "explain" => tebako_cli::trace::explain::trace_explain(&args[1..]),
         other => Err(CliExit::Usage(format!(
             "unknown trace subcommand '{other}'"
         ))),

--- a/crates/tebako-cli/src/trace/explain-signatures.yaml
+++ b/crates/tebako-cli/src/trace/explain-signatures.yaml
@@ -43,7 +43,7 @@ signatures:
   # answer, format: null, deps: []) never fires — nothing was walked.
   - name: os-bind-module-not-found
     hop: OS bind
-    diagnosis: the OS bind itself — the closure resolved and the loader still refused
+    diagnosis: the closure resolved and the loader still refused
     when:
       kind: event
       op: dlopen

--- a/crates/tebako-cli/src/trace/explain-signatures.yaml
+++ b/crates/tebako-cli/src/trace/explain-signatures.yaml
@@ -1,0 +1,89 @@
+# =============================================================================
+# explain-signatures.yaml — the `tebako trace explain` signature table
+# (spec 25 §5, phase T4)
+#
+# The table lives in DATA, extended as incidents teach new signatures —
+# never hard-coded into the bus (spec 25 §5's placement law; the bus in
+# crates/tfs knows nothing of it). explain.rs's engine interprets the
+# `when.kind` discriminators below; an unknown kind is a named load error,
+# not a silent skip. Seeded from the incident corpus (the §5 table).
+# =============================================================================
+
+schema: trace-explain-signatures
+schema_version: 1 # additive-only within 1: new signatures, new when kinds
+
+# The hop chain the capture replays into (spec 25 §5's order) — printed
+# as the report's axis.
+hop_chain: [mount, manifest read, resolve, materialize, OS bind]
+
+signatures:
+  # §5 row 1 — incident 13's root cause class. The env image mounts
+  # FIRST (spec 25 §2's multi-mount order), so a live stream (at least
+  # min_events events) carrying NO `mount`/`ok` event means the env
+  # image never mounted. The "prelude-class child stderr" half of the
+  # §5 signature is out-of-band: the bus never sees the child's stderr;
+  # the operator corroborates with it (the report says so).
+  - name: env-image-never-mounted
+    hop: mount
+    diagnosis: env image never mounted (handoff env lost)
+    when:
+      kind: absent
+      op: mount
+      verdict: ok
+      min_events: 1
+    note: >-
+      A mount event with an error verdict does NOT suppress this
+      signature — a failed mount IS the never-mounted case.
+
+  # §5 row 2 — the dlopen verdict naming the OS loader's
+  # module-not-found (windows error 126; the POSIX dlopen ENOENT
+  # analogue) with every closure dep materialized|host-system: the
+  # closure RESOLVED, so the failure is the bind itself. The dep list
+  # prints as the bisect candidates. An empty walk (the cache-hit
+  # answer, format: null, deps: []) never fires — nothing was walked.
+  - name: os-bind-module-not-found
+    hop: OS bind
+    diagnosis: the OS bind itself — the closure resolved and the loader still refused
+    when:
+      kind: event
+      op: dlopen
+      verdict_prefix: "error:"
+      errno: [126, 2]
+      closure:
+        non_empty: true
+        dep_verdicts: [materialized, host-system]
+    note: >-
+      Incident 13's four eprintln rounds named this by hand; the closure
+      walk in the dlopen event's detail carries it as structure now.
+
+  # §5 row 3 — a jail deny immediately preceding a dependent open/stat
+  # error: the error event's path is the denied path or beneath it (a
+  # component boundary), and no non-deny jail event for the denied path
+  # intervened. A policy-gated decision emits BOTH events by design
+  # (trace-event.yaml's jail notes) — this signature joins the pair.
+  - name: policy-denial
+    hop: policy
+    diagnosis: policy denial (the EACCES class)
+    when:
+      kind: deny-then-error
+      deny:
+        op: jail
+        verdict_prefix: "deny:"
+      error:
+        ops: [open, stat]
+        verdict_prefixes: ["denied:", "error:"]
+    note: >-
+      The evidence line is the dependent error event; the deny is quoted
+      as the related line (rule label carried).
+
+  # §5 row 4.
+  - name: materialize-error
+    hop: materialize
+    diagnosis: exec-cache write failure
+    when:
+      kind: event
+      op: materialize
+      verdict_prefix: "error:"
+    note: >-
+      The exec cache (ENOSPC/EROFS/EACCES on the cache dir) is the
+      classic; the errno names it.

--- a/crates/tebako-cli/src/trace/explain.rs
+++ b/crates/tebako-cli/src/trace/explain.rs
@@ -293,7 +293,7 @@ fn closure_matches(detail: Option<&Value>, rule: &ClosureRule) -> bool {
     deps.iter().all(|dep| {
         dep.find("verdict")
             .and_then(Value::as_string)
-            .is_some_and(|v| rule.dep_verdicts.iter().any(|allowed| *allowed == v))
+            .is_some_and(|v| rule.dep_verdicts.contains(&v))
     })
 }
 
@@ -438,7 +438,7 @@ pub fn replay(capture_text: &str, table: &SignatureTable) -> Diagnosis {
                 When::Absent { .. } => false,
                 w @ When::Event { .. } => event_matches(w, &event),
                 When::DenyThenError { error, .. } => {
-                    error.ops.iter().any(|op| *op == event.op)
+                    error.ops.contains(&event.op)
                         && error
                             .verdict_prefixes
                             .iter()

--- a/crates/tebako-cli/src/trace/explain.rs
+++ b/crates/tebako-cli/src/trace/explain.rs
@@ -1,0 +1,864 @@
+//! `tebako trace explain` — diagnosis (spec 25 §5, phase T4).
+//!
+//! Replays a capture (the bus's JSONL stream — a finished file or a
+//! live run's growing one; the tolerant per-line scan drops a crashed
+//! tail, the same leniency as `trace run`'s synthesis) into the hop
+//! chain — mount → manifest read → resolve → materialize → OS bind —
+//! and prints the FIRST hop whose verdict is red: the earliest event
+//! matching a signature, or the end-of-stream absence signature when no
+//! event matched.
+//!
+//! # The signature table is data
+//!
+//! §5's placement law: the table lives in `explain-signatures.yaml` in
+//! this crate (embedded with `include_str!` — the shipped binary reads
+//! no runtime data file), extended as incidents teach new signatures,
+//! never hard-coded into the bus. The engine below interprets the
+//! `when.kind` discriminators; an unknown kind is a named load error
+//! (spec 00 law 9 — the table is compiled-in data, so a load failure is
+//! a build-time bug the unit suite pins first).
+//!
+//! # Surface
+//!
+//! ```text
+//! tebako trace explain <capture.jsonl>
+//! ```
+//!
+//! - **stdout** is the diagnosis report and nothing else (the version
+//!   banner rides stderr for this subcommand — main.rs's
+//!   machine_stdout rule): the replay line (event counts, the hop
+//!   chain), then the RED hop with its evidence event, or the GREEN
+//!   verdict.
+//! - **stderr** carries the stream-tolerance notes (a skipped partial
+//!   line) — outside the report contract.
+//! - **Exit codes** (the trace-verbs convention): 0 = no red hop, 1 =
+//!   a red hop named, 2 = usage or I/O error.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use tebako_json::Value;
+
+/// The embedded signature table (the §5 data placement).
+const SIGNATURES_YAML: &str = include_str!("explain-signatures.yaml");
+
+// ---------------------------------------------------------------------
+// The signature table (the data model)
+// ---------------------------------------------------------------------
+
+/// The parsed `explain-signatures.yaml`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SignatureTable {
+    #[allow(dead_code)]
+    schema: String,
+    #[allow(dead_code)]
+    schema_version: u32,
+    /// The hop chain, printed as the report's axis (§5's order).
+    pub hop_chain: Vec<String>,
+    /// The signature corpus, in table order.
+    pub signatures: Vec<Signature>,
+}
+
+/// One signature: the stream shape → the named hop.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Signature {
+    /// The table key (reported as `[signature: <name>]`).
+    pub name: String,
+    /// The red hop this signature names (a hop-chain member or the
+    /// cross-cutting `policy`).
+    pub hop: String,
+    /// §5's named-hop sentence.
+    pub diagnosis: String,
+    /// The stream predicate.
+    pub when: When,
+    /// The incident provenance (carried into the report).
+    pub note: String,
+}
+
+/// The stream predicates (the `when.kind` discriminators).
+/// (serde's deny_unknown_fields cannot ride an internally tagged enum;
+/// the load test pins the table's spellings instead.)
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum When {
+    /// End-of-stream absence: the stream carried at least `min_events`
+    /// events but no `op` event with exactly this verdict. Evaluated
+    /// only when no per-event signature matched (the absent hop is
+    /// chronologically first anyway — the env image mounts first).
+    Absent {
+        op: String,
+        verdict: String,
+        #[serde(default = "default_min_events")]
+        min_events: usize,
+    },
+    /// One event: op + verdict prefix, optionally the errno set and a
+    /// closure-walk requirement.
+    Event {
+        op: String,
+        verdict_prefix: String,
+        #[serde(default)]
+        errno: Vec<i64>,
+        #[serde(default)]
+        closure: Option<ClosureRule>,
+    },
+    /// The jail correlation: a deny immediately preceding a dependent
+    /// open-class error (the error's path is the denied path or beneath
+    /// it; a non-deny jail event for the denied path clears the pending
+    /// deny).
+    DenyThenError { deny: DenyRule, error: ErrorRule },
+}
+
+fn default_min_events() -> usize {
+    1
+}
+
+/// The closure-walk requirement on an `event` match (the dlopen
+/// detail): the deps list must exist, be non-empty when `non_empty`,
+/// and every dep's verdict must be in `dep_verdicts`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClosureRule {
+    #[serde(default)]
+    pub non_empty: bool,
+    pub dep_verdicts: Vec<String>,
+}
+
+/// The deny arm of the jail correlation.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DenyRule {
+    pub op: String,
+    pub verdict_prefix: String,
+}
+
+/// The error arm of the jail correlation.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ErrorRule {
+    pub ops: Vec<String>,
+    pub verdict_prefixes: Vec<String>,
+}
+
+/// Load and validate the embedded table. Fails loudly on a schema
+/// drift (an unknown field/kind, an empty chain, a duplicate name) —
+/// compiled-in data that does not load is a build-time bug.
+pub fn load_signatures() -> Result<SignatureTable, String> {
+    let table: SignatureTable =
+        serde_yml::from_str(SIGNATURES_YAML).map_err(|e| format!("explain-signatures.yaml: {e}"))?;
+    if table.hop_chain.is_empty() {
+        return Err("explain-signatures.yaml: the hop chain is empty".to_string());
+    }
+    if table.signatures.is_empty() {
+        return Err("explain-signatures.yaml: no signatures".to_string());
+    }
+    let mut names = std::collections::HashSet::new();
+    for sig in &table.signatures {
+        if !names.insert(sig.name.as_str()) {
+            return Err(format!(
+                "explain-signatures.yaml: duplicate signature '{}'",
+                sig.name
+            ));
+        }
+    }
+    Ok(table)
+}
+
+// ---------------------------------------------------------------------
+// The replay
+// ---------------------------------------------------------------------
+
+/// One event, flattened to what the signatures read.
+struct FlatEvent {
+    /// The 1-based capture line number (the evidence reference).
+    line: usize,
+    ts: String,
+    pid: i64,
+    tid: i64,
+    op: String,
+    path: String,
+    verdict: String,
+    errno: Option<i64>,
+    detail: Option<Value>,
+}
+
+impl FlatEvent {
+    fn from_value(line: usize, doc: &Value) -> FlatEvent {
+        let get_str = |key: &str| {
+            doc.find(key)
+                .and_then(Value::as_string)
+                .unwrap_or_default()
+        };
+        let errno = match doc.find("errno") {
+            Some(Value::Number(s)) => s.parse::<i64>().ok(),
+            _ => None,
+        };
+        FlatEvent {
+            line,
+            ts: get_str("ts"),
+            pid: match doc.find("pid") {
+                Some(Value::Number(s)) => s.parse().unwrap_or(0),
+                _ => 0,
+            },
+            tid: match doc.find("tid") {
+                Some(Value::Number(s)) => s.parse().unwrap_or(0),
+                _ => 0,
+            },
+            op: get_str("op"),
+            path: get_str("path"),
+            verdict: get_str("verdict"),
+            errno,
+            detail: doc.find("detail").cloned(),
+        }
+    }
+
+    /// The event's errno: the typed field, else the verdict suffix
+    /// (`error:<n>` / `denied:<rule>` carry it — trace-event.yaml).
+    fn errno(&self) -> Option<i64> {
+        self.errno.or_else(|| {
+            let (_, suffix) = self.verdict.split_once(':')?;
+            suffix.parse().ok()
+        })
+    }
+
+    /// The evidence line (the report's pointer into the capture).
+    fn evidence(&self) -> String {
+        let errno = self
+            .errno
+            .map(|e| format!(" errno={e}"))
+            .unwrap_or_default();
+        format!(
+            "event #{} ({} pid={} tid={}): {} {} verdict={}{}",
+            self.line, self.ts, self.pid, self.tid, self.op, self.path, self.verdict, errno
+        )
+    }
+}
+
+/// A red hop: the signature that fired plus its evidence.
+#[derive(Debug)]
+pub struct RedHop {
+    /// The signature's table key.
+    pub signature: String,
+    /// The named red hop.
+    pub hop: String,
+    /// §5's named-hop sentence.
+    pub diagnosis: String,
+    /// The evidence event's line (0 for the absence signature).
+    pub evidence: Option<String>,
+    /// A related event line (the policy-denial signature's deny).
+    pub related: Option<String>,
+    /// The bisect candidates (the os-bind signature's closure deps).
+    pub bisect: Vec<String>,
+    /// The signature's provenance note.
+    pub note: String,
+}
+
+/// The replay's outcome.
+#[derive(Debug)]
+pub struct Diagnosis {
+    /// Well-formed events replayed.
+    pub events: usize,
+    /// Lines dropped as partial/corrupt (the crashed-tail leniency).
+    pub skipped_lines: usize,
+    /// The first red hop, when one fired.
+    pub red: Option<RedHop>,
+}
+
+/// The pending deny of the deny-then-error correlation.
+struct PendingDeny<'a> {
+    sig: &'a Signature,
+    path: String,
+    evidence: String,
+}
+
+/// 1 if `path` is the denied path or beneath it (a component boundary
+/// — `/secret/data/file` is dependent on `/secret/data`, `/secret/data2`
+/// is not).
+fn dependent(path: &str, denied: &str) -> bool {
+    path == denied || path.starts_with(&format!("{denied}/"))
+}
+
+/// The closure-walk requirement check (the dlopen detail): deps exist,
+/// non-empty when the rule asks, every dep's verdict in the rule's set.
+fn closure_matches(detail: Option<&Value>, rule: &ClosureRule) -> bool {
+    let Some(deps) = detail
+        .and_then(|d| d.find("closure"))
+        .and_then(|c| c.find("deps"))
+    else {
+        return false;
+    };
+    let Value::Array(deps) = deps else {
+        return false;
+    };
+    if rule.non_empty && deps.is_empty() {
+        return false;
+    }
+    deps.iter().all(|dep| {
+        dep.find("verdict")
+            .and_then(Value::as_string)
+            .is_some_and(|v| rule.dep_verdicts.iter().any(|allowed| *allowed == v))
+    })
+}
+
+/// The bisect-candidate lines for the os-bind signature: each dep's
+/// name → its resolution, with its verdict.
+fn closure_bisect(detail: Option<&Value>) -> Vec<String> {
+    let Some(Value::Array(deps)) = detail
+        .and_then(|d| d.find("closure"))
+        .and_then(|c| c.find("deps"))
+    else {
+        return Vec::new();
+    };
+    deps.iter()
+        .map(|dep| {
+            let name = dep
+                .find("name")
+                .and_then(Value::as_string)
+                .unwrap_or_default();
+            let resolved = dep
+                .find("resolved")
+                .and_then(Value::as_string)
+                .unwrap_or_else(|| "(host lookup)".to_string());
+            let verdict = dep
+                .find("verdict")
+                .and_then(Value::as_string)
+                .unwrap_or_default();
+            format!("{name} → {resolved} ({verdict})")
+        })
+        .collect()
+}
+
+/// One signature's per-event match (the `event` kind).
+fn event_matches(sig_when: &When, event: &FlatEvent) -> bool {
+    let When::Event {
+        op,
+        verdict_prefix,
+        errno,
+        closure,
+    } = sig_when
+    else {
+        return false;
+    };
+    if event.op != *op || !event.verdict.starts_with(verdict_prefix.as_str()) {
+        return false;
+    }
+    if !errno.is_empty() && !event.errno().is_some_and(|e| errno.contains(&e)) {
+        return false;
+    }
+    if let Some(rule) = closure {
+        if !closure_matches(event.detail.as_ref(), rule) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Replay a capture into the hop chain (spec 25 §5): the first
+/// signature match in stream order is the red hop; the absence
+/// signatures evaluate at end of stream only when nothing matched.
+pub fn replay(capture_text: &str, table: &SignatureTable) -> Diagnosis {
+    let mut events = 0usize;
+    let mut skipped_lines = 0usize;
+    let mut pending: Option<PendingDeny> = None;
+    let mut red: Option<RedHop> = None;
+    // The absence signatures' suppression: an (op, verdict) pair seen
+    // kills the absence rule asking for it.
+    let absent_sigs: Vec<&Signature> = table
+        .signatures
+        .iter()
+        .filter(|s| matches!(s.when, When::Absent { .. }))
+        .collect();
+    let mut absent_alive: Vec<bool> = vec![true; absent_sigs.len()];
+
+    for (i, line) in capture_text.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(doc) = tebako_json::parse(line) else {
+            // The trailing line may be a crashed tail's partial write;
+            // anything else is interleave damage. Both are dropped
+            // (the `trace run` synthesis's leniency, §3).
+            skipped_lines += 1;
+            eprintln!(
+                "tebako: trace explain: note: capture line {} is not a complete event — skipped",
+                i + 1
+            );
+            continue;
+        };
+        let event = FlatEvent::from_value(i + 1, &doc);
+        events += 1;
+
+        // The absence rules' liveness.
+        for (j, sig) in absent_sigs.iter().enumerate() {
+            if let When::Absent { op, verdict, .. } = &sig.when {
+                if event.op == *op && event.verdict == *verdict {
+                    absent_alive[j] = false;
+                }
+            }
+        }
+
+        // The deny-then-error correlations' state: a fresh deny for the
+        // pending path re-anchors the evidence; a non-deny jail event
+        // for it clears the correlation (the table's note).
+        enum PendingShift {
+            Reanchor(String),
+            Clear,
+        }
+        let shift = match &pending {
+            Some(p) => {
+                let (deny_op, deny_prefix) = match &p.sig.when {
+                    When::DenyThenError { deny, .. } => {
+                        (deny.op.as_str(), deny.verdict_prefix.as_str())
+                    }
+                    _ => unreachable!("pending only holds deny-then-error signatures"),
+                };
+                if event.op == deny_op && event.path == p.path {
+                    if event.verdict.starts_with(deny_prefix) {
+                        Some(PendingShift::Reanchor(event.evidence()))
+                    } else {
+                        Some(PendingShift::Clear)
+                    }
+                } else {
+                    None
+                }
+            }
+            None => None,
+        };
+        match shift {
+            Some(PendingShift::Reanchor(evidence)) => {
+                if let Some(p) = pending.as_mut() {
+                    p.evidence = evidence;
+                }
+            }
+            Some(PendingShift::Clear) => pending = None,
+            None => {}
+        }
+
+        // The per-event signatures, in table order; the first match in
+        // stream order ends the replay (§5: the FIRST red hop).
+        for sig in &table.signatures {
+            let matched = match &sig.when {
+                When::Absent { .. } => false,
+                w @ When::Event { .. } => event_matches(w, &event),
+                When::DenyThenError { error, .. } => {
+                    error.ops.iter().any(|op| *op == event.op)
+                        && error
+                            .verdict_prefixes
+                            .iter()
+                            .any(|p| event.verdict.starts_with(p.as_str()))
+                        && pending
+                            .as_ref()
+                            .is_some_and(|p| std::ptr::eq(p.sig, sig) && dependent(&event.path, &p.path))
+                }
+            };
+            if matched {
+                red = Some(RedHop {
+                    signature: sig.name.clone(),
+                    hop: sig.hop.clone(),
+                    diagnosis: sig.diagnosis.clone(),
+                    evidence: Some(event.evidence()),
+                    related: pending.as_ref().map(|p| p.evidence.clone()),
+                    bisect: closure_bisect(event.detail.as_ref()),
+                    note: sig.note.clone(),
+                });
+                break;
+            }
+        }
+        if red.is_some() {
+            break;
+        }
+
+        // A deny event arms its correlation (after the match scan, so a
+        // deny never matches its own event).
+        for sig in &table.signatures {
+            if let When::DenyThenError { deny, .. } = &sig.when {
+                if event.op == deny.op && event.verdict.starts_with(deny.verdict_prefix.as_str()) {
+                    pending = Some(PendingDeny {
+                        sig,
+                        path: event.path.clone(),
+                        evidence: event.evidence(),
+                    });
+                }
+            }
+        }
+    }
+
+    // End of stream: the absence signatures (only when nothing matched).
+    if red.is_none() {
+        for (sig, alive) in absent_sigs.iter().zip(absent_alive) {
+            let When::Absent { min_events, .. } = &sig.when else {
+                continue;
+            };
+            if alive && events >= *min_events {
+                red = Some(RedHop {
+                    signature: sig.name.clone(),
+                    hop: sig.hop.clone(),
+                    diagnosis: sig.diagnosis.clone(),
+                    evidence: None,
+                    related: None,
+                    bisect: Vec::new(),
+                    note: sig.note.clone(),
+                });
+                break;
+            }
+        }
+    }
+
+    Diagnosis {
+        events,
+        skipped_lines,
+        red,
+    }
+}
+
+/// The stdout report (the diagnosis contract).
+pub fn render_report(capture: &std::path::Path, diagnosis: &Diagnosis, table: &SignatureTable) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "tebako trace explain: {} — {} event(s) replayed (hop chain: {})\n",
+        capture.display(),
+        diagnosis.events,
+        table.hop_chain.join(" → ")
+    ));
+    match &diagnosis.red {
+        Some(red) => {
+            out.push_str(&format!(
+                "RED hop: {} — {} [signature: {}]\n",
+                red.hop, red.diagnosis, red.signature
+            ));
+            if let Some(evidence) = &red.evidence {
+                out.push_str(&format!("evidence: {evidence}\n"));
+            } else {
+                out.push_str(&format!(
+                    "evidence: no `{}` verdict reached the stream in {} event(s) — corroborate with the child's prelude-class stderr (spec 25 §5)\n",
+                    // The absence rule's (op, verdict), re-read from the
+                    // table for the message.
+                    table
+                        .signatures
+                        .iter()
+                        .find(|s| s.name == red.signature)
+                        .and_then(|s| match &s.when {
+                            When::Absent { op, verdict, .. } => {
+                                Some(format!("{op}/{verdict}"))
+                            }
+                            _ => None,
+                        })
+                        .unwrap_or_default(),
+                    diagnosis.events
+                ));
+            }
+            if let Some(related) = &red.related {
+                out.push_str(&format!("related:  {related}\n"));
+            }
+            if !red.bisect.is_empty() {
+                out.push_str(
+                    "bisect candidates (the closure walk resolved every dep — the OS loader refused the bind):\n",
+                );
+                for dep in &red.bisect {
+                    out.push_str(&format!("  - {dep}\n"));
+                }
+            }
+            out.push_str(&format!("note: {}\n", red.note));
+        }
+        None => {
+            out.push_str(&format!(
+                "GREEN: no red hop — every hop's verdict is clean in {} event(s)\n",
+                diagnosis.events
+            ));
+        }
+    }
+    out
+}
+
+/// `tebako trace explain <capture>` — never returns; the exit code is
+/// the diagnosis: 0 no red hop, 1 a red hop named, 2 usage or I/O
+/// error (the trace-verbs convention).
+pub fn trace_explain(args: &[String]) -> ! {
+    const USAGE: &str = "usage: tebako trace explain <capture.jsonl>";
+    let parsed: PathBuf = match args {
+        [capture] if !capture.starts_with('-') => PathBuf::from(capture),
+        [flag, ..] if flag.starts_with('-') => {
+            eprintln!("tebako: trace explain: unknown option '{flag}'\n{USAGE}");
+            std::process::exit(2);
+        }
+        _ => {
+            eprintln!("tebako: trace explain: {USAGE}");
+            std::process::exit(2);
+        }
+    };
+    let text = match std::fs::read_to_string(&parsed) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!(
+                "tebako: trace explain: cannot read {}: {e}",
+                parsed.display()
+            );
+            std::process::exit(2);
+        }
+    };
+    let table = match load_signatures() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("tebako: trace explain: the signature table does not load: {e}");
+            std::process::exit(2);
+        }
+    };
+    let diagnosis = replay(&text, &table);
+    print!("{}", render_report(&parsed, &diagnosis, &table));
+    std::process::exit(if diagnosis.red.is_some() { 1 } else { 0 });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A bus event line, the tfs::trace render shape (trace/mod.rs's
+    /// test helper grammar).
+    fn event(line_op: &str, path: &str, verdict: &str, ts: &str, detail: &str) -> String {
+        format!(
+            "{{\"v\":1,\"ts\":\"{ts}\",\"pid\":1,\"tid\":1,\"op\":\"{line_op}\",\"path\":\"{path}\",\"verdict\":\"{verdict}\",\"detail\":{detail},\"dur_us\":3}}"
+        )
+    }
+
+    fn event_errno(op: &str, path: &str, verdict: &str, errno: i64, detail: &str) -> String {
+        format!(
+            "{{\"v\":1,\"ts\":\"2026-08-20T01:00:00.000000Z\",\"pid\":1,\"tid\":1,\"op\":\"{op}\",\"path\":\"{path}\",\"verdict\":\"{verdict}\",\"detail\":{detail},\"dur_us\":3,\"errno\":{errno}}}"
+        )
+    }
+
+    #[test]
+    fn the_embedded_table_loads_and_pins_the_seed_rows() {
+        // The §5 seed: four signatures, the hop chain in §5's order.
+        let table = load_signatures().unwrap();
+        assert_eq!(
+            table.hop_chain,
+            vec!["mount", "manifest read", "resolve", "materialize", "OS bind"]
+        );
+        let names: Vec<&str> = table.signatures.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "env-image-never-mounted",
+                "os-bind-module-not-found",
+                "policy-denial",
+                "materialize-error"
+            ]
+        );
+    }
+
+    #[test]
+    fn absence_signature_fires_only_on_a_live_stream_without_the_verdict() {
+        let table = load_signatures().unwrap();
+        // A live stream with no mount/ok: the env image never mounted
+        // (a mount ERROR does not suppress — the note on the row).
+        let capture = [
+            event("mount", "/__tfs__", "error:2", "2026-08-20T01:00:00.000000Z", "{}"),
+            event("open", "/__tfs__/lib/x.rb", "error:2", "2026-08-20T01:00:01.000000Z", "{}"),
+        ]
+        .join("\n");
+        let d = replay(&capture, &table);
+        let red = d.red.expect("the absence signature fires");
+        assert_eq!(red.signature, "env-image-never-mounted");
+        assert_eq!(red.hop, "mount");
+        assert!(red.evidence.is_none());
+
+        // A mount/ok suppresses it.
+        let capture = [
+            event("mount", "/__tfs__", "ok", "2026-08-20T01:00:00.000000Z", "{\"action\":\"insert\",\"handle\":1}"),
+            event("open", "/__tfs__/lib/x.rb", "image:/__tfs__", "2026-08-20T01:00:01.000000Z", "{}"),
+        ]
+        .join("\n");
+        let d = replay(&capture, &table);
+        assert!(d.red.is_none());
+
+        // An EMPTY stream is not a diagnosis (min_events).
+        let d = replay("", &table);
+        assert!(d.red.is_none());
+        assert_eq!(d.events, 0);
+    }
+
+    #[test]
+    fn os_bind_signature_needs_the_closure_walked_and_resolved() {
+        let table = load_signatures().unwrap();
+        let closure = "{\"closure\":{\"format\":\"elf\",\"deps\":[{\"name\":\"libc.so\",\"resolved\":\"/tfs/lib/libc.so\",\"verdict\":\"materialized\"},{\"name\":\"libSystem.dylib\",\"resolved\":null,\"verdict\":\"host-system\"}]}}";
+        // error 126 + every dep materialized|host-system: the OS bind.
+        let capture = event_errno("dlopen", "/tfs/lib/app.so", "error:126", 126, closure);
+        let d = replay(&capture, &table);
+        let red = d.red.expect("the os-bind signature fires");
+        assert_eq!(red.signature, "os-bind-module-not-found");
+        assert_eq!(red.hop, "OS bind");
+        assert_eq!(red.bisect.len(), 2);
+        assert!(red.bisect[0].contains("libc.so → /tfs/lib/libc.so (materialized)"));
+        assert!(red.bisect[1].contains("libSystem.dylib"));
+
+        // The POSIX analogue: ENOENT.
+        let capture = event_errno("dlopen", "/tfs/lib/app.so", "error:2", 2, closure);
+        let d = replay(&capture, &table);
+        assert_eq!(
+            d.red.map(|r| r.signature).as_deref(),
+            Some("os-bind-module-not-found")
+        );
+
+        // A dep that errored: the closure did NOT resolve — no fire.
+        // (The mount/ok keeps the absence signature out of these
+        // negative cases: a mount-less fragment always reads as the
+        // never-mounted shape, by the signature's design.)
+        let mount = event("mount", "/__tfs__", "ok", "2026-08-20T00:59:59.000000Z", "{\"action\":\"insert\",\"handle\":1}");
+        let bad = "{\"closure\":{\"format\":\"elf\",\"deps\":[{\"name\":\"libx.so\",\"resolved\":null,\"verdict\":\"error:2\"}]}}";
+        let capture = format!(
+            "{mount}\n{}",
+            event_errno("dlopen", "/tfs/lib/app.so", "error:126", 126, bad)
+        );
+        let d = replay(&capture, &table);
+        assert!(d.red.is_none());
+
+        // The cache-hit empty walk (format null, deps []) never fires.
+        let empty = "{\"closure\":{\"format\":null,\"deps\":[]}}";
+        let capture = format!(
+            "{mount}\n{}",
+            event_errno("dlopen", "/tfs/lib/app.so", "error:126", 126, empty)
+        );
+        let d = replay(&capture, &table);
+        assert!(d.red.is_none());
+
+        // A different errno (EACCES) is not this signature.
+        let capture = format!(
+            "{mount}\n{}",
+            event_errno("dlopen", "/tfs/lib/app.so", "error:13", 13, closure)
+        );
+        let d = replay(&capture, &table);
+        assert!(d.red.is_none());
+    }
+
+    #[test]
+    fn policy_denial_joins_the_deny_with_the_dependent_error() {
+        let table = load_signatures().unwrap();
+        // deny → dependent open error: fires, quoting the deny.
+        let capture = [
+            event("jail", "/secret/data", "deny:user", "2026-08-20T01:00:00.000000Z", "{\"access\":\"read\"}"),
+            event("open", "/secret/data/file", "denied:user", "2026-08-20T01:00:01.000000Z", "{\"need\":\"read\"}"),
+        ]
+        .join("\n");
+        let d = replay(&capture, &table);
+        let red = d.red.expect("the policy-denial signature fires");
+        assert_eq!(red.signature, "policy-denial");
+        assert_eq!(red.hop, "policy");
+        let evidence = red.evidence.unwrap();
+        assert!(evidence.contains("open /secret/data/file"), "{evidence}");
+        let related = red.related.unwrap();
+        assert!(related.contains("jail /secret/data verdict=deny:user"), "{related}");
+
+        // The same path exactly also dependents; an error: verdict too.
+        let capture = [
+            event("jail", "/secret", "deny:manifest", "2026-08-20T01:00:00.000000Z", "{\"access\":\"write\"}"),
+            event("stat", "/secret", "error:13", "2026-08-20T01:00:01.000000Z", "{}"),
+        ]
+        .join("\n");
+        let d = replay(&capture, &table);
+        assert_eq!(
+            d.red.map(|r| r.signature).as_deref(),
+            Some("policy-denial")
+        );
+
+        // An unrelated path is not dependent (a component boundary).
+        let mount = event("mount", "/__tfs__", "ok", "2026-08-20T00:59:59.000000Z", "{\"action\":\"insert\",\"handle\":1}");
+        let capture = [
+            mount.clone(),
+            event("jail", "/secret/data", "deny:user", "2026-08-20T01:00:00.000000Z", "{\"access\":\"read\"}"),
+            event("open", "/secret/data2/file", "error:2", "2026-08-20T01:00:01.000000Z", "{}"),
+        ]
+        .join("\n");
+        let d = replay(&capture, &table);
+        assert!(d.red.is_none());
+
+        // An intervening non-deny jail event for the path clears it.
+        let capture = [
+            mount,
+            event("jail", "/secret", "deny:user", "2026-08-20T01:00:00.000000Z", "{\"access\":\"read\"}"),
+            event("jail", "/secret", "allow:user", "2026-08-20T01:00:01.000000Z", "{\"access\":\"read\"}"),
+            event("open", "/secret", "error:13", "2026-08-20T01:00:02.000000Z", "{}"),
+        ]
+        .join("\n");
+        let d = replay(&capture, &table);
+        assert!(d.red.is_none());
+    }
+
+    #[test]
+    fn materialize_error_names_the_exec_cache() {
+        let table = load_signatures().unwrap();
+        let capture = event_errno(
+            "materialize",
+            "/tfs/bin/tool",
+            "error:28",
+            28,
+            "{\"dest\":\"dlcache\"}",
+        );
+        let d = replay(&capture, &table);
+        let red = d.red.expect("the materialize signature fires");
+        assert_eq!(red.signature, "materialize-error");
+        assert_eq!(red.hop, "materialize");
+        assert_eq!(red.diagnosis, "exec-cache write failure");
+    }
+
+    #[test]
+    fn the_first_red_hop_in_stream_order_wins() {
+        let table = load_signatures().unwrap();
+        // The materialize error precedes the dlopen bind failure: the
+        // materialize hop is the report.
+        let closure = "{\"closure\":{\"format\":\"elf\",\"deps\":[{\"name\":\"libc.so\",\"resolved\":\"/tfs/lib/libc.so\",\"verdict\":\"materialized\"}]}}";
+        let capture = [
+            event("mount", "/__tfs__", "ok", "2026-08-20T01:00:00.000000Z", "{\"action\":\"insert\",\"handle\":1}"),
+            event_errno("materialize", "/tfs/bin/tool", "error:28", 28, "{}"),
+            event_errno("dlopen", "/tfs/lib/app.so", "error:126", 126, closure),
+        ]
+        .join("\n");
+        let d = replay(&capture, &table);
+        let red = d.red.unwrap();
+        assert_eq!(red.signature, "materialize-error");
+        assert!(red.evidence.unwrap().contains("event #2"));
+    }
+
+    #[test]
+    fn the_tolerant_scan_drops_a_crashed_tail() {
+        let table = load_signatures().unwrap();
+        let capture = [
+            event("mount", "/__tfs__", "ok", "2026-08-20T01:00:00.000000Z", "{\"action\":\"insert\",\"handle\":1}"),
+            event("open", "/__tfs__/lib/x.rb", "image:/__tfs__", "2026-08-20T01:00:01.000000Z", "{}"),
+            "{\"v\":1,\"ts\":\"2026-08-20T01:00:02".to_string(), // the crashed tail
+        ]
+        .join("\n");
+        let d = replay(&capture, &table);
+        assert_eq!(d.events, 2);
+        assert_eq!(d.skipped_lines, 1);
+        assert!(d.red.is_none());
+    }
+
+    #[test]
+    fn render_report_shapes() {
+        let table = load_signatures().unwrap();
+        // RED with evidence.
+        let capture = event_errno("materialize", "/tfs/bin/tool", "error:28", 28, "{}");
+        let d = replay(&capture, &table);
+        let report = render_report(std::path::Path::new("/tmp/c.jsonl"), &d, &table);
+        assert!(report.contains("hop chain: mount → manifest read → resolve → materialize → OS bind"), "{report}");
+        assert!(
+            report.contains("RED hop: materialize — exec-cache write failure [signature: materialize-error]"),
+            "{report}"
+        );
+        assert!(report.contains("evidence: event #1"), "{report}");
+
+        // The absence signature's evidence names the missing verdict.
+        let capture = event("open", "/x", "host", "2026-08-20T01:00:00.000000Z", "{}");
+        let d = replay(&capture, &table);
+        let report = render_report(std::path::Path::new("/tmp/c.jsonl"), &d, &table);
+        assert!(report.contains("RED hop: mount — env image never mounted (handoff env lost)"), "{report}");
+        assert!(report.contains("no `mount/ok` verdict"), "{report}");
+
+        // GREEN.
+        let capture = event("mount", "/__tfs__", "ok", "2026-08-20T01:00:00.000000Z", "{\"action\":\"insert\",\"handle\":1}");
+        let d = replay(&capture, &table);
+        let report = render_report(std::path::Path::new("/tmp/c.jsonl"), &d, &table);
+        assert!(report.contains("GREEN: no red hop"), "{report}");
+    }
+}

--- a/crates/tebako-cli/src/trace/explain.rs
+++ b/crates/tebako-cli/src/trace/explain.rs
@@ -145,8 +145,8 @@ pub struct ErrorRule {
 /// drift (an unknown field/kind, an empty chain, a duplicate name) —
 /// compiled-in data that does not load is a build-time bug.
 pub fn load_signatures() -> Result<SignatureTable, String> {
-    let table: SignatureTable =
-        serde_yml::from_str(SIGNATURES_YAML).map_err(|e| format!("explain-signatures.yaml: {e}"))?;
+    let table: SignatureTable = serde_yml::from_str(SIGNATURES_YAML)
+        .map_err(|e| format!("explain-signatures.yaml: {e}"))?;
     if table.hop_chain.is_empty() {
         return Err("explain-signatures.yaml: the hop chain is empty".to_string());
     }
@@ -185,11 +185,7 @@ struct FlatEvent {
 
 impl FlatEvent {
     fn from_value(line: usize, doc: &Value) -> FlatEvent {
-        let get_str = |key: &str| {
-            doc.find(key)
-                .and_then(Value::as_string)
-                .unwrap_or_default()
-        };
+        let get_str = |key: &str| doc.find(key).and_then(Value::as_string).unwrap_or_default();
         let errno = match doc.find("errno") {
             Some(Value::Number(s)) => s.parse::<i64>().ok(),
             _ => None,
@@ -447,9 +443,9 @@ pub fn replay(capture_text: &str, table: &SignatureTable) -> Diagnosis {
                             .verdict_prefixes
                             .iter()
                             .any(|p| event.verdict.starts_with(p.as_str()))
-                        && pending
-                            .as_ref()
-                            .is_some_and(|p| std::ptr::eq(p.sig, sig) && dependent(&event.path, &p.path))
+                        && pending.as_ref().is_some_and(|p| {
+                            std::ptr::eq(p.sig, sig) && dependent(&event.path, &p.path)
+                        })
                 }
             };
             if matched {
@@ -513,7 +509,11 @@ pub fn replay(capture_text: &str, table: &SignatureTable) -> Diagnosis {
 }
 
 /// The stdout report (the diagnosis contract).
-pub fn render_report(capture: &std::path::Path, diagnosis: &Diagnosis, table: &SignatureTable) -> String {
+pub fn render_report(
+    capture: &std::path::Path,
+    diagnosis: &Diagnosis,
+    table: &SignatureTable,
+) -> String {
     let mut out = String::new();
     out.push_str(&format!(
         "tebako trace explain: {} — {} event(s) replayed (hop chain: {})\n",
@@ -633,7 +633,13 @@ mod tests {
         let table = load_signatures().unwrap();
         assert_eq!(
             table.hop_chain,
-            vec!["mount", "manifest read", "resolve", "materialize", "OS bind"]
+            vec![
+                "mount",
+                "manifest read",
+                "resolve",
+                "materialize",
+                "OS bind"
+            ]
         );
         let names: Vec<&str> = table.signatures.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(
@@ -653,8 +659,20 @@ mod tests {
         // A live stream with no mount/ok: the env image never mounted
         // (a mount ERROR does not suppress — the note on the row).
         let capture = [
-            event("mount", "/__tfs__", "error:2", "2026-08-20T01:00:00.000000Z", "{}"),
-            event("open", "/__tfs__/lib/x.rb", "error:2", "2026-08-20T01:00:01.000000Z", "{}"),
+            event(
+                "mount",
+                "/__tfs__",
+                "error:2",
+                "2026-08-20T01:00:00.000000Z",
+                "{}",
+            ),
+            event(
+                "open",
+                "/__tfs__/lib/x.rb",
+                "error:2",
+                "2026-08-20T01:00:01.000000Z",
+                "{}",
+            ),
         ]
         .join("\n");
         let d = replay(&capture, &table);
@@ -665,8 +683,20 @@ mod tests {
 
         // A mount/ok suppresses it.
         let capture = [
-            event("mount", "/__tfs__", "ok", "2026-08-20T01:00:00.000000Z", "{\"action\":\"insert\",\"handle\":1}"),
-            event("open", "/__tfs__/lib/x.rb", "image:/__tfs__", "2026-08-20T01:00:01.000000Z", "{}"),
+            event(
+                "mount",
+                "/__tfs__",
+                "ok",
+                "2026-08-20T01:00:00.000000Z",
+                "{\"action\":\"insert\",\"handle\":1}",
+            ),
+            event(
+                "open",
+                "/__tfs__/lib/x.rb",
+                "image:/__tfs__",
+                "2026-08-20T01:00:01.000000Z",
+                "{}",
+            ),
         ]
         .join("\n");
         let d = replay(&capture, &table);
@@ -704,7 +734,13 @@ mod tests {
         // (The mount/ok keeps the absence signature out of these
         // negative cases: a mount-less fragment always reads as the
         // never-mounted shape, by the signature's design.)
-        let mount = event("mount", "/__tfs__", "ok", "2026-08-20T00:59:59.000000Z", "{\"action\":\"insert\",\"handle\":1}");
+        let mount = event(
+            "mount",
+            "/__tfs__",
+            "ok",
+            "2026-08-20T00:59:59.000000Z",
+            "{\"action\":\"insert\",\"handle\":1}",
+        );
         let bad = "{\"closure\":{\"format\":\"elf\",\"deps\":[{\"name\":\"libx.so\",\"resolved\":null,\"verdict\":\"error:2\"}]}}";
         let capture = format!(
             "{mount}\n{}",
@@ -736,8 +772,20 @@ mod tests {
         let table = load_signatures().unwrap();
         // deny → dependent open error: fires, quoting the deny.
         let capture = [
-            event("jail", "/secret/data", "deny:user", "2026-08-20T01:00:00.000000Z", "{\"access\":\"read\"}"),
-            event("open", "/secret/data/file", "denied:user", "2026-08-20T01:00:01.000000Z", "{\"need\":\"read\"}"),
+            event(
+                "jail",
+                "/secret/data",
+                "deny:user",
+                "2026-08-20T01:00:00.000000Z",
+                "{\"access\":\"read\"}",
+            ),
+            event(
+                "open",
+                "/secret/data/file",
+                "denied:user",
+                "2026-08-20T01:00:01.000000Z",
+                "{\"need\":\"read\"}",
+            ),
         ]
         .join("\n");
         let d = replay(&capture, &table);
@@ -747,26 +795,56 @@ mod tests {
         let evidence = red.evidence.unwrap();
         assert!(evidence.contains("open /secret/data/file"), "{evidence}");
         let related = red.related.unwrap();
-        assert!(related.contains("jail /secret/data verdict=deny:user"), "{related}");
+        assert!(
+            related.contains("jail /secret/data verdict=deny:user"),
+            "{related}"
+        );
 
         // The same path exactly also dependents; an error: verdict too.
         let capture = [
-            event("jail", "/secret", "deny:manifest", "2026-08-20T01:00:00.000000Z", "{\"access\":\"write\"}"),
-            event("stat", "/secret", "error:13", "2026-08-20T01:00:01.000000Z", "{}"),
+            event(
+                "jail",
+                "/secret",
+                "deny:manifest",
+                "2026-08-20T01:00:00.000000Z",
+                "{\"access\":\"write\"}",
+            ),
+            event(
+                "stat",
+                "/secret",
+                "error:13",
+                "2026-08-20T01:00:01.000000Z",
+                "{}",
+            ),
         ]
         .join("\n");
         let d = replay(&capture, &table);
-        assert_eq!(
-            d.red.map(|r| r.signature).as_deref(),
-            Some("policy-denial")
-        );
+        assert_eq!(d.red.map(|r| r.signature).as_deref(), Some("policy-denial"));
 
         // An unrelated path is not dependent (a component boundary).
-        let mount = event("mount", "/__tfs__", "ok", "2026-08-20T00:59:59.000000Z", "{\"action\":\"insert\",\"handle\":1}");
+        let mount = event(
+            "mount",
+            "/__tfs__",
+            "ok",
+            "2026-08-20T00:59:59.000000Z",
+            "{\"action\":\"insert\",\"handle\":1}",
+        );
         let capture = [
             mount.clone(),
-            event("jail", "/secret/data", "deny:user", "2026-08-20T01:00:00.000000Z", "{\"access\":\"read\"}"),
-            event("open", "/secret/data2/file", "error:2", "2026-08-20T01:00:01.000000Z", "{}"),
+            event(
+                "jail",
+                "/secret/data",
+                "deny:user",
+                "2026-08-20T01:00:00.000000Z",
+                "{\"access\":\"read\"}",
+            ),
+            event(
+                "open",
+                "/secret/data2/file",
+                "error:2",
+                "2026-08-20T01:00:01.000000Z",
+                "{}",
+            ),
         ]
         .join("\n");
         let d = replay(&capture, &table);
@@ -775,9 +853,27 @@ mod tests {
         // An intervening non-deny jail event for the path clears it.
         let capture = [
             mount,
-            event("jail", "/secret", "deny:user", "2026-08-20T01:00:00.000000Z", "{\"access\":\"read\"}"),
-            event("jail", "/secret", "allow:user", "2026-08-20T01:00:01.000000Z", "{\"access\":\"read\"}"),
-            event("open", "/secret", "error:13", "2026-08-20T01:00:02.000000Z", "{}"),
+            event(
+                "jail",
+                "/secret",
+                "deny:user",
+                "2026-08-20T01:00:00.000000Z",
+                "{\"access\":\"read\"}",
+            ),
+            event(
+                "jail",
+                "/secret",
+                "allow:user",
+                "2026-08-20T01:00:01.000000Z",
+                "{\"access\":\"read\"}",
+            ),
+            event(
+                "open",
+                "/secret",
+                "error:13",
+                "2026-08-20T01:00:02.000000Z",
+                "{}",
+            ),
         ]
         .join("\n");
         let d = replay(&capture, &table);
@@ -808,7 +904,13 @@ mod tests {
         // materialize hop is the report.
         let closure = "{\"closure\":{\"format\":\"elf\",\"deps\":[{\"name\":\"libc.so\",\"resolved\":\"/tfs/lib/libc.so\",\"verdict\":\"materialized\"}]}}";
         let capture = [
-            event("mount", "/__tfs__", "ok", "2026-08-20T01:00:00.000000Z", "{\"action\":\"insert\",\"handle\":1}"),
+            event(
+                "mount",
+                "/__tfs__",
+                "ok",
+                "2026-08-20T01:00:00.000000Z",
+                "{\"action\":\"insert\",\"handle\":1}",
+            ),
             event_errno("materialize", "/tfs/bin/tool", "error:28", 28, "{}"),
             event_errno("dlopen", "/tfs/lib/app.so", "error:126", 126, closure),
         ]
@@ -823,8 +925,20 @@ mod tests {
     fn the_tolerant_scan_drops_a_crashed_tail() {
         let table = load_signatures().unwrap();
         let capture = [
-            event("mount", "/__tfs__", "ok", "2026-08-20T01:00:00.000000Z", "{\"action\":\"insert\",\"handle\":1}"),
-            event("open", "/__tfs__/lib/x.rb", "image:/__tfs__", "2026-08-20T01:00:01.000000Z", "{}"),
+            event(
+                "mount",
+                "/__tfs__",
+                "ok",
+                "2026-08-20T01:00:00.000000Z",
+                "{\"action\":\"insert\",\"handle\":1}",
+            ),
+            event(
+                "open",
+                "/__tfs__/lib/x.rb",
+                "image:/__tfs__",
+                "2026-08-20T01:00:01.000000Z",
+                "{}",
+            ),
             "{\"v\":1,\"ts\":\"2026-08-20T01:00:02".to_string(), // the crashed tail
         ]
         .join("\n");
@@ -841,9 +955,14 @@ mod tests {
         let capture = event_errno("materialize", "/tfs/bin/tool", "error:28", 28, "{}");
         let d = replay(&capture, &table);
         let report = render_report(std::path::Path::new("/tmp/c.jsonl"), &d, &table);
-        assert!(report.contains("hop chain: mount → manifest read → resolve → materialize → OS bind"), "{report}");
         assert!(
-            report.contains("RED hop: materialize — exec-cache write failure [signature: materialize-error]"),
+            report.contains("hop chain: mount → manifest read → resolve → materialize → OS bind"),
+            "{report}"
+        );
+        assert!(
+            report.contains(
+                "RED hop: materialize — exec-cache write failure [signature: materialize-error]"
+            ),
             "{report}"
         );
         assert!(report.contains("evidence: event #1"), "{report}");
@@ -852,11 +971,20 @@ mod tests {
         let capture = event("open", "/x", "host", "2026-08-20T01:00:00.000000Z", "{}");
         let d = replay(&capture, &table);
         let report = render_report(std::path::Path::new("/tmp/c.jsonl"), &d, &table);
-        assert!(report.contains("RED hop: mount — env image never mounted (handoff env lost)"), "{report}");
+        assert!(
+            report.contains("RED hop: mount — env image never mounted (handoff env lost)"),
+            "{report}"
+        );
         assert!(report.contains("no `mount/ok` verdict"), "{report}");
 
         // GREEN.
-        let capture = event("mount", "/__tfs__", "ok", "2026-08-20T01:00:00.000000Z", "{\"action\":\"insert\",\"handle\":1}");
+        let capture = event(
+            "mount",
+            "/__tfs__",
+            "ok",
+            "2026-08-20T01:00:00.000000Z",
+            "{\"action\":\"insert\",\"handle\":1}",
+        );
         let d = replay(&capture, &table);
         let report = render_report(std::path::Path::new("/tmp/c.jsonl"), &d, &table);
         assert!(report.contains("GREEN: no red hop"), "{report}");

--- a/crates/tebako-cli/src/trace/import.rs
+++ b/crates/tebako-cli/src/trace/import.rs
@@ -1,0 +1,936 @@
+//! `tebako trace import procmon` — the spec 25 §6.2 offline converter
+//! (the rest of phase T3): a Windows procmon CSV export becomes the
+//! retrace-shaped JSON document `tebako trace cover` consumes as its
+//! outside stream (the kernel-layer producer of §6.1's three-layer
+//! model, normalized into retrace's format — producers normalize in,
+//! never the reverse; pure Rust, in-process, law 4).
+//!
+//! # Parity contract
+//!
+//! A safe-Rust port of retrace's `procmon2retrace`
+//! (tools/procmon2retrace/{procmon2retrace,convert,csv}.c — BSD-2-Clause,
+//! Ribose Inc; reference: the v2.8.0 tool, verified against the local
+//! clone @ v2.13.0). The golden fixture `tests/fixtures/correlate/
+//! 06-libsass-importer/` pins both sides: `outside.csv` is the procmon
+//! export (byte-verbatim upstream, CRLF + BOM via the .gitattributes
+//! `-text` exception) and `outside.json` is upstream's own conversion of
+//! it. This converter's stdout on `outside.csv` IS `outside.json`, byte
+//! for byte (unit-pinned below); `tests/trace_import.rs` then feeds the
+//! conversion to `tebako trace cover` and asserts the case's
+//! `expected.txt`/`exit.txt` — the §6.3 golden verdict reproduced from
+//! the CSV end.
+//!
+//! The pinned upstream semantics:
+//!
+//! - **The CSV scanner** (csv.c): byte-oriented state machine — quoted
+//!   fields (embedded commas/CR/LF, `""` escapes), CRLF/LF/CR record
+//!   ends, a UTF-8 BOM at buffer start, blank-line records dropped, a
+//!   trailing record without a final newline delivered, EOF inside an
+//!   open quote dropped and counted (the "truncated final record"
+//!   note). The fixed C buffers are parity, not safety: fields
+//!   truncate at 4095 bytes, a record keeps at most 16 fields, and a
+//!   record's total field storage is 64 KB (a field starting past the
+//!   cap converts as empty).
+//! - **The header row** (convert.c `pmconv_map_header`): column names
+//!   match case-insensitively (`Time of Day`, `Process Name`, `PID`,
+//!   `Operation`, `Path`, `Result`, `Detail`); the first record is the
+//!   header when `Operation` maps and at least one other column does.
+//!   An unrecognized first record is an EVENT under procmon's canonical
+//!   column order (the identity map).
+//! - **The entry** (convert.c `pmconv_entry`): one JSON object per
+//!   record — `time: 0`, `pid` (strtod of the PID column, 0 when
+//!   absent), `tid: 0`, `module: "ETW"`, `severity` (`INFO` when the
+//!   Result column is `SUCCESS`, else `WARN`), and the `message`
+//!   carrying `func` (Operation), `process`, `time_of_day`, `path`,
+//!   `result`, `detail` in that order, each omitted when its column is
+//!   unmapped or the row is short. A record with an empty/missing
+//!   Operation is a bad row: counted, skipped.
+//! - **The document** (parson's `json_serialize_to_string_pretty` +
+//!   procmon2retrace.c's emission): one JSON array, `[\n`, entries at
+//!   brace level 0 with 4-space indents and `,\n` leading separators,
+//!   closed `\n]\n` (or `]\n` when empty); strings escape `"` `\` `/`
+//!   and the C0 controls exactly as parson; numbers are C's `%1.17g`.
+//!
+//! # Surface and exit codes (spec 25 §6.2; upstream's verbs)
+//!
+//! ```text
+//! tebako trace import procmon <capture.csv>
+//! ```
+//!
+//! - **stdout** is the JSON document and nothing else (a machine
+//!   contract: the version banner rides stderr for this subcommand —
+//!   main.rs's machine_stdout rule, the `trace cover` precedent).
+//! - **stderr** carries the upstream summary
+//!   (`entries=N bad-rows=M`, plus `(truncated final record)` when the
+//!   tail dropped) under the tebako prefix.
+//! - **Exit codes** are upstream's: 0 = entries emitted, 1 = the
+//!   conversion ran but produced zero entries, 2 = usage or I/O error.
+//!
+//! Documented surface deviations from upstream (flag shape only; the
+//! in-format behavior above is byte-parity): upstream's optional
+//! `[out.json]` positional is the shell's redirection here (the spec's
+//! verb takes exactly one positional), and upstream's conversion-time
+//! `--pid N` scope filter rides `tebako trace cover --pid N` downstream
+//! (the correlator's pid coverage is the same join, §6.3) — the
+//! converted document keeps every pid.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+// ---------------------------------------------------------------------
+// The CSV scanner (csv.c port)
+// ---------------------------------------------------------------------
+
+/// csv.h's PMCSV_MAX_FIELDS: a record keeps at most 16 fields.
+const PMCSV_MAX_FIELDS: usize = 16;
+/// csv.h's PMCSV_FIELD_MAX: a field truncates at 4095 bytes.
+const PMCSV_FIELD_MAX: usize = 4096;
+/// csv.h's row storage: PMCSV_FIELD_MAX * PMCSV_MAX_FIELDS — a record's
+/// fields (plus their NUL separators) share one 64 KB buffer.
+const PMCSV_STORAGE: usize = PMCSV_FIELD_MAX * PMCSV_MAX_FIELDS;
+
+/// One scanned CSV record (upstream's `PmCsvRow`, owned per record —
+/// upstream reuses the buffer across the callback; the port hands the
+/// callback a borrow of the scanner's row, same lifetime rule).
+#[derive(Debug, Default)]
+pub struct CsvRow {
+    /// The record's fields, unescaped (doubled quotes folded), in
+    /// column order. Byte strings: procmon exports are not guaranteed
+    /// UTF-8 and the parson emission below is byte-faithful.
+    pub fields: Vec<Vec<u8>>,
+}
+
+/// The scanner's outcome counters (csv.c's return + `skipped`).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ScanStats {
+    /// Records delivered to the callback.
+    pub records: usize,
+    /// Records dropped for a missing closing quote at EOF.
+    pub truncated: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    /// Between fields (record start or after a comma).
+    FieldStart,
+    /// Inside an unquoted field.
+    Unquoted,
+    /// Inside a quoted field.
+    Quoted,
+    /// Saw `"` inside a quoted field: a doubled quote or the close.
+    Quote,
+}
+
+/// The scanner's mutable cursor (csv.c's `scan_state`): the shared
+/// per-record storage is emulated by `off` (the write cursor, NULs
+/// included) plus `cur` (the current field's stored bytes — exactly the
+/// bytes upstream's buffer would hold for it).
+struct ScanState {
+    row: CsvRow,
+    state: State,
+    off: usize,
+    field_len: usize,
+    cur: Vec<u8>,
+}
+
+impl ScanState {
+    fn push(&mut self, c: u8) {
+        // csv.c's push: the per-field cap first, then the buffer cap.
+        if self.field_len >= PMCSV_FIELD_MAX - 1 {
+            return;
+        }
+        if self.off < PMCSV_STORAGE - 1 {
+            self.cur.push(c);
+            self.field_len += 1;
+            self.off += 1;
+        }
+    }
+
+    fn end_field(&mut self) {
+        if self.row.fields.len() < PMCSV_MAX_FIELDS {
+            if self.off >= PMCSV_STORAGE {
+                // The field started past the buffer cap: upstream's NUL
+                // lands at the buffer end and the field pointer reads as
+                // the empty string. (A field IN PROGRESS can never reach
+                // this — push stops one byte earlier.)
+                self.row.fields.push(Vec::new());
+            } else {
+                self.row.fields.push(std::mem::take(&mut self.cur));
+            }
+        }
+        self.off += 1; // the NUL's byte, recorded even past the caps
+    }
+
+    /// csv.c's end_record: a blank line (one empty field and nothing
+    /// else) is not a record.
+    fn end_record(&mut self, cb: &mut dyn FnMut(&CsvRow), stats: &mut ScanStats) {
+        if self.row.fields.len() > 1 || self.row.fields.first().is_some_and(|f| !f.is_empty()) {
+            cb(&self.row);
+            stats.records += 1;
+        }
+        self.row.fields.clear();
+        self.off = 0;
+    }
+}
+
+fn is_rec_end(c: u8) -> bool {
+    c == b'\r' || c == b'\n'
+}
+
+/// Scan `text` as a procmon CSV export (csv.c's `pmcsv_scan`): `cb`
+/// fires once per delivered record; the row is reused, so the callback
+/// must copy anything it keeps. A UTF-8 BOM at buffer start is skipped.
+pub fn scan_csv(text: &[u8], cb: &mut dyn FnMut(&CsvRow)) -> ScanStats {
+    let mut st = ScanState {
+        row: CsvRow::default(),
+        state: State::FieldStart,
+        off: 0,
+        field_len: 0,
+        cur: Vec::new(),
+    };
+    let mut stats = ScanStats::default();
+    let mut i = 0usize;
+    // UTF-8 BOM at buffer start only (Excel round-trips).
+    if text.len() >= 3 && text[..3] == [0xEF, 0xBB, 0xBF] {
+        i = 3;
+    }
+    while i < text.len() {
+        let c = text[i];
+        match st.state {
+            State::FieldStart => {
+                st.field_len = 0;
+                if c == b'"' {
+                    st.state = State::Quoted;
+                } else if c == b',' {
+                    st.end_field();
+                } else if is_rec_end(c) {
+                    st.end_field();
+                    st.end_record(cb, &mut stats);
+                    st.state = State::FieldStart;
+                    if c == b'\r' && i + 1 < text.len() && text[i + 1] == b'\n' {
+                        i += 1;
+                    }
+                } else {
+                    st.push(c);
+                    st.state = State::Unquoted;
+                }
+            }
+            State::Unquoted => {
+                if c == b',' {
+                    st.end_field();
+                    st.state = State::FieldStart;
+                } else if is_rec_end(c) {
+                    st.end_field();
+                    st.end_record(cb, &mut stats);
+                    st.state = State::FieldStart;
+                    if c == b'\r' && i + 1 < text.len() && text[i + 1] == b'\n' {
+                        i += 1;
+                    }
+                } else {
+                    st.push(c);
+                }
+            }
+            State::Quoted => {
+                if c == b'"' {
+                    st.state = State::Quote;
+                } else {
+                    st.push(c);
+                }
+            }
+            State::Quote => {
+                if c == b'"' {
+                    st.push(b'"');
+                    st.state = State::Quoted;
+                } else if c == b',' {
+                    st.end_field();
+                    st.state = State::FieldStart;
+                } else if is_rec_end(c) {
+                    st.end_field();
+                    st.end_record(cb, &mut stats);
+                    st.state = State::FieldStart;
+                    if c == b'\r' && i + 1 < text.len() && text[i + 1] == b'\n' {
+                        i += 1;
+                    }
+                } else {
+                    // Stray text after a closing quote: tolerated,
+                    // appended (csv.c's documented leniency).
+                    st.push(c);
+                    st.state = State::Unquoted;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    // A trailing record without a final newline.
+    if st.state == State::Quoted {
+        stats.truncated += 1; // EOF inside an open quote: dropped
+    } else if st.state != State::FieldStart || st.off > 0 {
+        // Both sub-branches end the pending field (the FieldStart one
+        // is the file ending right after a comma — csv.c sets
+        // start=off and ends an empty field).
+        st.end_field();
+        if st.row.fields.len() > 1 || st.row.fields.first().is_some_and(|f| !f.is_empty()) {
+            cb(&st.row);
+            stats.records += 1;
+        }
+    }
+    stats
+}
+
+// ---------------------------------------------------------------------
+// The header mapping (convert.c port)
+// ---------------------------------------------------------------------
+
+/// The procmon CSV columns, by role (convert.h's PMCOL_*).
+const COL_TOD: usize = 0;
+const COL_PROCESS: usize = 1;
+const COL_PID: usize = 2;
+const COL_OPERATION: usize = 3;
+const COL_PATH: usize = 4;
+const COL_RESULT: usize = 5;
+const COL_DETAIL: usize = 6;
+const COL_COUNT: usize = 7;
+
+const COL_NAMES: [&[u8]; COL_COUNT] = [
+    b"time of day",
+    b"process name",
+    b"pid",
+    b"operation",
+    b"path",
+    b"result",
+    b"detail",
+];
+
+/// convert.c's `ieq`: ASCII case-insensitive equality.
+fn ieq(a: &[u8], b: &[u8]) -> bool {
+    a.eq_ignore_ascii_case(b)
+}
+
+/// The column map: `colmap[role]` is the field index or `NONE`. The
+/// identity map is procmon's canonical column order (the fallback when
+/// the first record is not a recognizable header).
+type ColMap = [usize; COL_COUNT];
+const NONE: usize = usize::MAX;
+const IDENTITY_COLMAP: ColMap = [0, 1, 2, 3, 4, 5, 6];
+
+/// convert.c's `pmconv_map_header`: the row is a header when Operation
+/// maps and at least one other column does (a lone Operation column is
+/// not a procmon header).
+fn map_header(row: &CsvRow) -> Option<ColMap> {
+    let mut colmap = [NONE; COL_COUNT];
+    let mut mapped = 0usize;
+    for (col, field) in row.fields.iter().enumerate() {
+        for role in 0..COL_COUNT {
+            if colmap[role] == NONE && ieq(field, COL_NAMES[role]) {
+                colmap[role] = col;
+                mapped += 1;
+                break;
+            }
+        }
+    }
+    if colmap[COL_OPERATION] == NONE || mapped <= 1 {
+        return None;
+    }
+    Some(colmap)
+}
+
+/// convert.c's `field_or_null`: the mapped field, or None when the
+/// column is unmapped or the row is short (a present-but-empty field is
+/// Some — the message carries `""`).
+fn field<'a>(row: &'a CsvRow, colmap: &ColMap, role: usize) -> Option<&'a [u8]> {
+    let idx = colmap[role];
+    if idx == NONE {
+        return None;
+    }
+    row.fields.get(idx).map(Vec::as_slice)
+}
+
+/// convert.c's pid read: strtod on the PID column (0 when absent or
+/// unparsable — the prefix parse below is strtod's decimal grammar:
+/// leading whitespace skipped, the longest valid prefix taken).
+fn row_pid(row: &CsvRow, colmap: &ColMap) -> f64 {
+    field(row, colmap, COL_PID)
+        .map(strtod_prefix)
+        .unwrap_or(0.0)
+}
+
+/// strtod's decimal form (the C-locale `isspace` skip; an exponent is
+/// consumed only with at least one digit). Hex floats and the inf/nan
+/// words are NOT parsed (a documented garbage-field deviation — procmon
+/// PID columns are decimal integers; upstream's strtod would take them,
+/// this port reads 0).
+fn strtod_prefix(s: &[u8]) -> f64 {
+    let mut i = 0usize;
+    while i < s.len() && matches!(s[i], b' ' | b'\t' | b'\n' | b'\x0b' | b'\x0c' | b'\r') {
+        i += 1;
+    }
+    let start = i;
+    if i < s.len() && matches!(s[i], b'+' | b'-') {
+        i += 1;
+    }
+    let digits_start = i;
+    while i < s.len() && s[i].is_ascii_digit() {
+        i += 1;
+    }
+    let int_digits = i - digits_start;
+    let mut frac_digits = 0usize;
+    if i < s.len() && s[i] == b'.' {
+        let frac_start = i + 1;
+        let mut j = frac_start;
+        while j < s.len() && s[j].is_ascii_digit() {
+            j += 1;
+        }
+        frac_digits = j - frac_start;
+        if int_digits > 0 || frac_digits > 0 {
+            i = j;
+        }
+    }
+    if int_digits == 0 && frac_digits == 0 {
+        return 0.0;
+    }
+    let mut end = i;
+    if i < s.len() && matches!(s[i], b'e' | b'E') {
+        let mut j = i + 1;
+        if j < s.len() && matches!(s[j], b'+' | b'-') {
+            j += 1;
+        }
+        let exp_start = j;
+        while j < s.len() && s[j].is_ascii_digit() {
+            j += 1;
+        }
+        if j > exp_start {
+            end = j;
+        }
+    }
+    std::str::from_utf8(&s[start..end])
+        .ok()
+        .and_then(|t| t.parse::<f64>().ok())
+        .unwrap_or(0.0)
+}
+
+// ---------------------------------------------------------------------
+// The JSON emission (parson's pretty printer, byte-exact)
+// ---------------------------------------------------------------------
+
+/// parson's `json_serialize_string` over bytes: `"` `\` `/` (the
+/// XML-embeddable escape) and the C0 controls; every other byte is
+/// copied verbatim (parson does not validate UTF-8 on output).
+fn parson_escape_into(out: &mut Vec<u8>, s: &[u8]) {
+    out.push(b'"');
+    for &c in s {
+        match c {
+            b'"' => out.extend_from_slice(b"\\\""),
+            b'\\' => out.extend_from_slice(b"\\\\"),
+            b'/' => out.extend_from_slice(b"\\/"),
+            0x08 => out.extend_from_slice(b"\\b"),
+            0x0c => out.extend_from_slice(b"\\f"),
+            b'\n' => out.extend_from_slice(b"\\n"),
+            b'\r' => out.extend_from_slice(b"\\r"),
+            b'\t' => out.extend_from_slice(b"\\t"),
+            c if c < 0x20 => out.extend_from_slice(format!("\\u{c:04x}").as_bytes()),
+            c => out.push(c),
+        }
+    }
+    out.push(b'"');
+}
+
+/// C's `%1.17g` (parson's FLOAT_FORMAT): 17 significant digits, the
+/// fixed style for exponents in [-4, 17), the scientific style
+/// otherwise, trailing zeros stripped.
+fn format_g17(v: f64) -> String {
+    const P: i32 = 17;
+    if v.is_nan() {
+        return "nan".to_string();
+    }
+    if v.is_infinite() {
+        return if v < 0.0 { "-inf" } else { "inf" }.to_string();
+    }
+    if v == 0.0 {
+        return if v.is_sign_negative() { "-0" } else { "0" }.to_string();
+    }
+    // The %e form at P-1 decimals: the printed exponent is the
+    // post-rounding one (Rust normalizes the mantissa to [1, 10)).
+    let sci = format!("{:.*e}", (P - 1) as usize, v.abs());
+    let epos = sci.rfind('e').expect("Rust's {:e} always carries e");
+    let x: i32 = sci[epos + 1..].parse().expect("Rust's {:e} exponent");
+    let strip = |s: String| -> String {
+        if s.contains('.') {
+            let s = s.trim_end_matches('0');
+            s.strip_suffix('.').unwrap_or(s).to_string()
+        } else {
+            s
+        }
+    };
+    if (-4..P).contains(&x) {
+        strip(format!("{:.*}", (P - 1 - x) as usize, v))
+    } else {
+        let mantissa = strip(sci[..epos].to_string());
+        let sign = if v < 0.0 { "-" } else { "" };
+        format!(
+            "{sign}{mantissa}e{}{:02}",
+            if x < 0 { "-" } else { "+" },
+            x.abs()
+        )
+    }
+}
+
+/// One CSV record → one retrace-shaped entry, parson-pretty at brace
+/// level 0 (convert.c's `pmconv_entry` + parson's serializer), as the
+/// document bytes. `None` is the bad row: an empty/missing Operation
+/// (upstream counts and skips).
+fn entry_json(row: &CsvRow, colmap: &ColMap) -> Option<Vec<u8>> {
+    let op = field(row, colmap, COL_OPERATION)?;
+    if op.is_empty() {
+        return None;
+    }
+    let result = field(row, colmap, COL_RESULT);
+    let severity = match result {
+        Some(r) if ieq(r, b"success") => "INFO",
+        _ => "WARN",
+    };
+    let mut out = Vec::new();
+    out.extend_from_slice(b"{\n");
+    out.extend_from_slice(format!("    \"time\": {},\n", format_g17(0.0)).as_bytes());
+    out.extend_from_slice(format!("    \"pid\": {},\n", format_g17(row_pid(row, colmap))).as_bytes());
+    out.extend_from_slice(b"    \"tid\": 0,\n");
+    out.extend_from_slice(b"    \"module\": \"ETW\",\n");
+    out.extend_from_slice(format!("    \"severity\": \"{severity}\",\n").as_bytes());
+    out.extend_from_slice(b"    \"message\": {\n");
+    // convert.c's set_if order: func, process, time_of_day, path,
+    // result, detail — each present only when its column mapped and the
+    // row carried it.
+    let members: [(usize, &[u8]); 6] = [
+        (COL_OPERATION, b"func"),
+        (COL_PROCESS, b"process"),
+        (COL_TOD, b"time_of_day"),
+        (COL_PATH, b"path"),
+        (COL_RESULT, b"result"),
+        (COL_DETAIL, b"detail"),
+    ];
+    let set: Vec<(&[u8], &[u8])> = members
+        .iter()
+        .filter_map(|(role, key)| field(row, colmap, *role).map(|v| (*key, v)))
+        .collect();
+    for (i, (key, value)) in set.iter().enumerate() {
+        out.extend_from_slice(b"        ");
+        parson_escape_into(&mut out, key);
+        out.extend_from_slice(b": ");
+        parson_escape_into(&mut out, value);
+        out.extend_from_slice(if i + 1 < set.len() { b",\n" } else { b"\n" });
+    }
+    out.extend_from_slice(b"    }\n}");
+    // The emitted keys are ASCII constants and the escape table covers
+    // every byte that could break the string, so the document is
+    // well-formed for arbitrary field bytes — a non-UTF-8 field is
+    // emitted byte-verbatim, exactly as upstream's parson emits it.
+    Some(out)
+}
+
+/// The conversion result counters (the stderr summary).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ImportStats {
+    /// Entries emitted into the document.
+    pub entries: usize,
+    /// Records skipped for an empty/missing Operation.
+    pub bad_rows: usize,
+    /// Records dropped for a missing closing quote at EOF.
+    pub truncated: usize,
+}
+
+/// Convert a procmon CSV export into the retrace-shaped JSON array
+/// document (procmon2retrace.c's main flow): the header row maps the
+/// columns or the first record converts under the canonical order.
+pub fn convert_procmon(text: &[u8]) -> (Vec<u8>, ImportStats) {
+    struct Conv {
+        colmap: ColMap,
+        header_done: bool,
+        first: bool,
+        out: Vec<u8>,
+        stats: ImportStats,
+    }
+    let mut conv = Conv {
+        colmap: IDENTITY_COLMAP,
+        header_done: false,
+        first: true,
+        out: b"[\n".to_vec(),
+        stats: ImportStats::default(),
+    };
+    let scan = scan_csv(text, &mut |row| {
+        if !conv.header_done {
+            conv.header_done = true;
+            if let Some(colmap) = map_header(row) {
+                conv.colmap = colmap;
+                return; // the header is consumed, not an event
+            }
+            conv.colmap = IDENTITY_COLMAP;
+        }
+        match entry_json(row, &conv.colmap) {
+            Some(entry) => {
+                if !conv.first {
+                    conv.out.extend_from_slice(b",\n");
+                }
+                conv.first = false;
+                conv.out.extend_from_slice(&entry);
+                conv.out.push(b'\n');
+                conv.stats.entries += 1;
+            }
+            None => conv.stats.bad_rows += 1,
+        }
+    });
+    conv.stats.truncated = scan.truncated;
+    conv.out.extend_from_slice(if conv.stats.entries > 0 {
+        b"\n]\n"
+    } else {
+        b"]\n"
+    });
+    (conv.out, conv.stats)
+}
+
+// ---------------------------------------------------------------------
+// The CLI verb
+// ---------------------------------------------------------------------
+
+/// The parsed `tebako trace import` argv.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceImportArgs {
+    /// The procmon CSV export to convert.
+    pub csv: PathBuf,
+}
+
+const IMPORT_USAGE: &str = "usage: tebako trace import procmon <capture.csv>";
+
+/// Parse the `trace import` argv (spec 25 §6.2's exact surface: one
+/// format token, one positional). Errors are the usage text or a named
+/// error — the caller exits 2 (the trace-verbs convention).
+pub fn parse_trace_import_args(args: &[String]) -> Result<TraceImportArgs, String> {
+    match args {
+        [format, csv] if format == "procmon" => Ok(TraceImportArgs {
+            csv: PathBuf::from(csv),
+        }),
+        [format, ..] if format != "procmon" && !format.starts_with('-') => Err(format!(
+            "unknown import format '{format}' (the outside producers: procmon)\n{IMPORT_USAGE}"
+        )),
+        _ => Err(IMPORT_USAGE.to_string()),
+    }
+}
+
+/// `tebako trace import procmon <csv>` — never returns; the process
+/// exit code is upstream procmon2retrace's: 0 entries emitted, 1 zero
+/// entries, 2 usage or I/O error.
+pub fn trace_import(args: &[String]) -> ! {
+    let parsed = match parse_trace_import_args(args) {
+        Ok(p) => p,
+        Err(msg) => {
+            eprintln!("tebako: trace import: {msg}");
+            std::process::exit(2);
+        }
+    };
+    let text = match std::fs::read(&parsed.csv) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!(
+                "tebako: trace import: cannot read {}: {e}",
+                parsed.csv.display()
+            );
+            std::process::exit(2);
+        }
+    };
+    let (doc, stats) = convert_procmon(&text);
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    if let Err(e) = lock.write_all(&doc).and_then(|()| lock.flush()) {
+        eprintln!("tebako: trace import: cannot write stdout: {e}");
+        std::process::exit(2);
+    }
+    eprintln!(
+        "tebako: trace import: entries={} bad-rows={}{}",
+        stats.entries,
+        stats.bad_rows,
+        if stats.truncated > 0 {
+            " (truncated final record)"
+        } else {
+            ""
+        }
+    );
+    std::process::exit(if stats.entries > 0 { 0 } else { 1 });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scan(text: &[u8]) -> (Vec<Vec<Vec<u8>>>, ScanStats) {
+        let mut rows = Vec::new();
+        let stats = scan_csv(text, &mut |row| rows.push(row.fields.clone()));
+        (rows, stats)
+    }
+
+    fn row(fields: &[&[u8]]) -> CsvRow {
+        CsvRow {
+            fields: fields.iter().map(|f| f.to_vec()).collect(),
+        }
+    }
+
+    #[test]
+    fn csv_scan_basic_shapes() {
+        // CRLF, LF and CR record ends; quoted fields with an embedded
+        // comma, CRLF and a doubled quote; the BOM at buffer start.
+        let (rows, stats) = scan(
+            b"\xEF\xBB\xBF\"a\",\"b,b\"\r\n\"c\r\nd\",\"e\"\"f\"\nlast,one\rfinal,line",
+        );
+        assert_eq!(stats, ScanStats { records: 4, truncated: 0 });
+        assert_eq!(rows[0], vec![b"a".to_vec(), b"b,b".to_vec()]);
+        assert_eq!(rows[1], vec![b"c\r\nd".to_vec(), b"e\"f".to_vec()]);
+        assert_eq!(rows[2], vec![b"last".to_vec(), b"one".to_vec()]);
+        assert_eq!(rows[3], vec![b"final".to_vec(), b"line".to_vec()]);
+
+        // Blank lines are not records; unquoted fields pass through.
+        let (rows, stats) = scan(b"\n\na,b\n\n\nc\n");
+        assert_eq!(stats.records, 2);
+        assert_eq!(rows[0], vec![b"a".to_vec(), b"b".to_vec()]);
+        assert_eq!(rows[1], vec![b"c".to_vec()]);
+
+        // EOF inside an open quote drops the record and counts it.
+        let (rows, stats) = scan(b"a,b\n\"truncated,never-closed");
+        assert_eq!(stats, ScanStats { records: 1, truncated: 1 });
+        assert_eq!(rows.len(), 1);
+
+        // Stray text after a closing quote is tolerated and appended.
+        let (rows, _) = scan(b"\"quoted\"tail,next\n");
+        assert_eq!(rows[0], vec![b"quotedtail".to_vec(), b"next".to_vec()]);
+
+        // A trailing comma at EOF completes an empty final field.
+        let (rows, _) = scan(b"a,b,");
+        assert_eq!(
+            rows[0],
+            vec![b"a".to_vec(), b"b".to_vec(), Vec::new()]
+        );
+    }
+
+    #[test]
+    fn csv_scan_caps() {
+        // The 4095-byte field cap truncates.
+        let big = vec![b'x'; 5000];
+        let mut text = b"hdr,".to_vec();
+        text.extend_from_slice(&big);
+        text.push(b'\n');
+        let (rows, _) = scan(&text);
+        assert_eq!(rows[0][1].len(), PMCSV_FIELD_MAX - 1);
+
+        // Fields past the 16th are ignored.
+        let text = (0..20).map(|i| format!("f{i}")).collect::<Vec<_>>().join(",") + "\n";
+        let (rows, _) = scan(text.as_bytes());
+        assert_eq!(rows[0].len(), PMCSV_MAX_FIELDS);
+        assert_eq!(rows[0][15], b"f15".to_vec());
+
+        // The 64 KB record storage is sized to exactly fit the other
+        // caps (16 fields × (4095 + the NUL) = 65536), so the
+        // past-the-cap empty-field branch is unreachable in upstream
+        // and in this port alike: 16 full fields survive verbatim.
+        let field = vec![b'x'; PMCSV_FIELD_MAX - 1];
+        let mut text = Vec::new();
+        for _ in 0..PMCSV_MAX_FIELDS {
+            text.extend_from_slice(&field);
+            text.push(b',');
+        }
+        text.push(b'\n');
+        let (rows, _) = scan(&text);
+        // (17th field past the comma at EOF: ignored, the trailing
+        // comma completes an unrecorded field.)
+        assert_eq!(rows[0].len(), PMCSV_MAX_FIELDS);
+        assert!(rows[0].iter().all(|f| f.len() == PMCSV_FIELD_MAX - 1));
+    }
+
+    #[test]
+    fn header_mapping_table() {
+        // The canonical header maps, case-insensitively.
+        let h = row(&[
+            b"Time of Day",
+            b"Process Name",
+            b"PID",
+            b"Operation",
+            b"Path",
+            b"Result",
+            b"Detail",
+        ]);
+        assert_eq!(map_header(&h), Some(IDENTITY_COLMAP));
+        let h = row(&[
+            b"time of day",
+            b"process name",
+            b"pid",
+            b"operation",
+            b"path",
+            b"result",
+            b"detail",
+        ]);
+        assert_eq!(map_header(&h), Some(IDENTITY_COLMAP));
+
+        // A reordered/subset header maps by name.
+        let h = row(&[b"Operation", b"Path", b"Result"]);
+        let mut want = [NONE; COL_COUNT];
+        want[COL_OPERATION] = 0;
+        want[COL_PATH] = 1;
+        want[COL_RESULT] = 2;
+        assert_eq!(map_header(&h), Some(want));
+
+        // No Operation column, or ONLY the Operation column: not a
+        // header (the row converts as an event under the identity map).
+        assert_eq!(map_header(&row(&[b"Time of Day", b"Path"])), None);
+        assert_eq!(map_header(&row(&[b"Operation"])), None);
+    }
+
+    #[test]
+    fn entry_shaping_table() {
+        // The full row, canonical order (the fixture's first record).
+        let r = row(&[
+            b"11:02:01.1001220 AM",
+            b"sassc.exe",
+            b"9012",
+            b"QueryOpen",
+            b"C:\\pkg\\scss\\_a.scss",
+            b"NAME NOT FOUND",
+            b"SyncType: Sync+Create",
+        ]);
+        let entry = entry_json(&r, &IDENTITY_COLMAP).unwrap();
+        let entry = String::from_utf8(entry).unwrap();
+        assert_eq!(
+            entry,
+            "{\n    \"time\": 0,\n    \"pid\": 9012,\n    \"tid\": 0,\n    \"module\": \"ETW\",\n    \"severity\": \"WARN\",\n    \"message\": {\n        \"func\": \"QueryOpen\",\n        \"process\": \"sassc.exe\",\n        \"time_of_day\": \"11:02:01.1001220 AM\",\n        \"path\": \"C:\\\\pkg\\\\scss\\\\_a.scss\",\n        \"result\": \"NAME NOT FOUND\",\n        \"detail\": \"SyncType: Sync+Create\"\n    }\n}"
+        );
+
+        // SUCCESS (any case) is INFO; a missing Result column is WARN.
+        let mut ok = r.fields.clone();
+        ok[COL_RESULT] = b"Success".to_vec();
+        let ok_row = CsvRow { fields: ok };
+        let entry = String::from_utf8(entry_json(&ok_row, &IDENTITY_COLMAP).unwrap()).unwrap();
+        assert!(entry.contains("\"severity\": \"INFO\""), "{entry}");
+        let mut noresult = [NONE; COL_COUNT];
+        noresult[COL_OPERATION] = 1;
+        noresult[COL_PATH] = 0;
+        let entry =
+            String::from_utf8(entry_json(&row(&[b"/x", b"open"]), &noresult).unwrap()).unwrap();
+        assert!(entry.contains("\"severity\": \"WARN\""), "{entry}");
+        assert!(!entry.contains("\"result\""), "{entry}");
+        assert!(entry.contains("\"pid\": 0,"), "{entry}");
+
+        // A short row omits the trailing columns (an empty PRESENT
+        // field is kept).
+        let short = row(&[b"tod", b"proc", b"5", b"open"]);
+        let entry = String::from_utf8(entry_json(&short, &IDENTITY_COLMAP).unwrap()).unwrap();
+        assert!(entry.contains("\"func\": \"open\""), "{entry}");
+        assert!(!entry.contains("\"path\""), "{entry}");
+        let empty_detail = row(&[b"t", b"p", b"5", b"open", b"/x", b"SUCCESS", b""]);
+        let entry =
+            String::from_utf8(entry_json(&empty_detail, &IDENTITY_COLMAP).unwrap()).unwrap();
+        assert!(entry.contains("\"detail\": \"\""), "{entry}");
+
+        // The bad row: an empty or missing Operation.
+        assert!(entry_json(&row(&[b"t", b"p", b"5", b""]), &IDENTITY_COLMAP).is_none());
+        assert!(entry_json(&row(&[b"t"]), &IDENTITY_COLMAP).is_none());
+    }
+
+    #[test]
+    fn g17_table() {
+        // C's %1.17g, the parson number spelling.
+        assert_eq!(format_g17(0.0), "0");
+        assert_eq!(format_g17(9012.0), "9012");
+        assert_eq!(format_g17(0.5), "0.5");
+        assert_eq!(format_g17(-3.0), "-3");
+        assert_eq!(format_g17(1234.5678), "1234.5678");
+        assert_eq!(format_g17(1e17), "1e+17");
+        // 2.5e-5 is not exactly representable; at 17 significant digits
+        // C's %1.17g prints the neighbor tail too (printf-verified).
+        assert_eq!(format_g17(2.5e-5), "2.5000000000000001e-05");
+        // An exact binary value stays short.
+        assert_eq!(format_g17(7.62939453125e-06), "7.62939453125e-06");
+        assert_eq!(format_g17(1e-4), "0.0001");
+        assert_eq!(format_g17(-1.25e100), "-1.25e+100");
+    }
+
+    #[test]
+    fn strtod_prefix_table() {
+        assert_eq!(strtod_prefix(b"9012"), 9012.0);
+        assert_eq!(strtod_prefix(b"  42"), 42.0);
+        assert_eq!(strtod_prefix(b"-7"), -7.0);
+        assert_eq!(strtod_prefix(b"3.5e2"), 350.0);
+        assert_eq!(strtod_prefix(b"1e"), 1.0); // the exponent needs digits
+        assert_eq!(strtod_prefix(b"12junk"), 12.0);
+        assert_eq!(strtod_prefix(b""), 0.0);
+        assert_eq!(strtod_prefix(b"abc"), 0.0);
+        assert_eq!(strtod_prefix(b"."), 0.0);
+        assert_eq!(strtod_prefix(b".5"), 0.5);
+    }
+
+    #[test]
+    fn document_shape() {
+        // Zero entries: "[\n]\n" (and the empty input converts, it does
+        // not error — the exit code carries the zero).
+        let (doc, stats) = convert_procmon(b"");
+        assert_eq!(doc, b"[\n]\n");
+        assert_eq!(stats.entries, 0);
+
+        // The header alone consumes the first record.
+        let (doc, stats) = convert_procmon(
+            b"\"Time of Day\",\"Process Name\",\"PID\",\"Operation\",\"Path\",\"Result\",\"Detail\"\r\n",
+        );
+        assert_eq!(doc, b"[\n]\n");
+        assert_eq!(stats.entries, 0);
+
+        // An unrecognized first record is an EVENT under the canonical
+        // column order (procmon2retrace.c's fallthrough).
+        let (doc, stats) = convert_procmon(b"t,p,7,open,/x,SUCCESS,d\n");
+        assert_eq!(stats.entries, 1);
+        assert!(String::from_utf8_lossy(&doc).contains("\"pid\": 7,"));
+
+        // The separator: ",\n" before every entry after the first; the
+        // close is "\n]\n".
+        let (doc, _) = convert_procmon(
+            b"t,p,1,open,/a,SUCCESS,d\nt,p,2,open,/b,SUCCESS,d\n",
+        );
+        let text = String::from_utf8_lossy(&doc);
+        assert!(text.starts_with("[\n{\n"), "{text}");
+        assert!(text.contains("}\n,\n{\n"), "{text}");
+        assert!(text.ends_with("}\n\n]\n"), "{text}");
+    }
+
+    #[test]
+    fn golden_csv_converts_byte_for_byte() {
+        // The parity contract: tests/fixtures/correlate/06-libsass-
+        // importer/outside.json is upstream procmon2retrace's own
+        // conversion of outside.csv — reproduce it exactly.
+        let dir = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/correlate/06-libsass-importer"
+        );
+        let csv = std::fs::read(format!("{dir}/outside.csv")).unwrap();
+        let want = std::fs::read(format!("{dir}/outside.json")).unwrap();
+        let (doc, stats) = convert_procmon(&csv);
+        assert_eq!(stats.entries, 6);
+        assert_eq!(stats.bad_rows, 0);
+        assert_eq!(stats.truncated, 0);
+        assert_eq!(
+            doc,
+            want,
+            "the conversion drifted from upstream's outside.json:\n--- want ---\n{}\n--- got ---\n{}",
+            String::from_utf8_lossy(&want),
+            String::from_utf8_lossy(&doc)
+        );
+    }
+
+    fn args(tokens: &[&str]) -> Vec<String> {
+        tokens.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn parse_import_args_table() {
+        let p = parse_trace_import_args(&args(&["procmon", "capture.csv"])).unwrap();
+        assert_eq!(p.csv, PathBuf::from("capture.csv"));
+
+        assert!(parse_trace_import_args(&args(&[])).is_err());
+        assert!(parse_trace_import_args(&args(&["procmon"])).is_err());
+        let err = parse_trace_import_args(&args(&["strace", "x.log"])).unwrap_err();
+        assert!(err.contains("unknown import format 'strace'"), "{err}");
+        assert!(parse_trace_import_args(&args(&["procmon", "a.csv", "extra"])).is_err());
+    }
+}

--- a/crates/tebako-cli/src/trace/import.rs
+++ b/crates/tebako-cli/src/trace/import.rs
@@ -492,7 +492,9 @@ fn entry_json(row: &CsvRow, colmap: &ColMap) -> Option<Vec<u8>> {
     let mut out = Vec::new();
     out.extend_from_slice(b"{\n");
     out.extend_from_slice(format!("    \"time\": {},\n", format_g17(0.0)).as_bytes());
-    out.extend_from_slice(format!("    \"pid\": {},\n", format_g17(row_pid(row, colmap))).as_bytes());
+    out.extend_from_slice(
+        format!("    \"pid\": {},\n", format_g17(row_pid(row, colmap))).as_bytes(),
+    );
     out.extend_from_slice(b"    \"tid\": 0,\n");
     out.extend_from_slice(b"    \"module\": \"ETW\",\n");
     out.extend_from_slice(format!("    \"severity\": \"{severity}\",\n").as_bytes());
@@ -676,10 +678,15 @@ mod tests {
     fn csv_scan_basic_shapes() {
         // CRLF, LF and CR record ends; quoted fields with an embedded
         // comma, CRLF and a doubled quote; the BOM at buffer start.
-        let (rows, stats) = scan(
-            b"\xEF\xBB\xBF\"a\",\"b,b\"\r\n\"c\r\nd\",\"e\"\"f\"\nlast,one\rfinal,line",
+        let (rows, stats) =
+            scan(b"\xEF\xBB\xBF\"a\",\"b,b\"\r\n\"c\r\nd\",\"e\"\"f\"\nlast,one\rfinal,line");
+        assert_eq!(
+            stats,
+            ScanStats {
+                records: 4,
+                truncated: 0
+            }
         );
-        assert_eq!(stats, ScanStats { records: 4, truncated: 0 });
         assert_eq!(rows[0], vec![b"a".to_vec(), b"b,b".to_vec()]);
         assert_eq!(rows[1], vec![b"c\r\nd".to_vec(), b"e\"f".to_vec()]);
         assert_eq!(rows[2], vec![b"last".to_vec(), b"one".to_vec()]);
@@ -693,7 +700,13 @@ mod tests {
 
         // EOF inside an open quote drops the record and counts it.
         let (rows, stats) = scan(b"a,b\n\"truncated,never-closed");
-        assert_eq!(stats, ScanStats { records: 1, truncated: 1 });
+        assert_eq!(
+            stats,
+            ScanStats {
+                records: 1,
+                truncated: 1
+            }
+        );
         assert_eq!(rows.len(), 1);
 
         // Stray text after a closing quote is tolerated and appended.
@@ -702,10 +715,7 @@ mod tests {
 
         // A trailing comma at EOF completes an empty final field.
         let (rows, _) = scan(b"a,b,");
-        assert_eq!(
-            rows[0],
-            vec![b"a".to_vec(), b"b".to_vec(), Vec::new()]
-        );
+        assert_eq!(rows[0], vec![b"a".to_vec(), b"b".to_vec(), Vec::new()]);
     }
 
     #[test]
@@ -719,7 +729,11 @@ mod tests {
         assert_eq!(rows[0][1].len(), PMCSV_FIELD_MAX - 1);
 
         // Fields past the 16th are ignored.
-        let text = (0..20).map(|i| format!("f{i}")).collect::<Vec<_>>().join(",") + "\n";
+        let text = (0..20)
+            .map(|i| format!("f{i}"))
+            .collect::<Vec<_>>()
+            .join(",")
+            + "\n";
         let (rows, _) = scan(text.as_bytes());
         assert_eq!(rows[0].len(), PMCSV_MAX_FIELDS);
         assert_eq!(rows[0][15], b"f15".to_vec());
@@ -885,9 +899,7 @@ mod tests {
 
         // The separator: ",\n" before every entry after the first; the
         // close is "\n]\n".
-        let (doc, _) = convert_procmon(
-            b"t,p,1,open,/a,SUCCESS,d\nt,p,2,open,/b,SUCCESS,d\n",
-        );
+        let (doc, _) = convert_procmon(b"t,p,1,open,/a,SUCCESS,d\nt,p,2,open,/b,SUCCESS,d\n");
         let text = String::from_utf8_lossy(&doc);
         assert!(text.starts_with("[\n{\n"), "{text}");
         assert!(text.contains("}\n,\n{\n"), "{text}");

--- a/crates/tebako-cli/src/trace/mod.rs
+++ b/crates/tebako-cli/src/trace/mod.rs
@@ -17,13 +17,16 @@
 //!
 //! `cover` (§6, phase T3) ships in the `cover` submodule: the escapes
 //! correlator, golden-parity with retrace-correlate on the shared
-//! fixtures. `explain` (§5, phase T4) and the procmon converter
-//! (`import`, §6.2 — the rest of T3) are later milestones; phase T2 was
-//! the spawn/resolve emission (the preload's posix_spawn surface and the
-//! driver's image-triple resolution — pure bus-side work, no consumer
-//! change needed here beyond the pinned spawn grammar below).
+//! fixtures. `import` (§6.2 — the rest of T3) ships in the `import`
+//! submodule: the procmon CSV → retrace JSON converter, byte-parity with
+//! upstream procmon2retrace. `explain` (§5, phase T4) is a later
+//! milestone; phase T2 was the spawn/resolve emission (the preload's
+//! posix_spawn surface and the driver's image-triple resolution — pure
+//! bus-side work, no consumer change needed here beyond the pinned spawn
+//! grammar below).
 
 pub mod cover;
+pub mod import;
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};

--- a/crates/tebako-cli/src/trace/mod.rs
+++ b/crates/tebako-cli/src/trace/mod.rs
@@ -19,13 +19,15 @@
 //! correlator, golden-parity with retrace-correlate on the shared
 //! fixtures. `import` (§6.2 — the rest of T3) ships in the `import`
 //! submodule: the procmon CSV → retrace JSON converter, byte-parity with
-//! upstream procmon2retrace. `explain` (§5, phase T4) is a later
-//! milestone; phase T2 was the spawn/resolve emission (the preload's
-//! posix_spawn surface and the driver's image-triple resolution — pure
-//! bus-side work, no consumer change needed here beyond the pinned spawn
-//! grammar below).
+//! upstream procmon2retrace. `explain` (§5, phase T4) ships in the
+//! `explain` submodule: the capture replay into the hop chain with the
+//! signature table in data (`explain-signatures.yaml`). Phase T2 was the
+//! spawn/resolve emission (the preload's posix_spawn surface and the
+//! driver's image-triple resolution — pure bus-side work, no consumer
+//! change needed here beyond the pinned spawn grammar below).
 
 pub mod cover;
+pub mod explain;
 pub mod import;
 
 use std::collections::BTreeMap;

--- a/crates/tebako-cli/tests/fixtures/explain/README.md
+++ b/crates/tebako-cli/tests/fixtures/explain/README.md
@@ -1,0 +1,22 @@
+# `tebako trace explain` replay fixtures (spec 25 §5/§7, phase T4)
+
+One `<name>.jsonl` capture per signature of `explain-signatures.yaml`
+(the §5 seed table) plus a clean run. The captures are synthetic
+reproductions of the incident corpus classes, authored line-by-line
+against `docs/spec/schemas/trace-event.yaml` (the envelope: v/ts/pid/
+tid/op/path/verdict/detail/dur_us, errno when the verdict carries one).
+§7's gate is the shape: a capture replays through `explain` and the
+named red hop matches the incident's hand-derived answer — each fixture
+names its expected verdict below, pinned by `tests/trace_explain.rs`.
+
+| capture                        | red hop (exit 1)                                   |
+|--------------------------------|----------------------------------------------------|
+| `env-image-never-mounted`      | mount — env image never mounted (handoff env lost) |
+| `os-bind-module-not-found`     | OS bind — the closure resolved, the loader refused |
+| `policy-denial`                | policy — policy denial (the EACCES class)          |
+| `materialize-error`            | materialize — exec-cache write failure             |
+| `clean-run`                    | GREEN (exit 0); the tail line is a crashed write   |
+
+The real incident-13 dogfood captures replay through the same verdicts
+factory-side (the msys dogfood rides the bus since T1); converting and
+archiving them here is follow-up, not a gate.

--- a/crates/tebako-cli/tests/fixtures/explain/clean-run.jsonl
+++ b/crates/tebako-cli/tests/fixtures/explain/clean-run.jsonl
@@ -1,0 +1,9 @@
+{"v":1,"ts":"2026-08-14T13:20:01.000001Z","pid":7010,"tid":1,"op":"mount","path":"/__tfs__","verdict":"ok","detail":{"action":"insert","handle":1,"image":"/c/host/cache/env.tfs"},"dur_us":377}
+{"v":1,"ts":"2026-08-14T13:20:01.010002Z","pid":7010,"tid":1,"op":"resolve","path":"/c/pkg/app.tpkg","verdict":"slot:1","detail":{"slot":"1","mount":"/tfs","offset":18874368,"size":4823041,"slots":2},"dur_us":92}
+{"v":1,"ts":"2026-08-14T13:20:01.020003Z","pid":7010,"tid":1,"op":"mount","path":"/tfs","verdict":"ok","detail":{"action":"union","handle":2,"image":"/c/pkg/app.tpkg"},"dur_us":450}
+{"v":1,"ts":"2026-08-14T13:20:01.100004Z","pid":7010,"tid":1,"op":"open","path":"/tfs/lib/app.rb","verdict":"image:/tfs","detail":{},"dur_us":8}
+{"v":1,"ts":"2026-08-14T13:20:01.200005Z","pid":7010,"tid":1,"op":"jail","path":"/work/repo/data.csv","verdict":"record","detail":{"access":"read"},"dur_us":2}
+{"v":1,"ts":"2026-08-14T13:20:01.300006Z","pid":7010,"tid":1,"op":"materialize","path":"/tfs/lib/native.so","verdict":"cache-hit","detail":{"dest":"dlcache","host":"/tmp/tebako-dl-71a/tfs/lib/native.so"},"dur_us":12}
+{"v":1,"ts":"2026-08-14T13:20:01.400007Z","pid":7010,"tid":1,"op":"dlopen","path":"/tfs/lib/native.so","verdict":"materialized:/tmp/tebako-dl-71a/tfs/lib/native.so","detail":{"closure":{"format":"elf","deps":[{"name":"libc.so","resolved":"/tfs/lib/libc.so","verdict":"materialized"}]}},"dur_us":8811}
+{"v":1,"ts":"2026-08-14T13:20:01.500008Z","pid":7010,"tid":1,"op":"spawn","path":"/usr/bin/git","verdict":"host","detail":{},"dur_us":15}
+{"v":1,"ts":"2026-08-14T13:20:01.60

--- a/crates/tebako-cli/tests/fixtures/explain/env-image-never-mounted.jsonl
+++ b/crates/tebako-cli/tests/fixtures/explain/env-image-never-mounted.jsonl
@@ -1,0 +1,3 @@
+{"v":1,"ts":"2026-08-13T22:14:03.112004Z","pid":3104,"tid":1,"op":"mount","path":"/__tfs__","verdict":"error:2","detail":{"action":"insert","image":"/c/host/cache/tebako-runtime-3.3.7-ruby-3.3.7-windows-x64.tfs"},"dur_us":41,"errno":2}
+{"v":1,"ts":"2026-08-13T22:14:03.114551Z","pid":3104,"tid":1,"op":"open","path":"/__tfs__/lib/ruby/3.3.0/rubygems.rb","verdict":"error:2","detail":{"need":"read"},"dur_us":6,"errno":2}
+{"v":1,"ts":"2026-08-13T22:14:03.114989Z","pid":3104,"tid":1,"op":"open","path":"/__tfs__/lib/ruby/3.3.0/i386-mswin64_140/rbconfig.rb","verdict":"error:2","detail":{"need":"read"},"dur_us":5,"errno":2}

--- a/crates/tebako-cli/tests/fixtures/explain/materialize-error.jsonl
+++ b/crates/tebako-cli/tests/fixtures/explain/materialize-error.jsonl
@@ -1,0 +1,3 @@
+{"v":1,"ts":"2026-08-14T11:47:55.700001Z","pid":6201,"tid":1,"op":"mount","path":"/__tfs__","verdict":"ok","detail":{"action":"insert","handle":1,"image":"/c/host/cache/env.tfs"},"dur_us":401}
+{"v":1,"ts":"2026-08-14T11:47:55.910440Z","pid":6201,"tid":1,"op":"materialize","path":"/tfs/bin/tool","verdict":"error:28","detail":{"dest":"dlcache"},"dur_us":1903,"errno":28}
+{"v":1,"ts":"2026-08-14T11:47:55.910812Z","pid":6201,"tid":1,"op":"exec","path":"/tfs/bin/tool","verdict":"error:28","detail":{},"dur_us":7,"errno":28}

--- a/crates/tebako-cli/tests/fixtures/explain/os-bind-module-not-found.jsonl
+++ b/crates/tebako-cli/tests/fixtures/explain/os-bind-module-not-found.jsonl
@@ -1,0 +1,4 @@
+{"v":1,"ts":"2026-08-13T22:31:40.000110Z","pid":4112,"tid":1,"op":"mount","path":"/__tfs__","verdict":"ok","detail":{"action":"insert","handle":1,"image":"/c/host/cache/env.tfs"},"dur_us":512}
+{"v":1,"ts":"2026-08-13T22:31:40.002031Z","pid":4112,"tid":1,"op":"resolve","path":"/c/pkg/sassc.tpkg","verdict":"whole","detail":{"slot":"-","mount":"/__tfs__"},"dur_us":87}
+{"v":1,"ts":"2026-08-13T22:31:40.009822Z","pid":4112,"tid":1,"op":"materialize","path":"/tfs/lib/libsass.so","verdict":"ok:/tmp/tebako-dl-9f2/tfs/lib/libsass.so","detail":{"dest":"dlcache","bytes":8411224},"dur_us":20311}
+{"v":1,"ts":"2026-08-13T22:31:40.030774Z","pid":4112,"tid":1,"op":"dlopen","path":"/tfs/lib/libsass.so","verdict":"error:126","detail":{"closure":{"format":"pe","deps":[{"name":"libsass-deps.dll","resolved":"/tfs/lib/libsass-deps.dll","verdict":"materialized"},{"name":"KERNEL32.dll","resolved":null,"verdict":"host-system"}]}},"dur_us":4402,"errno":126}

--- a/crates/tebako-cli/tests/fixtures/explain/policy-denial.jsonl
+++ b/crates/tebako-cli/tests/fixtures/explain/policy-denial.jsonl
@@ -1,0 +1,3 @@
+{"v":1,"ts":"2026-08-14T09:02:11.000004Z","pid":5877,"tid":1,"op":"mount","path":"/__tfs__","verdict":"ok","detail":{"action":"insert","handle":1,"image":"/c/host/cache/env.tfs"},"dur_us":388}
+{"v":1,"ts":"2026-08-14T09:02:11.410027Z","pid":5877,"tid":1,"op":"jail","path":"/work/repo/private","verdict":"deny:user","detail":{"access":"read"},"dur_us":2,"errno":13}
+{"v":1,"ts":"2026-08-14T09:02:11.410051Z","pid":5877,"tid":1,"op":"open","path":"/work/repo/private/token","verdict":"denied:user","detail":{"need":"read"},"dur_us":3,"errno":13}

--- a/crates/tebako-cli/tests/trace_explain.rs
+++ b/crates/tebako-cli/tests/trace_explain.rs
@@ -1,0 +1,181 @@
+//! `tebako trace explain` integration (spec 25 §5/§7, phase T4): the
+//! fixtures under `tests/fixtures/explain/` (the README.md there is the
+//! provenance contract — synthetic reproductions of the incident corpus
+//! classes, authored against trace-event.yaml) replay through the real
+//! binary, and the named red hop must match the incident's hand-derived
+//! answer (§7's gate shape).
+//!
+//! stdout is the diagnosis report alone (the version banner rides
+//! stderr — main.rs's machine_stdout rule); exit codes are the
+//! trace-verbs convention: 0 clean / 1 red hop / 2 usage-or-IO.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/explain")
+}
+
+struct Run {
+    rc: i32,
+    stdout: String,
+    stderr: String,
+}
+
+fn trace_explain(capture: &Path) -> Run {
+    let out = Command::new(env!("CARGO_BIN_EXE_tebako"))
+        .arg("trace")
+        .arg("explain")
+        .arg(capture)
+        .output()
+        .unwrap();
+    Run {
+        rc: out.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+/// One fixture's expectation: the exit code and the exact RED/GREEN
+/// verdict line (the §7 gate: the named hop matches the incident's
+/// hand-derived answer).
+struct Case {
+    fixture: &'static str,
+    exit: i32,
+    verdict_line: &'static str,
+    /// Extra stdout lines the report must carry (evidence pointers,
+    /// bisect candidates).
+    must_contain: &'static [&'static str],
+}
+
+#[test]
+fn explain_replays_the_fixtures_to_the_named_hops() {
+    let cases = [
+        Case {
+            fixture: "env-image-never-mounted",
+            exit: 1,
+            verdict_line:
+                "RED hop: mount — env image never mounted (handoff env lost) [signature: env-image-never-mounted]",
+            must_contain: &["no `mount/ok` verdict", "prelude-class stderr"],
+        },
+        Case {
+            fixture: "os-bind-module-not-found",
+            exit: 1,
+            verdict_line:
+                "RED hop: OS bind — the closure resolved and the loader still refused [signature: os-bind-module-not-found]",
+            must_contain: &[
+                "evidence: event #4",
+                "dlopen /tfs/lib/libsass.so verdict=error:126 errno=126",
+                "bisect candidates",
+                "libsass-deps.dll → /tfs/lib/libsass-deps.dll (materialized)",
+                "KERNEL32.dll",
+            ],
+        },
+        Case {
+            fixture: "policy-denial",
+            exit: 1,
+            verdict_line:
+                "RED hop: policy — policy denial (the EACCES class) [signature: policy-denial]",
+            must_contain: &[
+                "evidence: event #3",
+                "open /work/repo/private/token verdict=denied:user",
+                "related:  event #2",
+                "jail /work/repo/private verdict=deny:user",
+            ],
+        },
+        Case {
+            fixture: "materialize-error",
+            exit: 1,
+            verdict_line:
+                "RED hop: materialize — exec-cache write failure [signature: materialize-error]",
+            must_contain: &["evidence: event #2", "materialize /tfs/bin/tool verdict=error:28 errno=28"],
+        },
+        Case {
+            fixture: "clean-run",
+            exit: 0,
+            verdict_line: "GREEN: no red hop — every hop's verdict is clean in 8 event(s)",
+            must_contain: &[],
+        },
+    ];
+
+    for case in cases {
+        let capture = fixtures_dir().join(format!("{}.jsonl", case.fixture));
+        let run = trace_explain(&capture);
+        assert_eq!(
+            run.rc, case.exit,
+            "{}: exit code (stdout: {} stderr: {})",
+            case.fixture, run.stdout, run.stderr
+        );
+        assert!(
+            run.stdout.contains(case.verdict_line),
+            "{}: the verdict line\nwant: {}\nstdout: {}",
+            case.fixture,
+            case.verdict_line,
+            run.stdout
+        );
+        for line in case.must_contain {
+            assert!(
+                run.stdout.contains(line),
+                "{}: missing `{line}`\nstdout: {}",
+                case.fixture,
+                run.stdout
+            );
+        }
+        // The replay line names the hop chain (§5's axis).
+        assert!(
+            run.stdout
+                .contains("hop chain: mount → manifest read → resolve → materialize → OS bind"),
+            "{}: the hop chain line\nstdout: {}",
+            case.fixture,
+            run.stdout
+        );
+        // The banner never rides stdout (the machine-contract rule).
+        assert!(
+            !run.stdout.contains("Tebako executable packager version"),
+            "{}: the banner leaked to stdout: {}",
+            case.fixture,
+            run.stdout
+        );
+    }
+
+    // The clean fixture's crashed tail is dropped with a stderr note,
+    // never a failure (spec 25 law 1's leniency on the read side).
+    let run = trace_explain(&fixtures_dir().join("clean-run.jsonl"));
+    assert!(
+        run.stderr.contains("is not a complete event — skipped"),
+        "stderr: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn explain_usage_and_io_errors_exit_2() {
+    // No capture.
+    let out = Command::new(env!("CARGO_BIN_EXE_tebako"))
+        .arg("trace")
+        .arg("explain")
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("usage: tebako trace explain"), "stderr: {stderr}");
+    assert!(out.stdout.is_empty());
+
+    // An unknown option.
+    let out = Command::new(env!("CARGO_BIN_EXE_tebako"))
+        .arg("trace")
+        .arg("explain")
+        .arg("--verbose")
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("unknown option '--verbose'"), "stderr: {stderr}");
+
+    // An unreadable capture.
+    let missing = std::env::temp_dir().join(format!("tebako-explain-nope-{}.jsonl", std::process::id()));
+    let run = trace_explain(&missing);
+    assert_eq!(run.rc, 2, "stderr: {}", run.stderr);
+    assert!(run.stderr.contains("cannot read"), "stderr: {}", run.stderr);
+    assert!(run.stdout.is_empty());
+}

--- a/crates/tebako-cli/tests/trace_explain.rs
+++ b/crates/tebako-cli/tests/trace_explain.rs
@@ -158,7 +158,10 @@ fn explain_usage_and_io_errors_exit_2() {
         .unwrap();
     assert_eq!(out.status.code(), Some(2));
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("usage: tebako trace explain"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("usage: tebako trace explain"),
+        "stderr: {stderr}"
+    );
     assert!(out.stdout.is_empty());
 
     // An unknown option.
@@ -170,10 +173,14 @@ fn explain_usage_and_io_errors_exit_2() {
         .unwrap();
     assert_eq!(out.status.code(), Some(2));
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("unknown option '--verbose'"), "stderr: {stderr}");
+    assert!(
+        stderr.contains("unknown option '--verbose'"),
+        "stderr: {stderr}"
+    );
 
     // An unreadable capture.
-    let missing = std::env::temp_dir().join(format!("tebako-explain-nope-{}.jsonl", std::process::id()));
+    let missing =
+        std::env::temp_dir().join(format!("tebako-explain-nope-{}.jsonl", std::process::id()));
     let run = trace_explain(&missing);
     assert_eq!(run.rc, 2, "stderr: {}", run.stderr);
     assert!(run.stderr.contains("cannot read"), "stderr: {}", run.stderr);

--- a/crates/tebako-cli/tests/trace_import.rs
+++ b/crates/tebako-cli/tests/trace_import.rs
@@ -1,0 +1,188 @@
+//! `tebako trace import procmon` integration (spec 25 §6.2, the rest of
+//! phase T3). The parity contract, end to end: every golden correlate
+//! case that ships an `outside.csv` (a byte-verbatim procmon export —
+//! the upstream CTest regenerates `outside.json` from it with
+//! procmon2retrace and diffs) must
+//!
+//!   1. convert to that case's `outside.json`, byte for byte —
+//!      `tebako trace import procmon outside.csv` IS upstream's
+//!      conversion (the document-level parity pin), and
+//!   2. drive `tebako trace cover` to the case's golden verdict when
+//!      the conversion is the `--outside` stream: `expected.txt` on
+//!      stdout, byte for byte, and the `exit.txt` code.
+//!
+//! stdout is the machine contract for both verbs (the version banner
+//! rides stderr — main.rs's machine_stdout rule); stderr stays outside
+//! the contract by design.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn cases_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/correlate")
+}
+
+/// The golden runner's chomp: strip trailing LF/CR from a line file.
+fn read_line_file(path: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(path).ok()?;
+    Some(text.trim_end_matches(['\n', '\r']).to_string())
+}
+
+struct Run {
+    rc: i32,
+    stdout: Vec<u8>,
+    stderr: String,
+}
+
+fn tebako(args: &[String]) -> Run {
+    let out = Command::new(env!("CARGO_BIN_EXE_tebako"))
+        .args(args)
+        .output()
+        .unwrap();
+    Run {
+        rc: out.status.code().unwrap_or(-1),
+        stdout: out.stdout,
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+fn trace_import(csv: &Path) -> Run {
+    tebako(&[
+        "trace".to_string(),
+        "import".to_string(),
+        "procmon".to_string(),
+        csv.to_string_lossy().into_owned(),
+    ])
+}
+
+/// The cases shipping a procmon CSV (today exactly 06-libsass-importer;
+/// the loop picks up any future one).
+fn csv_cases() -> Vec<PathBuf> {
+    let mut cases: Vec<PathBuf> = std::fs::read_dir(cases_dir())
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.join("outside.csv").is_file())
+        .collect();
+    cases.sort();
+    assert!(!cases.is_empty(), "the golden tree ships an outside.csv case");
+    cases
+}
+
+#[test]
+fn golden_csv_converts_byte_for_byte_and_drives_cover() {
+    for case in csv_cases() {
+        let name = case.file_name().unwrap().to_string_lossy().into_owned();
+
+        // 1. The document-level parity pin: the conversion IS
+        //    outside.json, byte for byte (upstream's own conversion).
+        let csv = case.join("outside.csv");
+        let run = trace_import(&csv);
+        let want_json = std::fs::read(case.join("outside.json")).unwrap();
+        assert_eq!(run.rc, 0, "{name}: import exit code (stderr: {})", run.stderr);
+        assert_eq!(
+            run.stdout,
+            want_json,
+            "{name}: the conversion drifted from outside.json\n--- expected ---\n{}\n--- actual ---\n{}",
+            String::from_utf8_lossy(&want_json),
+            String::from_utf8_lossy(&run.stdout)
+        );
+        assert!(
+            run.stderr.contains("entries="),
+            "{name}: the stderr summary names the counts: {}",
+            run.stderr
+        );
+
+        // 2. The converted stream is cover's --outside: the golden
+        //    verdict reproduces (the process-substitution flow,
+        //    file-mediated here).
+        let dir = std::env::temp_dir().join(format!(
+            "tebako-import-e2e-{}-{name}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let converted = dir.join("outside.json");
+        std::fs::write(&converted, &run.stdout).unwrap();
+
+        let prefix = read_line_file(&case.join("prefix.txt")).unwrap();
+        let want_stdout = std::fs::read(case.join("expected.txt")).unwrap();
+        let want_exit: i32 = read_line_file(&case.join("exit.txt"))
+            .and_then(|s| s.parse().ok())
+            .unwrap();
+        let options: Vec<String> = read_line_file(&case.join("options.txt"))
+            .map(|s| s.split_whitespace().map(str::to_string).collect())
+            .unwrap_or_default();
+
+        let mut args = vec![
+            "trace".to_string(),
+            "cover".to_string(),
+            "--inside".to_string(),
+            case.join("inside.json").to_string_lossy().into_owned(),
+            "--outside".to_string(),
+            converted.to_string_lossy().into_owned(),
+            "--prefix".to_string(),
+            prefix,
+        ];
+        args.extend(options);
+        let run = tebako(&args);
+        assert_eq!(
+            run.stdout,
+            want_stdout,
+            "{name}: cover over the converted stream — stdout mismatch\n--- expected ---\n{}\n--- actual ---\n{}\nstderr: {}",
+            String::from_utf8_lossy(&want_stdout),
+            String::from_utf8_lossy(&run.stdout),
+            run.stderr
+        );
+        assert_eq!(
+            run.rc, want_exit,
+            "{name}: cover over the converted stream — exit code mismatch (stderr: {})",
+            run.stderr
+        );
+    }
+}
+
+#[test]
+fn import_usage_and_io_errors_exit_2() {
+    // No format token / no csv.
+    let run = tebako(&["trace".to_string(), "import".to_string()]);
+    assert_eq!(run.rc, 2, "stderr: {}", run.stderr);
+    assert!(run.stderr.contains("usage: tebako trace import procmon"));
+
+    // An unknown format names itself.
+    let run = tebako(&[
+        "trace".to_string(),
+        "import".to_string(),
+        "strace".to_string(),
+        "x.log".to_string(),
+    ]);
+    assert_eq!(run.rc, 2, "stderr: {}", run.stderr);
+    assert!(run.stderr.contains("unknown import format 'strace'"));
+
+    // An unreadable csv.
+    let missing = std::env::temp_dir().join(format!("tebako-import-nope-{}.csv", std::process::id()));
+    let run = trace_import(&missing);
+    assert_eq!(run.rc, 2, "stderr: {}", run.stderr);
+    assert!(run.stderr.contains("cannot read"), "stderr: {}", run.stderr);
+
+    // stdout stays clean on every error path (the document is the only
+    // stdout writer).
+    let run = tebako(&["trace".to_string(), "import".to_string()]);
+    assert!(run.stdout.is_empty());
+}
+
+#[test]
+fn import_zero_entries_exits_1_with_the_empty_document() {
+    // A header-only capture converts to the empty array document and
+    // exits 1 (upstream's `(entries > 0) ? 0 : 1`).
+    let dir = std::env::temp_dir().join(format!("tebako-import-empty-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let csv = dir.join("header-only.csv");
+    std::fs::write(
+        &csv,
+        "\"Time of Day\",\"Process Name\",\"PID\",\"Operation\",\"Path\",\"Result\",\"Detail\"\r\n",
+    )
+    .unwrap();
+    let run = trace_import(&csv);
+    assert_eq!(run.rc, 1, "stderr: {}", run.stderr);
+    assert_eq!(run.stdout, b"[\n]\n");
+    assert!(run.stderr.contains("entries=0"), "stderr: {}", run.stderr);
+}

--- a/crates/tebako-cli/tests/trace_import.rs
+++ b/crates/tebako-cli/tests/trace_import.rs
@@ -64,7 +64,10 @@ fn csv_cases() -> Vec<PathBuf> {
         .filter(|p| p.join("outside.csv").is_file())
         .collect();
     cases.sort();
-    assert!(!cases.is_empty(), "the golden tree ships an outside.csv case");
+    assert!(
+        !cases.is_empty(),
+        "the golden tree ships an outside.csv case"
+    );
     cases
 }
 
@@ -78,7 +81,11 @@ fn golden_csv_converts_byte_for_byte_and_drives_cover() {
         let csv = case.join("outside.csv");
         let run = trace_import(&csv);
         let want_json = std::fs::read(case.join("outside.json")).unwrap();
-        assert_eq!(run.rc, 0, "{name}: import exit code (stderr: {})", run.stderr);
+        assert_eq!(
+            run.rc, 0,
+            "{name}: import exit code (stderr: {})",
+            run.stderr
+        );
         assert_eq!(
             run.stdout,
             want_json,
@@ -95,10 +102,8 @@ fn golden_csv_converts_byte_for_byte_and_drives_cover() {
         // 2. The converted stream is cover's --outside: the golden
         //    verdict reproduces (the process-substitution flow,
         //    file-mediated here).
-        let dir = std::env::temp_dir().join(format!(
-            "tebako-import-e2e-{}-{name}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("tebako-import-e2e-{}-{name}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let converted = dir.join("outside.json");
         std::fs::write(&converted, &run.stdout).unwrap();
@@ -158,7 +163,8 @@ fn import_usage_and_io_errors_exit_2() {
     assert!(run.stderr.contains("unknown import format 'strace'"));
 
     // An unreadable csv.
-    let missing = std::env::temp_dir().join(format!("tebako-import-nope-{}.csv", std::process::id()));
+    let missing =
+        std::env::temp_dir().join(format!("tebako-import-nope-{}.csv", std::process::id()));
     let run = trace_import(&missing);
     assert_eq!(run.rc, 2, "stderr: {}", run.stderr);
     assert!(run.stderr.contains("cannot read"), "stderr: {}", run.stderr);

--- a/crates/tebako-cli/tests/trace_run.rs
+++ b/crates/tebako-cli/tests/trace_run.rs
@@ -189,7 +189,7 @@ fn trace_run_rejects_a_missing_package_and_bad_options() {
         r.stderr
     );
 
-    // Bare `trace` and the later-milestone subcommands name themselves.
+    // Bare `trace` names the subcommands.
     let r = tebako_trace(&[]);
     assert_eq!(r.rc, 1);
     assert!(
@@ -197,15 +197,21 @@ fn trace_run_rejects_a_missing_package_and_bad_options() {
         "stderr: {}",
         r.stderr
     );
-    for sub in ["explain", "import"] {
-        let r = tebako_trace(&[sub]);
-        assert_eq!(r.rc, 1);
-        assert!(
-            r.stderr.contains(&format!(
-                "'tebako trace {sub}' is a later tebako-rs milestone"
-            )),
-            "stderr: {}",
-            r.stderr
-        );
-    }
+    // The shipped verbs' own usage errors are exit 2 (the trace-verbs
+    // convention; their usage lines name themselves). trace_import.rs /
+    // trace_explain.rs carry the full surface pins.
+    let r = tebako_trace(&["import"]);
+    assert_eq!(r.rc, 2);
+    assert!(
+        r.stderr.contains("usage: tebako trace import procmon"),
+        "stderr: {}",
+        r.stderr
+    );
+    let r = tebako_trace(&["explain"]);
+    assert_eq!(r.rc, 2);
+    assert!(
+        r.stderr.contains("usage: tebako trace explain"),
+        "stderr: {}",
+        r.stderr
+    );
 }

--- a/docs/spec/00-INDEX.md
+++ b/docs/spec/00-INDEX.md
@@ -55,7 +55,7 @@ spec 02 §6).
 22. [22 — Runtime-native interposition](22-runtime-native-interposition.md) — the generalized hooks: loader/exec/resource interposition inside the runtime, the documented interface, and the death of per-gem adapters (the spec-18 contract's runtime-internal half)
 23. [23 — Declarative composition and needs resolution](23-declarative-composition.md) — the fully declarative slice stack: D1 needs / D2 composition doc / D3 press-baked union / D4-D5 operator surfaces; deny-safe by default, the needs-check law (PLANNED)
 24. [24 — Declarative overlays](24-declarative-overlays.md) — write areas and key bindings: the gated COW write gate, `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT`, the record-mode fold-in, exit 68 (PARTIAL)
-25. [25 — Trace observability](25-trace-observability.md) — the interception bus, `tebako trace run|explain|cover`, the escapes correlation (PARTIAL — the bus + `trace run` + the spawn/resolve emission + `trace cover` (golden-parity escapes correlator) shipped; the procmon converter is the rest of T3, `explain` T4)
+25. [25 — Trace observability](25-trace-observability.md) — the interception bus, `tebako trace run|explain|cover|import`, the escapes correlation (PARTIAL — all four phases' code shipped: the bus + `trace run` (T1), the spawn/resolve emission (T2), `trace cover` + the procmon converter `trace import` (T3), `trace explain` (T4); the remainder is the §8 dogfood legs, not code)
 26. [26 — Payload checks](26-payload-checks.md) — the in-image self-validation contract: the `checks:` manifest block, `tebako check` at press/install/discovery moments, SKIP discipline, exit 79 (PARTIAL — the block + the engine shipped; the §3 press/install gate wiring remains)
 
 ## Locked invariants (all specs subordinate to these)

--- a/docs/spec/25-trace-observability.md
+++ b/docs/spec/25-trace-observability.md
@@ -4,11 +4,15 @@
 interception bus + `docs/spec/schemas/trace-event.yaml` + `tebako trace
 run`; phase T2 shipped 2026-08-20: the `spawn`/`resolve` emission — the
 preload's posix_spawn surface and the driver's image-triple resolution;
-phase T3 shipped 2026-08-20 for the correlator half: `tebako trace
-cover` (§6.3) — the escapes report, golden-parity with retrace's shared
-correlate fixtures; the procmon converter (`tebako trace import`, §6.2)
-remains PLANNED within T3, and `explain` is T4 — re-phased 2026-08-20:
-emission completeness precedes the replay/correlation front-ends.
+phase T3 shipped: `tebako trace cover` (§6.3) 2026-08-20 — the escapes
+report, golden-parity with retrace's shared correlate fixtures — and
+2026-08-21 the procmon converter (`tebako trace import procmon`, §6.2),
+byte-parity with upstream procmon2retrace on the golden 06 fixture;
+phase T4 shipped 2026-08-21: `tebako trace explain` (§5) — the capture
+replay with the signature table in data. All four phases' CODE is on
+main; the PARTIAL remainder is dogfood, not code: the §8 legs (retrace
+libc-layer on both platforms; the kernel-layer leg as §6.4 lands) and
+the real incident-13 captures' archival into the explain fixtures.
 Owner-signed 2026-08-19 — architecture A: the in-tfs
 event bus + `tebako trace` front-ends; outside capture rides the
 three-layer producer model of §6.1, with retrace as the libc-boundary
@@ -338,8 +342,8 @@ block T1/T2:
 |-------|----------|---------|
 | T1 | the bus + schema + `run` (discovery) | the msys dogfood rides the bus; a payload author onboards a fresh gem without hand diagnostics |
 | T2 | the `spawn`/`resolve` emission: the preload's posix_spawn surface reports `spawn` (a child-process decision — the correlator's process-tree signal), and the driver emits one `resolve` event per `--tebako-image` triple (the payload/slot identity: whole / `slot:<n>` + offset/size/mount, or the named failure class) | a traced boot of a broken composition names the failing triple in the capture itself — no stderr spelunking; a traced run's spawns regroup by pid |
-| T3 | `cover` (certification) + the procmon converter | `cover` SHIPPED 2026-08-20 (the §6.3 correlator + the shared golden tree green in CI); the converter (`import`, §6.2) is PLANNED. Remaining dogfood: a leg under retrace on both platforms (libc layer); a kernel-layer leg (ptrace/eBPF on linux, procmon-converter on windows) as the §6.4 prerequisites land; escapes report in CI |
-| T4 | `explain` (diagnosis) | replay the incident-13 captures; the named hop matches history |
+| T3 | `cover` (certification) + the procmon converter | `cover` SHIPPED 2026-08-20 (the §6.3 correlator + the shared golden tree green in CI); the converter (`import`, §6.2) SHIPPED 2026-08-21 (byte-parity with procmon2retrace on the golden 06 case, the converted stream driving cover to expected.txt/exit.txt). Remaining dogfood: a leg under retrace on both platforms (libc layer); a kernel-layer leg (ptrace/eBPF on linux, procmon-converter on windows) as the §6.4 prerequisites land; escapes report in CI |
+| T4 | `explain` (diagnosis) | SHIPPED 2026-08-21: the replay + the signature table in data (`explain-signatures.yaml`), fixtures replaying the incident classes to their hand-derived answers (§7's gate shape). Remaining dogfood: replay the real incident-13 captures; the named hop matches history |
 
 (Re-phased 2026-08-20: emission completeness precedes the front-ends —
 the original T2 (`explain`) is T4, the original T3 (`cover` + the

--- a/docs/spec/schemas/trace-event.yaml
+++ b/docs/spec/schemas/trace-event.yaml
@@ -8,10 +8,10 @@
 #
 # SSOT: this file owns the grammar; crates/tfs/src/trace.rs (the emitter),
 # crates/tebako-driver/src/driver.rs (the resolve emitter), and
-# crates/tebako-cli/src/trace/ (the `tebako trace run|cover` consumers)
-# mirror it — keep the four in sync in the same PR. The property test in
-# crates/tfs/src/trace.rs drives the op matrix against a mounted fixture
-# and validates every emitted event against this grammar.
+# crates/tebako-cli/src/trace/ (the `tebako trace run|cover|explain`
+# consumers) mirror it — keep the four in sync in the same PR. The
+# property test in crates/tfs/src/trace.rs drives the op matrix against a
+# mounted fixture and validates every emitted event against this grammar.
 # =============================================================================
 
 schema: trace-event


### PR DESCRIPTION
# spec 25: the remaining CLI surface — `trace import procmon` (rest of T3) + `trace explain` (T4)

Two commits of surface plus fmt/doc-sync commits, against main @ `5907e45c` (T1 #422, T2 #427, T3-cover #428 all merged).

## Task 1 — `tebako trace import procmon` (spec 25 §6.2)

The offline procmon CSV → retrace JSON converter, a safe-Rust port of retrace's `procmon2retrace` (v2.8.0+; verified against the local clone @ v2.13.0: `procmon2retrace.c`, `convert.c`, `csv.c`, and parson's pretty printer):

- **csv.c's scanner byte-exactly**: quoted fields (embedded commas/CR/LF, `""` escapes), CRLF/LF/CR record ends, the UTF-8 BOM at buffer start, blank-line drops, the trailing record without a final newline, EOF-in-open-quote counted and dropped (`truncated final record`), and the C fixed caps as parity (4095-byte fields, 16 fields/record, the 64 KB record storage — sized to exactly fit the other two, so the past-cap branch is as unreachable here as upstream).
- **convert.c's header mapping + entry shaping**: case-insensitive role names; an unrecognized first record converts as an EVENT under the canonical column order (upstream's fallthrough); `time`/`tid` 0, `pid` via a strtod-prefix parse, `module: "ETW"`, severity `INFO` on `SUCCESS` (any case) else `WARN`; the `message` keys in upstream's `set_if` order (`func, process, time_of_day, path, result, detail`), omitted when unmapped or short; the empty/missing-Operation bad row counted and skipped.
- **parson's pretty printer reproduced byte-exactly**: the `[\n` … `,\n` … `\n]\n` array document, 4-space indents, the `\"`/`\\`/`\/` + C0 escape set, numbers as C's `%1.17g` (a real `%g` emulation — the post-rounding exponent picks the style; printf-verified table in the unit suite).

**Parity contract, pinned at both levels**: the unit suite converts `tests/fixtures/correlate/06-libsass-importer/outside.csv` (byte-verbatim upstream, CRLF + BOM) to that case's `outside.json` — upstream's own conversion — **byte for byte**; `tests/trace_import.rs` then feeds the converted stream to `tebako trace cover` for every golden case shipping an `outside.csv` (06 today) and asserts `expected.txt` byte-for-byte plus the `exit.txt` code. The §6.3 golden verdict reproduces from the CSV end.

**Surface** (spec's exact shape): `tebako trace import procmon <csv>`; stdout is the JSON document alone (the banner rides stderr — the machine_stdout rule now covers `trace import`); stderr carries upstream's `entries=N bad-rows=M` summary under the tebako prefix; exit codes upstream's — 0 entries emitted / 1 zero entries / 2 usage-or-IO. Documented flag-shape deviations (in-format behavior is byte-parity): upstream's `[out.json]` positional is shell redirection here; its conversion-time `--pid N` rides `cover --pid` downstream (the same join, §6.3).

## Task 2 — `tebako trace explain` (spec 25 §5, phase T4)

Replays a bus capture (JSONL; tolerant of a crashed tail — `trace run`'s leniency) into the §5 hop chain — mount → manifest read → resolve → materialize → OS bind — and prints the FIRST hop whose verdict is red: the earliest event matching a signature, the end-of-stream absence signature only when nothing matched.

- **The signature table is data** per §5's placement law: `crates/tebako-cli/src/trace/explain-signatures.yaml`, embedded via `include_str!` (no runtime data file), seeded with the incident corpus's four rows. The engine interprets three `when.kind` discriminators — `absent` (env-image-never-mounted: a live stream with no `mount/ok`; the env image mounts first), `event` with optional errno set + closure rule (os-bind-module-not-found: dlopen error 126|ENOENT with a non-empty, fully materialized|host-system walk — the dep list prints as the bisect candidates; the cache-hit empty walk never fires; materialize-error), and `deny-then-error` (policy-denial: the jail deny immediately preceding the dependent open/stat error — trace-event.yaml's same-decision event pair; a non-deny jail event for the path clears the correlation).
- **Surface**: `tebako trace explain <capture.jsonl>`; stdout is the diagnosis report alone (machine_stdout covers `explain`); exit 0 clean / 1 red hop / 2 usage-or-IO.
- **Fixtures**: `tests/fixtures/explain/` — one capture per signature plus a clean run with a crashed tail, synthetic reproductions of the incident classes authored against trace-event.yaml, replayed by `tests/trace_explain.rs` to the incidents' hand-derived answers (§7's gate shape). Archiving the REAL incident-13 dogfood captures is named as factory-side follow-up in the fixture README.
- `tests/trace_run.rs`'s later-milestone placeholder pins for `explain`/`import` become the shipped verbs' usage pins (exit 2, the verbs' own usage lines).

## Gates (vcpkg env, debug; `cargo test --release` never)

- `cargo fmt --check` — clean
- `cargo clippy -p tebako-cli --all-targets -- -D warnings` — 0 warnings
- `cargo build -p tebako-bootstrap` — OK (the cli_e2e dogfood binary)
- `cargo test -p tebako-cli` — ALL suites green on HEAD: lib 131 (trace 40: cover 19 / import 9 / explain 8 / mod 4), trace_cover 3/3 (all 10 golden cases), trace_import 3/3, trace_explain 2/2, trace_run 4/4, cli_e2e 13/13, check 12, install 29, install_env 2, install_local 6, publish 10, info 9, run 6, suite 6, registry_cli 1 — 237 passed, 0 failed
- Dogfood smoke on the built binary: `trace import procmon` of fixture 06's `outside.csv` is byte-identical (`diff` rc 0) to the golden `outside.json`; `trace cover --pid 9012` on the converted stream prints the two escape lines and exits 1; `trace explain` on the materialize-error fixture prints the RED materialize hop and exits 1; on the clean-run fixture (crashed tail tolerated) it prints GREEN and exits 0

## Doc sync (this PR)

- `docs/spec/25` status block + §8 phasing table: the converter (rest of T3) and explain (T4) shipped 2026-08-21; the PARTIAL remainder is the §8 dogfood legs, not code.
- `docs/spec/00-INDEX.md` spec-25 row: full shipped surface, PARTIAL = dogfood.
- `docs/spec/schemas/trace-event.yaml` SSOT comment names the full consumer set.
- `README.md` command table gains `trace import` / `trace explain`.

## Notes for the reviewer

- The dispatch brief cited "§7 defines `explain`" — the spec defines explain in **§5** (§7 is testing/gates). Implemented per §5 with §7's acceptance; no surface invented beyond it (one positional, the report, the 0/1/2 codes).
- One design consequence worth a look: the absence signature means a *filtered* capture fragment with no `mount/ok` reads as "env image never mounted" — that is the §5 signature's documented semantics (the operator corroborates with the child's prelude-class stderr, out-of-band by construction).
