### PR TITLE
chore: limnifs 0.2.57 → 0.2.61 — omnizip 0.16.92 absorbed

### DIFF
--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -41,7 +41,7 @@ serde_yml = "0.0.12"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
 # — pure Rust, no `limni` binary anywhere.
-limnifs-write = "0.2.57"
+limnifs-write = "0.2.61"
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -34,7 +34,7 @@ serde_yaml = "0.9"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
 # §6) — pure Rust, no `limni` binary anywhere.
-limnifs-write = "0.2.57"
+limnifs-write = "0.2.61"
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is
@@ -64,4 +64,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # The floor-recipe structural test parses the emitted metadata through
 # the reader (spec 20 §5 constraint 1: no SharedInline handle anywhere)
 # — test-only, never linked into the shipped binary.
-limnifs-core = "0.2.57"
+limnifs-core = "0.2.61"

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -54,7 +54,7 @@ sqfs-sys = { version = "0.2.1", path = "../sqfs-sys", optional = true }
 # §5's floor recipe is lz4-only (metadata lz4-hc, content lz4-or-store),
 # and the 0.2.54 writer self-check refuses to emit un-decodable zstd
 # frames regardless.
-limnifs-core = { version = "0.2.57", optional = true }
+limnifs-core = { version = "0.2.61", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext


### PR DESCRIPTION
## chore: limnifs 0.2.57 → 0.2.61

Bumps the crates.io pins for the LimniFS backend: `limnifs-core` (the tfs reader) and `limnifs-write` (the `press`/`mkimage` writer).

v0.2.61 absorbs **omnizip 0.16.92**: the LZMA2 100 MB scale fixes (chunk bisect + raw-store tails, the no-EOPM chunk mode, the range-coder conditional tail byte, the xz Index/Footer field fixes) and the zstd high-level ratio fixes (minMatch floor + the RLE-literals writer). Upstream: 662 tests green; xz/zstd conformance canaries 6/6 byte-exact against the system CLIs; LZMA parity within ~1% of `xz -6` on size and faster at 100 MB.

Pure version-string change — no API drift in the 0.2.x line (each prior bump rode green CI unchanged). Cargo.lock stays gitignored per workspace convention.

## Test plan

- [ ] CI green (full matrix incl. the limnifs backend legs and dogfood)
