### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "tests/contract"]
 
 [workspace.package]
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"

--- a/crates/libtfs-preload/Cargo.toml
+++ b/crates/libtfs-preload/Cargo.toml
@@ -25,7 +25,7 @@ crate-type = ["cdylib", "rlib"]
 # image format is dwarfs-t, and a shim that cannot mount a payload
 # payload-side (ENOTSUP) is a shim that cannot do its job. squashfs
 # stays opt-in via the tfs crate's own features.
-tfs = { version = "0.1.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
 libc = "0.2"
 
 [dev-dependencies]

--- a/crates/tebako-bootstrap/Cargo.toml
+++ b/crates/tebako-bootstrap/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["tebako", "bootstrap", "launcher", "tpkg"]
 categories = ["filesystem", "no-std"]
 
 [dependencies]
-tpkg = { version = "0.1.0", path = "../tpkg" }
-tebako-signer = { version = "0.1.0", path = "../tebako-signer", optional = true }
-tebako-http = { version = "0.1.0", path = "../tebako-http" }
-tebako-term = { version = "0.1.0", path = "../tebako-term" }
+tpkg = { version = "0.2.0", path = "../tpkg" }
+tebako-signer = { version = "0.2.0", path = "../tebako-signer", optional = true }
+tebako-http = { version = "0.2.0", path = "../tebako-http" }
+tebako-term = { version = "0.2.0", path = "../tebako-term" }
 # OpenPGP trailer verification is OPTIONAL (feature `openpgp-verify`,
 # default OFF): the shipped bootstrap runs unverified-first — every
 # package loads with a loud warning, and TEBAKO_REQUIRE_SIGNED=1 fails
@@ -55,5 +55,5 @@ path = "src/lib.rs"
 # cfg-gated to match. The shipped bootstrap stays unverified-first on
 # every platform (the feature above is unaffected).
 [target.'cfg(not(windows))'.dev-dependencies]
-tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
+tebako-signer = { version = "0.2.0", path = "../tebako-signer" }
 rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }

