### PR TITLE
fix(preload): the fork/exec deadlock (runtime 0.16.4, POSIX)

### DIFF
--- a/crates/libtfs-preload/Cargo.toml
+++ b/crates/libtfs-preload/Cargo.toml
@@ -31,3 +31,8 @@ libc = "0.2"
 [dev-dependencies]
 # Test-image fixtures (exec proofs mount a zip through the shim).
 zip = { version = "2", default-features = false, features = ["deflate"] }
+# The in-process DwarFS writer for the fork-exec fixture image (same path
+# form as tfs-cli's mkimage): the fork/exec regression needs a backend
+# with a worker pool — the zip backend has none and cannot distinguish
+# the guard from the bug.
+dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }

--- a/crates/libtfs-preload/src/lib.rs
+++ b/crates/libtfs-preload/src/lib.rs
@@ -74,7 +74,21 @@
 //!   glibc exposes NO `openat2` wrapper/symbol, so there is nothing to
 //!   interpose on linux-gnu (a raw `syscall(2)` caller bypasses userland
 //!   interposition by construction).
-//! - Not interposed in v1: `fork`, `openat2` (glibc has no wrapper at
+//! - `fork` is not interposed, but its child side is GUARDED: a
+//!   `pthread_atfork` child handler arms a process-global flag, and every
+//!   shim's engine entry answers "pass through" while it is set. The
+//!   engine's backends are not fork-safe — dwarfs-t's block-cache worker
+//!   pool dies at `fork`, so a backend-touching call in the child (e.g.
+//!   the execve materialization probe under a `/` mount) would wait on
+//!   threads that no longer exist (the 2026-08-22 git-clone deadlock,
+//!   runtime 0.16.4). A fork child that goes on to `exec` re-enters a
+//!   fresh, healthy shim through the inherited preload env, so the
+//!   child-namespace propagation above is unaffected; a child that never
+//!   execs sees the host filesystem only — memfs fds it inherited answer
+//!   EIO, and an inherited memfs `DIR*` passed to the host dir family is
+//!   a caller bug (that path wedged before this guard).
+//! - Not interposed in v1: `fork` itself (its child side is guarded —
+//!   see above), `openat2` (glibc has no wrapper at
 //!   all — see above), `fstatat64` on macOS (the legacy 32-bit-inode
 //!   layout), the LFS `__xstat64`/`__lxstat64`/
 //!   `__fxstat64`/`__fxstatat64` versioned forms on Linux, `fdopendir`

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -24,11 +24,17 @@
 //! to the real implementation without touching the engine (correct: engine
 //! IO is host IO by definition, and the context lock would otherwise
 //! deadlock).
+//!
+//! Fork children: the engine's backends are not fork-safe (see the
+//! `IN_FORK_CHILD` guard below) — a `pthread_atfork` child handler arms a
+//! process-global flag, and every engine entry in a fork child gets `None`
+//! (the same "pass through to the real libc" answer re-entrancy gets).
 
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::ffi::{c_char, c_int, c_void, CStr};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 use tfs::context::TebakoCDirent;
@@ -71,9 +77,71 @@ thread_local! {
     static IN_ENGINE: Cell<bool> = const { Cell::new(false) };
 }
 
