### PR TITLE
arscope: demote STB_GNU_UNIQUE definitions to weak — the gnu link unit folds under binutils 2.34 (#413)

### DIFF
--- a/.github/workflows/lib/link-unit-floor-link-check.sh
+++ b/.github/workflows/lib/link-unit-floor-link-check.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# link-unit-floor-link-check.sh — prove the staged gnu link unit FOLDS
+# under the floor's binutils (tebako#413): compile a trivial C consumer
+# and link it against the unit's two scoped archives plus the closure
+# with the floor's ld (2.34 — ubuntu:20.04 never bumps binutils).
+# binutils < 2.35 reads a group-less STB_GNU_UNIQUE definition as STRONG
+# and rejects a symtab whose local symbols trail sh_info, so any binding
+# the scoper failed to demote — or any inconsistently filed symbol —
+# fails THIS link with "multiple definition" / "local symbol at index N"
+# before the probe ever runs. The zero-UNIQUE gate in
+# lib/link-unit-stage.sh is the static half; this link is the dynamic
+# half, exercising every archive member the consumer pulls.
+#
+# The link shape mirrors a factory consumer: demand-driven extraction
+# from --start-group'd archives (no --whole-archive — the unit is not
+# promised to be whole-archive-clean; the vendored codec copies bundle
+# some strong C symbols twice, harmless under demand-driven links). The
+# closure's C++ objects were compiled in this same container
+# (gnu-floor-build.sh's ppa gcc-11), so the floor's c++ driver — gcc-11
+# via update-alternatives — resolves their libstdc++ references itself.
+#
+# Runs INSIDE the ubuntu:20.04 floor container; called from
+# ci/gnu-floor-build.sh after lib/link-unit-stage.sh.
+# Required env: PLATFORM (tebako platform id).
+set -euo pipefail
+
+unit="out/link-unit-$PLATFORM"
+[ -f "$unit/libtfs.a" ] || { echo "link-unit-floor-link-check: $unit missing (stage first)" >&2; exit 64; }
+
+probe_dir="$(mktemp -d)"
+trap 'rm -rf "$probe_dir"' EXIT
+
+# The staged include/tebako/fs/c_api.h has a dangling include
+# (tebako/fs/platform.h ships nowhere — a separate pre-existing gap), so
+# the consumer declares the two exports it needs, exactly the ABI shape.
+cat > "$probe_dir/consumer.c" <<'EOF'
+#include <stdint.h>
+#include <stdio.h>
+uint32_t tebako_driver_contract_version(void);
+int tebako_fs_init_from_file(const char *archive_path, const char *mount_point);
+
+int main(void) {
+    uint32_t cv = tebako_driver_contract_version();
+    int rc = tebako_fs_init_from_file("/nonexistent.tfs", "/__tebako__");
+    printf("probe: contract=%u init_from_file(missing)=%d\n", cv, rc);
+    return (cv > 0 && rc != 0) ? 0 : 1;
+}
+EOF
+
+echo "== floor toolchain =="
+ld --version | head -1
+c++ --version | head -1
+
+echo "== consumer link (demand-driven extraction, floor ld) =="
+cc -c "$probe_dir/consumer.c" -o "$probe_dir/consumer.o"
+c++ -o "$probe_dir/probe" "$probe_dir/consumer.o" \
+  -Wl,--start-group "$unit/libtebako_driver.a" "$unit/libtfs.a" "$unit"/closure/*.a -Wl,--end-group \
+  -lpthread -ldl -lm
+
+echo "== run the probe (exercises the extracted driver code) =="
+"$probe_dir/probe"
+echo "link-unit-floor-link-check: OK ($PLATFORM folds under $(ld --version | head -1))"

--- a/.github/workflows/lib/link-unit-stage.sh
+++ b/.github/workflows/lib/link-unit-stage.sh
@@ -45,4 +45,24 @@ mkdir -p "out/link-unit-$PLATFORM"
 # bash 3.2 (the macOS runners' /bin/bash) calls an empty "${array[@]}"
 # unbound under set -u — the [@]+ guard expands to nothing instead.
 ruby tools/stage_link_unit "out/link-unit-$PLATFORM" ${target_args[@]+"${target_args[@]}"} --skip-build
+
+# tebako#413 floor gate: the two SCOPED archives must carry no
+# STB_GNU_UNIQUE definitions. The scoper's rewrite drops the SHT_GROUP
+# COMDAT the binding folds through, and binutils ld < 2.35 (the
+# factory's ubuntu:20.04 floor) reads a group-less UNIQUE as a STRONG
+# definition — every second archive member defining the same inline is a
+# "multiple definition" error (v0.1.9's libtfs.a carried 1356). arscope
+# demotes them to STB_WEAK; nm prints a unique symbol as "u", so any
+# survivor fails this gate before the unit ships. The closure archives
+# are NOT gated: their groups survive (nothing rewrites them) and fold
+# normally at any binutils. Mach-O/musl legs carry none by construction
+# (nm prints no "u" type there) — the gate is a no-op, kept fail-closed.
+for a in "out/link-unit-$PLATFORM/libtfs.a" "out/link-unit-$PLATFORM/libtebako_driver.a"; do
+  uniq_count=$(nm "$a" 2>/dev/null | grep -cE ' u [^ ]' || true)
+  if [ "$uniq_count" != "0" ]; then
+    echo "::error::link-unit-stage GATE-FAIL: $a carries $uniq_count STB_GNU_UNIQUE symbol(s) — binutils 2.34 reads group-less UNIQUE as strong (tebako#413); the scoper must demote them to weak" >&2
+    exit 65
+  fi
+done
+
 tar -czf "out/link-unit-${VERSION}-${PLATFORM}.tar.gz" -C out "link-unit-$PLATFORM"

--- a/ci/gnu-floor-build.sh
+++ b/ci/gnu-floor-build.sh
@@ -187,3 +187,9 @@ fi
 echo "== link unit (tebako-driver + tfs, scoped, + closure) =="
 cargo build --release --target "$TARGET" -p tfs -p tebako-driver -p libtfs-preload
 bash .github/workflows/lib/link-unit-stage.sh
+
+echo "== link unit floor link check (tebako#413) =="
+# The staged unit must fold under THIS container's binutils 2.34 with a
+# trivial consumer — the property the factory's re-pin relies on. Runs
+# in-leg so a scoper regression fails the release build, not the factory.
+bash .github/workflows/lib/link-unit-floor-link-check.sh

--- a/crates/tebako-arscope/src/main.rs
+++ b/crates/tebako-arscope/src/main.rs
@@ -19,6 +19,12 @@
 //! Rename, never hide: hiding per-object breaks intra-archive
 //! references; renaming preserves them.
 //!
+//! Two ELF-only repairs ride the same pass (tebako#413): defined
+//! STB_GNU_UNIQUE symbols demote to STB_WEAK — the rewrite drops the
+//! SHT_GROUP the binding folds through, and binutils < 2.35 reads a
+//! group-less UNIQUE as a strong duplicate — and FILE bookkeeping
+//! symbols stay in the local symtab region the writer's layout expects.
+//!
 //! ```text
 //! tebako-arscope <in.a> <out.a> [--keep-prefix tebako_] [--prefix __tebako_internal_]
 //! ```
@@ -36,6 +42,11 @@ use object::{
 const KEEP_PREFIX: &str = "tebako_";
 /// The default internal prefix for scoped symbols.
 const SCOPE_PREFIX: &str = "__tebako_internal_";
+/// ELF st_info bindings (the object crate has no named constants for
+/// them): glibc-target g++'s vague-linkage binding and its demotion
+/// target (see the STB_GNU_UNIQUE neutralization in scope_object).
+const STB_GNU_UNIQUE: u8 = 10;
+const STB_WEAK: u8 = 2;
 
 fn main() -> ExitCode {
     let mut args = std::env::args().skip(1);
@@ -566,17 +577,57 @@ fn scope_object(
         // g++'s vague-linkage binding — template/inline statics;
         // libstdc++.a alone carries 154) to SymbolScope::Unknown, and its
         // writer asserts a defined symbol is scoped (write/mod.rs:434).
-        // Re-scope to Linkage for the write: the passthrough st_info
-        // flags keep the UNIQUE binding in the emitted symbol, so the
-        // output is byte-equivalent to what the pre-assert writer
-        // produced — the v0.1.0 gnu link unit shipped exactly this shape
-        // and the factory consumed it. Only the gnu legs carry such
+        // Re-scope to Linkage for the write. Only the gnu legs carry such
         // members (musl and Mach-O have no GNU_UNIQUE), which is why the
         // floor leg's scoper panic (run 30988106906) was the first time
         // a gnu release build reached this code.
+        //
+        // The same reader maps a FILE symbol's SHN_UNDEF to
+        // SymbolScope::Unknown too (the SHN_UNDEF short-circuit runs
+        // before the binding match — read/elf/symbol.rs:452). Left
+        // unscoped, the writer files it in the NON-LOCAL symtab region
+        // while the passthrough st_info keeps STB_LOCAL: an inconsistent
+        // symtab ("local symbol at index N (>= sh_info of N)") that
+        // binutils 2.34 rejects outright (tebako#413's floor). Re-scope
+        // FILE bookkeeping to Compilation — the writer's local region,
+        // where its binding belongs (rustc emits one FILE symbol per TU).
         let scope = match symbol.scope() {
+            SymbolScope::Unknown if symbol.kind() == object::SymbolKind::File => {
+                SymbolScope::Compilation
+            }
             SymbolScope::Unknown if !symbol.is_undefined() => SymbolScope::Linkage,
             scope => scope,
+        };
+        // STB_GNU_UNIQUE neutralization (tebako#413): the binding is a
+        // DYNAMIC-linking construct (an ld.so process-singleton across
+        // DSOs) and the scoped link unit is a STATIC archive set with no
+        // DSO boundary for it to govern. Worse, the rewrite cannot keep
+        // the SHT_GROUP COMDAT section the binding folds through (the
+        // object crate emits no .group — see the SHF_GROUP clear above),
+        // leaving a group-less GNU_UNIQUE that binutils ld 2.34 (the
+        // factory's ubuntu:20.04 floor) treats as a STRONG definition:
+        // the second archive member defining the same inline variable
+        // (libstdc++'s __to_chars_10_impl::__digits, std::ranges::
+        // __cust::*, nlohmann::json statics) is a "multiple definition"
+        // error (tebako-runtime-ruby#107; v0.1.9's libtfs.a carried
+        // 1356). Demote DEFINED GNU_UNIQUE symbols to WEAK: name-based
+        // coalescing at static link time is exactly the vague-linkage
+        // semantics minus the DSO property — the same object g++
+        // -fno-gnu-unique would have emitted. Undefined GNU_UNIQUE
+        // references stay strong: a reference must resolve, never
+        // silently zero.
+        let mut weak = symbol.is_weak();
+        let flags = match flags {
+            object::SymbolFlags::Elf { st_info, st_other }
+                if !symbol.is_undefined() && st_info >> 4 == STB_GNU_UNIQUE =>
+            {
+                weak = true;
+                object::SymbolFlags::Elf {
+                    st_info: (STB_WEAK << 4) | (st_info & 0x0f),
+                    st_other,
+                }
+            }
+            other => other,
         };
         let id = out.add_symbol(object::write::Symbol {
             name: renamed.into_bytes(),
@@ -584,7 +635,7 @@ fn scope_object(
             size: symbol.size(),
             kind: symbol.kind(),
             scope,
-            weak: symbol.is_weak(),
+            weak,
             section,
             flags,
         });
@@ -803,7 +854,12 @@ mod tests {
     /// them on the gnu legs) reads back as SymbolScope::Unknown; the
     /// rewrite must re-scope it for the writer instead of panicking on
     /// its defined-symbol assert (the floor leg's scoper panic, release
-    /// run 30988106906). ELF-only: Mach-O has no such binding.
+    /// run 30988106906) — and, since tebako#413, demote the binding to
+    /// STB_WEAK (the rewrite drops the SHT_GROUP the binding folds
+    /// through, and binutils 2.34 rejects group-less duplicates). The
+    /// second fixture symbol is an UNDEFINED GNU_UNIQUE reference: it
+    /// must stay strong (a reference must resolve, never silently zero).
+    /// ELF-only: Mach-O has no such binding.
     fn fixture_object_gnu_unique() -> Vec<u8> {
         let arch = if cfg!(target_arch = "aarch64") {
             object::Architecture::Aarch64
@@ -832,11 +888,44 @@ mod tests {
                 st_other: 0,
             },
         });
+        out.add_symbol(object::write::Symbol {
+            name: b"_ZN1WIiE1uE".to_vec(),
+            value: 0,
+            size: 0,
+            kind: object::SymbolKind::Unknown,
+            scope: object::SymbolScope::Unknown,
+            weak: false,
+            section: object::write::SymbolSection::Undefined,
+            // st_info = STB_GNU_UNIQUE (10) << 4 | STT_NOTYPE (0)
+            flags: object::SymbolFlags::Elf {
+                st_info: 10 << 4,
+                st_other: 0,
+            },
+        });
+        // The TU bookkeeping symbol every rustc/g++ object carries:
+        // STB_LOCAL | STT_FILE at SHN_UNDEF — object 0.37's reader maps
+        // the SHN_UNDEF to SymbolScope::Unknown, and without the re-scope
+        // in scope_object the writer would file it in the non-local
+        // symtab region (a symtab binutils 2.34 rejects as inconsistent).
+        out.add_symbol(object::write::Symbol {
+            name: b"fixture.c".to_vec(),
+            value: 0,
+            size: 0,
+            kind: object::SymbolKind::File,
+            scope: object::SymbolScope::Compilation,
+            weak: false,
+            section: object::write::SymbolSection::Undefined,
+            // st_info = STB_LOCAL (0) << 4 | STT_FILE (4)
+            flags: object::SymbolFlags::Elf {
+                st_info: 4,
+                st_other: 0,
+            },
+        });
         out.write().expect("fixture object")
     }
 
     #[test]
-    fn gnu_unique_symbols_survive_the_rewrite() {
+    fn gnu_unique_definitions_demote_to_weak_references_stay_strong() {
         let fixture = fixture_object_gnu_unique();
         let obj = File::parse(&fixture[..]).expect("parse the fixture");
         let sym = obj
@@ -859,11 +948,65 @@ mod tests {
         )
         .expect("scope the fixture");
         let obj = File::parse(&bytes[..]).expect("parse the rewritten object");
+
+        // The definition demotes to STB_WEAK, type (STT_OBJECT) intact.
         let sym = obj
             .symbols()
             .find(|s| s.name().ok() == Some("_ZN1HIiE1vE"))
             .expect("the unique symbol survives the rewrite");
         assert!(!sym.is_undefined());
+        assert!(
+            sym.is_weak(),
+            "a defined GNU_UNIQUE demotes to weak (tebako#413)"
+        );
+        match sym.flags() {
+            object::SymbolFlags::Elf { st_info, .. } => {
+                assert_eq!(st_info >> 4, STB_WEAK, "the emitted binding is WEAK");
+                assert_eq!(st_info & 0x0f, 1, "the symbol type is preserved");
+            }
+            other => panic!("expected ELF symbol flags, got {other:?}"),
+        }
+
+        // The undefined GNU_UNIQUE reference keeps its strong binding:
+        // demoting a reference to weak would let a missing definition
+        // resolve to zero instead of failing the link.
+        let sym = obj
+            .symbols()
+            .find(|s| s.name().ok() == Some("_ZN1WIiE1uE"))
+            .expect("the undefined reference survives the rewrite");
+        assert!(sym.is_undefined());
+        match sym.flags() {
+            object::SymbolFlags::Elf { st_info, .. } => {
+                assert_eq!(
+                    st_info >> 4,
+                    STB_GNU_UNIQUE,
+                    "an undefined reference stays GNU_UNIQUE (strong)"
+                );
+            }
+            other => panic!("expected ELF symbol flags, got {other:?}"),
+        }
+
+        // The FILE bookkeeping symbol must stay in the local symtab
+        // region: binutils 2.34 rejects a symtab whose local symbols
+        // are not all ahead of sh_info ("local symbol at index N (>=
+        // sh_info of N)"). Assert the ordering invariant directly: no
+        // STB_LOCAL symbol may follow the first non-local one.
+        let mut seen_nonlocal = false;
+        for s in obj.symbols() {
+            let local = matches!(
+                s.flags(),
+                object::SymbolFlags::Elf { st_info, .. } if st_info >> 4 == 0
+            );
+            if local {
+                assert!(
+                    !seen_nonlocal,
+                    "local symbol '{}' follows a non-local one — the rewritten symtab is inconsistent (binutils 2.34 rejects it)",
+                    s.name().unwrap_or("<unnamed>")
+                );
+            } else {
+                seen_nonlocal = true;
+            }
+        }
     }
 
     /// A fixture object with one defined global and two undefined


### PR DESCRIPTION
## Why

tamatebako/tebako#413 — the gnu link unit must link under the runtime factory's binutils floor (ubuntu:20.04, **ld 2.34**; focal never bumps binutils). Today the factory's runtime-exe link against the published v0.1.9 unit dies with hundreds of `multiple definition` errors (factory job 95217789911: **834**), which forced the factory pin off the floor in tamatebako/tebako-runtime-ruby#107.

Root cause, confirmed on the downloaded v0.1.9 unit: `tebako-arscope`'s rewrite strips the `SHT_GROUP` COMDAT sections (the object crate emits no `.group`) but passed `STB_GNU_UNIQUE` symbol bindings through unchanged. Scoped `libtfs.a` carried **1356 GNU_UNIQUE definitions across 436 members, zero SHT_GROUP sections**. binutils < 2.35 reads a group-less GNU_UNIQUE definition as a **strong** definition, so every second archive member defining the same g++ vague-linkage inline (`std::ranges::__cust::*`, `__to_chars_10_impl::__digits`, `_Sp_make_shared_tag`, nlohmann statics, guard variables — 1201 of the 2271 whole-archive errors) is a duplicate. The closure archives (botan, dwarfs, …) also carry GNU_UNIQUE but **with their groups intact** — nothing rewrites them — so they fold fine at any binutils.

## What

**`crates/tebako-arscope/src/main.rs`** — two repairs in the same symbol pass:

1. **Defined GNU_UNIQUE → STB_WEAK** (the #413 fix). The binding is a *dynamic*-linking construct (an ld.so process-singleton across DSOs); the scoped link unit is a static archive set with no DSO boundary for it to govern. Demotion to weak gives name-based coalescing at static link time — exactly vague linkage minus the DSO property, i.e. the object `g++ -fno-gnu-unique` would have emitted. **Undefined** GNU_UNIQUE references stay strong: a reference must resolve, never silently zero.
2. **FILE bookkeeping symbols re-scoped to `Compilation`** (latent, same floor). object 0.37's reader maps a FILE symbol's `SHN_UNDEF` to `SymbolScope::Unknown`; left unscoped, the writer files it in the *non-local* symtab region while the passthrough st_info keeps `STB_LOCAL` — an inconsistent symtab ld 2.34 rejects with `local symbol at index N (>= sh_info of N)`. Non-firing on the v0.1.9 build (an older object resolution), live on the shipping path today.

**Gates (fail-closed):**

- `.github/workflows/lib/link-unit-stage.sh` — after staging, both scoped archives (`libtfs.a`, `libtebako_driver.a`) must carry **zero** `STB_GNU_UNIQUE` symbols (`nm` prints them as `u`), else exit 65. Runs on every POSIX leg; a no-op on macOS/musl by construction. The closure is deliberately *not* gated (its groups survive; see above).
- `.github/workflows/lib/link-unit-floor-link-check.sh` (new, wired into `ci/gnu-floor-build.sh` after staging) — compiles a trivial C consumer and links it against driver + tfs + closure with the floor's ld 2.34, demand-driven through `--start-group`, then runs the probe. The link shape mirrors a factory consumer; a scoper regression now fails the release build in-leg instead of the factory.

## Evidence

Local rehearsal in the exact floor container shape (`ubuntu:20.04`, **GNU ld 2.34**, ppa **g++-11 11.5.0** — what `gnu-floor-build.sh` installs), consumer = the check's trivial probe:

| unit under test | consumer link | errors |
|---|---|---|
| original v0.1.9 | **RED** | 833 `multiple definition`, 0 undefined — matches the factory's 834 |
| v0.1.9 with `libtfs.a` re-scoped by patched arscope (identity prefix) | **GREEN** | probe runs: `contract=2 init_from_file(missing)=-1` |

Gate exercised with binutils 2.34 `nm`: original unit → 1356 unique → rc 65; fixed unit → 0 → rc 0. `__to_chars_10_impl::__digits` now emits `WEAK DEFAULT OBJECT`.

Repo gates: `cargo test -p tebako-arscope` 5/5 (the GNU_UNIQUE test now asserts demotion, type preservation, strong references, and the symtab local-before-non-local invariant); `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean; `bash -n` + shellcheck clean on both shell scripts (two pre-existing info findings untouched).

## Follow-ups this PR deliberately does NOT fix (flagged for the re-pin)

1. **libstdc++ ceiling — the *next* blocker the factory re-pin will hit.** The closure's C++ objects are compiled in the floor container with ppa **gcc-11 headers**, so they reference GLIBCXX **3.4.29** symbols (`std::__throw_bad_array_new_length`, `basic_ostringstream::str() const &`, …). The factory's container tops out at libstdc++ **3.4.28** → the same factory log carries **302 undefined references** that survive this fix. This class is invisible in tebako's own floor leg (its `c++` *is* gcc-11) — hence the gate above can't see it. Options: (a) the factory link gains a ≥ 3.4.29 libstdc++ (container package, or tebako ships gcc-11's static `libstdc++.a`/`libgcc*.a` in the gnu closure — the static-absorption policy the shipped binaries already use); (b) tebako builds the gnu closure with a ≤ 3.4.28 header ceiling (clang or gcc-10 headers — larger). Needs an owner decision; tebako-runtime-ruby#107's re-pin will arbitrate.
2. **Pre-existing strong duplicates in the vendored codec copies** (zstd/lz4/lzma/zlib/bz2 bundled twice by the cargo staticlibs — 1070 errors under a `--whole-archive` scan, equally present in v0.1.9). Non-firing in demand-driven links, which is why the floor check deliberately does not use `--whole-archive`; the unit is not promised whole-archive-clean.
3. **Latent arscope issues (non-firing today, noted in code):** `keeps_name` trims leading underscores so `__tebako_internal_*` false-matches keep prefix `tebako_` (double-scoping the same archive is unsafe — use `--prefix ''` for identity re-scopes), and the ELF pass-A defined-set doesn't filter keep-prefixed names.
4. The staged `include/tebako/fs/c_api.h` has a dangling `#include <tebako/fs/platform.h>` (ships nowhere) — the floor-check consumer declares the two exports directly instead.

## Merge discipline

Draft; **do not merge** — per the owner-locked rule, nothing lands on `main` until the whole change chain validates end-to-end. The acceptance is the factory re-pin going green, which also needs follow-up 1 above decided. A `release.yml` dry-run dispatch on this branch exercises the gnu floor leg with both new gates.
