### PR TITLE
fix(preload): cover the LFS64/fortify alias surface — fopen64/openat64/__openat_2/__fxstatat64 (#439)

### DIFF
--- a/crates/libtfs-preload/src/lib.rs
+++ b/crates/libtfs-preload/src/lib.rs
@@ -31,12 +31,18 @@
 //!
 //! Interposed surface: `open`, `openat`, `stat`, `lstat`, `fstat`,
 //! `fstatat` (+`fstatat64`/`__xstat`/`__lxstat`/`__fxstat`/`__fxstatat`/
-//! `statx`/`getdents64` and the LFS `open64`/`stat64`/`lstat64`/`fstat64`/
-//! `pread64` family on Linux — roadmap 39), `access`,
+//! `__xstat64`/`__lxstat64`/`__fxstat64`/`__fxstatat64`/`statx`/
+//! `getdents64` and the LFS `open64`/`openat64`/`stat64`/`lstat64`/
+//! `fstat64`/`pread64` family on Linux — roadmap 39; the fortified
+//! `__read_chk` and `__openat_2`, and `fopen64` — tebako#439:
+//! libcrypto's `o_fopen.c` defines `_FILE_OFFSET_BITS=64` itself on
+//! linux, so every `BIO_new_file`/`X509_LOOKUP_load_file` binds
+//! `fopen64`, never `fopen`), `access`,
 //! `faccessat`, `opendir`, `readdir` (+`readdir64` on Linux),
 //! `readdir_r`, `rewinddir`/`telldir`/`seekdir`, `dirfd`, `closedir`,
 //! `pread`, `read`, `lseek` (additive — stdio fseek on a memfs fd must
-//! stay on the VFS), `close`, `mkdir`, `unlink`, `rename`, `dlopen`, and
+//! stay on the VFS), `close`, `mkdir`, `unlink`, `rename`, `dlopen`,
+//! `fopen` (read modes), and
 //! `execve`/`posix_spawn`/`posix_spawnp` (memfs paths materialize through
 //! the `dlmap2file` host cache; roadmap 39). Memfs paths are served by
 //! the engine; host paths pass through, gated by the SAME `host_policy`
@@ -90,8 +96,9 @@
 //! - Not interposed in v1: `fork` itself (its child side is guarded —
 //!   see above), `openat2` (glibc has no wrapper at
 //!   all — see above), `fstatat64` on macOS (the legacy 32-bit-inode
-//!   layout), the LFS `__xstat64`/`__lxstat64`/
-//!   `__fxstat64`/`__fxstatat64` versioned forms on Linux, `fdopendir`
+//!   layout), the fortify open family beyond `__openat_2`
+//!   (`__open_2`/`__open64_2`/`__openat64_2` on Linux — no importer
+//!   observed in the 0.16.6 linux-gnu runtime), `fdopendir`
 //!   (a host fdopendir passes through whole; a memfs directory can never
 //!   be fd-opened, so it never arises), and syscall()-direct IO (raw
 //!   `syscall(2)` calls bypass userland interposition by construction —

--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -33,9 +33,20 @@
 //! interposed too (the wrapper lives INSIDE libc and calls the syscall
 //! stub directly, so an interposed `read` never sees a fortified caller
 //! — the debian/temurin JDK's libjli imports exactly it for the jar
-//! END-record read). `__fxstatat64` remains a documented gap, as do
-//! `readv`/`preadv`/`sendfile`/`copy_file_range` and the write-side
-//! `pwrite64`/`ftruncate64`/`statvfs64` family on memfs fds. A
+//! END-record read), and the fortified `__openat_2` (the three-arg
+//! `openat`; its check is compile-time, so the runtime symbol is plain
+//! openat — the 0.16.6 runtime's vendored C++ imports it, tebako#439).
+//! `openat64` (Rust std's openat spelling under `_FILE_OFFSET_BITS=64`)
+//! and `fopen64` (tebako#439: libcrypto's `crypto/o_fopen.c` defines
+//! `_FILE_OFFSET_BITS=64` itself on linux, so `openssl_fopen` — the
+//! `BIO_new_file` / `X509_LOOKUP_load_file` choke point — binds
+//! `fopen64`, never `fopen`) are interposed as delegations to their
+//! plain-name bodies, as is `__fxstatat64` (to `__fxstatat` — the
+//! versioned stat family's last *64 form). Remaining documented gaps:
+//! the rest of the fortify open family (`__open_2`/`__open64_2`/
+//! `__openat64_2` — no importer observed in the 0.16.6 linux-gnu
+//! runtime), `readv`/`preadv`/`sendfile`/`copy_file_range`, and the
+//! write-side `pwrite64`/`ftruncate64`/`statvfs64` family on memfs fds. A
 //! pre-existing landmine OUTSIDE the JDK path: the plain
 //! `stat`/`lstat`/`fstat`/`stat64`/`lstat64`/`fstat64` host passthroughs
 //! resolve dynamic symbols glibc only exports ≥ 2.33 — on an older

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -752,6 +752,37 @@ pub unsafe extern "C" fn open64(path: *const c_char, flags: c_int, mode: c_int) 
     unsafe { open(path, flags, mode) }
 }
 
