### PR TITLE
fix(driver): scrub the micro interpose dylib from the child-facing env — #448

### DIFF
--- a/crates/tebako-driver/src/ffi/interpose.rs
+++ b/crates/tebako-driver/src/ffi/interpose.rs
@@ -13,6 +13,14 @@
 //!    `TEBAKO_LOADER_INTERPOSED` sentinel,
 //! 3. `execv`s itself with the original argv and environ.
 //!
+//! The re-exec'd child (4.) scrubs the micro dylib's entry and the
+//! sentinel back OUT of the env before the boot proceeds: the dylib is
+//! bound to this exe's own `tebako_fs_*` exports — meaningless in any
+//! spawned child and LETHAL in one whose Mach-O slice cannot load it
+//! (dyld terminates an arm64e target over an inherited arm64-only
+//! insertion; tebako#448). The already-loaded dylib stays live in THIS
+//! process — dyld only consults the var at exec.
+//!
 //! The sentinel makes the re-exec fire exactly once; because it precedes
 //! all mounting there is no double boot, no partial-mount window, and no
 //! launcher-ABI change. ANY failure warns loudly on stderr and the boot
@@ -30,8 +38,8 @@ use std::path::{Path, PathBuf};
 
 use libc::c_char;
 
-/// The once-per-process sentinel: set by the inserting parent, seen by
-/// the re-exec'd child (which skips this whole path).
+/// The once-per-process sentinel: set by the inserting parent, seen and
+/// scrubbed by the re-exec'd child (which skips the insertion itself).
 pub(crate) const SENTINEL: &str = "TEBAKO_LOADER_INTERPOSED";
 
 /// The dyld insertion variable the dylib path rides.
@@ -90,6 +98,66 @@ fn compose_insert_libraries(dylib: &Path, existing: Option<OsString>) -> OsStrin
 /// are the re-exec'd child — skip entirely.
 fn should_insert(sentinel: Option<&OsStr>) -> bool {
     sentinel.is_none()
+}
+
+/// The cache-dir marker every inserted micro-dylib path carries
+/// (`<temp>/tebako-interpose/<sha256>.dylib`). Any tebako version's entry
+/// matches — an ancestor runtime's micro is as foreign to a child as ours.
+fn is_micro_dylib_entry(entry: &OsStr) -> bool {
+    let bytes = entry.as_bytes();
+    bytes
+        .windows(b"tebako-interpose/".len())
+        .any(|w| w == b"tebako-interpose/")
+        && bytes.ends_with(b".dylib")
+}
+
+/// The re-exec'd child's env cleanup (tebako#448's root fix): the micro
+/// dylib is bound to THIS exe's own `tebako_fs_*` exports — meaningless
+/// in any child (dynamic_lookup finds nothing there) and LETHAL in one
+/// whose selected Mach-O slice cannot load it: dyld TERMINATES an arm64e
+/// target over an inherited arm64-only insertion, and the interpreter of
+/// an exec'd SCRIPT is exactly such a target (deploy's `o/p/ruby` shim
+/// script execs /bin/sh — fat x86_64+arm64e — under the armed var).
+///
+/// dyld consults DYLD_INSERT_LIBRARIES only at exec: pruning it here
+/// unloads nothing in THIS process (the dylib stays loaded, the tuples
+/// stay live) but keeps the micro out of every child's env. Any
+/// non-tebako entries ride through verbatim. The sentinel is cleared with
+/// it — a respawned tebako child self-inserts at its own boot head
+/// instead of inheriting a dylib bound to the wrong exe's symbols.
+/// Injection (spec 22 §3) later points the var at the self-contained
+/// preload shim when the env image declares one — that delivery is
+/// unaffected.
+fn scrub_insertion_for_children() {
+    match scrub_insert_value(std::env::var_os(INSERT_VAR)) {
+        Some(v) => std::env::set_var(INSERT_VAR, v),
+        None => std::env::remove_var(INSERT_VAR),
+    }
+    std::env::remove_var(SENTINEL);
+}
+
+/// The scrub's pure decision: the insert list minus every micro-dylib
+/// entry, or `None` when nothing (else) is listed — the var then comes
+/// out of the env entirely rather than riding on as an empty string.
+fn scrub_insert_value(existing: Option<OsString>) -> Option<OsString> {
+    let v = existing?;
+    let entries: Vec<OsString> = v
+        .as_bytes()
+        .split(|b| *b == b':')
+        .filter(|e| !e.is_empty())
+        .map(OsStr::from_bytes)
+        .filter(|e| !is_micro_dylib_entry(e))
+        .map(OsString::from)
+        .collect();
+    if entries.is_empty() {
+        return None;
+    }
+    let mut out = entries[0].clone();
+    for e in &entries[1..] {
+        out.push(":");
+        out.push(e);
+    }
+    Some(out)
 }
 
 /// Install the dylib at its content-keyed path. A present file IS the
