### PR TITLE
fix(preload): strip DYLD_INSERT_LIBRARIES for exec targets our dylib cannot load (arm64e) — #448

### DIFF
--- a/crates/libtfs-preload/src/lib.rs
+++ b/crates/libtfs-preload/src/lib.rs
@@ -66,7 +66,11 @@
 //!   binary is NOT policy-gated (it is not an IO route in the policy's op
 //!   classes — the child's own IO stays jailed via env propagation).
 //!   Platform binaries under SIP (macOS) strip `DYLD_*` — they leave the
-//!   VFS, as does any statically linked child.
+//!   VFS, as does any statically linked child. A macOS exec/spawn target
+//!   whose Mach-O cannot load this (per-arch) dylib — an arm64e slice
+//!   dyld would prefer, or no host-arch slice at all — gets a rebuilt
+//!   env WITHOUT `DYLD_INSERT_LIBRARIES` for that one exec (tebako#448):
+//!   dyld TERMINATES a child over an incompatible insertion otherwise.
 //! - A mount at `/` is legitimate (the app payload mounts there, spec
 //!   17): covered-but-not-held paths fall through to the host with the
 //!   policy gate consulted, exactly like any other mount. Non-UTF-8 paths

--- a/crates/libtfs-preload/src/sys/macho_arch.rs
+++ b/crates/libtfs-preload/src/sys/macho_arch.rs
@@ -1,0 +1,575 @@
+//! macOS: the arm64e exec guard (tebako#448).
+//!
+//! The interpose dylib is built per host architecture (arm64-only on
+//! Apple Silicon). When a virtualized process execs a target whose Mach-O
+//! slice dyld will SELECT is a different ABI — an arm64e slice (dyld
+//! prefers arm64e over arm64 when both exist), or a binary with no
+//! host-arch slice at all (x86_64-only under Rosetta) — dyld tries to
+//! load the inherited `DYLD_INSERT_LIBRARIES` entry into the child, finds
+//! no compatible slice in it, and TERMINATES the child:
+//!
+//! ```text
+//! dyld[…]: terminating because inserted dylib '…/libtfs_preload.dylib'
+//! could not be loaded: … (mach-o file, but is an incompatible
+//! architecture (have 'arm64', need 'arm64e'))
+//! ```
+//!
+//! SIP-protected platform binaries strip `DYLD_*` silently and were never
+//! affected; the dying children are third-party arm64e binaries (the
+//! macos-14 CI toolchain — the 0.16.7 `native_ext_press_builds_and_
+//! packages` leg). Before the fork/exec propagation fix the insertion
+//! never crossed exec, so this is a shipped regression on that line.
+//!
+//! The guard: the interposed execve/posix_spawn/posix_spawnp probe the
+//! target's Mach-O header (one open+read of the first page through the
+//! REAL libc — the probe must not re-enter the engine through the
+//! interposed open, and the loader's exec mechanics are not a policy op)
+//! and, when the slice table says this dylib cannot load, forward a
+//! rebuilt envp with `DYLD_INSERT_LIBRARIES` REMOVED for that one exec.
+//! Scripts and unreadable/non-Mach-O targets keep insertion — today's
+//! behavior; the shebang interpreter's own arch decides there.
+
+use std::ffi::{c_char, CStr, CString};
+
+/// The environment variable the guard strips.
+const INSERT_VAR: &[u8] = b"DYLD_INSERT_LIBRARIES";
+
+/// The CPU types the decision knows (mach/machine.h).
+const CPU_TYPE_X86_64: u32 = 0x0100_0007;
+const CPU_TYPE_ARM64: u32 = 0x0100_000c;
+
+/// One Mach-O slice's identity — a (cputype, cpusubtype) pair from the
+/// mach_header_64 or a fat_arch entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Slice {
+    cputype: u32,
+    cpusubtype: u32,
+}
+
+/// The host architecture the decision is compiled for — the interpose
+/// dylib's own (only) slice.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HostArch {
+    X86_64,
+    Arm64,
+}
+
+/// This build's host arch.
+pub(crate) const HOST_ARCH: HostArch = if cfg!(target_arch = "aarch64") {
+    HostArch::Arm64
+} else {
+    HostArch::X86_64
+};
+
+/// An arm64e slice: CPU_SUBTYPE_ARM64E (2) with the 0x8000_0000
+/// capability bit (what Xcode's `-arch arm64e` emits: 0x8000_0002).
+fn is_arm64e(cpusubtype: u32) -> bool {
+    (cpusubtype & 0x00ff_ffff) == 2 && (cpusubtype & 0x8000_0000) != 0
+}
+
+/// May this dylib load into a process running one of `slices`? dyld
+/// selects the best slice for the host: on Apple Silicon that is arm64e
+/// when the table offers it (preferred over arm64), else arm64, else an
+/// x86_64 slice under Rosetta; on Intel, x86_64. The dylib loads iff the
+/// SELECTED slice is its own ABI — so on arm64 hosts an offered arm64e
+/// slice is fatal even when an arm64 slice rides alongside.
+pub(crate) fn dylib_loadable(host: HostArch, slices: &[Slice]) -> bool {
+    match host {
+        HostArch::Arm64 => {
+            let arm64e = slices
+                .iter()
+                .any(|s| s.cputype == CPU_TYPE_ARM64 && is_arm64e(s.cpusubtype));
+            let arm64 = slices
+                .iter()
+                .any(|s| s.cputype == CPU_TYPE_ARM64 && !is_arm64e(s.cpusubtype));
+            !arm64e && arm64
+        }
+        HostArch::X86_64 => slices.iter().any(|s| s.cputype == CPU_TYPE_X86_64),
+    }
+}
+
+// ---------------------------------------------------------------------
+// The Mach-O header parse (pure bytes; unit-tested below)
+// ---------------------------------------------------------------------
+
+fn u32_at(buf: &[u8], off: usize, be: bool) -> Option<u32> {
+    let b: [u8; 4] = buf.get(off..off + 4)?.try_into().ok()?;
+    Some(if be {
+        u32::from_be_bytes(b)
+    } else {
+        u32::from_le_bytes(b)
+    })
+}
+
+/// Parse the slice table of the Mach-O file whose header page is `buf`:
+/// thin 64-bit Mach-O (either endianness) or fat (either endianness;
+/// the fat_arch table itself carries the per-slice types — the slice
+/// sub-headers are never sought). None = not a Mach-O / truncated /
+/// implausible — the caller keeps insertion (today's behavior).
+pub(crate) fn parse_slices(buf: &[u8]) -> Option<Vec<Slice>> {
+    match buf.get(..4)? {
+        // MH_MAGIC_64 / MH_CIGAM_64 as raw byte patterns (no integer
+        // endianness confusion: the pattern selects the field order).
+        [0xcf, 0xfa, 0xed, 0xfe] => parse_thin(buf, false),
+        [0xfe, 0xed, 0xfa, 0xcf] => parse_thin(buf, true),
+        // FAT_MAGIC / FAT_CIGAM.
+        [0xca, 0xfe, 0xba, 0xbe] => parse_fat(buf, true),
+        [0xbe, 0xba, 0xfe, 0xca] => parse_fat(buf, false),
+        _ => None,
+    }
+}
+
+fn parse_thin(buf: &[u8], be: bool) -> Option<Vec<Slice>> {
+    Some(vec![Slice {
+        cputype: u32_at(buf, 4, be)?,
+        cpusubtype: u32_at(buf, 8, be)?,
+    }])
+}
+
+fn parse_fat(buf: &[u8], be: bool) -> Option<Vec<Slice>> {
+    let nfat = u32_at(buf, 4, be)? as usize;
+    // The whole table must fit in the probed page (a garbage nfat just
+    // fails here → not-a-parse → keep insertion).
+    let mut out = Vec::with_capacity(nfat.min(16));
+    for i in 0..nfat {
+        let off = 8 + i * 20; // sizeof(struct fat_arch)
+        out.push(Slice {
+            cputype: u32_at(buf, off, be)?,
+            cpusubtype: u32_at(buf, off + 4, be)?,
+        });
+    }
+    Some(out)
+}
+
+/// Read one exec target's slice table: the first page carries every
+/// realistic header (thin or fat). Real-libc IO ONLY (`plat::real_*`,
+/// never the interposed symbols): the probe must not re-enter the engine,
+/// and a host exec is not a jail-gated IO route, so the jail must not
+/// gate it either.
+pub(crate) fn probe_slices(path: &str) -> Option<Vec<Slice>> {
+    let c = CString::new(path).ok()?;
+    // SAFETY: plain libc through the interpose tuple's original; `c` is
+    // NUL-terminated and outlives the call.
+    let fd = unsafe { super::plat::real_open()(c.as_ptr(), libc::O_RDONLY) };
+    if fd < 0 {
+        return None;
+    }
+    let mut buf = [0u8; 4096];
+    // SAFETY: fd is open; buf is writable for its length.
+    let n = unsafe { super::plat::real_read()(fd, buf.as_mut_ptr().cast(), buf.len()) };
+    // SAFETY: plain libc; fd is ours.
+    unsafe { super::plat::real_close()(fd) };
+    if n < 0 {
+        return None;
+    }
+    parse_slices(&buf[..n as usize])
+}
+
+// ---------------------------------------------------------------------
+// The envp rebuild (the strip) + spawnp PATH resolution
+// ---------------------------------------------------------------------
+
+/// The rebuilt environment for one exec/spawn call: every entry except
+/// `DYLD_INSERT_LIBRARIES` (REMOVED, not emptied). Owns its bytes; the
+/// caller binds it to a local that outlives the real call (execve never
+/// returns on success — the kernel reclaims the address space;
+/// posix_spawn copies the envp before it returns, so the drop after the
+/// call is correct there).
+pub(crate) struct StrippedEnv {
+    /// Held for lifetime only — the pointer vector indexes these bytes.
+    _strings: Vec<CString>,
+    /// The NULL-terminated envp vector to forward.
+    ptrs: Vec<*mut c_char>,
+}
+
+impl StrippedEnv {
+    pub(crate) fn as_envp(&self) -> *const *mut c_char {
+        self.ptrs.as_ptr()
+    }
+}
+
+/// Walk envp's entries. `None` for a NULL envp (execve's empty-env form —
+/// nothing to strip, nothing to probe for).
+unsafe fn for_each_env(envp: *const *mut c_char, mut f: impl FnMut(&CStr)) {
+    if envp.is_null() {
+        return;
+    }
+    let mut cur = envp;
+    // SAFETY: envp is the intercepted call's envp — a NULL-terminated
+    // vector of NUL-terminated strings, per the call contract.
+    while !(unsafe { *cur }).is_null() {
+        // SAFETY: per the contract above.
+        f(unsafe { CStr::from_ptr(*cur) });
+        // SAFETY: advancing within the vector; the NULL slot ends the loop.
+        cur = unsafe { cur.add(1) };
+    }
+}
+
+/// An env entry's name (the bytes before the first `=`).
+fn entry_name(entry: &[u8]) -> &[u8] {
+    match entry.iter().position(|&b| b == b'=') {
+        Some(i) => &entry[..i],
+        None => entry,
+    }
+}
+
+/// Does envp carry the insertion variable? The cheap pre-check — every
+/// gate consults this FIRST so a process exec'ing without insertion (the
+/// common case) pays no filesystem IO at all.
+unsafe fn envp_has_insert(envp: *const *mut c_char) -> bool {
+    let mut found = false;
+    unsafe { for_each_env(envp, |e| found |= entry_name(e.to_bytes()) == INSERT_VAR) };
+    found
+}
+
+/// Build the stripped environment. None when envp is NULL or carries no
+/// insertion variable (nothing to do — forward verbatim).
+unsafe fn strip_insert(envp: *const *mut c_char) -> Option<StrippedEnv> {
+    if envp.is_null() {
+        return None;
+    }
+    let mut strings: Vec<CString> = Vec::new();
+    let mut stripped = false;
+    unsafe {
+        for_each_env(envp, |e| {
+            if entry_name(e.to_bytes()) == INSERT_VAR {
+                stripped = true;
+            } else {
+                strings.push(e.to_owned());
+            }
+        })
+    };
+    if !stripped {
+        return None;
+    }
+    let mut ptrs: Vec<*mut c_char> = strings.iter().map(|s| s.as_ptr().cast_mut()).collect();
+    ptrs.push(std::ptr::null_mut());
+    Some(StrippedEnv {
+        _strings: strings,
+        ptrs,
+    })
+}
+
+/// envp's PATH value (None when the vector carries none — execvp's
+/// default-path fallback is not replicated: an unresolvable name passes
+/// through unchanged).
+unsafe fn envp_path(envp: *const *mut c_char) -> Option<String> {
+    let mut found = None;
+    unsafe {
+        for_each_env(envp, |e| {
+            if found.is_none() {
+                if let Some(rest) = e.to_bytes().strip_prefix(b"PATH=") {
+                    found = Some(String::from_utf8_lossy(rest).into_owned());
+                }
+            }
+        })
+    };
+    found
+}
+
+/// posix_spawnp/execvp bare-name resolution for the PROBE: walk envp's
+/// PATH, first readable hit wins (an empty component is the cwd, per
+/// execvp tradition). Unresolvable → None: the caller passes through
+/// unchanged (the real spawnp's own search answers for the exec).
+unsafe fn resolve_on_path(name: &str, envp: *const *mut c_char) -> Option<String> {
+    let path = unsafe { envp_path(envp) }?;
+    for dir in path.split(':') {
+        let candidate = if dir.is_empty() {
+            name.to_owned()
+        } else {
+            format!("{dir}/{name}")
+        };
+        let Ok(c) = CString::new(candidate.as_str()) else {
+            continue;
+        };
+        // SAFETY: plain libc through the tuple's original; `c` outlives
+        // the call. Readable = opens O_RDONLY (the probe only reads).
+        let fd = unsafe { super::plat::real_open()(c.as_ptr(), libc::O_RDONLY) };
+        if fd >= 0 {
+            // SAFETY: plain libc; fd is ours.
+            unsafe { super::plat::real_close()(fd) };
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------
+// The gates (the shim call sites' entry points)
+// ---------------------------------------------------------------------
+
+/// The strip decision for an exec/spawn of the explicit host path
+/// `target` (the materialized copy for a memfs route, the original path
+/// otherwise): Some(stripped envp) when insertion must not reach this
+/// target, None to forward envp verbatim.
+pub(crate) unsafe fn strip_for_path_target(
+    target: &str,
+    envp: *const *mut c_char,
+) -> Option<StrippedEnv> {
+    if !unsafe { envp_has_insert(envp) } {
+        return None;
+    }
+    let slices = probe_slices(target)?;
+    if dylib_loadable(HOST_ARCH, &slices) {
+        return None;
+    }
+    note_strip(target);
+    unsafe { strip_insert(envp) }
+}
+
+/// The strip decision for a posix_spawnp target that may be a bare name:
+/// bare names resolve through the caller's PATH first (first readable
+/// hit); unresolvable → None (passthrough, today's behavior).
+pub(crate) unsafe fn strip_for_spawnp_target(
+    file: &str,
+    envp: *const *mut c_char,
+) -> Option<StrippedEnv> {
+    if file.contains('/') {
+        return unsafe { strip_for_path_target(file, envp) };
+    }
+    if !unsafe { envp_has_insert(envp) } {
+        return None;
+    }
+    let resolved = unsafe { resolve_on_path(file, envp) }?;
+    let slices = probe_slices(&resolved)?;
+    if dylib_loadable(HOST_ARCH, &slices) {
+        return None;
+    }
+    note_strip(&resolved);
+    unsafe { strip_insert(envp) }
+}
+
+/// The strip note, on the crate's existing debug channel
+/// (`TEBAKO_DEBUG_TFS` — the same flag the open/openat shims use).
+fn note_strip(target: &str) {
+    if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+        eprintln!(
+            "[preload] strip DYLD_INSERT_LIBRARIES for exec of {target}: \
+             no loadable slice for this dylib (tebako#448)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ARM64: u32 = CPU_TYPE_ARM64;
+    const ARM64E: u32 = 0x8000_0002;
+    const X86_64: u32 = CPU_TYPE_X86_64;
+
+    /// A thin 64-bit Mach-O header page (little-endian MH_MAGIC_64).
+    fn thin(cputype: u32, cpusubtype: u32) -> Vec<u8> {
+        let mut b = vec![0u8; 64];
+        b[0..4].copy_from_slice(&0xfeedfacfu32.to_le_bytes());
+        b[4..8].copy_from_slice(&cputype.to_le_bytes());
+        b[8..12].copy_from_slice(&cpusubtype.to_le_bytes());
+        b
+    }
+
+    /// A thin 64-bit Mach-O header, big-endian (MH_CIGAM_64).
+    fn thin_be(cputype: u32, cpusubtype: u32) -> Vec<u8> {
+        let mut b = vec![0u8; 64];
+        b[0..4].copy_from_slice(&0xfeedfacfu32.to_be_bytes());
+        b[4..8].copy_from_slice(&cputype.to_be_bytes());
+        b[8..12].copy_from_slice(&cpusubtype.to_be_bytes());
+        b
+    }
+
+    /// A fat header page holding the given slice table (big-endian
+    /// FAT_MAGIC, the spelling every universal binary uses).
+    fn fat(entries: &[(u32, u32)]) -> Vec<u8> {
+        let mut b = vec![0u8; 8 + entries.len() * 20];
+        b[0..4].copy_from_slice(&0xcafebabeu32.to_be_bytes());
+        b[4..8].copy_from_slice(&(entries.len() as u32).to_be_bytes());
+        for (i, &(cpu, sub)) in entries.iter().enumerate() {
+            let off = 8 + i * 20;
+            b[off..off + 4].copy_from_slice(&cpu.to_be_bytes());
+            b[off + 4..off + 8].copy_from_slice(&sub.to_be_bytes());
+        }
+        b
+    }
+
+    /// A fat header, little-endian (FAT_CIGAM — the rare spelling).
+    fn fat_le(entries: &[(u32, u32)]) -> Vec<u8> {
+        let mut b = vec![0u8; 8 + entries.len() * 20];
+        b[0..4].copy_from_slice(&0xcafebabeu32.to_le_bytes());
+        b[4..8].copy_from_slice(&(entries.len() as u32).to_le_bytes());
+        for (i, &(cpu, sub)) in entries.iter().enumerate() {
+            let off = 8 + i * 20;
+            b[off..off + 4].copy_from_slice(&cpu.to_le_bytes());
+            b[off + 4..off + 8].copy_from_slice(&sub.to_le_bytes());
+        }
+        b
+    }
+
+    #[test]
+    fn parses_thin_arm64() {
+        let s = parse_slices(&thin(ARM64, 0)).expect("thin arm64 parses");
+        assert_eq!(
+            s,
+            [Slice {
+                cputype: ARM64,
+                cpusubtype: 0
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_thin_arm64e() {
+        let s = parse_slices(&thin(ARM64, ARM64E)).expect("thin arm64e parses");
+        assert!(is_arm64e(s[0].cpusubtype));
+        // …and the big-endian spelling of the same header.
+        let s = parse_slices(&thin_be(ARM64, ARM64E)).expect("thin be parses");
+        assert!(is_arm64e(s[0].cpusubtype));
+    }
+
+    #[test]
+    fn parses_fat_arm64_arm64e() {
+        let s = parse_slices(&fat(&[(ARM64, 0), (ARM64, ARM64E)])).expect("fat parses");
+        assert_eq!(s.len(), 2);
+        assert_eq!(s[0].cputype, ARM64);
+        assert!(is_arm64e(s[1].cpusubtype));
+        // The little-endian fat spelling parses identically.
+        let s = parse_slices(&fat_le(&[(ARM64, 0), (ARM64, ARM64E)])).expect("fat le parses");
+        assert!(is_arm64e(s[1].cpusubtype));
+    }
+
+    #[test]
+    fn parses_fat_x86_64_arm64() {
+        let s = parse_slices(&fat(&[(X86_64, 3), (ARM64, 0)])).expect("fat parses");
+        assert_eq!(s[0].cputype, X86_64);
+        assert_eq!(s[1].cputype, ARM64);
+    }
+
+    #[test]
+    fn rejects_non_macho_and_garbage() {
+        assert_eq!(parse_slices(b"#!/bin/sh\necho hi\n"), None);
+        assert_eq!(parse_slices(&[0xde, 0xad, 0xbe, 0xef, 1, 2, 3]), None);
+        assert_eq!(parse_slices(&[]), None);
+        // A fat header whose table overruns the probed page.
+        let mut b = vec![0u8; 64];
+        b[0..4].copy_from_slice(&0xcafebabeu32.to_be_bytes());
+        b[4..8].copy_from_slice(&1000u32.to_be_bytes());
+        assert_eq!(parse_slices(&b), None);
+        // A truncated thin header.
+        assert_eq!(parse_slices(&0xfeedfacfu32.to_le_bytes()), None);
+    }
+
+    #[test]
+    fn dylib_loadable_decision_matrix() {
+        let arm64 = Slice {
+            cputype: ARM64,
+            cpusubtype: 0,
+        };
+        let arm64e = Slice {
+            cputype: ARM64,
+            cpusubtype: ARM64E,
+        };
+        let x64 = Slice {
+            cputype: X86_64,
+            cpusubtype: 3,
+        };
+        // arm64 host: keep iff an arm64 slice AND no arm64e slice.
+        assert!(dylib_loadable(HostArch::Arm64, &[arm64]));
+        assert!(!dylib_loadable(HostArch::Arm64, &[arm64e]));
+        assert!(!dylib_loadable(HostArch::Arm64, &[arm64, arm64e]));
+        assert!(!dylib_loadable(HostArch::Arm64, &[x64]));
+        assert!(dylib_loadable(HostArch::Arm64, &[x64, arm64]));
+        // A plain subtype-2 WITHOUT the capability bit is not arm64e (the
+        // Xcode-emitted spelling carries the bit).
+        assert!(dylib_loadable(
+            HostArch::Arm64,
+            &[Slice {
+                cputype: ARM64,
+                cpusubtype: 2
+            }]
+        ));
+        // x86_64 host: keep iff an x86_64 slice.
+        assert!(dylib_loadable(HostArch::X86_64, &[x64]));
+        assert!(!dylib_loadable(HostArch::X86_64, &[arm64]));
+        assert!(dylib_loadable(HostArch::X86_64, &[x64, arm64e]));
+    }
+
+    /// A fake envp vector owning its strings; `ptrs` is what the shim
+    /// receives.
+    struct FakeEnv {
+        _strings: Vec<CString>,
+        ptrs: Vec<*mut c_char>,
+    }
+
+    fn fake_env(entries: &[&str]) -> FakeEnv {
+        let strings: Vec<CString> = entries.iter().map(|s| CString::new(*s).unwrap()).collect();
+        let mut ptrs: Vec<*mut c_char> = strings.iter().map(|s| s.as_ptr().cast_mut()).collect();
+        ptrs.push(std::ptr::null_mut());
+        FakeEnv {
+            _strings: strings,
+            ptrs,
+        }
+    }
+
+    /// Read an envp back into strings (test-side mirror of the walk).
+    unsafe fn collect(envp: *const *mut c_char) -> Vec<String> {
+        let mut out = Vec::new();
+        unsafe { for_each_env(envp, |e| out.push(e.to_string_lossy().into_owned())) };
+        out
+    }
+
+    #[test]
+    fn strip_removes_the_insertion_variable() {
+        let env = fake_env(&[
+            "PATH=/usr/bin",
+            "DYLD_INSERT_LIBRARIES=/x/libtfs_preload.dylib",
+            "TEBAKO_TFS_MOUNTS=/i:/tfs",
+        ]);
+        let stripped = unsafe { strip_insert(env.ptrs.as_ptr()) }.expect("the var is stripped");
+        let got = unsafe { collect(stripped.as_envp()) };
+        assert_eq!(got, ["PATH=/usr/bin", "TEBAKO_TFS_MOUNTS=/i:/tfs"]);
+    }
+
+    #[test]
+    fn strip_without_the_variable_is_a_passthrough() {
+        let env = fake_env(&["PATH=/usr/bin", "FOO=1"]);
+        assert!(unsafe { strip_insert(env.ptrs.as_ptr()) }.is_none());
+        assert!(unsafe { strip_insert(std::ptr::null()) }.is_none());
+        // …and the cheap pre-check agrees (no probe IO would follow).
+        assert!(!unsafe { envp_has_insert(env.ptrs.as_ptr()) });
+        assert!(!unsafe { envp_has_insert(std::ptr::null()) });
+    }
+
+    #[test]
+    fn strip_only_the_named_variable() {
+        // A same-prefix decoy and an empty value: the name match is exact.
+        let env = fake_env(&["DYLD_INSERT_LIBRARIES_EXTRA=keep", "DYLD_INSERT_LIBRARIES="]);
+        let stripped = unsafe { strip_insert(env.ptrs.as_ptr()) }.expect("stripped");
+        let got = unsafe { collect(stripped.as_envp()) };
+        assert_eq!(got, ["DYLD_INSERT_LIBRARIES_EXTRA=keep"]);
+    }
+
+    #[test]
+    fn envp_path_and_spawnp_resolution() {
+        let dir = std::env::temp_dir().join(format!("macho-arch-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let tool = dir.join("mytool");
+        std::fs::write(&tool, b"#!/bin/sh\n").unwrap();
+        let spec = format!("PATH=/nope:{}", dir.display());
+        let env = fake_env(&[&spec, "OTHER=1"]);
+        assert_eq!(
+            unsafe { envp_path(env.ptrs.as_ptr()) },
+            Some(format!("/nope:{}", dir.display()))
+        );
+        let hit =
+            unsafe { resolve_on_path("mytool", env.ptrs.as_ptr()) }.expect("the readable hit");
+        assert_eq!(hit, tool.to_string_lossy());
+        // A name that is nowhere: unresolvable.
+        assert!(unsafe { resolve_on_path("no-such-tool", env.ptrs.as_ptr()) }.is_none());
+        // …and a missing PATH resolves nothing.
+        let env2 = fake_env(&["OTHER=1"]);
+        assert!(unsafe { resolve_on_path("mytool", env2.ptrs.as_ptr()) }.is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -44,6 +44,8 @@ use crate::route::{self, PathRoute};
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "macos")]
+mod macho_arch;
+#[cfg(target_os = "macos")]
 mod macos;
 #[cfg(target_os = "linux")]
 pub(crate) mod statx_abi;
@@ -1476,6 +1478,12 @@ pub unsafe extern "C" fn readdir_r(
 /// copy (execve needs a host path); a host path execs the original
 /// ungated — exec of a host binary is not an IO route in the policy's op
 /// classes, and the child's own IO stays jailed via env propagation.
+///
+/// macOS: envp crosses the arm64e insertion gate (tebako#448,
+/// `macho_arch`): a target whose Mach-O slices cannot load this dylib
+/// (an arm64e slice dyld would prefer, or no host-arch slice at all) gets
+/// a rebuilt envp WITHOUT `DYLD_INSERT_LIBRARIES` — dyld would TERMINATE
+/// the child over the incompatible insertion otherwise.
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn execve(
     path: *const c_char,
@@ -1486,20 +1494,39 @@ pub unsafe extern "C" fn execve(
         return unsafe { plat::real_execve()(path, argv, envp) };
     };
     match engine_call(|| route::vfs_materialize_exec(p)) {
-        // SAFETY: `host` outlives the call; argv/envp forward verbatim.
-        Some(PathRoute::Vfs(host)) => unsafe { plat::real_execve()(host.as_ptr(), argv, envp) },
+        // SAFETY: `host` and the gate's rebuilt envp outlive the call;
+        // argv forwards verbatim.
+        Some(PathRoute::Vfs(host)) => {
+            #[cfg(target_os = "macos")]
+            let gate = host
+                .to_str()
+                .ok()
+                .and_then(|h| unsafe { macho_arch::strip_for_path_target(h, envp) });
+            #[cfg(target_os = "macos")]
+            let envp = gate.as_ref().map_or(envp, macho_arch::StrippedEnv::as_envp);
+            unsafe { plat::real_execve()(host.as_ptr(), argv, envp) }
+        }
         Some(PathRoute::Denied(e)) => {
             set_errno(e);
             -1
         }
-        Some(PathRoute::Host) | None => unsafe { plat::real_execve()(path, argv, envp) },
+        Some(PathRoute::Host) | None => {
+            #[cfg(target_os = "macos")]
+            let gate = unsafe { macho_arch::strip_for_path_target(p, envp) };
+            #[cfg(target_os = "macos")]
+            let envp = gate.as_ref().map_or(envp, macho_arch::StrippedEnv::as_envp);
+            unsafe { plat::real_execve()(path, argv, envp) }
+        }
     }
 }
 
 /// Interposed `posix_spawn` (roadmap 39): the execve routing with the
 /// spawn contract — the return IS the errno (never -1). The trace op is
 /// `spawn` (spec 25 §2: a child is created — the stream's process-tree
-/// signal), never `exec`.
+/// signal), never `exec`. envp crosses the same macOS insertion gate as
+/// execve (tebako#448); the gate's rebuilt envp is dropped after the
+/// spawn returns — posix_spawn copies the environment into the child
+/// before returning, so the buffer's drop is safe.
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn posix_spawn(
     pid: *mut libc::pid_t,
@@ -1513,13 +1540,24 @@ pub unsafe extern "C" fn posix_spawn(
         return unsafe { plat::real_posix_spawn()(pid, path, file_actions, attrp, argv, envp) };
     };
     match engine_call(|| route::vfs_materialize_spawn(p)) {
-        Some(PathRoute::Vfs(host)) => unsafe {
-            plat::real_posix_spawn()(pid, host.as_ptr(), file_actions, attrp, argv, envp)
-        },
+        Some(PathRoute::Vfs(host)) => {
+            #[cfg(target_os = "macos")]
+            let gate = host
+                .to_str()
+                .ok()
+                .and_then(|h| unsafe { macho_arch::strip_for_path_target(h, envp) });
+            #[cfg(target_os = "macos")]
+            let envp = gate.as_ref().map_or(envp, macho_arch::StrippedEnv::as_envp);
+            unsafe { plat::real_posix_spawn()(pid, host.as_ptr(), file_actions, attrp, argv, envp) }
+        }
         Some(PathRoute::Denied(e)) => e,
-        Some(PathRoute::Host) | None => unsafe {
-            plat::real_posix_spawn()(pid, path, file_actions, attrp, argv, envp)
-        },
+        Some(PathRoute::Host) | None => {
+            #[cfg(target_os = "macos")]
+            let gate = unsafe { macho_arch::strip_for_path_target(p, envp) };
+            #[cfg(target_os = "macos")]
+            let envp = gate.as_ref().map_or(envp, macho_arch::StrippedEnv::as_envp);
+            unsafe { plat::real_posix_spawn()(pid, path, file_actions, attrp, argv, envp) }
+        }
     }
 }
 
@@ -1527,7 +1565,10 @@ pub unsafe extern "C" fn posix_spawn(
 /// posix_spawn (the `spawn` trace op, spec 25 §2); a bare name is a host
 /// PATH search (memfs dirs are not in the host PATH — pass through,
 /// stated honestly in the crate docs; no VFS decision exists, so no
-/// trace event).
+/// trace event). The macOS insertion gate (tebako#448) resolves a bare
+/// name through the caller's PATH for its Mach-O probe (first readable
+/// hit; unresolvable → passthrough unchanged) — the real spawnp's own
+/// search still answers for the exec itself.
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn posix_spawnp(
     pid: *mut libc::pid_t,
@@ -1541,16 +1582,33 @@ pub unsafe extern "C" fn posix_spawnp(
         return unsafe { plat::real_posix_spawnp()(pid, file, file_actions, attrp, argv, envp) };
     };
     if !p.contains('/') {
+        #[cfg(target_os = "macos")]
+        let gate = unsafe { macho_arch::strip_for_spawnp_target(p, envp) };
+        #[cfg(target_os = "macos")]
+        let envp = gate.as_ref().map_or(envp, macho_arch::StrippedEnv::as_envp);
         return unsafe { plat::real_posix_spawnp()(pid, file, file_actions, attrp, argv, envp) };
     }
     match engine_call(|| route::vfs_materialize_spawn(p)) {
-        Some(PathRoute::Vfs(host)) => unsafe {
-            plat::real_posix_spawnp()(pid, host.as_ptr(), file_actions, attrp, argv, envp)
-        },
+        Some(PathRoute::Vfs(host)) => {
+            #[cfg(target_os = "macos")]
+            let gate = host
+                .to_str()
+                .ok()
+                .and_then(|h| unsafe { macho_arch::strip_for_path_target(h, envp) });
+            #[cfg(target_os = "macos")]
+            let envp = gate.as_ref().map_or(envp, macho_arch::StrippedEnv::as_envp);
+            unsafe {
+                plat::real_posix_spawnp()(pid, host.as_ptr(), file_actions, attrp, argv, envp)
+            }
+        }
         Some(PathRoute::Denied(e)) => e,
-        Some(PathRoute::Host) | None => unsafe {
-            plat::real_posix_spawnp()(pid, file, file_actions, attrp, argv, envp)
-        },
+        Some(PathRoute::Host) | None => {
+            #[cfg(target_os = "macos")]
+            let gate = unsafe { macho_arch::strip_for_path_target(p, envp) };
+            #[cfg(target_os = "macos")]
+            let envp = gate.as_ref().map_or(envp, macho_arch::StrippedEnv::as_envp);
+            unsafe { plat::real_posix_spawnp()(pid, file, file_actions, attrp, argv, envp) }
+        }
     }
 }
 

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -966,3 +966,175 @@ fn fork_child_exec_under_root_mount_completes() {
         "the grandchild's host read under the root mount"
     );
 }
+
+// ---------------------------------------------------------------------
+// tebako#448: the macOS insertion guard (arm64e / Rosetta exec targets)
+// ---------------------------------------------------------------------
+
+/// Compile the insert-probe for one `-arch`. None — with a stderr note,
+/// the suite's documented skip idiom — when the toolchain cannot build
+/// that arch at all (the absent-prerequisite arm; the standard-fixture
+/// "a cc that fails is a hard failure" rule does not cover optional arch
+/// slices).
+#[cfg(target_os = "macos")]
+fn compile_arch_probe(f: &Fixtures, arch: &str) -> Option<PathBuf> {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/insert-probe.c");
+    let out = f.dir.join("bin").join(format!("insert-probe-{arch}"));
+    let o = Command::new("cc")
+        .arg("-O2")
+        .arg("-arch")
+        .arg(arch)
+        .arg("-o")
+        .arg(&out)
+        .arg(&src)
+        .output()
+        .unwrap();
+    if !o.status.success() {
+        eprintln!(
+            "skip: cc -arch {arch} unsupported: {}",
+            String::from_utf8_lossy(&o.stderr)
+        );
+        return None;
+    }
+    Some(out)
+}
+
+/// Preflight: does the probe RUN here unarmed (no insertion, no mounts)?
+/// Distinguishes a usable arch leg from a host that cannot run the arch
+/// at all — Rosetta absent, or a kernel refusing third-party arm64e
+/// (macOS 14.1: "not running binary built against preview arm64e ABI").
+#[cfg(target_os = "macos")]
+fn arch_probe_runs(probe: &Path) -> bool {
+    Command::new(probe)
+        .env_remove("DYLD_INSERT_LIBRARIES")
+        .env_remove("TEBAKO_TFS_MOUNTS")
+        .output()
+        .map(|o| o.status.code() == Some(42))
+        .unwrap_or(false)
+}
+
+/// Launch the inserted spawn-helper so its INTERPOSED exec/spawn surface
+/// execs the probe with the inherited env — the guard's decision point.
+/// `path_override` arms the spawnp bare-name leg's PATH search; `debug`
+/// sets TEBAKO_DEBUG_TFS so the guard's own strip note lands on stderr.
+#[cfg(target_os = "macos")]
+fn run_guarded(f: &Fixtures, mode: &str, target: &str, path: Option<&Path>, debug: bool) -> Run {
+    let mut cmd = Command::new(f.dir.join("bin").join("spawn-helper"));
+    cmd.arg(mode)
+        .arg(target)
+        .arg("x")
+        .env(preload_var(), &f.shim)
+        .env("TEBAKO_TFS_MOUNTS", "")
+        .env_remove("TEBAKO_JAIL")
+        .env_remove("DYLD_PRINT_LIBRARIES");
+    if let Some(p) = path {
+        cmd.env("PATH", p);
+    }
+    if debug {
+        cmd.env("TEBAKO_DEBUG_TFS", "1");
+    }
+    let out = cmd.output().unwrap();
+    let signal = std::os::unix::process::ExitStatusExt::signal(&out.status);
+    Run {
+        rc: out.status.code().unwrap_or(-1),
+        signal,
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+/// tebako#448 — the macOS insertion guard. A virtualized parent (the
+/// shim loaded via DYLD_INSERT_LIBRARIES) execs a child whose Mach-O the
+/// arm64-only interpose dylib cannot load: before the fix the forwarded
+/// insertion made dyld TERMINATE the child ("mach-o file, but is an
+/// incompatible architecture (have 'arm64', need 'arm64e')" — the 0.16.7
+/// native_ext leg on macos-14). The interposed execve/posix_spawn/
+/// posix_spawnp must strip DYLD_INSERT_LIBRARIES for exactly those
+/// targets and keep it otherwise.
+///
+/// Three legs: an arm64 CONTROL (insertion kept — the child reports the
+/// var and exits 42), an x86_64-only probe under Rosetta (no arm64 slice
+/// → stripped; runs all three exec surfaces incl. spawnp's bare-name PATH
+/// resolution), and an arm64e probe — the issue's exact shape — which
+/// skips loudly on hosts whose kernel refuses third-party arm64e
+/// binaries (macOS 14.1's "preview arm64e ABI" refusal; the macos-14 CI
+/// runners run them, and that is where the bug bit).
+#[cfg(target_os = "macos")]
+#[test]
+fn exec_strips_insertion_when_the_target_cannot_load_the_dylib() {
+    let Some(f) = fixtures() else { return };
+
+    // The arm64 control: the guard must NOT strip what dyld can load —
+    // the inserted child reports the inherited var and exits 42. (cc must
+    // build the host's own arch — a hard failure otherwise, per the
+    // suite's skip policy.)
+    let arm64 = compile_arch_probe(f, "arm64").expect("the host arch compiles");
+    let r = run_guarded(f, "execve", arm64.to_str().unwrap(), None, false);
+    assert_eq!(
+        r.rc, 42,
+        "arm64 control (signal: {:?}), stderr: {}",
+        r.signal, r.stderr
+    );
+    assert_eq!(r.stdout, "INSERT:set\n", "the control keeps insertion");
+
+    // The x86_64-only leg: no arm64 slice → the arm64 dylib cannot load
+    // (dyld's own words on this host, pre-fix: "incompatible architecture
+    // (have 'arm64', need 'x86_64')" + SIGABRT). Stripped, the child runs.
+    if let Some(x64) = compile_arch_probe(f, "x86_64") {
+        if arch_probe_runs(&x64) {
+            for mode in ["execve", "posix_spawn"] {
+                let r = run_guarded(f, mode, x64.to_str().unwrap(), None, true);
+                assert_eq!(
+                    r.rc, 42,
+                    "x86_64 {mode} (signal: {:?} — pre-fix dyld aborts here), stderr: {}",
+                    r.signal, r.stderr
+                );
+                assert_eq!(r.stdout, "INSERT:unset\n", "x86_64 {mode} kept the var");
+                // The guard's own note on the crate's debug channel —
+                // proof the strip fired, not that dyld relented.
+                assert!(
+                    r.stderr.contains("[preload] strip DYLD_INSERT_LIBRARIES"),
+                    "x86_64 {mode}: the guard note, stderr: {}",
+                    r.stderr
+                );
+            }
+            // spawnp of a BARE name: the guard resolves it through the
+            // caller's PATH, then strips by the resolved file's slices.
+            let r = run_guarded(
+                f,
+                "posix_spawnp",
+                "insert-probe-x86_64",
+                Some(&f.dir.join("bin")),
+                false,
+            );
+            assert_eq!(
+                r.rc, 42,
+                "x86_64 posix_spawnp (signal: {:?}), stderr: {}",
+                r.signal, r.stderr
+            );
+            assert_eq!(r.stdout, "INSERT:unset\n", "spawnp bare-name strip");
+        } else {
+            eprintln!("skip: the x86_64 probe does not run here (Rosetta absent)");
+        }
+    }
+
+    // The arm64e leg — the issue's exact dyld kill.
+    if let Some(arm64e) = compile_arch_probe(f, "arm64e") {
+        if arch_probe_runs(&arm64e) {
+            for mode in ["execve", "posix_spawn"] {
+                let r = run_guarded(f, mode, arm64e.to_str().unwrap(), None, false);
+                assert_eq!(
+                    r.rc, 42,
+                    "arm64e {mode} (signal: {:?} — the tebako#448 kill), stderr: {}",
+                    r.signal, r.stderr
+                );
+                assert_eq!(r.stdout, "INSERT:unset\n", "arm64e {mode} kept the var");
+            }
+        } else {
+            eprintln!(
+                "skip: this host's kernel refuses third-party arm64e binaries \
+                 (preview ABI) — the arm64e leg proves out on macos-14 CI"
+            );
+        }
+    }
+}

--- a/crates/libtfs-preload/tests/fixtures/insert-probe.c
+++ b/crates/libtfs-preload/tests/fixtures/insert-probe.c
@@ -1,0 +1,16 @@
+/* insert-probe: the tebako#448 exec-guard child probe. Reports whether
+ * the insertion variable reached the process image (INSERT:set/unset) and
+ * exits 42 — the guard e2e asserts that pair per arch leg. Built per-arch
+ * by the test (cc -arch …), never by the fixtures builder. */
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+#ifdef __APPLE__
+    const char *var = "DYLD_INSERT_LIBRARIES";
+#else
+    const char *var = "LD_PRELOAD";
+#endif
+    printf("INSERT:%s\n", getenv(var) ? "set" : "unset");
+    return 42;
+}

--- a/crates/libtfs-preload/tests/fixtures/spawn-helper.c
+++ b/crates/libtfs-preload/tests/fixtures/spawn-helper.c
@@ -35,6 +35,19 @@ int main(int argc, char **argv) {
         waitpid(pid, &status, 0);
         return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
     }
+    if (strcmp(argv[1], "posix_spawnp") == 0) {
+        /* argv[2] may be a bare name: the caller's PATH (in environ)
+         * resolves it — the tebako#448 guard's spawnp leg. */
+        pid_t pid;
+        int s = posix_spawnp(&pid, argv[2], NULL, NULL, child_argv, environ);
+        if (s != 0) {
+            dprintf(2, "posix_spawnp %s: %s\n", argv[2], strerror(s));
+            return s;
+        }
+        int status;
+        waitpid(pid, &status, 0);
+        return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    }
     dprintf(2, "spawn-helper: unknown mode %s\n", argv[1]);
     return 64;
 }


### PR DESCRIPTION
## Symptom

On macOS arm64, when a process virtualized by libtfs-preload (`DYLD_INSERT_LIBRARIES` carrying our arm64-only interpose dylib) execs a child whose best Mach-O slice is **arm64e**, dyld TERMINATES the child:

```
dyld[…]: terminating because inserted dylib '…/libtfs_preload.dylib' could not be loaded:
… (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e'))
```

SIP-protected Apple platform binaries strip the variable silently and are fine; the dying children are non-platform arm64e binaries (the toolchain on GitHub macos-14 runners). This is a shipped regression on the 0.16.7 runtime line: the v0.2.2 link unit newly propagates insertion across exec (the fork/exec fix), so `tebako press` of a native-extension gem now fails at `bundle install` → extconf (CI run 32691849954, job 97326807784, `test (macos-14)`, `native_ext_press_builds_and_packages`).

## Root cause

The interposed `execve` / `posix_spawn` / `posix_spawnp` in `crates/libtfs-preload/src/sys/mod.rs` forwarded `envp` **verbatim**. dyld loads every `DYLD_INSERT_LIBRARIES` entry into the child and hard-fails when an entry has no slice matching the child's selected ABI. Our interpose dylib is arm64-only; dyld prefers a target's arm64e slice over its arm64 slice whenever both exist, so insertion that loaded fine in the arm64 parent is fatal in an arm64e child.

## Mechanism

The same kill is reproducible for any target whose selected slice our dylib cannot satisfy. Reproduced locally on an M-series Mac (macOS 14.1.1) with the x86_64-under-Rosetta case, pre-fix (baseline build of this branch's parent):

```
$ DYLD_INSERT_LIBRARIES=…/libtfs_preload.dylib /tmp/probe-x86_64
dyld[46385]: terminating because inserted dylib '…/libtfs_preload.dylib' could not be loaded:
tried: '…/libtfs_preload.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')) …
Abort trap: 6            # rc 134
$ DYLD_INSERT_LIBRARIES=…/libtfs_preload.dylib /tmp/probe-arm64 ; echo $?   # same-arch control
42                       # insertion loads fine
```

## The fix

All three exec surfaces now gate `envp` through a small macOS-only helper, `crates/libtfs-preload/src/sys/macho_arch.rs`, before forwarding:

1. Cheap pre-check: if `envp` is NULL or carries no `DYLD_INSERT_LIBRARIES`, forward verbatim (no filesystem IO at all).
2. Otherwise probe the exec target's Mach-O header — one open+read of the first page (4 KB) through the **real** libc (the interpose tuple originals), so the probe neither re-enters the engine nor trips the jail. Thin 64-bit Mach-O (either endianness) and fat headers (either endianness; per-slice types come from the `fat_arch` table itself). Not Mach-O (scripts) or unreadable → keep insertion (today's behavior; the shebang interpreter's own arch decides).
3. Decision (host arch is a compile-time constant of the dylib):
   - **aarch64 host**: strip iff the target has an arm64e slice (`CPU_TYPE_ARM64`, subtype base 2 with the `0x80000000` capability bit — what Xcode's `-arch arm64e` emits, `0x80000002`; verified against a locally built arm64e binary) **or** has no plain arm64 slice at all (e.g. x86_64-only under Rosetta).
   - **x86_64 host**: strip iff the target has no `CPU_TYPE_X86_64` slice.
4. Stripping = forwarding a rebuilt envp with `DYLD_INSERT_LIBRARIES` **removed** (not emptied) for that one exec; `argv` untouched. The rebuilt buffer owns its strings and outlives the real call (execve never returns on success — the kernel reclaims it; posix_spawn copies the env before returning, so the drop after the call is safe there).
5. `posix_spawnp` bare names (no `/`) resolve through the caller's PATH first (walk envp's PATH entry; first readable hit wins; empty component = cwd); unresolvable → passthrough unchanged. The real spawnp's own search still answers for the exec itself.
6. Each strip logs a note on the crate's existing debug channel (`TEBAKO_DEBUG_TFS`, the same flag the `open`/`openat` shims use) — no new channel, nothing on the spec-25 trace bus's additive-only op vocabulary.

Linux is untouched (the module and every call-site gate are `cfg(target_os = "macos")`; ELF interposition has no such dyld kill).

## Regression test

New macOS-gated e2e in `crates/libtfs-preload/tests/e2e.rs` (`exec_strips_insertion_when_the_target_cannot_load_the_dylib`) with a new per-arch probe fixture (`tests/fixtures/insert-probe.c`, prints `INSERT:set`/`INSERT:unset` from `getenv` and exits 42) and a `posix_spawnp` mode added to `spawn-helper.c`. The parent is launched with insertion armed, so its **interposed** execve/posix_spawn/posix_spawnp exec the probe — the guard's real decision point.

Legs:

- **arm64 control**: insertion kept — `INSERT:set`, rc 42.
- **x86_64-only** (Rosetta): insertion stripped on all three surfaces — `INSERT:unset`, rc 42, plus the guard's own `[preload] strip DYLD_INSERT_LIBRARIES …` note asserted on stderr. Pre-fix this child is the `Abort trap: 6` above.
- **arm64e**: the issue's exact shape. **Skips loudly on this dev host** — macOS 14.1.1's kernel refuses ALL third-party arm64e binaries (`exec_mach_imgact: not running binary "t448-e" built against preview arm64e ABI`; verified for both Xcode 15.0.1 clang and Homebrew LLVM 22 output, with and without any insertion), so no arm64e binary can run here to observe the strip. The preflight (build `cc -arch arm64e`, run unarmed, expect 42) gates the leg; it runs and proves the kill→fix transition on the macos-14 CI runners where the bug bit.

Unit tests in `macho_arch.rs` cover the parser (thin arm64 / thin arm64e / big-endian thin / fat arm64+arm64e / fat x86_64+arm64 / little-endian fat / script / garbage / truncated fat table), the full host×slices decision matrix, and the envp strip / PATH resolution.

## Evidence (this machine, debug profile)

`cargo test -p libtfs-preload` — all green, including the new test:

```
running 16 tests
test sys::macho_arch::tests::dylib_loadable_decision_matrix ... ok
test sys::macho_arch::tests::parses_thin_arm64 ... ok
test sys::macho_arch::tests::parses_thin_arm64e ... ok
test sys::macho_arch::tests::parses_fat_arm64_arm64e ... ok
test sys::macho_arch::tests::parses_fat_x86_64_arm64 ... ok
test sys::macho_arch::tests::rejects_non_macho_and_garbage ... ok
test sys::macho_arch::tests::strip_only_the_named_variable ... ok
test sys::macho_arch::tests::strip_removes_the_insertion_variable ... ok
test sys::macho_arch::tests::strip_without_the_variable_is_a_passthrough ... ok
test sys::macho_arch::tests::envp_path_and_spawnp_resolution ... ok
…
test result: ok. 16 passed; 0 failed

running 19 tests
test exec_strips_insertion_when_the_target_cannot_load_the_dylib ... ok
…
test result: ok. 19 passed; 0 failed
```

The new test's `--nocapture` run (the arm64e leg's documented local skip; x86_64/arm64 legs executed with all assertions):

```
skip: this host's kernel refuses third-party arm64e binaries (preview ABI) — the arm64e leg proves out on macos-14 CI
test exec_strips_insertion_when_the_target_cannot_load_the_dylib ... ok
```

Manual mechanism proof with the built shim (inserted parent → interposed exec):

```
=== arm64 control via interposed execve (insertion kept) ===
INSERT:set
rc=42
=== x86_64 child via interposed execve (strip fires) ===
[preload] strip DYLD_INSERT_LIBRARIES for exec of …/insert-probe-x86_64: no loadable slice for this dylib (tebako#448)
INSERT:unset
rc=42
=== x86_64 child via interposed posix_spawn ===
INSERT:unset
rc=42
=== x86_64 bare-name via interposed posix_spawnp (PATH resolution) ===
INSERT:unset
rc=42
```

Also green: `cargo build -p tebako-driver -p tebako-cli`, `cargo clippy -p libtfs-preload --all-targets -- -D warnings`, `cargo fmt --all -- --check`.

## Files

- `crates/libtfs-preload/src/sys/macho_arch.rs` — new macOS-only module: Mach-O slice parser, host-arch loadability decision, envp strip, spawnp PATH resolution, unit tests.
- `crates/libtfs-preload/src/sys/mod.rs` — the three exec surfaces route envp through the guard (cfg-gated macOS-only).
- `crates/libtfs-preload/src/lib.rs` — crate docs: the guard in the child-namespace propagation contract.
- `crates/libtfs-preload/tests/e2e.rs` — the regression test + helpers.
- `crates/libtfs-preload/tests/fixtures/insert-probe.c` — new probe.
- `crates/libtfs-preload/tests/fixtures/spawn-helper.c` — additive `posix_spawnp` mode.

Fixes #448
