### PR TITLE
chore: default runtime line 0.16.3 -> 0.16.9

### DIFF
--- a/crates/tebako-resolve/src/lib.rs
+++ b/crates/tebako-resolve/src/lib.rs
@@ -55,8 +55,18 @@ pub use transport::{HttpTransport, Transport};
 /// layout and are NOT served (no old contract, no compat readers). From
 /// 0.16.3 the runtimes carry the union-aware driver (the L2 `mounts:`
 /// block the press writes, spec 03 §6) and the io.c zero-copy guard
-/// (the linux deploy fix).
-pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.3";
+/// (the linux deploy fix). From 0.16.7 the runtimes link the v0.2.2
+/// driver unit (#433/#441/#443: the preload openssl BIO IO cover, the
+/// gnu link-unit floor, the LFS64/fortify alias surface) on ruby source
+/// v0.2.27, with the driver-owned SSL_CERT_FILE and the CRL_CHECK_ALL
+/// removal (the tebako#437 TLS family) — verified end-to-end by the
+/// factory's per-leg https_handshake boot smoke. From 0.16.9 the
+/// runtimes link the v0.2.4 driver unit (#448/#449/#451: neither the
+/// preload interpose dylib nor the driver's micro dylib reaches a
+/// child process — dyld's arm64e insertion termination can no longer
+/// kill runtime-spawned children; the 0.16.7/0.16.8 native-ext press
+/// regression).
+pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.9";
 
 /// Fetch `reference` (pin-verified at the fetch boundary) and install it
 /// as `payloads/<name>/<version>.tfs` — or return the existing entry.


### PR DESCRIPTION
## What

Bumps `DEFAULT_TEBAKO_VERSION` (the runtime line the loader resolves when nothing pins one) from 0.16.3 to **0.16.9**, with the doc comment carried forward.

## Why 0.16.9

The 0.16.9 catalog links the **v0.2.4 driver unit** — the complete tebako#448 fix:

- **#449** (v0.2.3 unit, 0.16.8 line): the preload interpose dylib strips `DYLD_INSERT_LIBRARIES` for exec targets it cannot load (arm64e) — the preload half.
- **#451** (v0.2.4 unit, this line): the driver scrubs its **micro interpose dylib** and the sentinel from the child-facing env at boot — the propagation half, and the actual root cause of the macos-14 native-ext press failures seen on this PR's earlier heads (bundler's extconf spawns the `o/p/ruby` shim *script*; its interpreter is a fat x86_64+arm64e `/bin/sh`, which dyld terminates over the inherited arm64-only insertion).

On top of the 0.16.7 line's cargo: #433/#441/#443 (preload openssl BIO IO cover, gnu link-unit floor, LFS64/fortify alias surface), the tebako#437 TLS family (driver-owned `SSL_CERT_FILE`, CRL_CHECK_ALL removal), on ruby source v0.2.27 — all verified end-to-end by the factory's per-leg https_handshake boot smoke.

## Gate

The macos-14 `native_ext_press_builds_and_packages` e2e — the exact leg that was red on the 0.16.7 and 0.16.8 lines — must go green here. That is the acceptance for this bump.
