### PR TITLE
feat: LimniFS becomes the default image format (spec 20 §6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # The temporary limnifs-write [patch] rides a git fork (see workspace
+  # Cargo.toml; lifts when limnifs#189 ships in a release) — use the git
+  # CLI for the fetch, matching local builds.
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   # Must match the builtin-baseline in dwarfs-t/vcpkg.json (mirrors
   # dwarfs-t's and dwarfs-rs's CI; the vendored dwarfs build needs vcpkg).
   VCPKG_COMMIT: f14401ca0f2754347c3864da7488a9b955b4e47a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,24 @@ codegen-units = 1
 panic = "abort"
 strip = "symbols"
 
+
+# ⚠ TEMPORARY [patch] — DRAFT-ONLY STATE, MUST NOT REACH main AS-IS ⚠
+#
+# WHY: the LimniFS floor recipe (spec 20 §5) requires a limnifs-write that
+#   (1) skips the shared inline table — every reader on the floor
+#       (limnifs-core ≤ 0.2.51, tebako's own tfs included) rejects flag
+#       0x08 via its own reserved mask (upstream: limnifs#186), and
+#   (2) raises the metadata externalization threshold to 1000 KiB — the
+#       stock 768 KiB externalizes realistic trees' metadata to a sidecar,
+#       which the self-contained rule forbids (upstream: limnifs#187).
+# No crates.io release carries those fixes yet.
+#
+# LIFT CONDITION: repoint to a crates.io release as soon as upstream ships
+# a limnifs-write with #186/#187 fixed; this whole block then disappears.
+#
+# KNOWN BREAKAGE: the path below is machine-local — any other machine
+# (CI included) fails to resolve it, so CI stays RED while this lives.
+# That is deliberate: this branch is a draft PR, never merged in this
+# state (AGENTS.md hard rule).
+[patch.crates-io]
+limnifs-write = { path = "/Users/mulgogi/src/tamatebako/.scratch-53/limnifs-src/limnifs-write" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,23 +22,20 @@ panic = "abort"
 strip = "symbols"
 
 
-# ⚠ TEMPORARY [patch] — DRAFT-ONLY STATE, MUST NOT REACH main AS-IS ⚠
+# TEMPORARY [patch] — git fork carrying exactly one commit on top of
+# limni-v0.2.54: the `defaults.shared_inline` knob (proposed upstream as
+# limnifs#189; fork branch linked from the issue). The floor recipe
+# (spec 20 §5) needs `shared_inline = false`: published 0.16.3–0.16.5
+# drivers ship limnifs-core < 0.2.53, whose INODE_FLAG_RESERVED_MASK
+# (0xF8) covers the defined SHARED_INLINE bit 0x08 (limnifs#186), so any
+# image with the table is rejected at mount by every floor reader.
 #
-# WHY: the LimniFS floor recipe (spec 20 §5) requires a limnifs-write that
-#   (1) skips the shared inline table — every reader on the floor
-#       (limnifs-core ≤ 0.2.51, tebako's own tfs included) rejects flag
-#       0x08 via its own reserved mask (upstream: limnifs#186), and
-#   (2) raises the metadata externalization threshold to 1000 KiB — the
-#       stock 768 KiB externalizes realistic trees' metadata to a sidecar,
-#       which the self-contained rule forbids (upstream: limnifs#187).
-# No crates.io release carries those fixes yet.
+# Everything ELSE the floor recipe needs is stock 0.2.54: the #187
+# threshold knob (defaults to 1000 KiB), the #315 writer-side zstd
+# self-check, lz4-hc metadata. This patch carries NO other change.
 #
-# LIFT CONDITION: repoint to a crates.io release as soon as upstream ships
-# a limnifs-write with #186/#187 fixed; this whole block then disappears.
-#
-# KNOWN BREAKAGE: the path below is machine-local — any other machine
-# (CI included) fails to resolve it, so CI stays RED while this lives.
-# That is deliberate: this branch is a draft PR, never merged in this
-# state (AGENTS.md hard rule).
+# LIFT CONDITION: upstream ships a release with #189 merged → repoint to
+# crates.io and delete this block. The constraint itself dies when the
+# runtime floor embeds limnifs-core ≥ 0.2.53 (runtime ≥ 0.16.6).
 [patch.crates-io]
-limnifs-write = { path = "/Users/mulgogi/src/tamatebako/.scratch-53/limnifs-src/limnifs-write" }
+limnifs-write = { git = "https://github.com/tamatebako/limnifs", branch = "tebako-floor-gate" }

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Layers:
   byte-specified, versioned, optionally signed (`docs/spec/02`).
 - **TFS** — the userland virtual filesystem (`tebako_fs_*` C ABI, Rust):
   multi-mount images with longest-prefix routing, backends
-  (dwarfs-t / zip / tar / squashfs), a Rust COW overlay, and the
-  enforcement point for jails (`docs/spec/11`).
+  (limnifs (the default) / dwarfs-t / zip / tar / squashfs), a Rust COW
+  overlay, and the enforcement point for jails (`docs/spec/11`).
 - **Manifests** — every payload is self-describing: `kind`
   (app/runtime/toolkit/data), `provides` (executables, libs, interpreter),
   `requires` (language/toolkit/data/executable deps with
@@ -166,7 +166,8 @@ jails, trust, encryption, TFS, comparisons, factories, distribution).
 
 - **Shipped**: the full Rust stack — packager, loader (macOS/Linux),
   runtime-as-image, opt-in signing + rotation, multi-mount TFS with
-  tar/zip/squashfs/dwarfs-t backends + COW overlay, host-access jails,
+  limnifs (the default image format)/dwarfs-t/zip/tar/squashfs backends +
+  COW overlay, host-access jails,
   the preload exec shim, payload manifests + registries + shims, suite
   packages, encryption (opt-in), and the ruby runtime factory line
   (ruby 3.1–4.0, 7 platforms).

--- a/crates/libtfs-preload/Cargo.toml
+++ b/crates/libtfs-preload/Cargo.toml
@@ -21,11 +21,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # The engine, embedded in-process: the shim is a TFS consumer, never a
 # format. The pure-cargo backends (zip/tar) cover the fixture cases; the
-# vendored dwarfs backend is mandatory in production — the ecosystem's
-# image format is dwarfs-t, and a shim that cannot mount a payload
-# payload-side (ENOTSUP) is a shim that cannot do its job. squashfs
-# stays opt-in via the tfs crate's own features.
-tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+# vendored dwarfs backend is mandatory in production, and limnifs is the
+# ecosystem's DEFAULT image format (spec 20 §6) — a shim that cannot
+# mount a payload payload-side (ENOTSUP) is a shim that cannot do its
+# job. squashfs stays opt-in via the tfs crate's own features.
+tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs", "backend-limnifs"] }
 libc = "0.2"
 
 [dev-dependencies]

--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -68,7 +68,7 @@ regex = "1"
 tfs = { version = "0.2.1", path = "../tfs" }
 
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs", "backend-limnifs"] }
 # The runtime/SDK install locks (src/resolve.rs flock port): LockFileEx on
 # one byte at offset 0 — the tebako-shim runtime.rs shape. FFI is
 # quarantined in that one function.

--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -41,7 +41,7 @@ serde_yml = "0.0.12"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
 # — pure Rust, no `limni` binary anywhere.
-limnifs-write = "0.2.50"
+limnifs-write = "0.2.54"
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tebako-cli/src/image.rs
+++ b/crates/tebako-cli/src/image.rs
@@ -73,24 +73,29 @@ fn write_dwarfs_image(out: &Path, source: &Path) -> Result<(), TebakoError> {
 /// resolves. Content drops ride lz4-or-store: the runtime-floor
 /// readers (every published runtime of the v0.16.x era) reject brotli
 /// streams beyond the small-buffer case, and the omnizip zstd decoder
-/// shipping in limnifs-core ≤ 0.2.51 mis-decodes some valid zstd frames
-/// (frame checksum mismatch on bytes libzstd itself accepts). The
+/// shipping in limnifs-core ≤ 0.2.54 mis-decodes some valid zstd frames
+/// (omnizip-rs#315, still open; frame checksum mismatch on bytes libzstd
+/// itself accepts). The
 /// metadata blob rides lz4-HC (codec 0x13): every floor reader decodes
 /// it through the SAME fast-lz4 decoder (limnifs-core's
 /// `Lz4HcCodec::decompress` delegates), and the HC match finder keeps a
 /// realistic tree's blob under the inline ceiling — the
 /// native-extension e2e tree: 830 KiB lz4-hc vs 1049 KiB fast lz4,
 /// which overshoots the writer's 1000 KiB threshold; `store` (2.5 MB)
-/// overshoots the readers' 1 MiB hard ceiling outright. Spec 20 §5's
-/// floor rule pins the full recipe. The writer must also emit no
-/// shared-inline table (the floor readers reject the inode flag) and
-/// inline the metadata up to the readers' 1 MiB ceiling.
+/// overshoots the readers' 1 MiB hard ceiling outright. The
+/// shared-inline table stays off (`defaults.shared_inline = false`):
+/// every floor reader (limnifs-core < 0.2.53) rejects its inode flag
+/// 0x08 via its own reserved mask (limnifs#186; the knob rides the
+/// tebako-floor-gate fork until limnifs#189 ships). Spec 20 §5's
+/// floor rule pins the full recipe. The metadata is inlined up to the
+/// readers' 1 MiB ceiling.
 fn write_limnifs_image(out: &Path, source: &Path) -> Result<(), TebakoError> {
     let mut config = limnifs_write::WriteConfig::default_v0_1();
     config.dictionaries.enabled = false;
     config.defaults.metadata_codec = "lz4-hc".to_string();
     config.defaults.text_codec = "lz4".to_string();
     config.defaults.binary_codec = "lz4".to_string();
+    config.defaults.shared_inline = false;
     config.tournament.codecs = vec!["store".to_string(), "lz4".to_string()];
     let artifact = limnifs_write::write_directory_with_config(source, &config).map_err(|e| {
         plain_error(format!(

--- a/crates/tebako-cli/src/image.rs
+++ b/crates/tebako-cli/src/image.rs
@@ -70,10 +70,28 @@ fn write_dwarfs_image(out: &Path, source: &Path) -> Result<(), TebakoError> {
 /// exactly this shape). Dictionaries are disabled: a dictionary section
 /// would sit between the history section and the slab region (and tag
 /// drops with dictionary ids), neither of which the v1 backend
-/// resolves.
+/// resolves. Content drops ride lz4-or-store: the runtime-floor
+/// readers (every published runtime of the v0.16.x era) reject brotli
+/// streams beyond the small-buffer case, and the omnizip zstd decoder
+/// shipping in limnifs-core ≤ 0.2.51 mis-decodes some valid zstd frames
+/// (frame checksum mismatch on bytes libzstd itself accepts). The
+/// metadata blob rides lz4-HC (codec 0x13): every floor reader decodes
+/// it through the SAME fast-lz4 decoder (limnifs-core's
+/// `Lz4HcCodec::decompress` delegates), and the HC match finder keeps a
+/// realistic tree's blob under the inline ceiling — the
+/// native-extension e2e tree: 830 KiB lz4-hc vs 1049 KiB fast lz4,
+/// which overshoots the writer's 1000 KiB threshold; `store` (2.5 MB)
+/// overshoots the readers' 1 MiB hard ceiling outright. Spec 20 §5's
+/// floor rule pins the full recipe. The writer must also emit no
+/// shared-inline table (the floor readers reject the inode flag) and
+/// inline the metadata up to the readers' 1 MiB ceiling.
 fn write_limnifs_image(out: &Path, source: &Path) -> Result<(), TebakoError> {
     let mut config = limnifs_write::WriteConfig::default_v0_1();
     config.dictionaries.enabled = false;
+    config.defaults.metadata_codec = "lz4-hc".to_string();
+    config.defaults.text_codec = "lz4".to_string();
+    config.defaults.binary_codec = "lz4".to_string();
+    config.tournament.codecs = vec!["store".to_string(), "lz4".to_string()];
     let artifact = limnifs_write::write_directory_with_config(source, &config).map_err(|e| {
         plain_error(format!(
             "limnifs writer: scanning {}: {e}",
@@ -82,7 +100,7 @@ fn write_limnifs_image(out: &Path, source: &Path) -> Result<(), TebakoError> {
     })?;
     if let Some(sidecar) = &artifact.metadata_sidecar {
         return Err(plain_error(format!(
-            "limnifs writer: the tree's metadata externalized ({} bytes to '{}') — a self-contained tebako image inlines the metadata; the tree is too large for this format today",
+            "limnifs writer: the tree's metadata externalized ({} bytes to '{}') — a self-contained tebako image inlines the metadata; the tree is too large for this format today (press with --format dwarfs for trees this size)",
             sidecar.bytes.len(),
             sidecar.locator
         )));
@@ -148,9 +166,9 @@ mod tests {
     }
 
     /// The limnifs press path (spec 20 §6): the image detects as
-    /// limnifs and mounts through the tfs backend.
+    /// limnifs and mounts through the tfs backend — windows included
+    /// (the windows tfs ships dwarfs+limnifs).
     #[test]
-    #[cfg(not(windows))] // windows ships a dwarfs-only tfs (TODO.v2-1/02)
     fn limnifs_image_roundtrip_through_the_backend() {
         let (dir, src) = fixture_tree("limnifs");
         let out = dir.join("fs.tfs");

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -399,10 +399,10 @@ pub(crate) fn stitch(
                 Some(&format!("image not found: {}", path.display())),
             ));
         }
-        if *format_id > tpkg::TPKG_FORMAT_RUNTIME {
+        if *format_id > tpkg::TPKG_FORMAT_LIMNIFS {
             return Err(packaging_error(
                 126,
-                Some(&format!("invalid format_id {format_id} (0..4 expected)")),
+                Some(&format!("invalid format_id {format_id} (0..=5 expected)")),
             ));
         }
         if mount.len() >= tpkg::TPKG_MOUNT_POINT_LEN {

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -689,7 +689,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
     let mut suite: Option<PathBuf> = None;
     let mut jail: Option<String> = None;
     let mut no_install = false;
-    let mut format = tebako_cli::options::PressImageFormat::Dwarfs;
+    let mut format = tebako_cli::options::PressImageFormat::Limnifs;
 
     let mut i = 0;
     while i < args.len() {

--- a/crates/tebako-cli/src/options.rs
+++ b/crates/tebako-cli/src/options.rs
@@ -37,10 +37,10 @@ impl PressMode {
     }
 }
 
-/// The application image format (spec 20 §6, the PLANNED `--format`
-/// press flag): which writer the packager's image build runs and which
-/// `format_id` hint the app-image slots are stamped with. `dwarfs` is
-/// the default; the flag never changes anything else about press.
+/// The application image format (spec 20 §6): which writer the
+/// packager's image build runs and which `format_id` hint the app-image
+/// slots are stamped with. `limnifs` is the default (spec 20 §6); the
+/// flag never changes anything else about press.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PressImageFormat {
     Dwarfs,
@@ -121,7 +121,7 @@ pub struct PressOptions {
     /// default (installable on explicit request).
     pub no_install: bool,
     /// --format <dwarfs|limnifs> (spec 20 §6): the application image
-    /// format. Dwarfs by default.
+    /// format. Limnifs by default; `dwarfs` stays an explicit opt-in.
     pub format: PressImageFormat,
 }
 

--- a/crates/tebako-cli/tests/cli_e2e.rs
+++ b/crates/tebako-cli/tests/cli_e2e.rs
@@ -226,6 +226,15 @@ fn press_simple_script_runs() {
         )),
         "unexpected press output:\n{log}"
     );
+    // Default press = limnifs (spec 20 §6): the app slot carries the
+    // format_id 5 hint.
+    let mut f = fs::File::open(&package).unwrap();
+    let trailer = tpkg::read_from(&mut f).unwrap();
+    assert_eq!(
+        trailer.slots[0].format_id,
+        tpkg::TPKG_FORMAT_LIMNIFS,
+        "the default press stamps the limnifs format hint"
+    );
     let (code, out) = run(&mut Command::new(&package));
     assert_eq!(code, 0, "packaged binary failed:\n{out}");
     assert_eq!(out, "Hello!  This is test-00 talking from inside DwarFS\n");
@@ -690,8 +699,11 @@ fn gem_press_command(gem: &GoldenGem, env: &PressEnv, entry: &str, output: &Path
 ///   an environment-state difference, not a behavioral one);
 /// - the image build lines: the gem shells out to mkdwarfs ("-- Running
 ///   mkdwarfs script" + the "   ... @ <mkdwarfs> ..." echo) while the CLI
-///   builds in-process ("-- Building DwarFS image ...") — the owner rule
-///   is no mkdwarfs anywhere on the Rust side;
+///   builds in-process ("-- Building dwarfs image ..." — the gem's
+///   capitalized "-- Building DwarFS image" spelling is the oracle's) —
+///   the owner rule is no mkdwarfs anywhere on the Rust side. The golden
+///   rs press pins `--format dwarfs` (like-for-like with the dwarfs-only
+///   gem; the CLI default is limnifs, spec 20 §6);
 /// - the bundler deploy ops the gem still emits but the CLI dropped
 ///   (roadmap 25 items 4–5): the `force_ruby_platform` config op and the
 ///   install op's `--prefer-local` (the retired dependency API / the
@@ -708,6 +720,7 @@ fn normalize_press_log(log: &str) -> String {
                 && !line.starts_with("   ... tfs-ruby-")
                 && !line.contains(" --tebako-extract ")
                 && !line.starts_with("-- Building DwarFS image")
+                && !line.starts_with("-- Building dwarfs image")
                 && !line.contains("bundle config set --local force_ruby_platform")
                 && !gem_image_build
         })
@@ -757,9 +770,13 @@ fn golden_scenario(gem: &GoldenGem, tag: &str, fixture: &str, entry: &str, expec
     assert_eq!(code, 0, "gem-pressed binary failed:\n{gem_out}");
 
     // The gem's press left its own version key; re-seed the CLI's so its
-    // cache guard stays silent as well.
+    // cache guard stays silent as well. The rs press pins `--format
+    // dwarfs`: the golden compares like-for-like against the dwarfs-only
+    // reference gem (the CLI default is limnifs, spec 20 §6).
     seed_rs_version_file(&env.prefix);
-    let (code, rs_log) = run(&mut press_command(&env, entry, &package));
+    let (code, rs_log) = run(press_command(&env, entry, &package)
+        .arg("--format")
+        .arg("dwarfs"));
     assert!(code == 0, "tebako-rs press failed:\n{rs_log}");
     let (code, rs_out) = run(&mut Command::new(&package));
     assert_eq!(code, 0, "tebako-rs-pressed binary failed:\n{rs_out}");
@@ -1431,7 +1448,11 @@ fn native_ext_press_builds_and_packages() {
     // The built extension sits in the app image at its gem-correct path
     // (a .gem install drops the built artifact into the gem's lib tree).
     let image = work.join("prefix").join("o").join("p").join("fs.tfs");
-    let fs_image = dwarfs_t::Filesystem::open(&image).unwrap();
+    // The default press writes limnifs (spec 20 §6): inspect the app
+    // image through the format-neutral backend, never a format-specific
+    // reader.
+    let mount = tfs::mount::build_from_file(&image.to_string_lossy(), "/mnt-native-ext")
+        .expect("the app image mounts");
     let ext = if cfg!(target_os = "macos") {
         "bundle"
     } else {
@@ -1439,7 +1460,7 @@ fn native_ext_press_builds_and_packages() {
     };
     let artifact = format!("lib/ruby/gems/3.3.0/gems/toyext-0.1.0/lib/toyext/toyext.{ext}");
     assert!(
-        fs_image.stat(&artifact).is_ok(),
+        mount.backend.stat(&artifact).is_ok(),
         "built extension missing from the app image at {artifact}"
     );
 

--- a/crates/tebako-cli/tests/cli_e2e.rs
+++ b/crates/tebako-cli/tests/cli_e2e.rs
@@ -303,6 +303,13 @@ fn press_gemfile_fontist_modern_resolution_and_platform_gems() {
     };
     let package = env.work.join("fontist-app");
     let mut cmd = press_command(&env, "main.rb", &package);
+    // Press dwarfs explicitly: the fontist tree's lz4-HC metadata blob
+    // (~3 MiB) overshoots the limnifs inline ceiling, so the default
+    // format stops this tree at the spec 20 §5.3 "too large for this
+    // format today" named error. Resolution and platform gems are this
+    // test's subject, not the image format (the fontist feedstock's
+    // press must pass --format dwarfs the same way).
+    cmd.arg("--format").arg("dwarfs");
     cmd.env("VERBOSE", "yes"); // surface the deploy driver's bundle output
     let (code, log) = run(&mut cmd);
 

--- a/crates/tebako-driver/Cargo.toml
+++ b/crates/tebako-driver/Cargo.toml
@@ -41,7 +41,7 @@ sha2 = "0.10"
 tfs = { version = "0.2.1", path = "../tfs" }
 
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs", "backend-limnifs"] }
 
 # build.rs compiles the interpose dylib for darwin targets only (its
 # TARGET check early-returns elsewhere), but it references the cc crate

--- a/crates/tebako-info/Cargo.toml
+++ b/crates/tebako-info/Cargo.toml
@@ -28,7 +28,7 @@ serde_yml = "0.0.12"
 tfs = { version = "0.2.1", path = "../tfs" }
 
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs", "backend-limnifs"] }
 
 [dev-dependencies]
 # In-process dwarfs-t writer for manifest-carrying image fixtures.

--- a/crates/tebako-pkg/Cargo.toml
+++ b/crates/tebako-pkg/Cargo.toml
@@ -26,7 +26,7 @@ sha2 = "0.10"
 tfs = { version = "0.2.1", path = "../tfs" }
 
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs", "backend-limnifs"] }
 
 [dev-dependencies]
 tebako-contract-tests = { version = "0.2.1", path = "../../tests/contract" }

--- a/crates/tebako-pkg/src/lib.rs
+++ b/crates/tebako-pkg/src/lib.rs
@@ -113,7 +113,8 @@ pub fn parse_image_spec(spec: &str) -> PackageImage {
     }
 }
 
-/// Sniff the image format from magic bytes (dwarfs/squashfs/zip, else auto).
+/// Sniff the image format from magic bytes (dwarfs/squashfs/zip/limnifs,
+/// else auto).
 pub fn sniff_format(path: &Path) -> u32 {
     let Ok(mut f) = fs::File::open(path) else {
         return tpkg::TPKG_FORMAT_AUTO;
@@ -129,6 +130,8 @@ pub fn sniff_format(path: &Path) -> u32 {
         tpkg::TPKG_FORMAT_SQUASHFS
     } else if magic.starts_with(b"PK\x03\x04") || magic.starts_with(b"PK\x05\x06") {
         tpkg::TPKG_FORMAT_ZIP
+    } else if magic.starts_with(b"LMFS") {
+        tpkg::TPKG_FORMAT_LIMNIFS
     } else {
         tpkg::TPKG_FORMAT_AUTO
     }
@@ -140,6 +143,7 @@ fn format_name(format_id: u32) -> &'static str {
         tpkg::TPKG_FORMAT_DWARFS => "dwarfs",
         tpkg::TPKG_FORMAT_SQUASHFS => "squashfs",
         tpkg::TPKG_FORMAT_ZIP => "zip",
+        tpkg::TPKG_FORMAT_LIMNIFS => "limnifs",
         _ => "auto",
     }
 }

--- a/crates/tebako-pkg/tests/info.rs
+++ b/crates/tebako-pkg/tests/info.rs
@@ -201,8 +201,9 @@ fn full_report_unsigned_classic() {
     assert!(!out.contains("backend:"), "{out}");
 }
 
-// squashfs slots mount on POSIX only — the windows tfs is dwarfs-only,
-// where the probe renders the named mount-failure state (TODO.v2-1/02).
+// squashfs slots mount on POSIX only — the windows tfs ships no squashfs
+// backend, so the probe renders the named mount-failure state there
+// (TODO.v2-1/02).
 #[cfg(not(windows))]
 #[test]
 fn full_report_signed_lean_and_depths() {
@@ -389,8 +390,8 @@ fn slot_view_and_errors() {
     assert!(out.contains("      schema_version: 1\n"), "{out}");
 
     // A plain-image slot reports the named note. POSIX only — the
-    // windows tfs is dwarfs-only, the sqfs slot reports the named mount
-    // failure there (TODO.v2-1/02).
+    // windows tfs ships no squashfs backend; the sqfs slot reports the
+    // named mount failure there (TODO.v2-1/02).
     #[cfg(not(windows))]
     {
         let (rc, out, _) = run(&["info", "--slot", "1", pkg.to_str().unwrap()], &w.0, &home);
@@ -794,6 +795,37 @@ fn format_detection_per_slot() {
         out.contains("    [3] ") && out.contains("format: auto  "),
         "{out}"
     );
+}
+
+// ---------------------------------------------------------------------
+// LimniFS sniff (spec 20 §6): the bundle verb's magic sniff must stamp
+// the limnifs hint — the format_name catch-all rendered such slots as
+// "auto" before §6, and an auto hint on an LMFS image misinforms every
+// hint-only reader (depth-0 info, legacy dump). Mount detection stays
+// authoritative; the hint is a mirror.
+// ---------------------------------------------------------------------
+
+#[test]
+fn limnifs_magic_sniffs_the_limnifs_hint() {
+    let w = TempDir::new("plimsniff");
+    let home = test_home("plimsniff");
+    // A bare LMFS-magic file suffices: bundle is a container op (no
+    // mount), so the sniff alone decides the slot's format hint.
+    let img = w.0.join("payload.lim");
+    let mut bytes = b"LMFS".to_vec();
+    bytes.resize(512, 0);
+    std::fs::write(&img, bytes).unwrap();
+    let pkg = w.0.join("pkg");
+    bundle(&home, &w, &[], &[&img], &pkg);
+
+    let mut f = std::fs::File::open(&pkg).unwrap();
+    let trailer = tpkg::read_from(&mut f).unwrap();
+    assert_eq!(trailer.slots[0].format_id, tpkg::TPKG_FORMAT_LIMNIFS);
+
+    // The legacy dump names the hint (was "auto" via the catch-all).
+    let (rc, out, _) = run(&["info", pkg.to_str().unwrap()], &w.0, &home);
+    assert_eq!(rc, 0, "{out}");
+    assert!(out.contains("format=limnifs"), "{out}");
 }
 
 // ---------------------------------------------------------------------

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -34,7 +34,7 @@ serde_yaml = "0.9"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
 # §6) — pure Rust, no `limni` binary anywhere.
-limnifs-write = "0.2.50"
+limnifs-write = "0.2.54"
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -44,7 +44,7 @@ libc = "0.2"
 tfs = { version = "0.2.1", path = "../tfs" }
 
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs", "backend-limnifs"] }
 
 [[bin]]
 name = "tfs"

--- a/crates/tfs-cli/src/lib.rs
+++ b/crates/tfs-cli/src/lib.rs
@@ -1058,10 +1058,28 @@ pub fn cmd_mkimage(format: &str, source_dir: &Path, output: &Path) -> Result<(),
 /// in slab-ordinal order. Dictionaries are disabled: a dictionary
 /// section would sit between the history section and the slab region
 /// (and reference per-drop dictionary ids), neither of which the v1
-/// backend resolves.
+/// backend resolves. Content drops ride lz4-or-store: the
+/// runtime-floor readers (every published runtime of the v0.16.x era)
+/// reject brotli streams beyond the small-buffer case, and the omnizip
+/// zstd decoder shipping in limnifs-core ≤ 0.2.51 mis-decodes some
+/// valid zstd frames (frame checksum mismatch on bytes libzstd itself
+/// accepts). The metadata blob rides lz4-HC (codec 0x13): every floor
+/// reader decodes it through the SAME fast-lz4 decoder (limnifs-core's
+/// `Lz4HcCodec::decompress` delegates), and the HC match finder keeps a
+/// realistic tree's blob under the inline ceiling — the
+/// native-extension e2e tree: 830 KiB lz4-hc vs 1049 KiB fast lz4,
+/// which overshoots the writer's 1000 KiB threshold; `store` (2.5 MB)
+/// overshoots the readers' 1 MiB hard ceiling outright. Spec 20 §5's
+/// floor rule pins the full recipe. The writer must also emit no
+/// shared-inline table (the floor readers reject the inode flag) and
+/// inline the metadata up to the readers' 1 MiB ceiling.
 fn write_limnifs_image(source: &Path, output: &Path) -> Result<(), (String, i32)> {
     let mut config = limnifs_write::WriteConfig::default_v0_1();
     config.dictionaries.enabled = false;
+    config.defaults.metadata_codec = "lz4-hc".to_string();
+    config.defaults.text_codec = "lz4".to_string();
+    config.defaults.binary_codec = "lz4".to_string();
+    config.tournament.codecs = vec!["store".to_string(), "lz4".to_string()];
     let artifact = limnifs_write::write_directory_with_config(source, &config).map_err(|e| {
         (
             format!("limnifs writer: scanning {}: {e}", source.display()),
@@ -1071,7 +1089,7 @@ fn write_limnifs_image(source: &Path, output: &Path) -> Result<(), (String, i32)
     if let Some(sidecar) = &artifact.metadata_sidecar {
         return Err((
             format!(
-                "limnifs writer: the tree's metadata externalized ({} bytes to '{}') — a self-contained tebako image inlines the metadata; the tree is too large for this format today",
+                "limnifs writer: the tree's metadata externalized ({} bytes to '{}') — a self-contained tebako image inlines the metadata; the tree is too large for this format today (mkimage with --format dwarfs for trees this size)",
                 sidecar.bytes.len(),
                 sidecar.locator
             ),
@@ -1657,9 +1675,8 @@ mod tests {
     }
 
     /// `mkimage --format limnifs` (spec 20 §6): the image detects as
-    /// limnifs and the backend serves the tree back. Windows ships a
-    /// dwarfs-only tfs, so the mount half of the check is POSIX-only —
-    /// the unsupported-format named error is platform-independent.
+    /// limnifs and the backend serves the tree back — on windows too
+    /// (the windows tfs ships dwarfs+limnifs; squashfs stays POSIX-only).
     #[test]
     fn mkimage_limnifs_writes_a_mountable_image() {
         let dir = std::env::temp_dir().join(format!("tfs-cli-mkimage-{}", std::process::id()));
@@ -1670,7 +1687,6 @@ mod tests {
         let out = dir.join("fs.tfs");
         cmd_mkimage("limnifs", &src, &out).expect("mkimage limnifs");
 
-        #[cfg(not(windows))]
         {
             let mount = tfs::mount::build_from_file(&out.to_string_lossy(), "/mnt")
                 .expect("the written image mounts");

--- a/crates/tfs-cli/src/lib.rs
+++ b/crates/tfs-cli/src/lib.rs
@@ -1061,24 +1061,28 @@ pub fn cmd_mkimage(format: &str, source_dir: &Path, output: &Path) -> Result<(),
 /// backend resolves. Content drops ride lz4-or-store: the
 /// runtime-floor readers (every published runtime of the v0.16.x era)
 /// reject brotli streams beyond the small-buffer case, and the omnizip
-/// zstd decoder shipping in limnifs-core ≤ 0.2.51 mis-decodes some
-/// valid zstd frames (frame checksum mismatch on bytes libzstd itself
-/// accepts). The metadata blob rides lz4-HC (codec 0x13): every floor
+/// zstd decoder shipping in limnifs-core ≤ 0.2.54 mis-decodes some
+/// valid zstd frames (omnizip-rs#315, still open; frame checksum
+/// mismatch on bytes libzstd itself accepts). The metadata blob rides lz4-HC (codec 0x13): every floor
 /// reader decodes it through the SAME fast-lz4 decoder (limnifs-core's
 /// `Lz4HcCodec::decompress` delegates), and the HC match finder keeps a
 /// realistic tree's blob under the inline ceiling — the
 /// native-extension e2e tree: 830 KiB lz4-hc vs 1049 KiB fast lz4,
 /// which overshoots the writer's 1000 KiB threshold; `store` (2.5 MB)
-/// overshoots the readers' 1 MiB hard ceiling outright. Spec 20 §5's
-/// floor rule pins the full recipe. The writer must also emit no
-/// shared-inline table (the floor readers reject the inode flag) and
-/// inline the metadata up to the readers' 1 MiB ceiling.
+/// overshoots the readers' 1 MiB hard ceiling outright. The
+/// shared-inline table stays off (`defaults.shared_inline = false`):
+/// every floor reader (limnifs-core < 0.2.53) rejects its inode flag
+/// 0x08 via its own reserved mask (limnifs#186; the knob rides the
+/// tebako-floor-gate fork until limnifs#189 ships). Spec 20 §5's
+/// floor rule pins the full recipe. The metadata is inlined up to the
+/// readers' 1 MiB ceiling.
 fn write_limnifs_image(source: &Path, output: &Path) -> Result<(), (String, i32)> {
     let mut config = limnifs_write::WriteConfig::default_v0_1();
     config.dictionaries.enabled = false;
     config.defaults.metadata_codec = "lz4-hc".to_string();
     config.defaults.text_codec = "lz4".to_string();
     config.defaults.binary_codec = "lz4".to_string();
+    config.defaults.shared_inline = false;
     config.tournament.codecs = vec!["store".to_string(), "lz4".to_string()];
     let artifact = limnifs_write::write_directory_with_config(source, &config).map_err(|e| {
         (

--- a/crates/tfs-cli/src/main.rs
+++ b/crates/tfs-cli/src/main.rs
@@ -10,7 +10,7 @@
 //! tfs stat [-v] <image> <path>
 //! tfs extract [-v] [-q|--quiet] [-d|--dest <dir>] <image> [files...]
 //! tfs find [-v] <image> <pattern>
-//! tfs mkimage --format dwarfs|limnifs <srcdir> -o <img> [-v]
+//! tfs mkimage [--format dwarfs|limnifs] <srcdir> -o <img> [-v]
 //! tfs exec <image>[:mount] [--image <image:mount>]...
 //!          [--jail <spec> | --compose <file.yaml>] -- <cmd> [args...]
 //! tfs needs --from-journal <journal.log>
@@ -405,13 +405,13 @@ fn cmd_mkimage_main(rest: &[String]) -> ExitCode {
     if let Err(e) = a.positional_count(
         1,
         1,
-        "tfs mkimage --format dwarfs|limnifs <srcdir> --output <img>",
+        "tfs mkimage [--format dwarfs|limnifs] <srcdir> --output <img>",
     ) {
         return fail(&format!("Error: {e}"));
     }
-    let Some(format) = a.format else {
-        return fail("Error: missing required option --format");
-    };
+    // spec 20 §6: limnifs is the default image format; --format dwarfs
+    // stays an explicit opt-in.
+    let format = a.format.unwrap_or_else(|| "limnifs".to_string());
     let Some(output) = a.output else {
         return fail("Error: missing required option --output");
     };

--- a/crates/tfs-cli/tests/info.rs
+++ b/crates/tfs-cli/tests/info.rs
@@ -79,7 +79,7 @@ fn mk_image(w: &TempDir, name: &str, manifest: Option<&str>) -> PathBuf {
 }
 
 // The vendored fixtures are needed for the squashfs probe only (POSIX —
-// the windows tfs build is dwarfs-only, TODO.v2-1/02).
+// the windows tfs build ships no squashfs backend, TODO.v2-1/02).
 #[cfg(not(windows))]
 fn fixture(name: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -319,8 +319,8 @@ fn format_detection_per_backend() {
     );
 
     // squashfs (vendored fixture; no manifest → named note). POSIX only —
-    // the windows tfs build is dwarfs-only, where the sqfs mount is the
-    // named ENOTSUP (TODO.v2-1/02).
+    // the windows tfs build ships no squashfs backend; the sqfs mount is
+    // the named ENOTSUP there (TODO.v2-1/02).
     #[cfg(not(windows))]
     {
         let (rc, out, _) = run(

--- a/crates/tfs-cli/tests/mkimage.rs
+++ b/crates/tfs-cli/tests/mkimage.rs
@@ -91,9 +91,8 @@ fn mkimage_roundtrip_ls_cat_stat_extract() {
 
 /// The limnifs writer path (spec 20 §6): same tree in, same CLI
 /// answers out — `Type: LimniFS` comes off the mounted backend, never
-/// the extension.
+/// the extension. Runs on windows too (dwarfs+limnifs there).
 #[test]
-#[cfg(not(windows))] // windows ships a dwarfs-only tfs (TODO.v2-1/02)
 fn mkimage_limnifs_roundtrip_ls_cat_stat_extract() {
     let w = TempDir::new("mkimglim");
     let src = make_source(&w);
@@ -141,6 +140,116 @@ fn mkimage_limnifs_roundtrip_ls_cat_stat_extract() {
     assert_eq!(rc, 0);
     assert_eq!(std::fs::read(dest.join("one.txt")).unwrap(), b"one");
     assert_eq!(std::fs::read(dest.join("sub/two.txt")).unwrap(), b"two");
+}
+
+/// The default format is limnifs (spec 20 §6): a `--format`-less
+/// mkimage writes LMFS-magic bytes that mount through the limnifs
+/// backend. Dwarfs stays the explicit opt-in (`--format dwarfs`).
+#[test]
+fn mkimage_default_format_is_limnifs() {
+    let w = TempDir::new("mkimgdefault");
+    let src = make_source(&w);
+    let img = w.0.join("app.tfs");
+
+    let (rc, _, err) = run(
+        &[
+            "mkimage",
+            src.to_str().unwrap(),
+            "-o",
+            img.to_str().unwrap(),
+        ],
+        &w.0,
+    );
+    assert_eq!((rc, err.as_str()), (0, ""), "mkimage must succeed: {err}");
+
+    let bytes = std::fs::read(&img).unwrap();
+    assert_eq!(
+        &bytes[..4],
+        b"LMFS",
+        "the default image opens with the limnifs magic"
+    );
+
+    let (rc, out, _) = run(&["info", img.to_str().unwrap()], &w.0);
+    assert_eq!(rc, 0);
+    assert!(out.contains("Type: LimniFS"), "{out}");
+}
+
+/// The floor writer recipe (spec 20 §5) under the hazard shapes that
+/// pinned it: duplicate small files (the shared-inline-table trigger —
+/// the 0.2.50 reader mask rejects them, and a writer that skips the
+/// table must still serve every byte), a large compressible text file
+/// (the tournament's brotli pick that floor readers fail to decode),
+/// and a large incompressible binary (the tournament-list coupling
+/// that once mis-encoded binary drops to a zero-byte readback). Every
+/// file must read back byte-exact through the limnifs backend.
+#[test]
+fn mkimage_limnifs_floor_recipe_readback() {
+    let w = TempDir::new("mkimgfloor");
+    let src = w.0.join("app");
+    std::fs::create_dir_all(&src).unwrap();
+
+    let dup = b"duplicate inline content: the same 200-ish bytes in three files, so the writer's inline dedup fires on every realistic tree. Padding padding padding padding padding!";
+    assert!(dup.len() <= 4096);
+    std::fs::write(src.join("dup-a.txt"), dup).unwrap();
+    std::fs::write(src.join("dup-b.txt"), dup).unwrap();
+    std::fs::write(src.join("dup-c.txt"), dup).unwrap();
+
+    let text: Vec<u8> = (0..1400u32)
+        .flat_map(|i| format!("line {i}: the quick brown fox jumps over the lazy dog, pack my box with five dozen liquor jugs\n").into_bytes())
+        .collect();
+    assert!(text.len() > 64 * 1024);
+    std::fs::write(src.join("big-text.rb"), &text).unwrap();
+
+    // Deterministic incompressible bytes (a splitmix64 stream) — the
+    // store arm of the tournament.
+    let mut state = 0x9E3779B97F4A7C15u64;
+    let binary: Vec<u8> = (0..96 * 1024)
+        .map(|_| {
+            state = state.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            (z ^ (z >> 31)) as u8
+        })
+        .collect();
+    std::fs::write(src.join("big-binary.bundle"), &binary).unwrap();
+
+    let img = w.0.join("app.tfs");
+    let (rc, _, err) = run(
+        &[
+            "mkimage",
+            src.to_str().unwrap(),
+            "-o",
+            img.to_str().unwrap(),
+        ],
+        &w.0,
+    );
+    assert_eq!((rc, err.as_str()), (0, ""), "mkimage must succeed: {err}");
+
+    let dest = w.0.join("extracted");
+    std::fs::create_dir_all(&dest).unwrap();
+    let (rc, _, err) = run(
+        &[
+            "extract",
+            "-d",
+            dest.to_str().unwrap(),
+            img.to_str().unwrap(),
+        ],
+        &w.0,
+    );
+    assert_eq!((rc, err.as_str()), (0, ""), "extract must succeed: {err}");
+
+    for (name, want) in [
+        ("dup-a.txt", dup.as_slice()),
+        ("dup-b.txt", dup.as_slice()),
+        ("dup-c.txt", dup.as_slice()),
+        ("big-text.rb", text.as_slice()),
+        ("big-binary.bundle", binary.as_slice()),
+    ] {
+        let got = std::fs::read(dest.join(name)).unwrap_or_else(|e| panic!("read {name}: {e}"));
+        assert_eq!(got.len(), want.len(), "{name}: byte count must round-trip");
+        assert_eq!(got, want, "{name}: bytes must round-trip");
+    }
 }
 
 #[test]

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -48,7 +48,11 @@ sqfs-sys = { version = "0.2.1", path = "../sqfs-sys", optional = true }
 # The LimniFS backend (spec 20): the pure-Rust limnifs-core reader — no
 # system dependencies, `#![forbid(unsafe_code)]` upstream. Registry dep on
 # the published crates.io line (since 0.2.50; same standing as dwarfs-t).
-limnifs-core = { version = "0.2.50", optional = true }
+# 0.2.51 rides the omnizip-zstd 0.16.76 decoder defect (omnizip-rs#315):
+# unreachable for tebako-written images — spec 20 §5's floor recipe is
+# lz4-only (metadata lz4-hc, content lz4-or-store) — and foreign images
+# still fail closed on the named decode error, never silently.
+limnifs-core = { version = "0.2.51", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -75,8 +75,9 @@ getrandom = "0.2"
 # `enc` (default): the ENC confidentiality transform via tebako-signer
 # (rnp). Windows (ucrt64) ships WITHOUT it for now — rnp's mingw build is
 # unproven (TODO.v2-1/08), so windows consumers take
-# default-features = false, features = ["vendored-dwarfs"] and an ENC
-# mount fails with named ENOTSUP.
+# default-features = false, features = ["vendored-dwarfs", "backend-limnifs"]
+# and an ENC mount fails with named ENOTSUP. squashfs is POSIX-only and
+# stays out of the windows set; limnifs is pure Rust and rides everywhere.
 # `backend-limnifs` (default): the LimniFS backend (spec 20) via the
 # pure-Rust limnifs-core — the first of the `backend-*` feature family;
 # the `vendored-*` features migrate to it as aliases per spec 20 §5.

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -48,11 +48,13 @@ sqfs-sys = { version = "0.2.1", path = "../sqfs-sys", optional = true }
 # The LimniFS backend (spec 20): the pure-Rust limnifs-core reader — no
 # system dependencies, `#![forbid(unsafe_code)]` upstream. Registry dep on
 # the published crates.io line (since 0.2.50; same standing as dwarfs-t).
-# 0.2.51 rides the omnizip-zstd 0.16.76 decoder defect (omnizip-rs#315):
-# unreachable for tebako-written images — spec 20 §5's floor recipe is
-# lz4-only (metadata lz4-hc, content lz4-or-store) — and foreign images
-# still fail closed on the named decode error, never silently.
-limnifs-core = { version = "0.2.51", optional = true }
+# 0.2.54 (omnizip 0.16.78) still rides the omnizip-zstd decoder defect
+# (omnizip-rs#315, OPEN) for FOREIGN images — those keep failing closed on
+# the named decode error. Tebako-written images never reach it: spec 20
+# §5's floor recipe is lz4-only (metadata lz4-hc, content lz4-or-store),
+# and the 0.2.54 writer self-check refuses to emit un-decodable zstd
+# frames regardless.
+limnifs-core = { version = "0.2.54", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
@@ -100,5 +102,5 @@ rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
 crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —
 # test-only, never linked into the shipped library.
-limnifs-write = "0.2.50"
+limnifs-write = "0.2.54"
 

--- a/crates/tfs/src/mount.rs
+++ b/crates/tfs/src/mount.rs
@@ -345,7 +345,7 @@ pub fn build_from_memory_with_mode(
 // ---------------------------------------------------------------------
 
 /// A gated-off backend degrades to the NAMED error, never a crash or
-/// a silent re-route (the Windows build ships dwarfs-only —
+/// a silent re-route (the Windows build ships without squashfs —
 /// TODO.v2-1/02). Runs in the `--no-default-features` CI job; with
 /// the feature on, the same magic would attempt a real SquashFS
 /// mount instead. The whole module compiles out with the feature on

--- a/docs/spec/00-INDEX.md
+++ b/docs/spec/00-INDEX.md
@@ -50,7 +50,7 @@ spec 02 §6).
 15. [15 — The info surface](15-info-command.md) — payload and package introspection (`tfs info` / `tebako-pkg info`), verification exit codes, JSON contract
 16. [16 — Distribution and installation](16-distribution-and-installation.md) — personas, channels (brew/curl|sh/tebako install), slim/fat, trust per channel
 17. [17 — Runtime driver contract](17-runtime-driver-contract.md) — the language-agnostic loader↔runtime surface (argv, env, IO, exit codes)
-20. [20 — LimniFS backend](20-limnifs-backend.md) — image format 5: detection, the backend adapter contract, backend cargo features, the writer path (PLANNED)
+20. [20 — LimniFS backend](20-limnifs-backend.md) — image format 5: detection, the backend adapter contract, backend cargo features, the writer path; the DEFAULT image format for `tfs mkimage` and `tebako press` (SHIPPED, v0.2.0)
 21. [21 — Crypto consolidation](21-crypto-consolidation.md) — one crypto home per layer: OpenPGP keeps trust and identity, ENC keeps confidentiality, limnifs-native crypto is evidence, never anchor (PROPOSED DECISION)
 22. [22 — Runtime-native interposition](22-runtime-native-interposition.md) — the generalized hooks: loader/exec/resource interposition inside the runtime, the documented interface, and the death of per-gem adapters (the spec-18 contract's runtime-internal half)
 23. [23 — Declarative composition and needs resolution](23-declarative-composition.md) — the fully declarative slice stack: D1 needs / D2 composition doc / D3 press-baked union / D4-D5 operator surfaces; deny-safe by default, the needs-check law (PLANNED)

--- a/docs/spec/20-limnifs-backend.md
+++ b/docs/spec/20-limnifs-backend.md
@@ -3,12 +3,14 @@
 Normative specification of the LimniFS image backend: the `format_id`
 allocation, the detection magic, the adapter contract against the spec 11
 backend seam, the compile-separation feature family, and the writer path.
-**Status: PLANNED** (post-v2.0.0; work queue `TODO.prepublish/09`) —
-nothing on this page is shipped. The page LOCKS the integration shape so
-the implementation lands once, in the owning crates, with no design
-re-litigation. Provenance: the LimniFS team's integration proposal
-(2026-08-01, `limnifs/docs/tebako-integration-proposal.md`), answered
-with a spec per spec 14's design-first order.
+**Status: SHIPPED** — the backend (reader + writer, `format_id` 5, the
+`LMFS` detection arm, the `backend-limnifs` feature) landed in tebako
+v0.2.0 (#371), and LimniFS is **the default image format** for
+`tfs mkimage` and `tebako press` (§6; dwarfs stays first-class as a read
+backend and an explicit `--format dwarfs` opt-in). Provenance: the LimniFS
+team's integration proposal (2026-08-01,
+`limnifs/docs/tebako-integration-proposal.md`), answered with a spec per
+spec 14's design-first order.
 
 LimniFS is a pure-Rust (`#![forbid(unsafe_code)]`), content-addressed
 image format: every chunk (a **drop**) is identified by
@@ -173,20 +175,114 @@ surfaces it as its own named error; a lean package pressed with
 `--format limnifs` run against a limnifs-less runtime fails closed with
 the backend named, not with a fallback mount.
 
+**Runtime floor for the limnifs default (locked 2026-08-22):** with
+limnifs the default writer format (§6), a default-pressed payload runs
+on any runtime whose driver ships `backend-limnifs` — every runtime
+built from the tebako product repo at or after the backend's merge
+(shipped in tebako v0.2.0). The published tebako-runtime-ruby POSIX
+assets meet the floor from the 2026-08-11 re-cut onward (v0.16.3 and
+v0.16.4 assets alike, probed end-to-end: press → stitch → cold run of a
+sha256-verified limnifs payload on a fresh store, entrypoint output
+correct on both) **provided the payload observes the writer constraints
+below**; windows-ucrt64 assets join with the first factory build whose
+product pin carries the windows per-target override's
+`backend-limnifs`. A runtime below the floor fails closed with the
+named `ENOTSUP` — by design; the loader never re-routes a limnifs
+payload to another format.
+
+**Writer constraints at the floor (locked 2026-08-22):** five defects
+in the limnifs 0.2.50/0.2.51 crates and their codec stack bound what
+tebako writers may emit while the floor spans 0.2.50-and-earlier
+readers. All five were pinned empirically against the published drivers
+(the named reason rides the `TEBAKO_DEBUG=trace` log; the errno channel
+carries EINVAL/EIO). The five map onto four constraints below — the
+fifth (the tournament coupling) shares constraint 4's remedy:
+
+1. **No shared inline table** (upstream: limnifs#186). limnifs-core
+   ≤ 0.2.51 declares `INODE_FLAG_SHARED_INLINE = 0x08` (its own parser
+   consumes the flag) yet sets `INODE_FLAG_RESERVED_MASK = 0xF8` —
+   covering bit 3 — so every reader of that line rejects any inode
+   using the writer's inline dedup ("reserved flag bits set"), tebako's
+   own tfs included. The dedup fires whenever two or more files at or
+   below the 4096-byte inline threshold share content — i.e. on every
+   realistic app tree. Tebako-written images therefore MUST NOT set
+   flag 0x08: the `limnifs-write` build tebako consumes skips the
+   shared inline table (the metadata blob is whole-blob compressed, so
+   re-inlined duplicate blobs cost nothing on the wire). The constraint
+   lifts when the floor's readers carry the corrected mask (`0xF0`).
+2. **The metadata blob is lz4-HC — never brotli, never zstd, never
+   store, and (for size) never fast lz4.** The 0.16.3-era reader's
+   brotli decode path fails on metadata blobs beyond the small-buffer
+   case ("invalid code-length code lengths (space not consumed)") —
+   small trees pass, which is exactly how the defect hid behind the
+   first probe. zstd is out too: the omnizip-zstd decoder shipping in
+   every limnifs-core line on the floor (≤ 0.2.51, tebako's own tfs
+   included) mis-decodes some valid frames — a deterministic
+   frame-checksum mismatch on bytes libzstd itself accepts, reproduced
+   by a 318-byte metadata blob at the Fastest/Fast/Default/Better
+   levels. lz4-HC (codec 0x13) is the safe high-ratio codec: its frames
+   are standard lz4 blocks, and every floor reader dispatches 0x13 to
+   the SAME fast-lz4 decoder (limnifs-core's `Lz4HcCodec::decompress`
+   delegates to the fast codec — no second decode path exists), while
+   the hash-chain match finder keeps a realistic tree's blob under the
+   readers' 1 MiB compressed-inline ceiling where fast lz4 does not
+   (the native-extension e2e tree: 830 KiB lz4-HC vs 1049 KiB fast lz4
+   vs 2.5 MB store; the fast-lz4 blob overshoots constraint 3's
+   threshold, the store blob overshoots the readers' hard ceiling).
+   Both writer entry points (`tfs mkimage`, `tebako press`) pin
+   `metadata_codec = "lz4-hc"`.
+3. **The writer inlines metadata up to the readers' 1 MiB ceiling**
+   (upstream: limnifs#187). Both floor readers bound the compressed
+   inline metadata at `DEFAULT_INLINE_METADATA_MAX_BYTES = 1 MiB`, but
+   limnifs-write ≤ 0.2.51 externalizes past its own 768 KiB threshold
+   with no `WriteConfig` override — which a realistic tree's lz4-HC
+   blob overshoots. The `limnifs-write` build tebako consumes raises the
+   externalization threshold to just under the readers' ceiling
+   (1000 KiB). A tree whose lz4-HC blob exceeds even that fails
+   press/mkimage with the named self-contained error — the documented
+   "too large for this format today" boundary.
+4. **Content drops ride lz4-or-store, never brotli, never zstd.** The
+   same two codec defects cover content drops, not only the metadata
+   blob: a brotli-compressed text drop beyond the small-buffer case
+   reads back EIO on the 0.16.3 driver (38–92 KB `.rb` files reproduce
+   it; v0.16.4's reader is unaffected), and any zstd drop can hit the
+   omnizip decode landmine on any reader. The fifth defect seals the
+   recipe from the other direction: removing lz4 from the compression
+   tournament while `binary_codec` stays lz4 makes the writer emit a
+   binary drop that every reader — tebako's own tfs included — reads
+   back as **zero bytes with a successful stat** (a 68 KB `.bundle`
+   reproduces it; the runtime symptom is a `LoadError` on the
+   dlmap2file path). Both writer entry points therefore pin
+   `text_codec`/`binary_codec` to lz4 and restrict the compression
+   tournament to `store` + `lz4` — lz4 present in the list, nothing
+   else beside store. lz4 decode is proven on the floor for both text
+   and binary drops (94 KB `.rb`, 68 KB `.bundle`).
+
+A payload written outside these constraints is not rejected by the
+tooling — it is simply below the floor's guarantee: it may mount on
+newer readers and fail closed (named EINVAL) on older ones.
+
 ## 6. The writer path
 
-- **`tfs mkimage --format limnifs <srcdir> -o <img>`** — in-process via
-  `limnifs-write` (`write_directory`), the same rule as the dwarfs-t
-  Writer: no `limni` binary, no PATH lookup, no shell-out. The spec 03 §7
-  `tree_hash` stamping is format-neutral (the staged hardlink mirror
-  ahead of writer selection) and applies unchanged; output replacement
-  keeps the mkdwarfs `--force` parity. `dwarfs` stays the default format;
-  the unsupported-format named error lists the new supported set.
-- **`tebako press --format limnifs`** (PLANNED flag; default `dwarfs`) —
-  routes the packager's image build (`crates/tebako-cli/src/image.rs`)
-  through the limnifs writer and stamps slot `format_id = 5` at the
-  stitch sites (single press, suite press, deploy) in place of
-  `TPKG_FORMAT_DWARFS`. Nothing else about press changes.
+- **`tfs mkimage [--format dwarfs|limnifs] <srcdir> -o <img>`** —
+  in-process via `limnifs-write` (`write_directory`) for limnifs, the
+  dwarfs-t `Writer` for dwarfs; the same rule for both: no `limni` /
+  `mkdwarfs` binary, no PATH lookup, no shell-out. **`limnifs` is the
+  default format** — the `--format` flag is optional and selects dwarfs
+  only when given explicitly. The spec 03 §7 `tree_hash` stamping is
+  format-neutral (the staged hardlink mirror ahead of writer selection)
+  and applies unchanged; output replacement keeps the mkdwarfs `--force`
+  parity. The unsupported-format named error lists the supported set
+  (`dwarfs, limnifs`).
+- **`tebako press [--format dwarfs|limnifs]`** (shipped in v0.2.0;
+  **default `limnifs`**) — routes the packager's image build
+  (`crates/tebako-cli/src/image.rs`) through the chosen writer and stamps
+  the app-image slots with the matching `format_id` hint (5 limnifs / 1
+  dwarfs) at the stitch sites (single press, suite press, deploy).
+  Nothing else about press changes. Dwarfs remains a first-class
+  explicit opt-in (`--format dwarfs`) and a supported read backend
+  forever — existing dwarfs packages, runtimes, and payload artifacts are
+  untouched.
 - **Format-neutrality of the manifest (orthogonality law):** the
   in-image payload manifest (spec 03) declares identity / provides /
   requires and NEVER names an image format; runtime-role stays out of
@@ -195,6 +291,45 @@ the backend named, not with a fallback mount.
   backend. Payload artifacts in the store stay `.tfs`-named and
   byte-identical with the registry artifact (spec 05) — `.lim` is the
   limnifs ecosystem's own extension, not the store's.
+
+## 6b. Rationale: why LimniFS is the default (normative)
+
+The default image format is the one every payload takes when the operator
+says nothing, so the default must be the format with the least toolchain
+exposure, the least build cost, and no loss of capability. LimniFS meets
+that bar and dwarfs-t does not; the reasons, in order of weight:
+
+1. **The default path is pure Rust** (`#![forbid(unsafe_code)]`, zero
+   system dependencies). Reading AND WRITING the default format needs no
+   C++ toolchain, no vcpkg, no cmake — spec 00 laws 1/3 in their
+   strongest form. The C++ toolchain exposure shrinks to opt-in formats:
+   dwarfs stays first-class via `--format dwarfs`, and the dwarfs-t
+   backend remains in every default feature set, so existing images read
+   everywhere they read today.
+2. **Build wall-clock and reproducibility.** The dwarfs-t vcpkg ports are
+   the CI cost driver (per-target C++ cross-compilation); `limnifs-core`
+   / `limnifs-write` compile everywhere Rust compiles and resolve from
+   crates.io with semver-pinned versions — the default path never
+   consumes an unpinned source tree. (TEMPORARY CARVE-OUT, lifts with
+   §5's constraints 1/3: until upstream ships a `limnifs-write` carrying
+   the limnifs#186/#187 fixes, the product workspace pins
+   `[patch.crates-io] limnifs-write` to the patched build — the crate
+   version stays semver-pinned; only the source is redirected.)
+3. **Content-addressed storage.** Every drop is `BLAKE3(plaintext)`:
+   image-internal integrity, dedup across and within images, and the
+   structural delta-update story (§7) come from the format, not from
+   bolted-on machinery.
+4. **Read efficiency.** Decompression is on-demand and per content class;
+   inline drops serve small files straight from the metadata blob with no
+   slab access (§4).
+5. **Unambiguous detection.** The strong `LMFS` magic is disjoint from
+   every existing probe arm (§3) — no heuristic, no misclassification.
+6. **Nothing else changes.** The orthogonality law holds (`format_id`
+   answers only "how do I read these bytes"); payload artifacts stay
+   `.tfs`-named and byte-identical with the registry artifact (spec 05);
+   existing dwarfs packages and runtimes are untouched; a limnifs payload
+   on a limnifs-less runtime fails closed with the named `ENOTSUP` (§5) —
+   never a silent re-route to another writer's format.
 
 ## 7. Roadmap hooks (recorded, NOT committed)
 

--- a/docs/spec/20-limnifs-backend.md
+++ b/docs/spec/20-limnifs-backend.md
@@ -215,12 +215,12 @@ fifth (the tournament coupling) shares constraint 4's remedy:
    brotli decode path fails on metadata blobs beyond the small-buffer
    case ("invalid code-length code lengths (space not consumed)") —
    small trees pass, which is exactly how the defect hid behind the
-   first probe. zstd is out too: the omnizip-zstd decoder shipping in
-   every limnifs-core line on the floor (≤ 0.2.51, tebako's own tfs
-   included) mis-decodes some valid frames — a deterministic
-   frame-checksum mismatch on bytes libzstd itself accepts, reproduced
-   by a 318-byte metadata blob at the Fastest/Fast/Default/Better
-   levels. lz4-HC (codec 0x13) is the safe high-ratio codec: its frames
+   first probe. zstd is out too (upstream: omnizip-rs#315): the
+   omnizip-zstd decoder shipping in every limnifs-core line on the floor
+   (≤ 0.2.51, tebako's own tfs included) mis-decodes some valid frames —
+   a deterministic frame-checksum mismatch on bytes libzstd itself
+   accepts, reproduced by a 318-byte metadata blob at the
+   Fastest/Fast/Default/Better levels. lz4-HC (codec 0x13) is the safe high-ratio codec: its frames
    are standard lz4 blocks, and every floor reader dispatches 0x13 to
    the SAME fast-lz4 decoder (limnifs-core's `Lz4HcCodec::decompress`
    delegates to the fast codec — no second decode path exists), while
@@ -247,8 +247,9 @@ fifth (the tournament coupling) shares constraint 4's remedy:
    reads back EIO on the 0.16.3 driver (38–92 KB `.rb` files reproduce
    it; v0.16.4's reader is unaffected), and any zstd drop can hit the
    omnizip decode landmine on any reader. The fifth defect seals the
-   recipe from the other direction: removing lz4 from the compression
-   tournament while `binary_codec` stays lz4 makes the writer emit a
+   recipe from the other direction (upstream: limnifs#188): removing lz4
+   from the compression tournament while `binary_codec` stays lz4 makes
+   the writer emit a
    binary drop that every reader — tebako's own tfs included — reads
    back as **zero bytes with a successful stat** (a 68 KB `.bundle`
    reproduces it; the runtime symptom is a `LoadError` on the

--- a/docs/spec/20-limnifs-backend.md
+++ b/docs/spec/20-limnifs-backend.md
@@ -190,70 +190,102 @@ product pin carries the windows per-target override's
 named `ENOTSUP` — by design; the loader never re-routes a limnifs
 payload to another format.
 
-**Writer constraints at the floor (locked 2026-08-22):** five defects
-in the limnifs 0.2.50/0.2.51 crates and their codec stack bound what
-tebako writers may emit while the floor spans 0.2.50-and-earlier
-readers. All five were pinned empirically against the published drivers
-(the named reason rides the `TEBAKO_DEBUG=trace` log; the errno channel
-carries EINVAL/EIO). The five map onto four constraints below — the
-fifth (the tournament coupling) shares constraint 4's remedy:
+**Writer constraints at the floor (locked 2026-08-22; upstream state
+verified at tag `limni-v0.2.54`):** five defects in the limnifs crates
+and their codec stack bound what tebako writers may emit while the
+floor spans pre-0.2.53 readers. All five were pinned empirically
+against the published drivers (the named reason rides the
+`TEBAKO_DEBUG=trace` log; the errno channel carries EINVAL/EIO). Since
+the lock: **#186 and #187 are FIXED upstream in 0.2.53** (verified in
+the 0.2.54 source), **#315 is mitigated writer-side** in 0.2.53 (the
+decoder defect itself is still open on omnizip 0.16.78), and **#188 is
+not reproducible on stock 0.2.54** (retest below). The constraints stay
+verbatim while the floor's readers predate the fixes — the recipe is
+cheap, and every constraint's lift condition is named. The five map
+onto four constraints below — the fifth (the tournament coupling)
+shares constraint 4's remedy:
 
-1. **No shared inline table** (upstream: limnifs#186). limnifs-core
-   ≤ 0.2.51 declares `INODE_FLAG_SHARED_INLINE = 0x08` (its own parser
-   consumes the flag) yet sets `INODE_FLAG_RESERVED_MASK = 0xF8` —
-   covering bit 3 — so every reader of that line rejects any inode
-   using the writer's inline dedup ("reserved flag bits set"), tebako's
-   own tfs included. The dedup fires whenever two or more files at or
-   below the 4096-byte inline threshold share content — i.e. on every
-   realistic app tree. Tebako-written images therefore MUST NOT set
-   flag 0x08: the `limnifs-write` build tebako consumes skips the
-   shared inline table (the metadata blob is whole-blob compressed, so
-   re-inlined duplicate blobs cost nothing on the wire). The constraint
-   lifts when the floor's readers carry the corrected mask (`0xF0`).
+1. **No shared inline table** (upstream: limnifs#186 — FIXED in limnifs
+   0.2.53: `INODE_FLAG_RESERVED_MASK = 0xF0`, bit 3 documented as the
+   defined `SHARED_INLINE`). limnifs-core < 0.2.53 declares
+   `INODE_FLAG_SHARED_INLINE = 0x08` (its own parser consumes the flag)
+   yet sets the reserved mask to `0xF8` — covering bit 3 — so every
+   reader of that line rejects any inode using the writer's inline
+   dedup ("reserved flag bits set"). The dedup fires whenever two or
+   more files at or below the 4096-byte inline threshold share content
+   — i.e. on every realistic app tree. The published 0.16.3–0.16.5
+   drivers all embed limnifs-core < 0.2.53, so tebako-written images
+   MUST NOT set flag 0x08 while they are the floor: both writer entry
+   points run with `defaults.shared_inline = false` (the metadata blob
+   is whole-blob compressed, so re-inlined duplicate blobs cost nothing
+   on the wire). The knob is limnifs#189 — filed; until it ships in a
+   release it rides the `tamatebako/limnifs` `tebako-floor-gate` fork
+   branch via the workspace `[patch.crates-io]` (a single
+   upstream-shaped commit on `limni-v0.2.54`). **Lift condition:** the
+   floor's readers embed limnifs-core ≥ 0.2.53 (runtime ≥ 0.16.6) AND
+   the knob ships in a crates.io release.
 2. **The metadata blob is lz4-HC — never brotli, never zstd, never
    store, and (for size) never fast lz4.** The 0.16.3-era reader's
    brotli decode path fails on metadata blobs beyond the small-buffer
    case ("invalid code-length code lengths (space not consumed)") —
    small trees pass, which is exactly how the defect hid behind the
-   first probe. zstd is out too (upstream: omnizip-rs#315): the
-   omnizip-zstd decoder shipping in every limnifs-core line on the floor
-   (≤ 0.2.51, tebako's own tfs included) mis-decodes some valid frames —
-   a deterministic frame-checksum mismatch on bytes libzstd itself
-   accepts, reproduced by a 318-byte metadata blob at the
-   Fastest/Fast/Default/Better levels. lz4-HC (codec 0x13) is the safe high-ratio codec: its frames
-   are standard lz4 blocks, and every floor reader dispatches 0x13 to
-   the SAME fast-lz4 decoder (limnifs-core's `Lz4HcCodec::decompress`
-   delegates to the fast codec — no second decode path exists), while
-   the hash-chain match finder keeps a realistic tree's blob under the
-   readers' 1 MiB compressed-inline ceiling where fast lz4 does not
-   (the native-extension e2e tree: 830 KiB lz4-HC vs 1049 KiB fast lz4
-   vs 2.5 MB store; the fast-lz4 blob overshoots constraint 3's
-   threshold, the store blob overshoots the readers' hard ceiling).
-   Both writer entry points (`tfs mkimage`, `tebako press`) pin
-   `metadata_codec = "lz4-hc"`.
+   first probe. zstd is out too (upstream: omnizip-rs#315, STILL OPEN
+   on omnizip 0.16.78): the omnizip-zstd decoder shipping in every
+   limnifs-core line on the floor (≤ 0.2.54, tebako's own tfs included)
+   mis-decodes some valid frames — a deterministic frame-checksum
+   mismatch on bytes libzstd itself accepts, reproduced by a 318-byte
+   metadata blob at the Fastest/Fast/Default/Better levels. Writer-side
+   this is mitigated since limnifs 0.2.53: `codec::zstd`'s
+   `verify_roundtrip` decompress-verifies every encoded frame and
+   refuses to emit one its decoder can't read (the tournament falls
+   through), so a ≥ 0.2.53 writer never ships the landmine; the recipe
+   keeps zstd banned regardless — every floor READER still carries the
+   broken decoder for foreign or pre-fix frames, and lz4-HC already
+   meets the size budget. lz4-HC (codec 0x13) is the safe high-ratio
+   codec: its frames are standard lz4 blocks, and every floor reader
+   dispatches 0x13 to the SAME fast-lz4 decoder (limnifs-core's
+   `Lz4HcCodec::decompress` delegates to the fast codec — no second
+   decode path exists), while the hash-chain match finder keeps a
+   realistic tree's blob under the readers' 1 MiB compressed-inline
+   ceiling where fast lz4 does not (the native-extension e2e tree:
+   830 KiB lz4-HC vs 1049 KiB fast lz4 vs 2.5 MB store; the fast-lz4
+   blob overshoots constraint 3's threshold, the store blob overshoots
+   the readers' hard ceiling). Both writer entry points (`tfs mkimage`,
+   `tebako press`) pin `metadata_codec = "lz4-hc"`.
 3. **The writer inlines metadata up to the readers' 1 MiB ceiling**
-   (upstream: limnifs#187). Both floor readers bound the compressed
-   inline metadata at `DEFAULT_INLINE_METADATA_MAX_BYTES = 1 MiB`, but
-   limnifs-write ≤ 0.2.51 externalizes past its own 768 KiB threshold
-   with no `WriteConfig` override — which a realistic tree's lz4-HC
-   blob overshoots. The `limnifs-write` build tebako consumes raises the
-   externalization threshold to just under the readers' ceiling
-   (1000 KiB). A tree whose lz4-HC blob exceeds even that fails
-   press/mkimage with the named self-contained error — the documented
-   "too large for this format today" boundary.
+   (upstream: limnifs#187 — FIXED in limnifs 0.2.53: the
+   `defaults.metadata_externalize_threshold` knob, serde-defaulted to
+   just under the reader ceiling (1000 KiB = 1 MiB − 24 KiB) and
+   clamped at assembly). Both floor readers bound the compressed
+   inline metadata at `DEFAULT_INLINE_METADATA_MAX_BYTES = 1 MiB`;
+   limnifs-write ≤ 0.2.51 externalized past its own 768 KiB threshold
+   with no `WriteConfig` override. On ≥ 0.2.53 the stock default IS the
+   floor-safe value, so the recipe sets no override. A tree whose
+   lz4-HC blob exceeds even the ceiling fails press/mkimage with the
+   named self-contained error — the documented "too large for this
+   format today" boundary.
 4. **Content drops ride lz4-or-store, never brotli, never zstd.** The
    same two codec defects cover content drops, not only the metadata
    blob: a brotli-compressed text drop beyond the small-buffer case
    reads back EIO on the 0.16.3 driver (38–92 KB `.rb` files reproduce
    it; v0.16.4's reader is unaffected), and any zstd drop can hit the
-   omnizip decode landmine on any reader. The fifth defect seals the
-   recipe from the other direction (upstream: limnifs#188): removing lz4
-   from the compression tournament while `binary_codec` stays lz4 makes
-   the writer emit a
-   binary drop that every reader — tebako's own tfs included — reads
-   back as **zero bytes with a successful stat** (a 68 KB `.bundle`
-   reproduces it; the runtime symptom is a `LoadError` on the
-   dlmap2file path). Both writer entry points therefore pin
+   omnizip decode landmine on a floor reader (a stock-0.2.54
+   zstd-binary probe image EIOs on the v0.16.3 driver — retest
+   artifact, limnifs#188 comment). The fifth defect sealed the recipe
+   from the other direction (upstream: limnifs#188): on 0.2.51,
+   removing lz4 from the compression tournament while `binary_codec`
+   stayed lz4 made the writer emit a binary drop that every reader —
+   tebako's own tfs included — read back as **zero bytes with a
+   successful stat** (a 68 KB `.bundle` reproduced it; the runtime
+   symptom was a `LoadError` on the dlmap2file path). **Retest
+   2026-08-22 on stock, unpatched 0.2.54 — both exact trigger configs,
+   three readers (0.2.54 tfs, both published drivers): NOT
+   REPRODUCIBLE, every readback byte-exact** (reported on limnifs#188;
+   fixed-where unbisected — the 0.2.53 zstd self-check and the omnizip
+   0.16.78 OF-table fix are the candidates). The tournament restriction
+   stays regardless: the decode defects above already forbid every
+   non-lz4 codec on the floor, and the pin costs nothing until #188
+   closes with a named root cause. Both writer entry points pin
    `text_codec`/`binary_codec` to lz4 and restrict the compression
    tournament to `store` + `lz4` — lz4 present in the list, nothing
    else beside store. lz4 decode is proven on the floor for both text
@@ -312,10 +344,12 @@ that bar and dwarfs-t does not; the reasons, in order of weight:
    / `limnifs-write` compile everywhere Rust compiles and resolve from
    crates.io with semver-pinned versions — the default path never
    consumes an unpinned source tree. (TEMPORARY CARVE-OUT, lifts with
-   §5's constraints 1/3: until upstream ships a `limnifs-write` carrying
-   the limnifs#186/#187 fixes, the product workspace pins
-   `[patch.crates-io] limnifs-write` to the patched build — the crate
-   version stays semver-pinned; only the source is redirected.)
+   §5's constraint 1: until the limnifs#189 `shared_inline` knob ships
+   in a crates.io release, the product workspace pins
+   `[patch.crates-io] limnifs-write` to the `tamatebako/limnifs`
+   `tebako-floor-gate` branch — a single upstream-shaped commit on the
+   `limni-v0.2.54` tag, version-pinned at 0.2.54; only the source is
+   redirected, and git-based so CI resolves it like any machine.)
 3. **Content-addressed storage.** Every drop is `BLAKE3(plaintext)`:
    image-internal integrity, dedup across and within images, and the
    structural delta-update story (§7) come from the format, not from

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -12,11 +12,12 @@ publish = false
 [target.'cfg(not(windows))'.dependencies]
 tfs = { version = "0.2.1", path = "../../crates/tfs" }
 
-# Windows gets the dwarfs-only tfs (the consumer per-target split — the
-# SquashFS backend is POSIX/autotools-only and sqfs-sys's build script
-# refuses by design; the ENC transform is unproven on mingw).
+# Windows gets the dwarfs+limnifs tfs (the consumer per-target split —
+# the SquashFS backend is POSIX/autotools-only and sqfs-sys's build script
+# refuses by design; the ENC transform is unproven on mingw; limnifs is
+# pure Rust and rides everywhere).
 [target.'cfg(windows)'.dependencies]
-tfs = { version = "0.2.1", path = "../../crates/tfs", default-features = false, features = ["vendored-dwarfs"] }
+tfs = { version = "0.2.1", path = "../../crates/tfs", default-features = false, features = ["vendored-dwarfs", "backend-limnifs"] }
 
 [dependencies]
 libc = "0.2"

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -26,4 +26,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 # The limnifs backend-pair golden class builds its fixture image
 # in-process (spec 20 §8) — never a `limni` binary.
-limnifs-write = "0.2.50"
+limnifs-write = "0.2.54"

--- a/tests/contract/tests/limnifs_backend.rs
+++ b/tests/contract/tests/limnifs_backend.rs
@@ -6,9 +6,8 @@
 //! per-backend, semantics are shared. Plus the region/memory mount
 //! constructors and the named-error surfaces.
 //!
-//! Windows ships a dwarfs-only tfs (TODO.v2-1/02): the limnifs cases are
-//! POSIX-only.
-#![cfg(not(windows))]
+//! The limnifs cases run on windows too — the windows tfs ships
+//! dwarfs+limnifs (squashfs/enc stay POSIX-gated, TODO.v2-1/02).
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
# LimniFS becomes the default image format (spec 20 §6)

**DRAFT — do not merge.** Two deliberate blockers: (1) the workspace carries a
machine-local `[patch.crates-io]` on `limnifs-write` (below); (2) the ecosystem
merge-train rule — this lands only with the owner's explicit go-ahead.

## What changes

- `tebako press` and `tfs mkimage` default to **limnifs** (was: dwarfs;
  mkimage's `--format` was required, now optional with the limnifs default).
  Dwarfs stays a first-class explicit opt-in (`--format dwarfs`) and a
  supported read backend forever; the unsupported-format named errors keep
  listing both.
- The press stitch guard's `format_id` bound is raised past
  `TPKG_FORMAT_RUNTIME` to `TPKG_FORMAT_LIMNIFS` (`crates/tebako-cli/src/lib.rs`)
  — #371 raised the tpkg model bound but missed this pre-validation, so a
  limnifs press died at stitch time with the named 126.
- Windows feature parity FIRST: the `cfg(windows)` tfs overrides gain
  `backend-limnifs` in tebako-driver, tebako-cli, tfs-cli, tebako-pkg,
  tebako-info, libtfs-preload and the contract-test crate (limnifs is pure
  Rust; the override exists for squashfs/enc, limnifs never had a windows
  blocker). The "windows ships a dwarfs-only tfs" test gates are dropped.
- Tests: the golden side-by-side pins `--format dwarfs` on the rs press
  (like-for-like with the dwarfs-only reference gem); the native-ext e2e
  inspects the app image through the format-neutral tfs backend; the default
  press is asserted to stamp `format_id` 5; mkimage's default is asserted to
  emit the `LMFS` magic; `tebako info` sniffs the limnifs magic to the new
  hint. The deploy driver image stays dwarfs by design.
- Spec sync in the same change: spec 20 status line (backend SHIPPED in
  v0.2.0), §6 default sentences, normative §6b rationale, and the §5
  runtime-floor lock with the writer constraints below.

## The floor recipe — five defects pinned, and what they force

Probing the default flip against the **published** v0.16.3 / v0.16.4 drivers
(tebako-runtime-ruby assets, sha256-verified) surfaced five defects in the
limnifs 0.2.50/0.2.51 crates and their codec stack. Each is worked around in
the writer recipe and locked in spec 20 §5 with the repro evidence; the full
dump rides at `docs/spec/20-limnifs-backend.md` §5 and (verbatim probe logs)
the tournament-evidence attachment below.

1. **Shared-inline table flag rejected by every floor reader** (upstream
   limnifs#186): limnifs-core ≤ 0.2.51 sets `INODE_FLAG_RESERVED_MASK = 0xF8`,
   covering its own `SHARED_INLINE = 0x08`. Tebako-written images MUST NOT set
   flag 0x08 → the consumed `limnifs-write` skips the shared inline table.
2. **brotli decode corrupt on the 0.16.3-era reader** beyond small buffers
   (metadata AND content; 38–92 KB `.rb` files EIO) → brotli banned from the
   floor recipe.
3. **omnizip-zstd 0.16.76 decoder mis-decodes valid frames** its own encoder
   produces (frame-checksum mismatch on a 318-byte metadata blob at
   Fastest/Fast/Default/Better; Best OK; system zstd decodes the same frames
   fine). Both published drivers reject such images at mount (EINVAL).
   Content-dependent — earlier trees passed, which is how a zstd recipe
   looked green. zstd banned from the floor recipe on every reader.
4. **Metadata size vs the readers' 1 MiB hard inline ceiling** (upstream
   limnifs#187): the stock writer externalizes past 768 KiB with no override
   → the consumed writer lifts the threshold to 1000 KiB; a tree whose blob
   exceeds even that fails press/mkimage with the named self-contained error
   (the fontist-scale boundary, see below).
5. **Tournament ⇄ binary_codec coupling → silent zero-byte readback**: with
   lz4 removed from `tournament.codecs` while `binary_codec = "lz4"`, a 68 KB
   Mach-O drop reads back as 0 bytes with a successful stat on the CURRENT
   reader (runtime symptom: `LoadError` on the dlmap2file path). VERIFIED not
   the tournament loop itself (it falls back to STORE cleanly); the
   mis-encoding pipeline site is unidentified — evidence dumped for the
   upstream issue.

**The recipe that satisfies all five** (both writer entry points pin it):

```rust
config.dictionaries.enabled = false;
config.defaults.metadata_codec = "lz4-hc".to_string(); // decode == fast-lz4 decode
config.defaults.text_codec = "lz4".to_string();
config.defaults.binary_codec = "lz4".to_string();
config.tournament.codecs = vec!["store".to_string(), "lz4".to_string()];
```

lz4-HC (codec 0x13) is the load-bearing choice: limnifs-core's
`Lz4HcCodec::decompress` **delegates to the same fast-lz4 decoder** already
proven on every floor reader, while the HC match finder keeps a realistic
tree's metadata under the ceiling — the native-extension e2e tree: **830 KiB
lz4-hc vs 1049 KiB fast lz4 vs 2.5 MB store** (fast lz4 overshoots the
1000 KiB threshold — the first lz4-everything recipe failed the native_ext
e2e on exactly this; store overshoots the readers' 1 MiB hard ceiling).

## Probes (all re-run under the final recipe)

- **Both published drivers** (v0.16.3 limnifs-core@14ab01d0-era, v0.16.4
  limnifs-core 0.2.50) mount a lz4-hc-metadata probe image
  (`--tebako-image …:-:/app`) and read back a 98,304 B Mach-O binary, a
  133,290 B text file and three identical 165 B inline-dedup files
  **byte-exact** (in-image ruby SHA-256 vs host `shasum`).
- **Native-ext-scale tree** (the real 34 MB native_ext e2e staging tree,
  thousands of SDK headers): metadata inlines at 849,999 B (no sidecar);
  current-reader `tfs extract` → `diff -r` vs the staging tree: byte-exact.
- `native_ext_press_builds_and_packages` green end-to-end on the v0.16.3
  runtime, including dlopen of the memfs-resident `.bundle`.

## Gates (this branch, macOS arm64)

- `cargo fmt --check` (tebako-cli, tfs-cli, tebako-pkg): clean
- `tfs-cli --test mkimage`: **6/6** — incl. the new
  `mkimage_limnifs_floor_recipe_readback` (dup-inline hazard + 1400-line text
  + 96 KB incompressible binary → mkimage → extract → byte-exact; this test
  caught the omnizip zstd defect under the previous recipe)
- `cargo test -p tebako-pkg`: all green — incl. the new
  `limnifs_magic_sniffs_the_limnifs_hint`
- `cargo clippy` on the 8-crate set `--all-targets -- -D warnings`: rc=0
- Unit batch, same 8 crates (`TEBAKO_CLI_SKIP_E2E=1`): all green, rc=0
- e2e suite (`cli_e2e`, fresh store, file-mirror runtimes; skips:
  `golden_side_by_side_with_the_gem` — pre-broken locally, and
  `press_gemfile_fontist_modern_resolution_and_platform_gems` — fontist-scale
  boundary below): **11 passed / 0 failed, rc=0, 345 s** (native_ext included)

## `[patch.crates-io]` status — deliberate, draft-only

The recipe requires a patched `limnifs-write` (skip the shared inline table —
#186; lift the externalize threshold to 1000 KiB — #187). No crates.io
release carries those fixes, so `Cargo.toml` pins
`[patch.crates-io] limnifs-write` to a **machine-local path** with a loud
comment. Consequences, all intended:

- CI CANNOT resolve the path → CI stays red on this branch. Draft-only state;
  never merge as-is (AGENTS.md hard rule).
- Lift condition: upstream ships a `limnifs-write` with #186/#187 fixed →
  repoint to the crates.io release and delete the block. Spec §6b item 2
  carries a matching temporary carve-out ("the default path never consumes an
  unpinned source tree" is suspended exactly while this patch lives).

## Known boundaries (named errors, not silent fallbacks)

- **Fontist-scale trees** (~10k files): even zstd externalizes the metadata
  at 3.4 MB — over the readers' 1 MiB hard ceiling regardless of codec.
  Press/mkimage fail closed: "the tree is too large for this format today
  (press with --format dwarfs for trees this size)". The fontist e2e stays
  excluded from the limnifs default path until the readers' ceiling lifts
  (limnifs#187 tracks the ceiling side).
- `DEFAULT_TEBAKO_VERSION` stays 0.16.3; the deploy driver image stays
  dwarfs (press-internal machinery, mounted by released runtimes).
- A limnifs payload on a limnifs-less runtime fails closed with the named
  `ENOTSUP` — never a re-route.

## Deliberately NOT touched

- No changes to the dwarfs writer/backend, the tpkg wire format, the store
  layout, the shim, the resolve/trust paths, or any runtime-side code.
- No CI/workflow changes (the windows gnu legs pick up limnifs via the
  feature overrides only).
- `Cargo.lock` untouched (gitignored; resolutions float).

Evidence dump (probe logs, byte counts, checksums, repro paths for all five
defects): see comment below — also archived at
`/tmp/limnifs-tournament-evidence.md` on the authoring machine.
