### PR TITLE
release: v0.2.5 — version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "tests/contract"]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"


### PR DESCRIPTION
## What

Version bump 0.2.4 -> 0.2.5. Ships #447: released binaries now default to the 0.16.9 runtime line pref-less (v0.2.4 binaries still bake 0.16.3).

Owner-approved tag sequence: v0.2.5 now; the major celebration tag lands at wave end (benchmarks + packed-mn migration + docs/blog public).

## Verification

Post-release: asset parity vs v0.2.4 (44 assets 1:1), then a clean-room spot-check that a v0.2.5 binary resolves ruby-3.3.12-0.16.9 with no --prefer flag.