+/// Linux: `openat64` (the LFS alias of `openat`). glibc's fcntl.h
+/// redirects `openat` to this DISTINCT symbol under `_FILE_OFFSET_BITS=64`
+/// — Rust std's dir-walk openat callers bind it directly (the 0.16.6
+/// linux-gnu runtime exe imports it — tebako#439). Same layout, same
+/// routing: delegate to the plain-name body, exactly like `open64`.
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn openat64(
+    dirfd: c_int,
+    path: *const c_char,
+    flags: c_int,
+    mode: c_int,
+) -> c_int {
+    unsafe { openat(dirfd, path, flags, mode) }
+}
+
+/// Linux: `__openat_2` — the `_FORTIFY_SOURCE=2` three-argument `openat`.
+/// The check happens at COMPILE time (glibc's bits/fcntl2.h rejects
+/// O_CREAT/O_TMPFILE without a mode there); the runtime symbol IS plain
+/// openat, so the shim delegates exactly like the LFS aliases — the
+/// `__read_chk` precedent: the fortify entry is a DISTINCT exported symbol
+/// that an interposed plain name never sees (the 0.16.6 runtime's vendored
+/// C++ imports it — tebako#439).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn __openat_2(dirfd: c_int, path: *const c_char, flags: c_int) -> c_int {
+    // The fortify contract guarantees flags carry no O_CREAT/O_TMPFILE
+    // (compile-time rejection), so the openat body's mode is unused.
+    unsafe { openat(dirfd, path, flags, 0) }
+}
+
 /// Linux: `stat64` (the LFS alias of `stat`).
 #[cfg(target_os = "linux")]
 #[no_mangle]
@@ -1049,6 +1080,21 @@ pub unsafe extern "C" fn fopen(path: *const c_char, mode: *const c_char) -> *mut
     }
 }
 
+/// Linux: `fopen64` (the LFS alias of `fopen`) — the tebako#439 hole.
+/// libcrypto's `crypto/o_fopen.c` defines `_FILE_OFFSET_BITS=64` ITSELF
+/// on linux ("aliases fopen to fopen64"), so `openssl_fopen` — every
+/// `BIO_new_file` / `X509_LOOKUP_load_file` (ruby's
+/// `X509::Store#add_file`/`set_default_paths`), `RAND_load_file`,
+/// config read — binds `fopen64`, never `fopen` (the 0.16.6 linux-gnu
+/// runtime exe: `openssl_fopen` is a tail-call to `fopen64@plt`; FLAC
+/// and libstdc++'s `__basic_file::open` bind it too). Same layout, same
+/// routing: delegate to the plain-name body (the `open64` precedent).
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn fopen64(path: *const c_char, mode: *const c_char) -> *mut libc::FILE {
+    unsafe { fopen(path, mode) }
+}
+
 /// macOS's `fopen$DARWIN_EXTSN` (the extended-signature export the 64-bit
 /// SDK binds) — the same body as `fopen`.
 #[cfg(target_os = "macos")]