+// ---------------------------------------------------------------------
+// Fork-child guard (the 2026-08-22 preload fork/exec deadlock)
+// ---------------------------------------------------------------------
+
+/// Set in the child side of every `fork` (see `register_fork_guard`).
+///
+/// WHY: the engine's backends are not fork-safe. dwarfs-t's block cache
+/// runs a worker pool whose threads die at `fork`; any backend-touching
+/// route in the child — e.g. the execve materialization probe's
+/// `__tpkg__/manifest.yaml` read behind a `/` mount — waits on a
+/// promise/future that no dead thread will ever complete, wedging the
+/// child permanently (proven against runtime 0.16.4: payload mounted at
+/// `/`, payload spawns `git clone` → git's pre-exec helper child hangs in
+/// `std::condition_variable::wait` inside the block-cache dispatch).
+///
+/// The guard makes every engine entry in a fork child answer `None`,
+/// which every shim already maps to "pass through to the real libc /
+/// fail safe". A fork child that goes on to `exec` therefore calls the
+/// REAL execve with the original arguments, and the exec'd image
+/// re-enters a fresh, healthy shim through the inherited preload env —
+/// the spec 22 §3 child-namespace propagation never depended on engine
+/// calls in the pre-exec window. A fork child that never execs sees the
+/// host only; memfs fds it inherited answer EIO (they would be stale
+/// copies of parent engine state even if served).
+static IN_FORK_CHILD: AtomicBool = AtomicBool::new(false);
+
+/// The atfork CHILD handler: arm the fork-child guard. Runs in the child,
+/// on the forking thread, before the child's `fork` caller resumes.
+///
+/// Declared `unsafe` purely for signature compatibility: it coerces to
+/// the (safe) `extern "C" fn()` slot some libc bindings declare.
+unsafe extern "C" fn mark_fork_child() {
+    // Relaxed is sufficient: the handler runs on the forking thread in
+    // the child's address space, and fork copies ONLY that thread — the
+    // store and every later load are same-thread program order.
+    IN_FORK_CHILD.store(true, Ordering::Relaxed);
+}
+
+/// Register the atfork child handler. Called ONCE from [`init`] (the
+/// library constructor's payload), unconditionally — cheap, and NOT
+/// behind `route::initialize`'s OnceLock: the guard must exist in every
+/// process that has the shim loaded, however it was configured.
+///
+/// A registration failure (ENOMEM) leaves the historical unguarded
+/// behavior; following the trace-arm precedent that is a loud stderr
+/// note, never an init error.
+pub(crate) fn register_fork_guard() {
+    // SAFETY: plain libc call; the handler is a valid extern "C" fn.
+    let rc = unsafe { libc::pthread_atfork(None, None, Some(mark_fork_child)) };
+    if rc != 0 {
+        eprintln!(
+            "libtfs-preload: pthread_atfork registration failed (rc={rc}); \
+             fork children keep the engine (deadlock risk)"
+        );
+    }
+}
+
 /// Run `f` (a route-layer engine call) unless this thread is already
 /// inside the engine: re-entrant calls (the engine's own host IO) get
 /// `None` and the shim passes them straight to the real implementation.
+///
+/// Fork children (between `fork` and any `exec`) get `None` first, for
+/// the fail-safe reason on `IN_FORK_CHILD` above: the backends' worker
+/// threads do not survive `fork`, so an engine call there would wait on
+/// dead threads.
 ///
 /// pub(crate) for the TEST seam: a test that calls the route layer
 /// directly must enter through this guard exactly like the shims do.
