### PR TITLE
release: v0.2.4 — version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "tests/contract"]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"


### PR DESCRIPTION
## What

Workspace version bump 0.2.3 → 0.2.4 (one line, `#450`'s shape).

## Why

Ships #451 — `fix(driver): scrub the micro interpose dylib from the child-facing env (#448)`. The 0.16.8 runtime line's macos-14 native-ext press leg needs this unit: without it, children of the runtime (bundler's extconf spawning the `o/p/ruby` shim script → fat `/bin/sh`) die under dyld's arm64e insertion termination.

## After merge

Tag `v0.2.4` (lightweight, at the bump commit) + create/publish the release explicitly (the workflow triggers on `release:published`, not tag push) → verify the 44-asset set against v0.2.3 → factory re-pin (`link_unit_release` → v0.2.4) → publish runtime catalog 0.16.9 → retarget #447 to the 0.16.9 line.
