### PR TITLE
release: v0.2.3 — version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "tests/contract"]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"


### PR DESCRIPTION
## What

Workspace version 0.2.2 → 0.2.3 — the release bump, replicating v0.2.2's shape (#445). On merge: tag `v0.2.3` at the merged main, release workflow publishes the per-platform artifacts.

## What it ships

- **#448/#449** — libtfs-preload strips `DYLD_INSERT_LIBRARIES` for exec targets whose Mach-O slices cannot load the arm64 dylib (an arm64e slice dyld would prefer, or no host-arch slice). Fixes the shipped 0.16.7-line regression where dyld *terminated* such children during native-extension presses on macOS. Regression test synthesizes `-arch arm64`/`arm64e`/`x86_64` children; 17/17 checks green incl. `test (macos-14)`.
- **#446** — limnifs 0.2.57 → 0.2.61 (absorbs omnizip 0.16.92: the LZMA2 100 MB + zstd ratio fixes).

The 0.16.8 runtime re-cut (factory re-pin to this link unit) follows the release; then #447 retargets the default runtime line to 0.16.8.