@@ -1329,6 +1375,22 @@ pub unsafe extern "C" fn __lxstat64(ver: c_int, path: *const c_char, st: *mut li
 #[no_mangle]
 pub unsafe extern "C" fn __fxstat64(ver: c_int, fd: c_int, st: *mut libc::stat) -> c_int {
     unsafe { __fxstat(ver, fd, st) }
+}
+
+/// Linux: `__fxstatat64` (versioned LFS64 fstatat) — completes the
+/// versioned stat family's *64 forms (tebako#439: the 0.16.6 linux-gnu
+/// runtime exe imports it; previously the documented gap). Same
+/// delegation rationale as `__xstat64`.
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn __fxstatat64(
+    ver: c_int,
+    dirfd: c_int,
+    path: *const c_char,
+    st: *mut libc::stat,
+    flags: c_int,
+) -> c_int {
+    unsafe { __fxstatat(ver, dirfd, path, st, flags) }
 }
 
 /// Interposed `rewinddir` (roadmap 39): reset a memfs stream to its first

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -14,6 +14,10 @@
 //!   probe, __read_chk fortified read, __fxstat64, anonymous mmap with
 //!   the fd -1 bit-test lie, mmap64 CEN window on a flagged memfs fd —
 //!   spec 22 class E),
+//! - the tebako#439 alias surface (fopen64/openat64/__openat_2/
+//!   __fxstatat64 — the LFS64/fortify/versioned twins of already-covered
+//!   names, incl. OpenSSL 3.6's `openssl_fopen` → `fopen64`): the jail
+//!   gates each alias exactly like its plain-name twin,
 //! - named errors + EX_CONFIG (78) on misformatted env.
 //!
 //! Skip policy (documented in the crate README/spec): tests SKIP (pass
@@ -143,6 +147,7 @@ fn build_fixtures() -> Option<Fixtures> {
         "mmap-probe",
         "close-probe",
         "fork-exec",
+        "alias-probe",
     ] {
         let src = src_dir.join(format!("{name}.c"));
         let out = dir.join("bin").join(name);
@@ -724,6 +729,64 @@ fn at_family_linux_extensions() {
     let r = run(f, "at-probe", &["getdents64-file", &secret], None);
     assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
     assert_eq!(r.stdout.trim(), format!("ERRNO:{}", libc::ENOTDIR));
+}
+
+/// tebako#439 — the LFS64/fortify/versioned ALIAS surface is the same
+/// jail. OpenSSL 3.6's BIO file path binds `fopen64` (crypto/o_fopen.c
+/// defines `_FILE_OFFSET_BITS=64` itself on linux, so `openssl_fopen` —
+/// the `BIO_new_file`/`X509_LOOKUP_load_file` choke point behind ruby's
+/// `X509::Store#add_file` — tail-calls `fopen64@plt`, never `fopen`);
+/// Rust std binds `openat64`, vendored fortify C++ binds `__openat_2`,
+/// and `__fxstatat64` completes the versioned stat family (all four
+/// imported by the 0.16.6 linux-gnu runtime exe). Each alias must serve
+/// the memfs, fail EPERM under a deny jail, and pass an ro grant —
+/// exactly like its plain-name twin.
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_alias_surface_jail_parity() {
+    let Some(f) = fixtures() else { return };
+    let secret = format!("{MOUNT}/data/secret.txt");
+
+    // The alias serves the memfs (fopen64 delegates to the fopen body:
+    // the Vfs answer materializes through dlmap2file like any stdio
+    // read) — and keeps working under a deny jail (spec 08 §3).
+    for jail in [None, Some("deny")] {
+        let r = run(f, "alias-probe", &["fopen64", &secret], jail);
+        assert_eq!(
+            r.rc, 0,
+            "fopen64 memfs, jail {jail:?}, stderr: {}",
+            r.stderr
+        );
+        assert_eq!(r.stdout, SECRET, "fopen64 memfs stdout");
+    }
+
+    // The hole's shape: a denied HOST path through each alias → EPERM.
+    for leg in ["fopen64", "openat64", "__openat_2", "__fxstatat64"] {
+        let r = run(f, "alias-probe", &[leg, "/etc/hosts"], Some("deny"));
+        assert_eq!(
+            r.rc,
+            libc::EPERM,
+            "{leg} of a denied host path must fail EPERM, stderr: {}",
+            r.stderr
+        );
+    }
+
+    // The allowed-path control: an ro grant passes every read alias.
+    let ro_jail = format!("deny;{}:/work:ro", f.work.display());
+    let host = f.work.join("hostfile.txt");
+    let host = host.to_str().unwrap();
+    for leg in ["fopen64", "openat64", "__openat_2"] {
+        let r = run(f, "alias-probe", &[leg, host], Some(&ro_jail));
+        assert_eq!(r.rc, 0, "{leg} under the ro grant, stderr: {}", r.stderr);
+        assert_eq!(r.stdout, "HOST-FILE\n", "{leg} stdout");
+    }
+    let r = run(f, "alias-probe", &["__fxstatat64", host], Some(&ro_jail));
+    assert_eq!(
+        r.rc, 0,
+        "__fxstatat64 under the ro grant, stderr: {}",
+        r.stderr
+    );
+    assert_eq!(r.stdout.trim(), "SIZE:10");
 }
 
 #[test]

--- a/crates/libtfs-preload/tests/fixtures/alias-probe.c
+++ b/crates/libtfs-preload/tests/fixtures/alias-probe.c
@@ -1,0 +1,115 @@
+/* alias-probe: the LFS64/fortify/versioned alias surface (tebako#439) —
+ * the DISTINCT dynamic symbols a consumer binds instead of the plain
+ * names when built with _FILE_OFFSET_BITS=64 / _FORTIFY_SOURCE=2 /
+ * against pre-glibc-2.33 headers:
+ *
+ *   fopen64       — OpenSSL 3.6's openssl_fopen (crypto/o_fopen.c defines
+ *                   _FILE_OFFSET_BITS=64 itself on linux): every
+ *                   BIO_new_file / X509_LOOKUP_load_file (ruby's
+ *                   X509::Store#add_file/set_default_paths) binds this,
+ *                   never fopen. Also FLAC's *_init_file and libstdc++'s
+ *                   __basic_file::open.
+ *   openat64      — Rust std's openat spelling (the runtime's own
+ *                   dir-walk), any LFS64 C caller of openat.
+ *   __openat_2    — the _FORTIFY_SOURCE=2 three-arg openat (vendored
+ *                   C++ in the runtime exe binds it).
+ *   __fxstatat64  — the versioned LFS64 fstatat entry.
+ *
+ * All four are imported by the 0.16.6 linux-gnu-arm64 runtime exe (nm
+ * -D proof in the issue). The legs name the symbols EXPLICITLY (the
+ * at-probe __xstat idiom) so the probe pins exactly the alias,
+ * independent of the build's macro/redirect whims — a redirect that
+ * silently fell back to the plain (already interposed) name would make
+ * the deny assertions false-green.
+ *
+ * Each command cats the file to stdout (or prints SIZE for the stat
+ * leg) and exits 0; on failure it prints "<op>: <strerror>" to stderr
+ * and exits with the errno (EPERM=1, ...). Linux/glibc only. */
+#ifdef __linux__
+#define _GNU_SOURCE /* struct stat64, fopen64/openat64 declarations */
+#endif
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+static int fail(const char *what, const char *path, int e) {
+    dprintf(2, "%s %s: %s\n", what, path, strerror(e));
+    return e;
+}
+
+static int cat_fd(int fd) {
+    char buf[4096];
+    ssize_t n;
+    while ((n = read(fd, buf, sizeof buf)) > 0)
+        write(1, buf, (size_t)n);
+    close(fd);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+#ifdef __linux__
+    if (argc != 3) {
+        dprintf(2, "usage: alias-probe <cmd> <path>\n");
+        return 64;
+    }
+    const char *cmd = argv[1];
+    const char *path = argv[2];
+
+    if (strcmp(cmd, "fopen64") == 0) {
+        FILE *f = fopen64(path, "r");
+        if (!f)
+            return fail("fopen64", path, errno);
+        char buf[4096];
+        size_t n;
+        while ((n = fread(buf, 1, sizeof buf, f)) > 0)
+            write(1, buf, n);
+        fclose(f);
+        return 0;
+    }
+    if (strcmp(cmd, "openat64") == 0) {
+        int fd = openat64(AT_FDCWD, path, O_RDONLY);
+        if (fd < 0)
+            return fail("openat64", path, errno);
+        return cat_fd(fd);
+    }
+    if (strcmp(cmd, "__openat_2") == 0) {
+        /* glibc's fortified three-arg openat (bits/fcntl2.h): the mode
+         * check is compile-time, the runtime symbol takes no mode. */
+        extern int __openat_2(int dirfd, const char *path, int flags);
+        int fd = __openat_2(AT_FDCWD, path, O_RDONLY);
+        if (fd < 0)
+            return fail("__openat_2", path, errno);
+        return cat_fd(fd);
+    }
+    if (strcmp(cmd, "__fxstatat64") == 0) {
+        /* stat/stat64 are distinct C types on aarch64 (layout-identical);
+         * the probe names the wrapper's own type (the at-probe fstatat64
+         * idiom). The version argument is glibc-INTERNAL (no public
+         * macro): 1 on x86_64 (_STAT_VER_LINUX), 0 on the 64-bit new
+         * ports — aarch64 proven twice: the 0.16.6 runtime's own
+         * fstatat64 wrapper passes 0 to __fxstatat64, and 1 EINVALs on
+         * aarch64 glibc 2.41. */
+        extern int __fxstatat64(int ver, int dirfd, const char *path,
+                                struct stat64 *st, int flags);
+#if defined(__x86_64__)
+        const int ver = 1;
+#else
+        const int ver = 0;
+#endif
+        struct stat64 st64;
+        if (__fxstatat64(ver, AT_FDCWD, path, &st64, 0) < 0)
+            return fail("__fxstatat64", path, errno);
+        dprintf(1, "SIZE:%lld\n", (long long)st64.st_size);
+        return 0;
+    }
+    dprintf(2, "alias-probe: unknown command %s\n", cmd);
+    return 64;
+#else
+    (void)argc; (void)argv;
+    dprintf(2, "alias-probe: linux/glibc only\n");
+    return 64;
+#endif
+}

--- a/docs/spec/08-jails.md
+++ b/docs/spec/08-jails.md
@@ -206,6 +206,24 @@ interposition point) and any process that escapes the shim — stated
 honestly in the manifest and docs. OS-level network confinement
 (seatbelt/seccomp/WFP) is a possible later layer, never claimed today.
 
+The shim's coverage is SYMBOL-level (tebako#439): a jail holds only for
+the libc entry points the shim interposes — the named list in
+`crates/libtfs-preload` (lib.rs "Interposed surface"), which includes
+the LFS64/fortify/versioned twins (`open64`/`openat64`/`fopen64`,
+`__read_chk`/`__openat_2`, the `__xstat` family through `__fxstatat64`)
+because glibc hands `_FILE_OFFSET_BITS=64`/`_FORTIFY_SOURCE`/pre-2.33
+callers DISTINCT symbols that never touch the plain names (the #439
+hole: OpenSSL's `o_fopen.c` defines `_FILE_OFFSET_BITS=64` itself, so
+every `BIO_new_file`/`X509_LOOKUP_load_file` bound `fopen64` straight to
+libc). Known-uncovered at this layer: the remaining fortify open family
+(`__open_2`/`__open64_2`/`__openat64_2` — no importer observed in the
+0.16.6 linux-gnu runtime) and raw `syscall(2)` IO. Separately, the
+runtime EXE's own statically-linked native libraries are gated only for
+symbols the exe itself defines (spec 22 §2: `dlopen`/`dlerror` today —
+defining the file-IO family in the exe is follow-up wiring in the
+runtime factory, tebako-runtime-ruby); an
+interpreter's patched IO and preload-delivered children are covered.
+
 ## 6. Executor-layer trust (locked 2026-07-27)
 
 Tebako is the EXECUTOR of everything it runs — the parent that spawns


### PR DESCRIPTION
## Summary

Refs #439. Under a bound `TEBAKO_JAIL=deny`, ruby `File.binread("/etc/ssl/cert.pem")` fails `EPERM` (the patched interpreter IO routes through the engine's `host_policy`), but `OpenSSL::X509::Store#add_file("/etc/ssl/cert.pem")` **loaded the host file anyway**. This PR closes the coverage hole at the interpose layer and documents the remaining boundary precisely.

## Diagnosis — the exact missing surface

The 0.16.6 linux-gnu-arm64 runtime exe statically links ruby + the openssl gem + libssl/libcrypto (LD_DEBUG shows no `openssl.so`/`libcrypto.so` loads; only `libc/libdl/libm/libpthread`). Its dynamic imports therefore ARE every native library's libc surface. Symbol-level evidence (all against the shipped exe):

- **OpenSSL 3.6.0's BIO file path binds `fopen64`, never `fopen`.** `crypto/o_fopen.c` defines `_FILE_OFFSET_BITS 64` *itself* on `__linux` before including stdio.h — the comment says verbatim "Following definition aliases fopen to fopen64" — so `openssl_fopen()` compiles to a tail-call of `fopen64@plt` (disassembly: `openssl_fopen: cbz x0,…; b 0xe20d20 <fopen64@plt>`). The full chain is proven in the binary: `X509_load_cert_file_ex` (= `Store#add_file`) → `BIO_s_file`/`BIO_ctrl(BIO_C_SET_FILENAME)` → bss_file's `file_ctrl` → `openssl_fopen` → `fopen64@plt`; `BIO_new_file` → `openssl_fopen` likewise. The shim interposed `fopen` — a symbol libcrypto never calls on linux.
- The same uninterposed-alias class, all proven imported by the same exe (`llvm-readobj --dyn-symbols`): **`openat64`** (call sites: Rust std `remove_dir_all_recursive`/`Dir::open_file` — the exe's own Rust side), **`__openat_2`** (fortified 3-arg `openat`; vendored C++ — the `__read_chk` precedent exactly), **`__fxstatat64`** (the versioned LFS64 fstatat — the crate's own previously *documented* gap; the exe's vendored `fstatat64` wrapper tail-calls it with `_STAT_VER`=0).
- `fopen64` is also bound by the exe's vendored **FLAC** (`*_init_file`) and **libstdc++** (`__basic_file::open`, i.e. every C++ `ifstream`) — any C/C++ static archive built with `_FILE_OFFSET_BITS=64` lands here, not just OpenSSL.

## Fix

Four new linux shims in `crates/libtfs-preload/src/sys/mod.rs`, each a one-line delegation to its already-interposed plain-name body (the `open64`/`__xstat64` precedent — same layouts, same routing, the same `host_policy` gate):

- `fopen64` → the `fopen` body (read modes: memfs materialization via `dlmap2file`; denied host path → `EPERM`; write modes keep the existing passthrough behavior).
- `openat64` → the `openat` body.
- `__openat_2` → the `openat` body (the fortify contract rejects `O_CREAT`/`O_TMPFILE` at compile time, so no mode argument exists).
- `__fxstatat64` → the `__fxstatat` body.

No new `real_*` resolvers: delegation means the passthrough keeps using the plain symbols, which exist on every glibc (and the musl build is unaffected — these are exported but never called/resolved there, exactly like the existing `__xstat` family).

## Tests

`tests/fixtures/alias-probe.c` (new): pins each of the four symbols by **explicit extern** (the at-probe `__xstat` idiom) so the probe cannot false-green through a compiler redirect to an already-covered name; `__fxstatat64`'s version argument is arch-correct (`_STAT_VER` is glibc-internal: 1 on x86_64, 0 on aarch64 — both proven).

`tests/e2e.rs::linux_alias_surface_jail_parity` (new, linux-only): for each alias — memfs service (incl. under `deny`, spec 08 §3), `EPERM` on a denied host path, and the allowed-path control under an `ro` grant.

## Docs (the issue's floor)

- `crates/libtfs-preload/src/lib.rs` + `src/sys/linux.rs`: surface lists updated; the stale "LFS `__xstat64` family not interposed" claim removed (they have been interposed since roadmap 39 — only `__fxstatat64` remained, now covered); the remaining honest gaps named: the rest of the fortify open family (`__open_2`/`__open64_2`/`__openat64_2` — no importer observed in the 0.16.6 linux-gnu runtime), `readv`/`preadv`/`sendfile`/`copy_file_range`, write-side `pwrite64`/`ftruncate64`/`statvfs64` on memfs fds.
- `docs/spec/08-jails.md` §5: the jail's coverage is now stated as **symbol-level**, with the #439 lesson and the two structural boundaries: raw `syscall(2)` IO, and **the runtime exe's own statically-linked native libraries** (see below).

## Boundary / follow-up (out of scope here, with evidence)

This PR makes the coverage *exist* in the preload shim (the LD_PRELOAD delivery, spec 07 §8 tier 1 — and the symbol set the runtime exe would export). The **runtime exe itself** is a separate wiring question (tebako-runtime-ruby / spec 22): today the exe defines only Class-L `dlopen`/`dlerror`, and spec 22's Class-E table says the runtime is *never* preload-injected. Verified empirically: `LD_PRELOAD`-ing the shipped 0.16.6 `libtfs_preload.so` into the runtime exe wedges boot at an early interposed open (with or without a jail) — self-injection is not a supported shape. Closing the observed `add_file` hole end-to-end for the exe shape needs the exe to *define* the file-IO interpose family (the Class-L pattern); this PR's coverage is the prerequisite, and issue #439 stays open for that wiring.

## Verification

- [x] `cargo build -p libtfs-preload` (macOS arm64, debug) — clean.
- [x] `cargo test -p libtfs-preload` — 24/24 green (6 unit + 18 e2e; the new test is linux-gated, compiles out on macOS; the new fixture compiles on macOS via its stub); re-run after `cargo fmt`.
- [x] `cargo clippy -p libtfs-preload --all-targets` — clean. `cargo fmt --check` — clean.
- [x] Repro harness (`tebako-packages/metanorma` `tools/tls-repro`, ubuntu:24.04 arm64): baseline reproduced — `File.binread` → `EPERM`, `Store#add_file` → `OK` under `TEBAKO_JAIL=deny`.
- [x] Fixture symbol pin (linux container): the compiled `alias-probe` imports exactly `fopen64`, `openat64`, `__openat_2`, `__fxstatat64`.
- [x] Linux behavioral run (docker `rust:1.94.1-trixie` linux/arm64, this branch's `libtfs_preload.so` vs the shim extracted from the shipped 0.16.6 env image) — **16/16 legs green**:
  - new shim exports all four aliases; shipped shim exports none (negative control);
  - under `TEBAKO_JAIL=deny`, all four alias calls against `/etc/hosts` → `EPERM` on the new shim, **succeed** on the shipped shim (the hole, live);
  - `fopen64` serves a memfs path with and without the jail (no VFS regression);
  - under `TEBAKO_JAIL="/etc/hosts:ro"`, all four read the host file fine (allowed control).
- [ ] CI ubuntu-24.04 leg runs the new e2e on x86_64.
