### PR TITLE
chore: drop the limnifs [patch] fork — pins ride crates.io 0.2.57

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,22 +20,3 @@ lto = "fat"
 codegen-units = 1
 panic = "abort"
 strip = "symbols"
-
-
-# TEMPORARY [patch] — git fork carrying exactly one commit on top of
-# limni-v0.2.54: the `defaults.shared_inline` knob (proposed upstream as
-# limnifs#189; fork branch linked from the issue). The floor recipe
-# (spec 20 §5) needs `shared_inline = false`: published 0.16.3–0.16.5
-# drivers ship limnifs-core < 0.2.53, whose INODE_FLAG_RESERVED_MASK
-# (0xF8) covers the defined SHARED_INLINE bit 0x08 (limnifs#186), so any
-# image with the table is rejected at mount by every floor reader.
-#
-# Everything ELSE the floor recipe needs is stock 0.2.54: the #187
-# threshold knob (defaults to 1000 KiB), the #315 writer-side zstd
-# self-check, lz4-hc metadata. This patch carries NO other change.
-#
-# LIFT CONDITION: upstream ships a release with #189 merged → repoint to
-# crates.io and delete this block. The constraint itself dies when the
-# runtime floor embeds limnifs-core ≥ 0.2.53 (runtime ≥ 0.16.6).
-[patch.crates-io]
-limnifs-write = { git = "https://github.com/tamatebako/limnifs", branch = "tebako-floor-gate" }

--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -41,7 +41,7 @@ serde_yml = "0.0.12"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
 # — pure Rust, no `limni` binary anywhere.