@@ -83,6 +151,17 @@ thread_local! {
 /// route_matrix ubuntu hang; macOS test binaries do not interpose
 /// in-process, so only Linux CI saw it).
 pub(crate) fn engine_call<T>(f: impl FnOnce() -> T) -> Option<T> {
+    engine_call_inner(IN_FORK_CHILD.load(Ordering::Relaxed), f)
+}
+
+/// The gate body with the fork-child flag as an explicit input, so the
+/// unit pin can exercise both arms without mutating process-global state
+/// (a global-flag test would race the sibling tests that enter through
+/// `engine_call`).
+fn engine_call_inner<T>(in_fork_child: bool, f: impl FnOnce() -> T) -> Option<T> {
+    if in_fork_child {
+        return None;
+    }
     IN_ENGINE.with(|c| {
         if c.get() {
             return None;
@@ -1422,9 +1501,70 @@ pub unsafe extern "C" fn posix_spawnp(
 /// not mount, is a named configuration error: a clear stderr message
 /// naming the variable and the offending token, then EX_CONFIG (78).
 pub fn init() {
+    // Arm the fork-child guard FIRST, before any mount can happen: a
+    // backend worker pool comes into existence at mount time, and the
+    // guard must already be registered before any later fork.
+    register_fork_guard();
     if let Err(msg) = route::initialize() {
         eprintln!("libtfs-preload: {msg}");
         // SAFETY: plain libc call.
         unsafe { libc::exit(crate::spec::EX_CONFIG) };
+    }
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The guard gate: a fork child never enters the engine (`None` is
+    /// every shim's "pass through to the real libc / fail safe" answer);
+    /// a normal thread enters, and re-entrancy still answers `None`. Both
+    /// arms are exercised through `engine_call_inner`'s explicit flag
+    /// input so this test never mutates process-global state (a global
+    /// flag set here would race the sibling route tests that enter
+    /// through `engine_call`).
+    #[test]
+    fn fork_child_gate_short_circuits_engine_call() {
+        assert_eq!(engine_call_inner(true, || 42), None);
+        assert_eq!(engine_call_inner(false, || 42), Some(42));
+    }
+
+    /// The atfork wiring, for real: register, `fork`, and have the CHILD
+    /// answer whether the handler armed the flag. The child's post-fork
+    /// work is one atomic load and `_exit` (async-signal-safe in
+    /// practice); the parent asserts the exit code. The flag is set
+    /// copy-on-write in the child's address space only — the parent's
+    /// flag stays clear, so no sibling test is affected. Repeated
+    /// registration across test runs is harmless (the handlers all set
+    /// the same flag, and nothing else in this process forks).
+    #[test]
+    fn atfork_child_handler_arms_the_flag() {
+        register_fork_guard();
+        // SAFETY: plain fork; the child's post-fork work is an atomic
+        // load + _exit, both safe after fork in a threaded process.
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork failed: {}", std::io::Error::last_os_error());
+        if pid == 0 {
+            let rc = if IN_FORK_CHILD.load(Ordering::Relaxed) {
+                0
+            } else {
+                42
+            };
+            // SAFETY: plain libc call; never returns.
+            unsafe { libc::_exit(rc) };
+        }
+        let mut status = 0;
+        // SAFETY: pid is our child; status is a writable out-parameter.
+        assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
+        assert!(libc::WIFEXITED(status), "child did not exit normally");
+        assert_eq!(
+            libc::WEXITSTATUS(status),
+            0,
+            "fork child saw the guard flag clear"
+        );
     }
 }

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -39,6 +39,9 @@ struct Fixtures {
     dir: PathBuf,
     /// The test image (zip backend).
     zip: PathBuf,
+    /// The fork-exec test image (DWARFS backend — the fork/exec
+    /// regression needs a backend with a worker pool; zip has none).
+    dwarfs: PathBuf,
     /// The built shim cdylib.
     shim: PathBuf,
     /// A host directory with one readable file (jail grant fixture).
@@ -139,6 +142,7 @@ fn build_fixtures() -> Option<Fixtures> {
         "dir-stream",
         "mmap-probe",
         "close-probe",
+        "fork-exec",
     ] {
         let src = src_dir.join(format!("{name}.c"));
         let out = dir.join("bin").join(name);
@@ -236,9 +240,50 @@ fn build_fixtures() -> Option<Fixtures> {
         zw.finish().unwrap();
     }
 
+    // The fork-exec image (DWARFS backend — its block-cache worker pool is
+    // the fork hazard the guard exists for). Contents matter: an in-image
+    // `__tpkg__/manifest.yaml` WITHOUT the java_home annotation (the exec
+    // materialization probe reads exactly this file), plus one data file.
+    let dwarfs_path = dir.join("img.dwarfs");
+    {
+        let src = dir.join("dwarfs-src");
+        std::fs::create_dir_all(src.join("__tpkg__")).unwrap();
+        std::fs::create_dir_all(src.join("data")).unwrap();
+        // A minimal valid payload manifest WITHOUT the java_home
+        // annotation (the exec materialization probe reads exactly this
+        // file; the tolerant walk answers false → the closure walk).
+        let manifest = [
+            "schema_version: 1",
+            "identity:",
+            "  schema_version: 1",
+            "  kind: app",
+            "  name: fork-exec-e2e",
+            "  version: 0.0.1",
+            "  producer: {tool: libtfs-preload-e2e, tool_version: \"1\"}",
+            "  created: \"2026-08-22T00:00:00Z\"",
+            "  source:",
+            "    commit: \"0000000000000000000000000000000000000000\"",
+            "    builder: local",
+            "  digest:",
+            "    tree_hash: \"sha256:0000000000000000000000000000000000000000000000000000000000000000\"",
+            "    blob_sha256: \"0000000000000000000000000000000000000000000000000000000000000000\"",
+            "  signing: {state: unsigned}",
+            "  encryption: {state: none}",
+            "",
+        ]
+        .join("\n");
+        std::fs::write(src.join("__tpkg__/manifest.yaml"), manifest).unwrap();
+        std::fs::write(src.join("data/secret.txt"), SECRET.as_bytes()).unwrap();
+        let mut writer =
+            dwarfs_t::Writer::new(dwarfs_t::WriterOptions::default()).expect("dwarfs writer");
+        writer.add_tree(&src, "/").expect("dwarfs writer: scan");
+        writer.write(&dwarfs_path).expect("dwarfs writer: write");
+    }
+
     Some(Fixtures {
         dir,
         zip: zip_path,
+        dwarfs: dwarfs_path,
         shim,
         work,
         rust_tool,
@@ -811,4 +856,50 @@ fn macos_plain_close_on_a_memfs_fd() {
     let r = run(f, "close-probe", &[path.as_str()], None);
     assert_eq!(r.rc, 0, "close-probe failed, stderr: {}", r.stderr);
     assert!(r.stdout.contains("close-probe:ok"), "stdout: {}", r.stdout);
+}
+
+/// The 2026-08-22 fork/exec deadlock regression pin (runtime 0.16.4: a
+/// payload mounted at `/` spawning `git clone` wedged git's pre-exec
+/// helper child). The fixture forks; the CHILD execve's a HOST binary
+/// whose path is covered by the root mount — the exec materialization
+/// probe reads the in-image manifest through dwarfs-t's block cache,
+/// whose worker pool did not survive the fork, and waits on a future no
+/// dead thread completes. The fork-child guard passes every engine entry
+/// in a fork child through to the real libc, so the exec completes.
+///
+/// Needs the DWARFS image: the zip backend has no worker pool, so a zip
+/// mount cannot distinguish the guard from the bug. The fixture is its
+/// own watchdog — a wedged child is SIGKILLed and reported as rc 124, so
+/// a regression FAILS here instead of hanging the suite.
+///
+/// The exec'd grandchild (print-data, a non-SIP host binary) re-enters a
+/// fresh, healthy shim through the inherited preload env and reads a host
+/// file covered by the root mount — proving the spec 22 §3
+/// child-namespace propagation survives the guard.
+#[test]
+fn fork_child_exec_under_root_mount_completes() {
+    let Some(f) = fixtures() else { return };
+    let mut cmd = Command::new(f.dir.join("bin").join("fork-exec"));
+    cmd.arg(f.dir.join("bin").join("print-data"))
+        .arg(f.work.join("hostfile.txt"))
+        .env(preload_var(), &f.shim)
+        .env("TEBAKO_TFS_MOUNTS", format!("{}:/", f.dwarfs.display()))
+        .env_remove("DYLD_PRINT_LIBRARIES")
+        .env_remove("TEBAKO_JAIL");
+    let out = cmd.output().unwrap();
+    #[cfg(unix)]
+    let signal = std::os::unix::process::ExitStatusExt::signal(&out.status);
+    #[cfg(not(unix))]
+    let signal = None;
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "fork-exec failed (signal: {signal:?}, rc 124 = wedged child — the \
+         fork/exec deadlock regression), stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        out.stdout, b"HOST-FILE\n",
+        "the grandchild's host read under the root mount"
+    );
 }

--- a/crates/libtfs-preload/tests/fixtures/fork-exec.c
+++ b/crates/libtfs-preload/tests/fixtures/fork-exec.c
@@ -1,0 +1,62 @@
+/* fork-exec: the 2026-08-22 preload fork/exec deadlock regression pin
+ * (runtime 0.16.4: a payload mounted at `/` spawning `git clone` wedged
+ * git's pre-exec helper child). The parent forks; the CHILD execve's a
+ * HOST binary whose path is covered by the shim's root mount — the exec
+ * materialization probe reads the in-image manifest through the image
+ * backend, whose worker pool (the dwarfs-t block cache) did not survive
+ * the fork. Without the shim's fork-child guard the child wedges in the
+ * backend dispatch; with it, the child's engine entries pass through to
+ * the real execve and the exec completes.
+ *
+ * The parent is the watchdog: a wedged child is SIGKILLed after a grace
+ * window and reported as rc 124, so a regression FAILS the test instead
+ * of hanging the suite. */
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+extern char **environ;
+
+#define GRACE_MS 15000
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        dprintf(2, "usage: fork-exec <host-tool> <tool-arg>\n");
+        return 64;
+    }
+    pid_t pid = fork();
+    if (pid < 0) {
+        dprintf(2, "fork: %s\n", strerror(errno));
+        return errno;
+    }
+    if (pid == 0) {
+        /* Child: only async-signal-safe work before the exec. */
+        char *const child_argv[] = {argv[1], argv[2], NULL};
+        execve(argv[1], child_argv, environ);
+        _exit(errno ? errno : 1);
+    }
+    /* Parent watchdog: poll the child; kill + rc 124 on timeout. */
+    int status;
+    for (int waited = 0;; waited += 100) {
+        pid_t r = waitpid(pid, &status, WNOHANG);
+        if (r == pid) {
+            if (WIFEXITED(status)) return WEXITSTATUS(status);
+            if (WIFSIGNALED(status)) return 128 + WTERMSIG(status);
+        } else if (r < 0) {
+            dprintf(2, "waitpid: %s\n", strerror(errno));
+            return errno;
+        } else if (waited >= GRACE_MS) {
+            kill(pid, SIGKILL);
+            waitpid(pid, &status, 0);
+            dprintf(2, "fork-exec: child wedged — killed after %d ms\n", GRACE_MS);
+            return 124;
+        } else {
+            usleep(100000); /* 100 ms */
+        }
+    }
+}

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -166,8 +166,19 @@ The locked model is three tiers — **interposition-first, never FUSE**:
    of a HOST binary is not policy-gated (not an IO route
    in the policy's op classes — the child's own IO stays jailed via env
    propagation); SIP platform binaries strip `DYLD_*` and leave it; a
-   mount at `/` is refused (it would claim every host path and bypass
-   the jail); not interposed: fork, `openat2` (glibc exposes no wrapper
+   mount at `/` is legitimate under the union mount model (spec 03 §6 /
+   spec 17 §1 — the app payload mounts there): covered-but-not-held paths
+   fall through to the host with the jail consulted; fork is not
+   interposed but its child side is GUARDED — a `pthread_atfork` child
+   handler arms a process-global flag and every shim's engine entry
+   passes through to the real libc while it is set (the backends are not
+   fork-safe: dwarfs-t's block-cache worker pool dies at fork, so a
+   backend-touching call in the child — e.g. the execve materialization
+   probe under a `/` mount — would wait on threads that no longer exist;
+   the 2026-08-22 git-clone deadlock, runtime 0.16.4), and a fork child
+   that execs re-enters a fresh shim through the inherited preload env,
+   so the grandchild rule above is unaffected; not interposed: fork,
+   `openat2` (glibc exposes no wrapper
    or symbol on linux-gnu — nothing to interpose; a raw `syscall(2)`
    caller bypasses userland interposition by construction), fstatat64 on
    macOS (the legacy


### PR DESCRIPTION
# fix(preload): the fork/exec deadlock (runtime 0.16.4, POSIX)

## The defect

Runtime 0.16.4 deadlocks — permanently — when a payload mounted at `/`
spawns `git clone` (the check engine's shape). Runtime 0.16.3 passes the
identical scenario.

**Defective product range: `0bef9914..c124762e`.** Runtime 0.16.3 embeds
tebako @ `0bef9914`; 0.16.4 embeds @ `c124762e` (both verified from the
factory's link-unit job logs: run 31461582028/job 93686073381 →
0bef9914; run 32346716268 macos/arm64 → c124762e). The range adds the
spec 22 §3 child-injection machinery: the driver exports
`DYLD_INSERT_LIBRARIES`/`LD_PRELOAD` + `TEBAKO_TFS_MOUNTS` +
`TEBAKO_PRELOAD_SHIM` into the handoff env (#396 via 3235565b,
exec_materialize #397 via 4059b0e6). 0.16.3 exports **none** of these
(proven by env probe: an rt163 run prints all-nil env, and its clone
passes) — so git never saw the preload before 0.16.4.

## The mechanism (proven by live reproduction + stacks, not hypothesis)

With a payload mounted at `/`, git's pre-exec helper child wedged in:

```
git start_command
  → libtfs_preload.dylib +0x535c          (interposed execve — disassembly:
                                            the route-dispatch fn at 0x532c)
  → … → std::__assoc_sub_state::__sub_wait
  → std::condition_variable::wait → __psynch_cvwait
```

The chain: interposed `execve` → `route::vfs_materialize_exec` →
`FsContext::exec_materialize_op` → `find_mount` matches the `/` mount →
`mount_is_home(handle)` reads `__tpkg__/manifest.yaml` through the dwarfs
backend — and dwarfs-t's block cache dispatches reads to a **worker pool
whose threads died at `fork`**. The child waits on a promise/future no
dead thread will ever complete. The verdict is memoized per handle, but
git never exec'd before forking, so every child pays the manifest read —
100% deterministic. Without a `/` mount the path isn't covered and the
engine answers ENOENT in pure Rust (no backend, no pool), which is why
only the root-mount shape wedged.

## The fix (one seam)

`crates/libtfs-preload/src/sys/mod.rs`: a `pthread_atfork` child handler
arms a process-global `IN_FORK_CHILD` flag (registered unconditionally in
the shim constructor, before any mount), and `engine_call` — the single
entry every interposed shim already funnels through — answers `None`
while it is set. `None` is already every shim's "pass through to the real
libc / fail safe" arm:

- a fork child that goes on to `exec` calls the REAL execve with the
  original arguments, and the exec'd image re-enters a fresh, healthy
  shim through the inherited preload env — **the spec 22 §3
  child-namespace propagation never depended on engine calls in the
  pre-exec window** (pinned by the e2e below);
- a fork child that never execs sees the host filesystem only; memfs fds
  it inherited answer EIO (they would be stale copies of parent engine
  state even if served). Today such a child wedged — strictly better.

Explicitly not done: scrubbing the preload env in the driver (would kill
the designed child-namespace propagation), and touching dwarfs-t
(separate release chain — see follow-ups).

## Evidence

**Unit (6/6):** `fork_child_gate_short_circuits_engine_call` (both arms,
no global mutation) · `atfork_child_handler_arms_the_flag` (register,
real `fork`, child answers via exit code).

**E2E (18/18):** new `fork_child_exec_under_root_mount_completes` — a
DWARFS image (zip has no worker pool and cannot distinguish guard from
bug) mounted at `/`; the `fork-exec` C fixture forks and the child
execve's a host binary covered by the root mount. The fixture is its own
watchdog: a wedged child is SIGKILLed after 15 s and reported as rc 124,
so a regression fails instead of hanging CI. The exec'd grandchild
re-enters the shim and reads a host file under the root mount (the §3
propagation pin).

**Negative control vs the SHIPPING 0.16.4 shim** (byte-extracted from the
0.16.4 env image, sha256 `625f166d…`, byte-identical with the image's
copy): same fixture shape → `rc 124, "child wedged — killed after 15000
ms"`. The branch's shim, same shape → `rc 0`.

**End-to-end against the real 0.16.4 runtime pair:**

- BEFORE (0.16.4 exe + original env image): wedge, fresh stack captured
  (same signature as above).
- AFTER (same exe + env image rebuilt with ONLY
  `lib/tebako/libtfs_preload.dylib` swapped for this branch's release
  build, sha256 `af9443ed…`; `layout.yaml` and all else preserved):
  `git clone --branch v5 --depth 1 https://github.com/fontist/formulas.git`
  completed, **rc=0 in 6.6 s**.
- Non-root shape (`:-:/__app__`, passed pre-fix too): rc=0 in 8.0 s — no
  regression.

**Gates (worktree, macOS arm64):** `cargo fmt --check` clean ·
`cargo clippy -p libtfs-preload --all-targets -- -D warnings` clean ·
`cargo test -p libtfs-preload` (debug): 6/6 unit + 18/18 e2e.

## Follow-ups (NOT this PR)

1. **Factory re-cut**: runtime 0.16.5 embedding this product ref —
   sequenced by the owner (do not merge before the release-chain go-ahead).
2. **Deeper option**: `pthread_atfork` pool re-creation inside dwarfs-t's
   block cache would also cover ruby's in-process-engine fork path
   (`Process.fork` + a child VFS read wedges identically — PRE-EXISTING
   in both 0.16.3 and 0.16.4, out of scope here).
3. The driver's macOS micro-dylib (`libtebako_loader_interpose.dylib`)
   interposes only dlopen/dlerror, is exe-bound, and stays inert in
   children — no atfork registration needed there.

Spec 07 §8's coverage bullet is synced in this branch (the root-mount
sentence predated the union mount model; the fork-child guard contract is
now written down).