--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -11,26 +11,26 @@ keywords = ["tebako", "packager", "ruby", "dwarfs", "cli"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-tpkg = { version = "0.1.0", path = "../tpkg" }
-tebako-pkg = { version = "0.1.0", path = "../tebako-pkg" }
-tebako-http = { version = "0.1.0", path = "../tebako-http" }
+tpkg = { version = "0.2.0", path = "../tpkg" }
+tebako-pkg = { version = "0.2.0", path = "../tebako-pkg" }
+tebako-http = { version = "0.2.0", path = "../tebako-http" }
 # Registry/payload resolution for `tebako add-registry | install` (spec 04).
-tebako-resolve = { version = "0.1.0", path = "../tebako-resolve" }
+tebako-resolve = { version = "0.2.0", path = "../tebako-resolve" }
 # Release-API JSON for the publish upload leg (GitHub release documents).
-tebako-json = { version = "0.1.0", path = "../tebako-json" }
+tebako-json = { version = "0.2.0", path = "../tebako-json" }
 # The spec-15 introspection model (payload + package inspections, the
 # strict verify) — the `tebako inspect` surface renders through it.
-tebako-info = { version = "0.1.0", path = "../tebako-info" }
+tebako-info = { version = "0.2.0", path = "../tebako-info" }
 # Config writes (registries:), the manifest mirror and the shim link/unlink
 # — called as a library, never spawned (spec 14 §3: no shell-outs).
-tebako-shim = { version = "0.1.0", path = "../tebako-shim" }
+tebako-shim = { version = "0.2.0", path = "../tebako-shim" }
 # OpenPGP verification of signed registry entries (spec 09; strict when the
 # entry carries a signature, the v1-legacy warn when it does not).
-tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
+tebako-signer = { version = "0.2.0", path = "../tebako-signer" }
 # The bootstrap's embedded artifact-info block (spec 18 §2.2/S38): the
 # `tebako inspect --contract` card reads it through the owner crate — the
 # marker grammar has exactly one home.
-tebako-bootstrap = { version = "0.1.0", path = "../tebako-bootstrap" }
+tebako-bootstrap = { version = "0.2.0", path = "../tebako-bootstrap" }
 # (the tfs dependency is per-target, below — squashfs is POSIX-only)
 # The suite file (--suite) is authored YAML (spec 00 invariant 6) — the
 # tpkg manifest convention (serde_yml), not serde_yaml.
@@ -65,10 +65,10 @@ regex = "1"
 # there (TODO.v2-1/02). The per-target split lives in the consumer (cargo
 # features cannot be target-conditional from inside tfs).
 [target.'cfg(not(windows))'.dependencies]
-tfs = { version = "0.1.0", path = "../tfs" }
+tfs = { version = "0.2.0", path = "../tfs" }
 
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.1.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
 # The runtime/SDK install locks (src/resolve.rs flock port): LockFileEx on
 # one byte at offset 0 — the tebako-shim runtime.rs shape. FFI is
 # quarantined in that one function.

--- a/crates/tebako-driver/Cargo.toml
+++ b/crates/tebako-driver/Cargo.toml
@@ -17,12 +17,12 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 # The stack's one logging facility (mount/jail decisions at debug).
-tebako-log = { version = "0.1.0", path = "../tebako-log" }
+tebako-log = { version = "0.2.0", path = "../tebako-log" }
 # Trailer probing for `<self|package>:<slot>` resolution (spec 02).
-tpkg = { version = "0.1.0", path = "../tpkg" }
+tpkg = { version = "0.2.0", path = "../tpkg" }
 # The resolve trace events' detail values (spec 25 §7 blesses tebako-json
 # for trace emission; the envelope renderer lives in tfs::trace).
-tebako-json = { version = "0.1.0", path = "../tebako-json" }
+tebako-json = { version = "0.2.0", path = "../tebako-json" }
 # The env-image layout declaration (spec 18 C3) is authored YAML.
 serde = { version = "1", features = ["derive"] }
 serde_yml = "0.0.12"
@@ -38,10 +38,10 @@ sha2 = "0.10"
 # Windows ships dwarfs-only (squashfs-tools-ng is POSIX/autotools-only,
 # TODO.v2-1/02; ENC needs rnp's mingw build, TODO.v2-1/08).
 [target.'cfg(not(windows))'.dependencies]
-tfs = { version = "0.1.0", path = "../tfs" }
+tfs = { version = "0.2.0", path = "../tfs" }
 
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.1.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
 
 # build.rs compiles the interpose dylib for darwin targets only (its
 # TARGET check early-returns elsewhere), but it references the cc crate

--- a/crates/tebako-info/Cargo.toml
+++ b/crates/tebako-info/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["tebako", "tpkg", "tfs", "info", "introspection"]
 categories = ["filesystem", "parser-implementations"]
 
 [dependencies]
-tpkg = { version = "0.1.0", path = "../tpkg" }
-tebako-json = { version = "0.1.0", path = "../tebako-json" }
-tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
+tpkg = { version = "0.2.0", path = "../tpkg" }
+tebako-json = { version = "0.2.0", path = "../tebako-json" }
+tebako-signer = { version = "0.2.0", path = "../tebako-signer" }
 sha2 = "0.10"
 # errno values for the tree-hash walker's named skip reasons (verify.rs).
 libc = "0.2"
@@ -25,10 +25,10 @@ serde_yml = "0.0.12"
 # POSIX/autotools-only — Windows gets a dwarfs-only tfs, the backend
 # degrading to a named ENOTSUP (TODO.v2-1/02).
 [target.'cfg(not(windows))'.dependencies]
-tfs = { version = "0.1.0", path = "../tfs" }
+tfs = { version = "0.2.0", path = "../tfs" }
 
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.1.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
 
 [dev-dependencies]
 # In-process dwarfs-t writer for manifest-carrying image fixtures.

--- a/crates/tebako-pkg/Cargo.toml
+++ b/crates/tebako-pkg/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["tebako", "tpkg", "package", "cli"]
 categories = ["filesystem", "command-line-utilities"]
 
 [dependencies]
-tpkg = { version = "0.1.0", path = "../tpkg" }
-tebako-json = { version = "0.1.0", path = "../tebako-json" }
-tebako-info = { version = "0.1.0", path = "../tebako-info" }
-tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
+tpkg = { version = "0.2.0", path = "../tpkg" }
+tebako-json = { version = "0.2.0", path = "../tebako-json" }
+tebako-info = { version = "0.2.0", path = "../tebako-info" }
+tebako-signer = { version = "0.2.0", path = "../tebako-signer" }
 rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
 libc = "0.2"
 sha2 = "0.10"
@@ -23,15 +23,15 @@ sha2 = "0.10"
 # POSIX/autotools-only — Windows gets a dwarfs-only tfs, the backend
 # degrading to a named ENOTSUP (TODO.v2-1/02).
 [target.'cfg(not(windows))'.dependencies]
-tfs = { version = "0.1.0", path = "../tfs" }
+tfs = { version = "0.2.0", path = "../tfs" }
 
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.1.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
 
 [dev-dependencies]
-tebako-contract-tests = { version = "0.1.0", path = "../../tests/contract" }
-tebako-bootstrap = { version = "0.1.0", path = "../tebako-bootstrap" }
-tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
+tebako-contract-tests = { version = "0.2.0", path = "../../tests/contract" }
+tebako-bootstrap = { version = "0.2.0", path = "../tebako-bootstrap" }
+tebako-signer = { version = "0.2.0", path = "../tebako-signer" }
 # In-process dwarfs-t writer for manifest-carrying image fixtures.
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 

--- a/crates/tebako-resolve/Cargo.toml
+++ b/crates/tebako-resolve/Cargo.toml
@@ -11,17 +11,17 @@ keywords = ["tebako", "resolve", "reference", "cache", "registry"]
 categories = ["data-structures", "filesystem", "parser-implementations"]
 
 [dependencies]
-tebako-http = { version = "0.1.0", path = "../tebako-http" }
+tebako-http = { version = "0.2.0", path = "../tebako-http" }
 # Release-API JSON responses are parsed with the workspace's own minimal
 # JSON parser — no serde in the release-API stack, no native deps
 # (tebako-pkg proper pulls the imaging stack; the parser alone lives in
 # tebako-json).
-tebako-json = { version = "0.1.0", path = "../tebako-json" }
+tebako-json = { version = "0.2.0", path = "../tebako-json" }
 # The registry model (spec 04 §2) is authored YAML (owner rule): serde +
 # serde_yml, the tpkg manifest convention. The Platform/PayloadKind
 # vocabulary comes from tpkg itself — the single owner of the triplet ↔
 # release-asset-name mapping (spec 03 §3).
-tpkg = { version = "0.1.0", path = "../tpkg" }
+tpkg = { version = "0.2.0", path = "../tpkg" }
 serde = { version = "1", features = ["derive"] }
 serde_yml = "0.0.12"
 sha2 = "0.10"

--- a/crates/tebako-shim/Cargo.toml
+++ b/crates/tebako-shim/Cargo.toml
@@ -17,18 +17,18 @@ categories = ["command-line-utilities"]
 # spec 08 jail model (the mirror's capabilities.host, composed with the
 # dispatch flags into TEBAKO_JAIL — the engine stays out of the
 # dispatcher).
-tpkg = { version = "0.1.0", path = "../tpkg" }
+tpkg = { version = "0.2.0", path = "../tpkg" }
 # The release manifest index (spec 13) parses as DATA, never by string
 # scan: tebako-json's small parser — the substring-scan era read the next
 # entry's sha256 for image assets.
-tebako-json = { version = "0.1.0", path = "../tebako-json" }
+tebako-json = { version = "0.2.0", path = "../tebako-json" }
 # The stack's one logging facility (resolution decisions at debug).
-tebako-log = { version = "0.1.0", path = "../tebako-log" }
+tebako-log = { version = "0.2.0", path = "../tebako-log" }
 # Remote registry resolution at dispatch time (spec 04 §2 — item 33):
 # every registry form (service contents API, pinned release artifact, git
 # blob, file) behind the per-ref dispatch cache in src/regcache.rs. The
 # shim links tebako-resolve, never tebako-cli.
-tebako-resolve = { version = "0.1.0", path = "../tebako-resolve" }
+tebako-resolve = { version = "0.2.0", path = "../tebako-resolve" }
 # The authored config / disabled state / project pins are YAML (spec 00
 # invariant 6). serde_yaml 0.9 is the cached, pure-Rust (unsafe-libyaml)
 # choice — no native build, no async, no clap. (The manifest mirror's
@@ -37,7 +37,7 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 # In-process HTTP for runtime downloads (spec 00 invariant 1) — the same
 # crate the bootstrap resolves through.
-tebako-http = { version = "0.1.0", path = "../tebako-http" }
+tebako-http = { version = "0.2.0", path = "../tebako-http" }
 libc = "0.2"
 sha2 = "0.10"
 

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -13,18 +13,18 @@ categories = ["filesystem", "command-line-utilities"]
 [dependencies]
 # mkimage stamps identity.digest.tree_hash into a source tree's payload
 # manifest (spec 03 §7) via tpkg's merkle construction.
-tpkg = { version = "0.1.0", path = "../tpkg" }
+tpkg = { version = "0.2.0", path = "../tpkg" }
 # Hardlink staging area for the stamped tree (the author's source is
 # never mutated).
 tempfile = "3"
 # The encryption verbs (spec 10, enc.rs): DEK grant envelopes via
 # tebako-signer's rnp PKESK; plaintext blocks zeroized in the staging
 # loop; `tfs decrypt` streams through the pure-Rust tar writer.
-tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
+tebako-signer = { version = "0.2.0", path = "../tebako-signer" }
 zeroize = "1"
 tar = { version = "0.4", default-features = false }
-tebako-info = { version = "0.1.0", path = "../tebako-info" }
-tebako-json = { version = "0.1.0", path = "../tebako-json" }
+tebako-info = { version = "0.2.0", path = "../tebako-info" }
+tebako-json = { version = "0.2.0", path = "../tebako-json" }
 # `tfs exec --compose` reads authored YAML (invariant 6). serde_yaml 0.9 is
 # the cached, pure-Rust (unsafe-libyaml) parser — the shim's choice;
 # tpkg's manifest YAML rides serde_yml internally.
@@ -41,10 +41,10 @@ libc = "0.2"
 # POSIX/autotools-only — Windows gets a dwarfs-only tfs, the backend
 # degrading to a named ENOTSUP (TODO.v2-1/02).
 [target.'cfg(not(windows))'.dependencies]
-tfs = { version = "0.1.0", path = "../tfs" }
+tfs = { version = "0.2.0", path = "../tfs" }
 
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.1.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.0", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
 
 [[bin]]
 name = "tfs"
@@ -55,9 +55,9 @@ name = "tfs_cli"
 path = "src/lib.rs"
 
 [dev-dependencies]
-tebako-contract-tests = { version = "0.1.0", path = "../../tests/contract" }
+tebako-contract-tests = { version = "0.2.0", path = "../../tests/contract" }
 # The --verify signature tests mint a press-local key and detached .asc.
-tebako-signer = { version = "0.1.0", path = "../tebako-signer" }
+tebako-signer = { version = "0.2.0", path = "../tebako-signer" }
 rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
 # Exec-proof image fixtures (zip backend).
 zip = { version = "2", default-features = false, features = ["deflate"] }

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -18,10 +18,10 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [dependencies]
 libc = "0.2"
 # The stack's one logging facility (TEBAKO_DEBUG; zero cost when off).
-tebako-log = { version = "0.1.0", path = "../tebako-log" }
+tebako-log = { version = "0.2.0", path = "../tebako-log" }
 # The spec 25 trace bus's JSONL emission (spec 25 §7 blesses tebako-json —
 # workspace-internal, zero deps of its own — for event serialization).
-tebako-json = { version = "0.1.0", path = "../tebako-json" }
+tebako-json = { version = "0.2.0", path = "../tebako-json" }
 # The `zip` crate (pure Rust) rather than libzip-sys: the C ABI contract is
 # behavioral, not library-level; a pure-Rust reader keeps consumers and CI
 # free of a native libzip build, and the v1 scope (read-only, no encryption)
@@ -44,7 +44,7 @@ ruzstd = "0.7"
 # features to stay pure-cargo (the dwarfs backend then returns ENOTSUP).
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs", optional = true }
 # libsquashfs (squashfs-tools-ng) via vcpkg for the SquashFS backend.
-sqfs-sys = { version = "0.1.0", path = "../sqfs-sys", optional = true }
+sqfs-sys = { version = "0.2.0", path = "../sqfs-sys", optional = true }
 # The LimniFS backend (spec 20): the pure-Rust limnifs-core reader — no
 # system dependencies, `#![forbid(unsafe_code)]` upstream. Registry dep on
 # the published crates.io line (since 0.2.50; same standing as dwarfs-t).
@@ -53,13 +53,13 @@ limnifs-core = { version = "0.2.50", optional = true }
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
 # buffers. All pure-Rust RustCrypto crates — no shell-outs anywhere.
-tpkg = { version = "0.1.0", path = "../tpkg" }
+tpkg = { version = "0.2.0", path = "../tpkg" }
 # The exec probe's tolerant annotation read (exec_materialize): a value
 # walk of the in-image manifest — never the validating parse, which
 # would fail-closed a newer schema on an older runtime (spec 03's
 # compat rule: consumers ignore keys they predate). Same pin as tpkg.
 serde_yml = "0.0.12"
-tebako-signer = { version = "0.1.0", path = "../tebako-signer", optional = true }
+tebako-signer = { version = "0.2.0", path = "../tebako-signer", optional = true }
 aes-gcm = "0.10"
 hkdf = "0.12"
 sha2 = "0.10"

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -10,13 +10,13 @@ homepage.workspace = true
 publish = false
 
 [target.'cfg(not(windows))'.dependencies]
-tfs = { version = "0.1.0", path = "../../crates/tfs" }
+tfs = { version = "0.2.0", path = "../../crates/tfs" }
 
 # Windows gets the dwarfs-only tfs (the consumer per-target split — the
 # SquashFS backend is POSIX/autotools-only and sqfs-sys's build script
 # refuses by design; the ENC transform is unproven on mingw).
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.1.0", path = "../../crates/tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.0", path = "../../crates/tfs", default-features = false, features = ["vendored-dwarfs"] }
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION
## chore: bump the workspace version to 0.2.0

`[workspace.package] version 0.1.9 → 0.2.0` (the SSOT — every crate rides `workspace = true`), **plus the mechanical pin chase**: the workspace's path deps pin their siblings with `version = "0.1.0"`, and crossing the minor boundary breaks `^0.1.0` resolution (CI caught it instantly — `sqfs-sys = "^0.1.0"` vs candidate 0.2.0, `tfs` failing to resolve). All 58 workspace-internal sibling pins move to `"0.2.0"`; the **external** `dwarfs-t` pins (`../../../dwarfs-rs/dwarfs`, owned by the dwarfs-rs repo, still 0.1.x there) are deliberately untouched, as is third-party `reqwest = "0.13"`. 12 files, +60/−60.

This is the version-bump commit the v0.2.0 tag will point at, per the repo's release convention (v0.1.9 = `9177a4da` bump commit + tag).

Why 0.2.0: the 39 commits since v0.1.9 land two new CLI subcommand families — spec 25's `tebako trace` (run / spawn join / cover / import procmon / explain) and spec 26's `tebako check` — plus the #413 gnu link-unit floor fix and spec 22 W2. Feature-level delta ⇒ minor bump.

Local gate: `cargo metadata` resolves the full workspace (the failure mode the CI legs hit). Release mechanics after merge: tag `v0.2.0` on the resulting main HEAD → `gh release create` with the prepared notes → release.yml builds all legs (macos ×2, gnu ×2 in the ubuntu:20.04 floor container, musl ×2 in alpine, windows-link-unit, windows binaries) → ship gates → 44 assets + the finalize completeness gate.

Draft; merges on all-green per the standing rule.