-limnifs-write = "0.2.54"
+limnifs-write = "0.2.57"
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tebako-cli/src/image.rs
+++ b/crates/tebako-cli/src/image.rs
@@ -85,8 +85,8 @@ fn write_dwarfs_image(out: &Path, source: &Path) -> Result<(), TebakoError> {
 /// overshoots the readers' 1 MiB hard ceiling outright. The
 /// shared-inline table stays off (`defaults.shared_inline = false`):
 /// every floor reader (limnifs-core < 0.2.53) rejects its inode flag
-/// 0x08 via its own reserved mask (limnifs#186; the knob rides the
-/// tebako-floor-gate fork until limnifs#189 ships). Spec 20 §5's
+/// 0x08 via its own reserved mask (limnifs#186; the knob is stock
+/// since limnifs 0.2.57 — limnifs#189). Spec 20 §5's
 /// floor rule pins the full recipe. The metadata is inlined up to the
 /// readers' 1 MiB ceiling.
 fn write_limnifs_image(out: &Path, source: &Path) -> Result<(), TebakoError> {

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -34,7 +34,7 @@ serde_yaml = "0.9"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
 # §6) — pure Rust, no `limni` binary anywhere.
-limnifs-write = "0.2.54"
+limnifs-write = "0.2.57"
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is
@@ -61,3 +61,7 @@ tebako-signer = { version = "0.2.1", path = "../tebako-signer" }
 rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
 # Exec-proof image fixtures (zip backend).
 zip = { version = "2", default-features = false, features = ["deflate"] }
+# The floor-recipe structural test parses the emitted metadata through
+# the reader (spec 20 §5 constraint 1: no SharedInline handle anywhere)
+# — test-only, never linked into the shipped binary.
+limnifs-core = "0.2.57"

--- a/crates/tfs-cli/src/lib.rs
+++ b/crates/tfs-cli/src/lib.rs
@@ -1072,8 +1072,8 @@ pub fn cmd_mkimage(format: &str, source_dir: &Path, output: &Path) -> Result<(),
 /// overshoots the readers' 1 MiB hard ceiling outright. The
 /// shared-inline table stays off (`defaults.shared_inline = false`):
 /// every floor reader (limnifs-core < 0.2.53) rejects its inode flag
-/// 0x08 via its own reserved mask (limnifs#186; the knob rides the
-/// tebako-floor-gate fork until limnifs#189 ships). Spec 20 §5's
+/// 0x08 via its own reserved mask (limnifs#186; the knob is stock
+/// since limnifs 0.2.57 — limnifs#189). Spec 20 §5's
 /// floor rule pins the full recipe. The metadata is inlined up to the
 /// readers' 1 MiB ceiling.
 fn write_limnifs_image(source: &Path, output: &Path) -> Result<(), (String, i32)> {

--- a/crates/tfs-cli/tests/mkimage.rs
+++ b/crates/tfs-cli/tests/mkimage.rs
@@ -252,6 +252,66 @@ fn mkimage_limnifs_floor_recipe_readback() {
     }
 }
 
+/// Spec 20 §5 constraint 1, structurally: the floor recipe keeps the
+/// shared-inline table OFF (`defaults.shared_inline = false`), so no
+/// inode in an emitted image carries the 0x08 flag — the bit every
+/// floor-era reader (limnifs-core < 0.2.53) rejects via its reserved
+/// mask (limnifs#186). Mirrors upstream's #189 regression shape
+/// (limnifs-write's shared_inline_round_trip.rs): three identical
+/// inline-sized files are exactly the dedup trigger, so a knob-on
+/// regression fails here loudly. The parse surface is the reader's:
+/// the 0x08 flag decodes to `ContentHandle::SharedInline`, so "no
+/// SharedInline handle" IS "no 0x08 on the wire".
+#[test]
+fn mkimage_limnifs_floor_recipe_emits_no_shared_inline() {
+    let w = TempDir::new("mkimgnosil");
+    let src = w.0.join("app");
+    std::fs::create_dir_all(&src).unwrap();
+    let dup =
+        b"identical inline bytes in three small files - the shared-inline dedup trigger shape";
+    assert!(dup.len() <= 4096);
+    for name in ["dup-a.txt", "dup-b.txt", "dup-c.txt"] {
+        std::fs::write(src.join(name), dup).unwrap();
+    }
+
+    let img = w.0.join("app.tfs");
+    let (rc, _, err) = run(
+        &[
+            "mkimage",
+            src.to_str().unwrap(),
+            "-o",
+            img.to_str().unwrap(),
+        ],
+        &w.0,
+    );
+    assert_eq!((rc, err.as_str()), (0, ""), "mkimage must succeed: {err}");
+
+    let bytes = std::fs::read(&img).unwrap();
+    let mut cursor = limnifs_core::ManifestCursor::new(&bytes);
+    limnifs_core::parse_manifest_header(&mut cursor).expect("header parses");
+    limnifs_core::parse_feature_flags_section(&mut cursor).expect("feature flags parse");
+    let reference =
+        limnifs_core::parse_metadata_reference(&mut cursor).expect("metadata reference parses");
+    let inline = reference
+        .inline_metadata
+        .as_deref()
+        .expect("a self-contained image inlines the metadata");
+    let blob = limnifs_core::parse_metadata_blob(&mut limnifs_core::ManifestCursor::new(inline))
+        .expect("metadata blob parses");
+
+    let mut dups = 0;
+    for inode in &blob.inodes {
+        match &inode.content_handle {
+            limnifs_core::ContentHandle::InlineData(d) if d.as_slice() == dup => dups += 1,
+            limnifs_core::ContentHandle::SharedInline(_) => {
+                panic!("the floor recipe must not emit SharedInline inodes")
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(dups, 3, "all three duplicates ride plain inline data");
+}
+
 #[test]
 fn mkimage_overwrites_existing_output() {
     let w = TempDir::new("mkimg3");

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -54,7 +54,7 @@ sqfs-sys = { version = "0.2.1", path = "../sqfs-sys", optional = true }
 # §5's floor recipe is lz4-only (metadata lz4-hc, content lz4-or-store),
 # and the 0.2.54 writer self-check refuses to emit un-decodable zstd
 # frames regardless.
-limnifs-core = { version = "0.2.54", optional = true }
+limnifs-core = { version = "0.2.57", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
@@ -102,5 +102,5 @@ rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
 crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —
 # test-only, never linked into the shipped library.
-limnifs-write = "0.2.54"
+limnifs-write = "0.2.57"
 

--- a/docs/spec/20-limnifs-backend.md
+++ b/docs/spec/20-limnifs-backend.md
@@ -218,12 +218,15 @@ shares constraint 4's remedy:
    MUST NOT set flag 0x08 while they are the floor: both writer entry
    points run with `defaults.shared_inline = false` (the metadata blob
    is whole-blob compressed, so re-inlined duplicate blobs cost nothing
-   on the wire). The knob is limnifs#189 — filed; until it ships in a
-   release it rides the `tamatebako/limnifs` `tebako-floor-gate` fork
-   branch via the workspace `[patch.crates-io]` (a single
-   upstream-shaped commit on `limni-v0.2.54`). **Lift condition:** the
-   floor's readers embed limnifs-core ≥ 0.2.53 (runtime ≥ 0.16.6) AND
-   the knob ships in a crates.io release.
+   on the wire). The knob is limnifs#189 — SHIPPED in limnifs 0.2.57
+   (`WriteConfig::defaults.shared_inline`, serde-defaulted true); the
+   limnifs pins ride crates.io semver and the workspace
+   `[patch.crates-io]` fork block is deleted. **Lift condition:** the
+   floor's readers embed limnifs-core ≥ 0.2.53 — i.e. a factory
+   runtime cut built on tebako ≥ v0.2.2, the tebako release whose link
+   unit first carries limnifs-core ≥ 0.2.53 (runtime 0.16.6 does NOT
+   lift anything: its link unit comes from tebako v0.2.1, which embeds
+   limnifs-core 0.2.51).
 2. **The metadata blob is lz4-HC — never brotli, never zstd, never
    store, and (for size) never fast lz4.** The 0.16.3-era reader's
    brotli decode path fails on metadata blobs beyond the small-buffer
@@ -343,13 +346,11 @@ that bar and dwarfs-t does not; the reasons, in order of weight:
    the CI cost driver (per-target C++ cross-compilation); `limnifs-core`
    / `limnifs-write` compile everywhere Rust compiles and resolve from
    crates.io with semver-pinned versions — the default path never
-   consumes an unpinned source tree. (TEMPORARY CARVE-OUT, lifts with
-   §5's constraint 1: until the limnifs#189 `shared_inline` knob ships
-   in a crates.io release, the product workspace pins
-   `[patch.crates-io] limnifs-write` to the `tamatebako/limnifs`
-   `tebako-floor-gate` branch — a single upstream-shaped commit on the
-   `limni-v0.2.54` tag, version-pinned at 0.2.54; only the source is
-   redirected, and git-based so CI resolves it like any machine.)
+   consumes an unpinned source tree. (CARVE-OUT LIFTED 2026-08-23: the
+   limnifs#189 `shared_inline` knob shipped in limnifs 0.2.57, the
+   limnifs deps resolve from crates.io semver-pinned at 0.2.57, and the
+   workspace `[patch.crates-io]` block that redirected `limnifs-write`
+   to the `tamatebako/limnifs` `tebako-floor-gate` fork is deleted.)
 3. **Content-addressed storage.** Every drop is `BLAKE3(plaintext)`:
    image-internal integrity, dedup across and within images, and the
    structural delta-update story (§7) come from the format, not from

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -26,4 +26,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 # The limnifs backend-pair golden class builds its fixture image
 # in-process (spec 20 §8) — never a `limni` binary.
-limnifs-write = "0.2.54"
+limnifs-write = "0.2.57"


### PR DESCRIPTION
## Drop the `[patch.crates-io]` limnifs fork — the #189 knob shipped in 0.2.57

limnifs 0.2.57 is on crates.io (all five crates) carrying the
`WriteConfig::defaults.shared_inline` knob (limnifs/limnifs#189, closed —
verified in the published source: `config/mod.rs:139`, serde-defaulted
true, wired at `lib.rs:386`). The `tebako-floor-gate` fork has served its
purpose: the workspace patch block is deleted and every limnifs dep
resolves from crates.io, semver-pinned at 0.2.57.

Changes:

- **Workspace `Cargo.toml`** — the TEMPORARY `[patch.crates-io]` block
  and its comment deleted (its own lift condition fired).
- **Pins → 0.2.57** — `limnifs-write` in crates/tebako-cli,
  crates/tfs-cli, crates/tfs (dev-dep), tests/contract; `limnifs-core`
  in crates/tfs.
- **The floor constraint is explicit config** (it already was: both
  writer entry points set `config.defaults.shared_inline = false`; this
  PR bumps the dep that makes the knob stock and updates the now-stale
  "rides the fork" comments). `crates/tfs/src/backends_limnifs.rs:528`
  is a test-only golden-fixture writer that asserts nothing about floor
  conformance — deliberately left un-knobbed.
- **Spec 20** — §5 constraint 1's tail rewritten (knob SHIPPED in
  0.2.57, patch dropped) with the lift condition corrected: runtime
  0.16.6 does NOT lift it (its link unit comes from tebako v0.2.1 =
  limnifs-core 0.2.51); the constraint lifts with a factory runtime cut
  built on tebako ≥ v0.2.2. §6's carve-out marked LIFTED. Every other
  constraint verbatim.
- **New structural test**
  `mkimage_limnifs_floor_recipe_emits_no_shared_inline`
  (crates/tfs-cli/tests/mkimage.rs): three identical inline-sized files
  through the production mkimage path, then the emitted metadata parsed
  through limnifs-core — zero `SharedInline` handles (the 0x08 flag's
  decoded form), all three duplicates plain inline. Mirrors upstream's
  #189 regression shape. Carries `limnifs-core` as a tfs-cli dev-dep
  (test-only).

Local gates (standard vcpkg + git-cli-fetch env):

- `cargo check -p tfs -p tfs-cli -p tebako-cli` — rc=0
- `cargo test -p tfs-cli --test mkimage` — all green, incl. the new
  structural test and the floor-recipe readback
- `cargo tree` — the limnifs family resolves all-crates.io at 0.2.57,
  no git source anywhere

Draft per the owner-locked rule; merge on green CI with the owner's
go-ahead.
