### PR TITLE
release: v0.2.2 — version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "tests/contract"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"


### PR DESCRIPTION
## release: v0.2.2 — version bump

One-line workspace version bump (`0.2.1` → `0.2.2`) ahead of the v0.2.2 tag. Ships on top of the landed fix trio:

- **#437 / #441** — the driver exports `SSL_CERT_FILE` from the materialized cert bundle (driver-owned; the shim-side fallback is gone).
- **#438 / #442** — the trace op-matrix pairs inside/outside rows on `(pid, tid)`; the parity flake is dead.
- **#439 / #443** — libtfs-preload interposes the LFS64/fortify alias surface (`fopen64`, `openat64`, `__openat_2`, `__fxstatat64`): OpenSSL 3.6's `o_fopen.c` self-defines `_FILE_OFFSET_BITS=64`, so every BIO file path bound `fopen64` — which the shipped shim never interposed — and libcrypto host reads bypassed `TEBAKO_JAIL=deny`. Proven live against the shipped 0.16.6 shim; fixed and e2e-pinned (`linux_alias_surface_jail_parity`).

Known follow-ups tracked in issues (not release blockers): #440 (registry single-abi on multi-platform entries — latent), #444 (pre-existing fopen write/append/update-mode gate gap), tamatebako/tebako-runtime-ruby#126 (runtime-exe must define the file-IO interpose family; spec 22 Class-E).

## Test plan

- [x] Fix trio each landed with the full 17-leg matrix green (unit + e2e + dogfood + CodeQL + parity)
- [x] #443's docker 16-leg behavioral proof vs the shipped 0.16.6 shim (EPERM on denied paths where the shipped shim succeeded)
- [ ] This PR: CI green on the version bump; tag + release workflow after merge