@@ -178,7 +246,11 @@ fn try_insert(cache_base: &Path, c_argv: *const *const c_char) -> Result<(), Str
 /// boot entries in [`crate::ffi`]).
 pub(crate) fn self_insert(c_argv: *mut *mut c_char) {
     if !should_insert(std::env::var_os(SENTINEL).as_deref()) {
-        return; // we are the re-exec'd child — the insertion fired exactly once
+        // We are the re-exec'd child — the insertion fired exactly once.
+        // The dylib is bound to THIS exe's exports; it must not ride the
+        // env into any child we spawn (tebako#448).
+        scrub_insertion_for_children();
+        return;
     }
     if let Err(reason) = try_insert(&std::env::temp_dir(), c_argv as *const *const c_char) {
         eprintln!("tebako: loader interposition unavailable: {reason}");
@@ -240,6 +312,62 @@ mod tests {
         assert!(should_insert(None));
         assert!(!should_insert(Some(OsStr::new("1"))));
         assert!(!should_insert(Some(OsStr::new(""))));
+    }
+
+    #[test]
+    fn the_micro_entry_marker_matches_only_the_cached_dylib_shape() {
+        assert!(is_micro_dylib_entry(OsStr::new(
+            "/tmp/tebako-interpose/ab12cd.dylib"
+        )));
+        assert!(is_micro_dylib_entry(OsStr::new(
+            "/var/folders/x/T/tebako-interpose/00ff.dylib"
+        )));
+        assert!(!is_micro_dylib_entry(OsStr::new("/a/x.dylib")));
+        assert!(!is_micro_dylib_entry(OsStr::new(
+            // the marker substring alone is not enough — no .dylib tail
+            "/tmp/tebako-interpose/README"
+        )));
+        assert!(!is_micro_dylib_entry(OsStr::new(
+            // a .dylib whose dir merely ends in the marker word
+            "/opt/tebako-interpose-other/x.dylib"
+        )));
+        assert!(!is_micro_dylib_entry(OsStr::new("")));
+    }
+
+    #[test]
+    fn the_scrub_drops_only_the_micro_entries() {
+        let micro = "/var/folders/x/T/tebako-interpose/ab12cd.dylib";
+        // No var at all → still no var.
+        assert_eq!(scrub_insert_value(None), None);
+        // Only the micro → the var comes out entirely.
+        assert_eq!(scrub_insert_value(Some(OsString::from(micro))), None);
+        // Micro first (the self-insertion shape) → the rest rides through.
+        assert_eq!(
+            scrub_insert_value(Some(OsString::from(format!(
+                "{micro}:/a/x.dylib:/b/y.dylib"
+            )))),
+            Some(OsString::from("/a/x.dylib:/b/y.dylib"))
+        );
+        // Micros from several ancestor runtimes all go (any cache root,
+        // any content key); order of the survivors is preserved.
+        let older = "/tmp/tebako-interpose/00ff11.dylib";
+        assert_eq!(
+            scrub_insert_value(Some(OsString::from(format!(
+                "/a/x.dylib:{micro}:{older}:/b/y.dylib"
+            )))),
+            Some(OsString::from("/a/x.dylib:/b/y.dylib"))
+        );
+        // An unrelated list is byte-identical on the far side.
+        assert_eq!(
+            scrub_insert_value(Some(OsString::from("/a/x.dylib:/b/y.dylib"))),
+            Some(OsString::from("/a/x.dylib:/b/y.dylib"))
+        );
+        // Empty segments carry nothing (the compose side never emits
+        // them, but an inherited foreign value might).
+        assert_eq!(
+            scrub_insert_value(Some(OsString::from(format!("{micro}::/a/x.dylib")))),
+            Some(OsString::from("/a/x.dylib"))
+        );
     }
 
     #[test]

--- a/crates/tebako-driver/tests/interpose.rs
+++ b/crates/tebako-driver/tests/interpose.rs
@@ -4,7 +4,10 @@
 //! interpose dylib inserted — the dyld mechanism that interposes
 //! `dlopen`/`dlerror` process-wide (the empirical verdict: tuples in an
 //! INSERTED dylib apply process-wide; the nm gate proves the tuples are
-//! in the embedded bytes).
+//! in the embedded bytes). The re-exec'd child then SCRUBS the dylib's
+//! entry and the sentinel back out of the env (tebako#448): the dylib
+//! stays loaded here, but nothing this process spawns inherits an
+//! insertion bound to this exe's exports.
 //!
 //! Hermetic: no network, no fixtures — the probe re-execs this very test
 //! binary with a fresh environment (sentinel and DYLD_INSERT_LIBRARIES
@@ -83,7 +86,8 @@ fn interpose_dylib_loaded() -> bool {
 /// The probe: enters the driver's boot the way the runtime exe's main
 /// does. The FIRST entry (no sentinel) never returns from here — the
 /// boot execv's this binary with the identical argv. The re-exec'd child
-/// (sentinel armed) completes the boot and reports.
+/// (sentinel seen, then scrubbed with the micro's insert entry)
+/// completes the boot and reports.
 #[test]
 fn self_insert_child_probe() {
     if std::env::var_os(PROBE_FLAG).is_none() {
@@ -111,23 +115,44 @@ fn self_insert_child_probe() {
         unsafe { tebako_driver::ffi::tebako_driver_boot(&mut argc, &mut argvp, root.as_ptr()) };
     assert_eq!(rc, 0, "the plain boot succeeds");
     // Only the re-exec'd child reaches here.
-    let sentinel = std::env::var("TEBAKO_LOADER_INTERPOSED").unwrap_or_default();
+    let sentinel = std::env::var_os("TEBAKO_LOADER_INTERPOSED");
     let insert_var = std::env::var("DYLD_INSERT_LIBRARIES").unwrap_or_default();
     let loaded = interpose_dylib_loaded();
     println!("PROBE depth={depth}");
-    println!("PROBE sentinel={sentinel}");
+    println!("PROBE sentinel_present={}", sentinel.is_some());
     println!("PROBE insert_var={insert_var}");
     println!("PROBE dylib_loaded={loaded}");
     assert_eq!(depth, 2, "the re-exec must fire exactly once");
-    assert_eq!(sentinel, "1", "the re-exec'd child sees the armed sentinel");
+    // tebako#448: the micro dylib is bound to THIS exe's exports — the
+    // re-exec'd child scrubs its entry (and the sentinel) back out of
+    // the env before the boot proceeds, so nothing it spawns inherits an
+    // insertion dyld may TERMINATE on (an arm64e target over an
+    // arm64-only entry).
     assert!(
-        insert_var.contains("tebako-interpose/"),
-        "DYLD_INSERT_LIBRARIES carries the content-keyed dylib path: {insert_var}"
+        sentinel.is_none(),
+        "the re-exec'd child scrubs the sentinel before the boot proceeds"
+    );
+    assert!(
+        !insert_var.contains("tebako-interpose/"),
+        "the micro dylib's entry is scrubbed out of the child-facing env: {insert_var}"
     );
     assert!(
         loaded,
         "the interpose dylib is in the process's dyld image list"
     );
+    // The scrub IS the child-inheritance contract: a spawned grandchild
+    // (a fat /bin/sh — exactly the tebako#448 dying shape on a
+    // terminating dyld) launches clean under the scrubbed env.
+    let out = Command::new("/bin/sh")
+        .arg("-c")
+        .arg("echo grandchild-ok")
+        .output()
+        .expect("spawn the grandchild probe");
+    assert!(
+        out.status.success(),
+        "the grandchild survives the inherited env: {out:?}"
+    );
+    assert!(String::from_utf8_lossy(&out.stdout).contains("grandchild-ok"));
 }
 
 /// The driver: spawns this test binary as a fresh process (sentinel and
@@ -163,6 +188,6 @@ fn self_insert_reexecs_once_and_inserts_the_dylib() {
         "the probe's markers appear exactly once — one completed boot:\n{stdout}"
     );
     assert!(stdout.contains("PROBE depth=2"), "{stdout}");
-    assert!(stdout.contains("PROBE sentinel=1"), "{stdout}");
+    assert!(stdout.contains("PROBE sentinel_present=false"), "{stdout}");
     assert!(stdout.contains("PROBE dylib_loaded=true"), "{stdout}");
 }


### PR DESCRIPTION
## What

The re-exec'd child of the boot-head self-insertion now **scrubs the micro interpose dylib's entry and the `TEBAKO_LOADER_INTERPOSED` sentinel back out of the environment** before the boot proceeds.

## Why (root cause of #448 on the runners)

- `self_insert` arms `DYLD_INSERT_LIBRARIES` with the embedded micro dylib (`loader_interpose.c`) and re-execs. The var propagates to **every child** the runtime spawns.
- The micro is bound to **this exe's own** `tebako_fs_*` exports via `-undefined dynamic_lookup` — meaningless in any child, and **lethal** in one whose selected Mach-O slice cannot load it: dyld **terminates** an arm64e target over an inherited arm64-only insertion.
- The deploy tree's `o/p/ruby` is a `#!/bin/sh` wrapper script; execve of a script launches `/bin/sh` (fat x86_64+arm64e on the macos-14 runners) under the armed var → bundler's extconf children died → `native_ext_press_builds_and_packages` failed on macos-14 in #447 (plus PoisonError cascades).
- Some dyld versions strip the var for restricted binaries (which is why local macOS 14.1.1 e2e passed); the runners' 14.8.7 terminates instead. The scrub makes the outcome version-independent.

dyld consults `DYLD_INSERT_LIBRARIES` only at exec, so pruning it **unloads nothing in this process** — the dylib stays loaded, the tuples stay live — while no spawned child inherits it. Non-tebako entries ride through verbatim. The sentinel is cleared with it: a respawned tebako child self-inserts at its own boot head rather than inheriting a dylib bound to the wrong exe's symbols.

The injection path (spec 22 §3) is unaffected: it points the var at the self-contained preload shim when the env image declares one — that delivery is orthogonal.

## Tests

- Unit tests pin the scrub decision: micro-only list → var removed entirely; micro entries from any cache root / any content key all go; foreign entries pass through byte-identical and in order; empty segments carry nothing; the marker matches only the `<…>/tebako-interpose/<sha>.dylib` shape.
- The `interpose` integration probe's contract flips: the re-exec'd child reports sentinel **absent** and **no** `tebako-interpose/` entry in the insert var, `dylib_loaded=true` (still interposed in-process), and a spawned grandchild — a fat `/bin/sh`, exactly the #448 dying shape — must survive.
- `cargo test -p tebako-driver`: 144 green (74 unit + 70 integration), fmt + clippy clean.

## Follow-up (not in this PR)

A parity hardening in `tamatebako/ruby`'s spawn patch (`process_c_tebako_spawn.patch`): `tfs_spawn_target_restricted` should treat a shebang script's **interpreter** as the restricted target (today it checks only the script's own path, and the post-materialize embedded-script path can arm the shim for a script child). Tracked separately; rides the next ruby source release.

Closes #448 (the propagation half; #449 covered the preload-shim half).
