### PR TITLE
feat(bench): spec 27 + tebako-bench skeleton — suite/platforms/schemas, validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,11 +283,11 @@ jobs:
 
       - name: cargo test (pure-Rust crates)
         working-directory: tebako-rs
-        run: cargo test -p tebako-bootstrap -p tebako-shim -p tebako-resolve -p tebako-http -p tebako-term -p tebako-json -p tpkg
+        run: cargo test -p tebako-bootstrap -p tebako-shim -p tebako-resolve -p tebako-http -p tebako-term -p tebako-json -p tpkg -p tebako-bench
 
       - name: clippy (pure-Rust crates)
         working-directory: tebako-rs
-        run: cargo clippy -p tebako-bootstrap -p tebako-shim -p tebako-resolve -p tebako-http -p tebako-term -p tebako-json -p tpkg --all-targets -- -D warnings
+        run: cargo clippy -p tebako-bootstrap -p tebako-shim -p tebako-resolve -p tebako-http -p tebako-term -p tebako-json -p tpkg -p tebako-bench --all-targets -- -D warnings
 
   # The bootstrap on the target the release binaries actually ship on
   # (x86_64-pc-windows-gnu, ucrt64 — TODO.prepublish/03). ring does not

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "tests/contract"]
+members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "crates/tebako-bench", "tests/contract"]
 
 [workspace.package]
 version = "0.2.5"

--- a/benchmarks/fixtures/test-iso.adoc
+++ b/benchmarks/fixtures/test-iso.adoc
@@ -1,0 +1,6 @@
+= Document title
+Author
+:docfile: test-iso.adoc
+:nodoc:
+:novalid:
+:no-isobib:

--- a/benchmarks/platforms.yaml
+++ b/benchmarks/platforms.yaml
@@ -1,0 +1,47 @@
+# Benchmark platform matrix (spec 27 §3) — the workflow's matrix is generated
+# FROM this document. Triplet spellings are the release workflow's platform
+# vocabulary. v1_asset: null and/or v2_payload: false are named gaps
+# (explicit {"status": "unavailable", "reason": …} rows), never silent skips.
+schema_version: 1
+
+# Old world: the packed-mn release the v1-exe arm downloads (+ .sha256.txt
+# sidecar, bare-hash format — spec 27 §9 spike c). packed-mn tags track
+# metanorma-cli: this tag IS the v1 arm's metanorma version (1.14.4).
+packed_mn: { repo: metanorma/packed-mn, tag: v1.14.4 }
+
+# v2_payload: whether the metanorma payload (suite targets' metanorma@1.16.9)
+# is published for the triplet. Payload 1.16.9-3 ships 3 of 7 triplets
+# (2026-08-24 release); the runtime catalog covers all 7.
+triplets:
+  linux-gnu-x86_64:
+    runner: ubuntu-24.04
+    v1_asset: metanorma-linux-x86_64.tgz
+    v2_payload: true
+  linux-gnu-arm64:
+    runner: ubuntu-24.04-arm
+    v1_asset: metanorma-linux-aarch64.tgz
+    v2_payload: false # no published payload — v2 arms are named gaps here
+  linux-musl-x86_64:
+    runner: ubuntu-24.04
+    container: alpine:3.21
+    v1_asset: metanorma-linux-musl-x86_64.tgz
+    v2_payload: false
+  linux-musl-arm64:
+    runner: ubuntu-24.04-arm
+    container: alpine:3.21
+    v1_asset: null # packed-mn never shipped musl-arm64 — gap both sides
+    v2_payload: false
+  macos-arm64:
+    runner: macos-14
+    v1_asset: metanorma-darwin-arm64.tgz # NOTE: AMFI-killed on a local macOS
+      # 14.1.1 machine (spec 27 §9 spike c); the leg records the outcome.
+    v2_payload: true
+  macos-x86_64:
+    runner: macos-15-intel
+    v1_asset: null # packed-mn dropped darwin-x86_64 after ~v1.13 — gap both sides
+    v2_payload: false
+  windows-ucrt64:
+    runner: windows-latest
+    v1_asset: metanorma-windows-x86_64.exe
+    v2_payload: true
+    v1_note: aibika-packed # old world on Windows is aibika, not tebako-v1

--- a/benchmarks/suite.yaml
+++ b/benchmarks/suite.yaml
@@ -1,0 +1,67 @@
+# Benchmark suite — metanorma compile: v2 tebako vs v1 packed-mn (spec 27 §2).
+# Authored SSOT for WHAT runs; the triplet → runner/asset mapping lives in
+# platforms.yaml. Validate with: tebako-bench validate --kind suite benchmarks/suite.yaml
+schema_version: 1
+name: metanorma-v1-vs-v2
+
+workloads:
+  # Small: the feedstock's CI-proven six-line ISO doc (public fonts only —
+  # vendored byte-identical from metanorma-feedstock fixtures/test-iso.adoc
+  # @ 79bddb4a6507ca4814ce7b25c2a81bf7586e51bc).
+  - id: compile-small-iso
+    source: { kind: vendored, path: benchmarks/fixtures/test-iso.adoc }
+    argv: ["compile", "{doc}", "--type", "iso", "--agree-to-terms"]
+    expect: { exit: 0, files: ["test-iso.xml"] }
+    timeout_s: 600
+
+  # Medium: the ISO 17301 rice document from mn-samples-iso (public fonts,
+  # so CI needs no private fontist-formulas access — decision 4). Pinned to
+  # the commit whose tree the harness fetches as an in-process HTTPS archive.
+  - id: compile-medium-rice
+    source:
+      kind: git
+      url: https://github.com/metanorma/mn-samples-iso
+      ref: eeec963ac6c58db6aeb194c758517f56fa66b845 # main @ 2026-08-11
+      path: sources/international-standard/rice-2016/document-en.adoc
+    argv: ["compile", "{doc}", "--agree-to-terms"]
+    expect: { exit: 0, files: ["document-en.xml"] }
+    timeout_s: 900
+
+  # Opt-in: the OIML r060 part-1 document — needs Futura PT from the PRIVATE
+  # fontist-formulas repo. Skipped unless the run opts in (spec 27 §2); never
+  # a gap row when skipped, because nothing was asked.
+  - id: compile-medium-oiml-r060
+    opt_in: true
+    source:
+      kind: git
+      url: https://github.com/metanorma/mn-samples-oiml
+      ref: ba74c74390d0ac22f9a89e4b4d448680a2d92122 # main @ 2026-07-29
+      path: sources/r060/1/document.adoc
+    argv: ["compile", "{doc}", "--agree-to-terms"]
+    expect: { exit: 0, files: ["document.xml"] }
+    timeout_s: 900
+
+targets:
+  # Old world: the packed-mn release executable (per-triplet asset from
+  # platforms.yaml). Frozen at metanorma-cli 1.14.4 — the version skew
+  # against the v2 payload (1.16.9) is accepted and reported (spec 27 §1).
+  - id: v1-packed-mn
+    kind: v1-exe
+
+  # New world, primary form: managed install + shim dispatch, warm store.
+  - id: v2-shim
+    kind: v2-managed
+    payload: "metanorma@1.16.9"
+    registries: ["tfs:github:tebako-packages/metanorma"]
+
+  # New world, one-file contract: a fat tpkg carrying the payload image +
+  # the runtime slot. Built in-leg from sha256-verified published artifacts;
+  # dwarfs-format images until the limnifs writer can carry the tree
+  # (spec 27 §9 spike b).
+  - id: v2-fat
+    kind: v2-press
+    payload: "metanorma@1.16.9"
+    fat: true
+    registries: ["tfs:github:tebako-packages/metanorma"]
+
+run_policy: { warmup: 1, repetitions: 5, cold_repetitions: 2, interleave: true }

--- a/crates/tebako-bench/Cargo.toml
+++ b/crates/tebako-bench/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "tebako-bench"
+description = "The spec 27 benchmark harness (v2 tebako vs v1 packed-mn): suite/platform/result models, schema validate, run + report. CI tooling — never shipped, never in release.yml's binary set"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["tebako", "benchmark", "ci", "metrics"]
+categories = ["development-tools"]
+
+[dependencies]
+# Pure Rust ONLY — no vcpkg, no tfs/dwarfs/sqfs/rnp: the crate rides the
+# pure-Rust CI legs (incl. test-windows) and must build where the product
+# stack cannot. Authored configs are YAML (serde_yml, the workspace
+# manifest convention); result documents are machine-written JSON.
+serde = { version = "1", features = ["derive"] }
+serde_yml = "0.0.12"
+serde_json = "1"
+# SHA-256 for artifact verification (the acquisition slice); spec 00's
+# trust-anchor rule applies to every downloaded byte.
+sha2 = "0.10"
+# Subcommand dispatch. NOTE: the product CLIs hand-roll their parsers; clap
+# is confined to this never-shipped crate deliberately.
+clap = { version = "4", features = ["derive"] }
+# `validate`'s schema gate (the same jsonschema the tpkg cross-checks use).
+jsonschema = "0.30"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/tebako-bench/src/error.rs
+++ b/crates/tebako-bench/src/error.rs
@@ -1,0 +1,40 @@
+//! The crate's named error (the workspace shape: message + exit code,
+//! mirroring tebako-cli's TebakoError). Validation findings are NOT errors
+//! in this sense — they are the `Ok(Vec<String>)` payload of
+//! `validate_text`; a BenchError is always an operational failure
+//! (spec 27 §8 exit 2).
+
+use std::fmt;
+
+#[derive(Debug)]
+pub struct BenchError {
+    pub code: i32,
+    pub message: String,
+}
+
+impl fmt::Display for BenchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for BenchError {}
+
+impl BenchError {
+    /// An operational failure (spec 27 §8 exit 2): unreadable input,
+    /// schema/model disagreement, an unimplemented surface, I/O.
+    pub fn operational(message: impl Into<String>) -> Self {
+        BenchError {
+            message: message.into(),
+            code: i32::from(crate::exit::OPERATIONAL),
+        }
+    }
+
+    /// The run/report stubs before their slices land: named, never a bare
+    /// exit (invariant 9).
+    pub fn not_implemented(surface: &str, slice: &str) -> Self {
+        BenchError::operational(format!(
+            "`tebako-bench {surface}` is not implemented yet (planned: {slice} of the spec 27 benchmark plan)"
+        ))
+    }
+}

--- a/crates/tebako-bench/src/lib.rs
+++ b/crates/tebako-bench/src/lib.rs
@@ -1,0 +1,43 @@
+//! tebako-bench — the spec 27 benchmark harness (v2 tebako vs v1 packed-mn).
+//!
+//! **CI TOOLING, NEVER SHIPPED.** This crate is NOT part of
+//! `.github/workflows/release.yml`'s shipped binary set and must never be
+//! added to it, never published to a release page, never installed by any
+//! installer. It drives the product binaries; it is not one of them. The
+//! audience law is unaffected: nothing a user or payload developer runs
+//! involves this crate.
+//!
+//! Constraints that follow (spec 27 §0):
+//!
+//! - **Pure Rust, no vcpkg** — no tfs/dwarfs/sqfs/rnp dependency, so the
+//!   crate builds in the pure-Rust CI legs (incl. `test-windows`).
+//! - **No shell-outs, ever** (spec 00 invariant 1 applies to tooling by
+//!   choice): downloads are in-process HTTP, archive handling in-process,
+//!   measurement in-process FFI. That uniformity is why ONE implementation
+//!   serves all seven triplets, musl and Windows included.
+//! - **Named errors, named exit codes** (invariant 9): the exit surface is
+//!   spec 27 §8 — 0 success/valid, 1 invalid/all-arms-failed, 2 operational
+//!   (including the not-implemented stubs).
+
+pub mod error;
+pub mod platforms;
+pub mod result;
+pub mod suite;
+pub mod validate;
+
+pub use error::BenchError;
+pub use platforms::{PlatformFile, Triplet};
+pub use result::{ResultFile, RunRecord, StatRecord};
+pub use suite::{RunPolicy, SuiteFile, Target, TargetKind, Workload};
+pub use validate::{validate_file, validate_text, DocKind};
+
+/// The process exit codes (spec 27 §8).
+pub mod exit {
+    /// Success; for `validate`: the document is VALID.
+    pub const OK: u8 = 0;
+    /// `validate`: the document is INVALID. `run`/`report`: completed with
+    /// every arm failed/unavailable (artifacts still written).
+    pub const INVALID: u8 = 1;
+    /// Operational error (I/O, parse, unknown kind, not implemented).
+    pub const OPERATIONAL: u8 = 2;
+}

--- a/crates/tebako-bench/src/main.rs
+++ b/crates/tebako-bench/src/main.rs
@@ -1,0 +1,117 @@
+//! tebako-bench — the spec 27 benchmark harness. CI TOOLING, NEVER SHIPPED
+//! (the boundary comment lives at the crate root; see lib.rs).
+//!
+//! ```text
+//! tebako-bench run --suite <suite.yaml> --platforms <platforms.yaml>
+//!                  --triplet <t> --out <dir> [--opt-in <workload-id>]...
+//! tebako-bench report <results.json>... --md <report.md> --json <dashboard.json>
+//! tebako-bench validate --kind suite|result <file>
+//! ```
+//!
+//! Exit codes (spec 27 §8): 0 success/valid · 1 invalid · 2 operational.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+use tebako_bench::error::BenchError;
+use tebako_bench::exit;
+use tebako_bench::validate::{self, DocKind};
+
+#[derive(Parser)]
+#[command(
+    name = "tebako-bench",
+    version,
+    about = "tebako benchmark harness (spec 27) — CI tooling, never shipped",
+    long_about = None
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Execute the benchmark matrix for one triplet (planned: the sampler,
+    /// acquisition, and run-engine slices of the spec 27 plan).
+    Run {
+        /// The suite document (benchmarks/suite.yaml).
+        #[arg(long)]
+        suite: PathBuf,
+        /// The platforms document (benchmarks/platforms.yaml).
+        #[arg(long)]
+        platforms: PathBuf,
+        /// The triplet this leg runs (the release vocabulary).
+        #[arg(long)]
+        triplet: String,
+        /// Output directory for results.json + logs/.
+        #[arg(long)]
+        out: PathBuf,
+        /// Opt an opt-in workload in (repeatable; e.g. --opt-in compile-medium-oiml-r060).
+        #[arg(long = "opt-in")]
+        opt_in: Vec<String>,
+    },
+    /// Merge N triplet result files into a markdown report + dashboard JSON
+    /// (planned: the report-renderer slice).
+    Report {
+        /// The per-triplet results.json files to merge.
+        #[arg(required = true)]
+        results: Vec<PathBuf>,
+        /// The markdown report destination.
+        #[arg(long)]
+        md: PathBuf,
+        /// The site-ingestible dashboard JSON destination.
+        #[arg(long)]
+        json: PathBuf,
+    },
+    /// Schema-check a suite or result document (both gates: the versioned
+    /// JSON Schema + the serde model, then the semantic rules).
+    Validate {
+        /// The document kind — explicit, never guessed (invariant 9).
+        #[arg(long)]
+        kind: DocKind,
+        /// The document to validate.
+        file: PathBuf,
+    },
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match run(cli) {
+        Ok(code) => ExitCode::from(code),
+        Err(e) => {
+            eprintln!("tebako-bench: {} [{}]", e.message, e.code);
+            ExitCode::from(e.code.clamp(1, 255) as u8)
+        }
+    }
+}
+
+fn run(cli: Cli) -> Result<u8, BenchError> {
+    match cli.command {
+        Command::Validate { kind, file } => {
+            let violations = validate::validate_file(kind, &file)?;
+            if violations.is_empty() {
+                println!("{}: VALID", file.display());
+                Ok(exit::OK)
+            } else {
+                for v in &violations {
+                    eprintln!("{}: {v}", file.display());
+                }
+                eprintln!(
+                    "{}: INVALID ({} violation(s))",
+                    file.display(),
+                    violations.len()
+                );
+                Ok(exit::INVALID)
+            }
+        }
+        Command::Run { .. } => Err(BenchError::not_implemented(
+            "run",
+            "slices 3–5 (sampler, acquisition, run engine)",
+        )),
+        Command::Report { .. } => Err(BenchError::not_implemented(
+            "report",
+            "slice 6 (report renderer)",
+        )),
+    }
+}

--- a/crates/tebako-bench/src/platforms.rs
+++ b/crates/tebako-bench/src/platforms.rs
@@ -1,0 +1,61 @@
+//! The platforms document model (spec 27 §3) — authored YAML, the
+//! triplet → runner + asset mapping the workflow's matrix is generated
+//! from. No JSON Schema artifact in this revision: this serde model is the
+//! structural gate, and `schema_version` reserves the versioning slot.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlatformFile {
+    pub schema_version: u32,
+    pub packed_mn: PackedMn,
+    /// Keyed by the release workflow's triplet spelling (linux-gnu-x86_64,
+    /// …, windows-ucrt64) so a benchmark row joins a release row directly.
+    pub triplets: BTreeMap<String, Triplet>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PackedMn {
+    /// GitHub `owner/repo` of the packed-mn releases.
+    pub repo: String,
+    /// The release tag. packed-mn tags track metanorma-cli: this tag IS the
+    /// v1 arm's metanorma version (the accepted, documented skew).
+    pub tag: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Triplet {
+    /// The CI runner label (the matrix's runs-on).
+    pub runner: String,
+    /// musl legs: the image the leg builds and runs inside.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container: Option<String>,
+    /// The packed-mn asset for the v1-exe arm. `null` is not a skip: one
+    /// explicit `unavailable` row per workload (named gaps, invariant 9).
+    pub v1_asset: Option<String>,
+    /// Whether the suite's payload is published for this triplet. `false`
+    /// gates both v2 arms to named-gap rows.
+    pub v2_payload: bool,
+    /// e.g. "aibika-packed" for the Windows old world — surfaced in reports.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub v1_note: Option<String>,
+}
+
+impl PlatformFile {
+    pub fn from_yaml(text: &str) -> Result<Self, serde_yml::Error> {
+        serde_yml::from_str(text)
+    }
+
+    pub fn semantic_violations(&self) -> Vec<String> {
+        let mut violations = Vec::new();
+        if self.schema_version != 1 {
+            violations.push(format!(
+                "schema_version: expected 1, got {}",
+                self.schema_version
+            ));
+        }
+        violations
+    }
+}

--- a/crates/tebako-bench/src/result.rs
+++ b/crates/tebako-bench/src/result.rs
@@ -1,0 +1,217 @@
+//! The result document model (spec 27 §6) — one machine-written JSON file
+//! per triplet per run, merged by `report`. Structurally gated by
+//! `schema/tebako-bench-result-v1.schema.json`; this serde model is the
+//! same shape (MECE cross-check in tests/validate.rs).
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResultFile {
+    pub schema_version: u32,
+    /// The suite's `name` — report merges only same-suite results.
+    pub suite: String,
+    /// The release workflow's triplet spelling.
+    pub triplet: String,
+    /// Mandatory environment metadata — numbers without their environment
+    /// are not numbers.
+    pub runner: RunnerMeta,
+    /// What actually ran (resolved versions, never requested ones). Fields
+    /// may be absent when no arm of that world ran on the triplet.
+    pub versions: Versions,
+    /// One record per attempted run AND one per named gap.
+    pub runs: Vec<RunRecord>,
+    /// Per (workload × target × mode) statistics over `Ok` runs only.
+    pub stats: Vec<StatRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunnerMeta {
+    /// The CI runner label (e.g. ubuntu-24.04, macos-14, windows-latest).
+    pub runs_on: String,
+    pub arch: String,
+    pub cpus: u32,
+    pub ram_bytes: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Versions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tebako: Option<String>,
+    /// The RESOLVED runtime (e.g. 0.16.9-3.3.12), never the requested line.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<String>,
+    /// The resolved payload release (e.g. 1.16.9-3).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<String>,
+    /// e.g. "v1.14.4 (metanorma-cli 1.14.4)" — the version-skew record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub packed_mn: Option<String>,
+    /// The v2 arms' image backend; numbers across formats never mix.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_format: Option<ImageFormat>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ImageFormat {
+    Dwarfs,
+    Limnifs,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunRecord {
+    pub workload: String,
+    pub target: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<RunMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iteration: Option<u32>,
+    pub status: RunStatus,
+    /// Instant-elapsed seconds around spawn→wait.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wall_s: Option<f64>,
+    /// POSIX getrusage(RUSAGE_CHILDREN) delta / Windows GetProcessTimes
+    /// (spec 27 §4 — one measured child at a time, the delta is exact).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_user_s: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_sys_s: Option<f64>,
+    /// Bytes, ALWAYS — ru_maxrss is KiB on Linux/musl and bytes on macOS;
+    /// the sampler normalizes at record time. Windows: PeakWorkingSetSize.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peak_rss_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit: Option<i32>,
+    /// failed runs: names the missed expectation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// unavailable rows: the mandatory human-readable gap reason.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RunMode {
+    Warm,
+    Cold,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RunStatus {
+    /// Expectation met; all metric fields present.
+    Ok,
+    /// Ran, expectation missed — never enters statistics.
+    Failed,
+    /// Killed at the workload's timeout_s.
+    Timeout,
+    /// The named-gap record: never attempted on this triplet; `reason`
+    /// mandatory. Gaps are explicit data (invariant 9).
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StatRecord {
+    pub workload: String,
+    pub target: String,
+    pub mode: RunMode,
+    /// Count of status-Ok runs in this cell.
+    pub n: u32,
+    /// The headline figure.
+    pub median_wall_s: f64,
+    /// The cross-noise-comparable figure (noise inflates, never deflates).
+    pub min_wall_s: f64,
+    pub max_wall_s: f64,
+    /// Sample standard deviation (n−1); absent when n < 2.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdev_wall_s: Option<f64>,
+    pub mean_wall_s: f64,
+    /// Median of (cpu_user_s + cpu_sys_s).
+    pub median_cpu_s: f64,
+    pub median_peak_rss_bytes: u64,
+}
+
+impl ResultFile {
+    pub fn from_json(text: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(text)
+    }
+
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Semantic checks beyond the schema's structural gate: the per-status
+    /// field requirements restated model-side (the run engine produces these
+    /// records; the check protects hand-written or merged result files), the
+    /// stats-cell uniqueness the schema cannot express.
+    pub fn semantic_violations(&self) -> Vec<String> {
+        let mut violations = Vec::new();
+        if self.schema_version != 1 {
+            violations.push(format!(
+                "schema_version: expected 1, got {}",
+                self.schema_version
+            ));
+        }
+        for (i, r) in self.runs.iter().enumerate() {
+            let at = format!("runs/{i}");
+            match r.status {
+                RunStatus::Ok => {
+                    for (name, present) in [
+                        ("mode", r.mode.is_some()),
+                        ("iteration", r.iteration.is_some()),
+                        ("wall_s", r.wall_s.is_some()),
+                        ("cpu_user_s", r.cpu_user_s.is_some()),
+                        ("cpu_sys_s", r.cpu_sys_s.is_some()),
+                        ("peak_rss_bytes", r.peak_rss_bytes.is_some()),
+                        ("exit", r.exit.is_some()),
+                    ] {
+                        if !present {
+                            violations.push(format!("{at}: an ok run carries {name} (spec 27 §6)"));
+                        }
+                    }
+                }
+                RunStatus::Failed => {
+                    for (name, present) in [
+                        ("mode", r.mode.is_some()),
+                        ("iteration", r.iteration.is_some()),
+                        ("exit", r.exit.is_some()),
+                        ("error", r.error.is_some()),
+                    ] {
+                        if !present {
+                            violations.push(format!("{at}: a failed run carries {name}"));
+                        }
+                    }
+                }
+                RunStatus::Timeout => {
+                    for (name, present) in [
+                        ("mode", r.mode.is_some()),
+                        ("iteration", r.iteration.is_some()),
+                        ("wall_s", r.wall_s.is_some()),
+                    ] {
+                        if !present {
+                            violations.push(format!("{at}: a timeout run carries {name}"));
+                        }
+                    }
+                }
+                RunStatus::Unavailable => {
+                    if r.reason.is_none() {
+                        violations.push(format!(
+                            "{at}: an unavailable row carries reason — the named gap is never silent (invariant 9)"
+                        ));
+                    }
+                }
+            }
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        for s in &self.stats {
+            if !seen.insert((&s.workload, &s.target, s.mode)) {
+                violations.push(format!(
+                    "stats: duplicate cell ({}, {}, {:?}) — one row per workload × target × mode",
+                    s.workload, s.target, s.mode
+                ));
+            }
+        }
+        violations
+    }
+}

--- a/crates/tebako-bench/src/suite.rs
+++ b/crates/tebako-bench/src/suite.rs
@@ -1,0 +1,166 @@
+//! The suite document model (spec 27 §2) — authored YAML, the WHAT-runs
+//! SSOT. Structurally gated by `schema/tebako-bench-suite-v1.schema.json`;
+//! this serde model is the same shape (the MECE cross-check lives in
+//! tests/validate.rs). Unknown keys are tolerated (forward compatibility);
+//! `schema_version` pins the version.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SuiteFile {
+    pub schema_version: u32,
+    pub name: String,
+    pub workloads: Vec<Workload>,
+    pub targets: Vec<Target>,
+    pub run_policy: RunPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Workload {
+    pub id: String,
+    /// Opt-in workloads (private-fonts/credentialed environments) run only
+    /// on explicit request; skipped ones emit NO result rows (spec 27 §2).
+    #[serde(default)]
+    pub opt_in: bool,
+    pub source: Source,
+    /// `{doc}` is the one substitution — the workload document's path in the
+    /// run scratch; every other token is literal.
+    pub argv: Vec<String>,
+    pub expect: Expect,
+    pub timeout_s: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Source {
+    pub kind: SourceKind,
+    /// vendored: repo-relative file path. git: the document's path inside
+    /// the pinned tree.
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// The pinned 40-hex commit (the YAML key is `ref`; floating refs are
+    /// invalid). Fetched as the host's in-process HTTPS archive — never a
+    /// git shell-out.
+    #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
+    pub git_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceKind {
+    Vendored,
+    Git,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Expect {
+    /// Expected process exit status (default 0).
+    #[serde(default)]
+    pub exit: i32,
+    /// Scratch-relative outputs that must exist and be non-empty.
+    pub files: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Target {
+    pub id: String,
+    pub kind: TargetKind,
+    /// `name@version` — the registry payload reference (v2 kinds).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<String>,
+    /// spec 04 registry references the v2 arms resolve through.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registries: Option<Vec<String>>,
+    /// v2-press explicitness flag: the package carries the runtime as a
+    /// slot (the one-file contract).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fat: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TargetKind {
+    /// The packed-mn release executable (asset named by platforms.yaml).
+    V1Exe,
+    /// Registry install + shim dispatch, warm store — v2's primary form.
+    V2Managed,
+    /// A fat tpkg assembled in-leg from verified published artifacts.
+    V2Press,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunPolicy {
+    /// Unmeasured priming runs per (workload × target).
+    pub warmup: u32,
+    /// Measured warm runs per (workload × target).
+    pub repetitions: u32,
+    /// Measured cold runs, each preceded by the spec 27 §5 cache wipe;
+    /// reported separately, never mixed into warm statistics.
+    pub cold_repetitions: u32,
+    /// true: rotate targets per iteration (drift decorrelation). false:
+    /// each target to completion in turn (debugging only).
+    pub interleave: bool,
+}
+
+impl SuiteFile {
+    pub fn from_yaml(text: &str) -> Result<Self, serde_yml::Error> {
+        serde_yml::from_str(text)
+    }
+
+    /// Semantic checks (spec 27 §8's second half): the cross-field rules the
+    /// schema cannot express (id uniqueness), plus the model-side restatement
+    /// of the kind-conditional requirements so the two gates agree (MECE —
+    /// tests/validate.rs asserts exactly that).
+    pub fn semantic_violations(&self) -> Vec<String> {
+        let mut violations = Vec::new();
+        if self.schema_version != 1 {
+            violations.push(format!(
+                "schema_version: expected 1, got {}",
+                self.schema_version
+            ));
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        for w in &self.workloads {
+            if !seen.insert(&w.id) {
+                violations.push(format!("workloads: duplicate id '{}'", w.id));
+            }
+            if w.source.kind == SourceKind::Git {
+                if w.source.url.is_none() {
+                    violations.push(format!("workloads/{}/source: a git source needs url", w.id));
+                }
+                match &w.source.git_ref {
+                    Some(r)
+                        if r.len() == 40
+                            && r.bytes().all(|b| b.is_ascii_digit()
+                                || (b'a'..=b'f').contains(&b)) => {}
+                    other => violations.push(format!(
+                        "workloads/{}/source/ref: '{}' is not a pinned 40-hex commit — floating refs are a named error (spec 27 §2)",
+                        w.id,
+                        other.as_deref().unwrap_or("<missing>")
+                    )),
+                }
+            }
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        for t in &self.targets {
+            if !seen.insert(&t.id) {
+                violations.push(format!("targets: duplicate id '{}'", t.id));
+            }
+            if matches!(t.kind, TargetKind::V2Managed | TargetKind::V2Press) {
+                if t.payload.is_none() {
+                    violations.push(format!(
+                        "targets/{}: a v2 target needs payload (name@version)",
+                        t.id
+                    ));
+                }
+                if t.registries.is_none() {
+                    violations.push(format!(
+                        "targets/{}: a v2 target needs registries (spec 04 references)",
+                        t.id
+                    ));
+                }
+            }
+        }
+        violations
+    }
+}

--- a/crates/tebako-bench/src/validate.rs
+++ b/crates/tebako-bench/src/validate.rs
@@ -1,0 +1,161 @@
+//! `tebako-bench validate` — the two-gate document check (spec 27 §8):
+//! the versioned JSON Schema (structure) AND the serde model (the shape the
+//! run engine consumes), then the model's semantic rules. Every violation
+//! is reported, one per line — never a bare exit (invariant 9).
+//!
+//! The schemas ride INSIDE the binary (include_str!) so an installed
+//! copy never depends on a repo-relative path; the unit-test cross-check
+//! exercises these same embedded bytes against the repo files.
+
+use crate::error::BenchError;
+use crate::result::ResultFile;
+use crate::suite::SuiteFile;
+
+pub const SUITE_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../schema/tebako-bench-suite-v1.schema.json"
+));
+pub const RESULT_SCHEMA: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../schema/tebako-bench-result-v1.schema.json"
+));
+
+/// The document kinds validate understands (explicit `--kind`, never a
+/// guess — invariant 9).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum DocKind {
+    Suite,
+    Result,
+}
+
+impl DocKind {
+    fn schema_text(&self) -> &'static str {
+        match self {
+            DocKind::Suite => SUITE_SCHEMA,
+            DocKind::Result => RESULT_SCHEMA,
+        }
+    }
+}
+
+/// Validate a file on disk. I/O failure is operational (exit 2).
+pub fn validate_file(kind: DocKind, path: &std::path::Path) -> Result<Vec<String>, BenchError> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| BenchError::operational(format!("cannot read {}: {e}", path.display())))?;
+    validate_text(kind, &text)
+}
+
+/// Validate a document, returning every violation found (empty = VALID).
+///
+/// Operational errors (a schema that fails to compile — a harness bug, not
+/// the document's) come back as `Err`. Parse failures and gate
+/// disagreements are violations (exit 1), prefixed with their gate.
+pub fn validate_text(kind: DocKind, text: &str) -> Result<Vec<String>, BenchError> {
+    let mut violations = Vec::new();
+
+    // Gate 0: the document must parse. Suites are authored YAML; results
+    // are machine-written JSON.
+    let instance: serde_json::Value = match kind {
+        DocKind::Suite => match serde_yml::from_str::<serde_yml::Value>(text) {
+            Ok(v) => yaml_to_json(&v),
+            Err(e) => {
+                violations.push(format!("yaml: {e}"));
+                return Ok(violations);
+            }
+        },
+        DocKind::Result => match serde_json::from_str(text) {
+            Ok(v) => v,
+            Err(e) => {
+                violations.push(format!("json: {e}"));
+                return Ok(violations);
+            }
+        },
+    };
+
+    // Gate 1: the versioned JSON Schema (the structural contract).
+    let schema: serde_json::Value = serde_json::from_str(kind.schema_text()).map_err(|e| {
+        BenchError::operational(format!(
+            "the embedded {} schema does not parse (harness bug): {e}",
+            kind_name(kind)
+        ))
+    })?;
+    let validator = jsonschema::validator_for(&schema).map_err(|e| {
+        BenchError::operational(format!(
+            "the embedded {} schema does not compile (harness bug): {e}",
+            kind_name(kind)
+        ))
+    })?;
+    for e in validator.iter_errors(&instance) {
+        violations.push(format!("schema: {}: {e}", e.instance_path));
+    }
+
+    // Gate 2: the serde model (the run engine's shape). A schema-passing
+    // document the model rejects is reported with its gate named — the
+    // unit-test cross-check keeps the two MECE on the shipped shapes.
+    match kind {
+        DocKind::Suite => match SuiteFile::from_yaml(text) {
+            Ok(suite) => violations.extend(
+                suite
+                    .semantic_violations()
+                    .into_iter()
+                    .map(|v| format!("semantic: {v}")),
+            ),
+            Err(e) => violations.push(format!("model: {e}")),
+        },
+        DocKind::Result => match ResultFile::from_json(text) {
+            Ok(result) => violations.extend(
+                result
+                    .semantic_violations()
+                    .into_iter()
+                    .map(|v| format!("semantic: {v}")),
+            ),
+            Err(e) => violations.push(format!("model: {e}")),
+        },
+    }
+
+    Ok(violations)
+}
+
+fn kind_name(kind: DocKind) -> &'static str {
+    match kind {
+        DocKind::Suite => "tebako-bench-suite-v1",
+        DocKind::Result => "tebako-bench-result-v1",
+    }
+}
+
+/// YAML value → JSON value (the schema gate speaks JSON).
+fn yaml_to_json(v: &serde_yml::Value) -> serde_json::Value {
+    match v {
+        serde_yml::Value::Null => serde_json::Value::Null,
+        serde_yml::Value::Bool(b) => serde_json::Value::Bool(*b),
+        serde_yml::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_json::Value::from(i)
+            } else if let Some(u) = n.as_u64() {
+                serde_json::Value::from(u)
+            } else if let Some(f) = n.as_f64() {
+                serde_json::Value::from(f)
+            } else {
+                serde_json::Value::Null
+            }
+        }
+        serde_yml::Value::String(s) => serde_json::Value::String(s.clone()),
+        serde_yml::Value::Sequence(seq) => {
+            serde_json::Value::Array(seq.iter().map(yaml_to_json).collect())
+        }
+        serde_yml::Value::Mapping(map) => {
+            let mut out = serde_json::Map::new();
+            for (k, v) in map {
+                match k {
+                    serde_yml::Value::String(key) => {
+                        out.insert(key.clone(), yaml_to_json(v));
+                    }
+                    other => {
+                        out.insert(format!("{other:?}"), yaml_to_json(v));
+                    }
+                }
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_yml::Value::Tagged(tagged) => yaml_to_json(&tagged.value),
+    }
+}

--- a/crates/tebako-bench/tests/fixtures/result-invalid-gap-no-reason.json
+++ b/crates/tebako-bench/tests/fixtures/result-invalid-gap-no-reason.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "suite": "golden-fixture-suite",
+  "triplet": "linux-musl-arm64",
+  "runner": { "runs_on": "ubuntu-24.04-arm", "arch": "aarch64", "cpus": 4, "ram_bytes": 8388608000 },
+  "versions": { "tebako": "0.2.4" },
+  "runs": [
+    {
+      "workload": "compile-small-iso", "target": "v1-packed-mn",
+      "status": "unavailable"
+    }
+  ],
+  "stats": []
+}

--- a/crates/tebako-bench/tests/fixtures/result-invalid-ok-missing-metrics.json
+++ b/crates/tebako-bench/tests/fixtures/result-invalid-ok-missing-metrics.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "suite": "golden-fixture-suite",
+  "triplet": "linux-gnu-x86_64",
+  "runner": { "runs_on": "ubuntu-24.04", "arch": "x86_64", "cpus": 4, "ram_bytes": 16777216000 },
+  "versions": { "tebako": "0.2.4", "image_format": "dwarfs" },
+  "runs": [
+    {
+      "workload": "compile-small-iso", "target": "v2-shim", "mode": "warm",
+      "iteration": 0, "status": "ok", "exit": 0
+    }
+  ],
+  "stats": []
+}

--- a/crates/tebako-bench/tests/fixtures/result-valid.json
+++ b/crates/tebako-bench/tests/fixtures/result-valid.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "suite": "golden-fixture-suite",
+  "triplet": "macos-arm64",
+  "runner": { "runs_on": "macos-14", "arch": "arm64", "cpus": 8, "ram_bytes": 16777216000 },
+  "versions": {
+    "tebako": "0.2.4",
+    "runtime": "0.16.9-3.3.12",
+    "payload": "1.16.9-3",
+    "packed_mn": "v1.14.4 (metanorma-cli 1.14.4)",
+    "image_format": "dwarfs"
+  },
+  "runs": [
+    {
+      "workload": "compile-small-iso", "target": "v2-shim", "mode": "warm",
+      "iteration": 3, "status": "ok",
+      "wall_s": 12.34, "cpu_user_s": 11.8, "cpu_sys_s": 0.4,
+      "peak_rss_bytes": 123456789, "exit": 0
+    },
+    {
+      "workload": "compile-small-iso", "target": "v1-packed-mn", "mode": "cold",
+      "iteration": 0, "status": "ok",
+      "wall_s": 45.6, "cpu_user_s": 30.1, "cpu_sys_s": 2.2,
+      "peak_rss_bytes": 234567890, "exit": 0
+    },
+    {
+      "workload": "compile-small-iso", "target": "v2-fat", "mode": "warm",
+      "iteration": 0, "status": "failed", "exit": 1,
+      "error": "expect.files: test-iso.xml missing"
+    },
+    {
+      "workload": "compile-medium-rice", "target": "v1-packed-mn", "mode": "warm",
+      "iteration": 1, "status": "timeout", "wall_s": 900.0
+    },
+    {
+      "workload": "compile-small-iso", "target": "v2-shim",
+      "status": "unavailable",
+      "reason": "no published payload for this triplet (metanorma 1.16.9-3 ships 3 of 7)"
+    }
+  ],
+  "stats": [
+    {
+      "workload": "compile-small-iso", "target": "v2-shim", "mode": "warm", "n": 5,
+      "median_wall_s": 12.3, "min_wall_s": 11.9, "max_wall_s": 13.1,
+      "stdev_wall_s": 0.4, "mean_wall_s": 12.4,
+      "median_cpu_s": 12.1, "median_peak_rss_bytes": 123000000
+    },
+    {
+      "workload": "compile-small-iso", "target": "v1-packed-mn", "mode": "cold", "n": 2,
+      "median_wall_s": 44.0, "min_wall_s": 43.0, "max_wall_s": 45.0,
+      "stdev_wall_s": 1.0, "mean_wall_s": 44.0,
+      "median_cpu_s": 32.0, "median_peak_rss_bytes": 230000000
+    },
+    {
+      "workload": "compile-small-iso", "target": "v2-shim", "mode": "cold", "n": 1,
+      "median_wall_s": 50.0, "min_wall_s": 50.0, "max_wall_s": 50.0,
+      "mean_wall_s": 50.0,
+      "median_cpu_s": 33.0, "median_peak_rss_bytes": 231000000
+    }
+  ]
+}

--- a/crates/tebako-bench/tests/fixtures/suite-invalid-floating-ref.yaml
+++ b/crates/tebako-bench/tests/fixtures/suite-invalid-floating-ref.yaml
@@ -1,0 +1,22 @@
+# INVALID: the git source's ref floats ("main" is not a pinned 40-hex
+# commit) — reproducibility is the point of the pin (spec 27 §2).
+schema_version: 1
+name: golden-fixture-suite
+workloads:
+  - id: compile-medium-rice
+    source:
+      kind: git
+      url: https://github.com/metanorma/mn-samples-iso
+      ref: main
+      path: sources/international-standard/rice-2016/document-en.adoc
+    argv: ["compile", "{doc}", "--agree-to-terms"]
+    expect: { exit: 0, files: ["document-en.xml"] }
+    timeout_s: 900
+targets:
+  - id: v1-packed-mn
+    kind: v1-exe
+  - id: v2-shim
+    kind: v2-managed
+    payload: "metanorma@1.16.9"
+    registries: ["tfs:github:tebako-packages/metanorma"]
+run_policy: { warmup: 1, repetitions: 5, cold_repetitions: 2, interleave: true }

--- a/crates/tebako-bench/tests/fixtures/suite-invalid-v2-missing-payload.yaml
+++ b/crates/tebako-bench/tests/fixtures/suite-invalid-v2-missing-payload.yaml
@@ -1,0 +1,16 @@
+# INVALID: a v2-managed target without payload + registries — the arm has
+# nothing to resolve (spec 27 §2's target contract).
+schema_version: 1
+name: golden-fixture-suite
+workloads:
+  - id: compile-small-iso
+    source: { kind: vendored, path: benchmarks/fixtures/test-iso.adoc }
+    argv: ["compile", "{doc}", "--type", "iso", "--agree-to-terms"]
+    expect: { exit: 0, files: ["test-iso.xml"] }
+    timeout_s: 600
+targets:
+  - id: v1-packed-mn
+    kind: v1-exe
+  - id: v2-shim
+    kind: v2-managed
+run_policy: { warmup: 1, repetitions: 5, cold_repetitions: 2, interleave: true }

--- a/crates/tebako-bench/tests/fixtures/suite-valid.yaml
+++ b/crates/tebako-bench/tests/fixtures/suite-valid.yaml
@@ -1,0 +1,31 @@
+schema_version: 1
+name: golden-fixture-suite
+workloads:
+  - id: compile-small-iso
+    source: { kind: vendored, path: benchmarks/fixtures/test-iso.adoc }
+    argv: ["compile", "{doc}", "--type", "iso", "--agree-to-terms"]
+    expect: { exit: 0, files: ["test-iso.xml"] }
+    timeout_s: 600
+  - id: compile-medium-rice
+    opt_in: true
+    source:
+      kind: git
+      url: https://github.com/metanorma/mn-samples-iso
+      ref: eeec963ac6c58db6aeb194c758517f56fa66b845
+      path: sources/international-standard/rice-2016/document-en.adoc
+    argv: ["compile", "{doc}", "--agree-to-terms"]
+    expect: { exit: 0, files: ["document-en.xml"] }
+    timeout_s: 900
+targets:
+  - id: v1-packed-mn
+    kind: v1-exe
+  - id: v2-shim
+    kind: v2-managed
+    payload: "metanorma@1.16.9"
+    registries: ["tfs:github:tebako-packages/metanorma"]
+  - id: v2-fat
+    kind: v2-press
+    payload: "metanorma@1.16.9"
+    fat: true
+    registries: ["tfs:github:tebako-packages/metanorma"]
+run_policy: { warmup: 1, repetitions: 5, cold_repetitions: 2, interleave: true }

--- a/crates/tebako-bench/tests/validate.rs
+++ b/crates/tebako-bench/tests/validate.rs
@@ -1,0 +1,156 @@
+//! Golden-fixture + cross-check tests for `tebako-bench validate`
+//! (spec 27 §8): every valid fixture passes BOTH gates (the embedded
+//! versioned JSON Schema and the serde model), every invalid fixture fails
+//! with named violations, the models round-trip, and the repo's authored
+//! documents (benchmarks/suite.yaml, benchmarks/platforms.yaml) validate —
+//! the schema and the model stay MECE by construction here (the tpkg
+//! pattern).
+
+use tebako_bench::platforms::PlatformFile;
+use tebako_bench::result::ResultFile;
+use tebako_bench::suite::SuiteFile;
+use tebako_bench::validate::{self, DocKind};
+
+fn fixture_path(name: &str) -> String {
+    format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"))
+}
+
+fn repo_path(name: &str) -> String {
+    format!("{}/../../{name}", env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read(path: &str) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+#[test]
+fn embedded_schemas_compile() {
+    for (name, text) in [
+        ("suite", validate::SUITE_SCHEMA),
+        ("result", validate::RESULT_SCHEMA),
+    ] {
+        let schema: serde_json::Value =
+            serde_json::from_str(text).unwrap_or_else(|e| panic!("{name} schema json: {e}"));
+        jsonschema::validator_for(&schema)
+            .unwrap_or_else(|e| panic!("{name} schema compiles: {e}"));
+    }
+}
+
+#[test]
+fn valid_fixtures_pass_both_gates() {
+    for (kind, name) in [
+        (DocKind::Suite, "suite-valid.yaml"),
+        (DocKind::Result, "result-valid.json"),
+    ] {
+        let violations = validate::validate_text(kind, &read(&fixture_path(name)))
+            .unwrap_or_else(|e| panic!("{name}: operational error: {e}"));
+        assert!(
+            violations.is_empty(),
+            "{name} must be VALID, violations: {violations:?}"
+        );
+    }
+}
+
+#[test]
+fn invalid_fixtures_are_named() {
+    for (kind, name, needle) in [
+        (DocKind::Suite, "suite-invalid-floating-ref.yaml", "ref"),
+        (
+            DocKind::Suite,
+            "suite-invalid-v2-missing-payload.yaml",
+            "payload",
+        ),
+        (
+            DocKind::Result,
+            "result-invalid-gap-no-reason.json",
+            "reason",
+        ),
+        (
+            DocKind::Result,
+            "result-invalid-ok-missing-metrics.json",
+            "wall_s",
+        ),
+    ] {
+        let violations = validate::validate_text(kind, &read(&fixture_path(name)))
+            .unwrap_or_else(|e| panic!("{name}: operational error: {e}"));
+        assert!(
+            !violations.is_empty(),
+            "{name} must be INVALID but validated clean"
+        );
+        let joined = violations.join("\n");
+        assert!(
+            joined.contains(needle),
+            "{name}: a violation must name '{needle}', got:\n{joined}"
+        );
+    }
+}
+
+#[test]
+fn models_round_trip() {
+    let suite_text = read(&fixture_path("suite-valid.yaml"));
+    let suite = SuiteFile::from_yaml(&suite_text).expect("suite parses");
+    let rendered = serde_yml::to_string(&suite).expect("suite renders");
+    let reparsed = SuiteFile::from_yaml(&rendered).expect("suite re-parses");
+    assert_eq!(suite, reparsed, "suite YAML round-trip");
+
+    let result_text = read(&fixture_path("result-valid.json"));
+    let result = ResultFile::from_json(&result_text).expect("result parses");
+    let rendered = result.to_json().expect("result renders");
+    let reparsed = ResultFile::from_json(&rendered).expect("result re-parses");
+    assert_eq!(result, reparsed, "result JSON round-trip");
+}
+
+/// The authored SSOT documents must validate against their own contracts —
+/// a suite that fails its schema is a bug on arrival.
+#[test]
+fn repo_authored_documents_validate() {
+    let violations =
+        validate::validate_text(DocKind::Suite, &read(&repo_path("benchmarks/suite.yaml")))
+            .expect("suite.yaml: operational");
+    assert!(
+        violations.is_empty(),
+        "benchmarks/suite.yaml must be VALID, violations: {violations:?}"
+    );
+
+    // platforms.yaml has no JSON Schema artifact in this revision (spec 27
+    // §3): the serde model + its semantic rules are the gate.
+    let platforms_text = read(&repo_path("benchmarks/platforms.yaml"));
+    let platforms =
+        PlatformFile::from_yaml(&platforms_text).expect("platforms.yaml parses the model");
+    assert!(
+        platforms.semantic_violations().is_empty(),
+        "platforms.yaml semantic violations"
+    );
+    assert_eq!(
+        platforms.triplets.len(),
+        7,
+        "the release vocabulary's seven triplets"
+    );
+}
+
+/// MECE: the schema gate and the model gate must agree on validity for
+/// every fixture — a disagreement is a harness bug, not a document verdict.
+#[test]
+fn schema_and_model_gates_agree() {
+    for (kind, name) in [
+        (DocKind::Suite, "suite-valid.yaml"),
+        (DocKind::Suite, "suite-invalid-floating-ref.yaml"),
+        (DocKind::Suite, "suite-invalid-v2-missing-payload.yaml"),
+        (DocKind::Result, "result-valid.json"),
+        (DocKind::Result, "result-invalid-gap-no-reason.json"),
+        (DocKind::Result, "result-invalid-ok-missing-metrics.json"),
+    ] {
+        let text = read(&fixture_path(name));
+        let violations = validate::validate_text(kind, &text).expect("operational");
+        let schema_failed = violations.iter().any(|v| v.starts_with("schema:"));
+        // The model gate is the serde parse AND the semantic rules — both
+        // are the crate's side of the contract.
+        let model_failed = violations
+            .iter()
+            .any(|v| v.starts_with("model:") || v.starts_with("semantic:"));
+        assert_eq!(
+            schema_failed, model_failed,
+            "{name}: gates disagree — violations: {violations:?}"
+        );
+    }
+}

--- a/docs/spec/00-INDEX.md
+++ b/docs/spec/00-INDEX.md
@@ -57,6 +57,7 @@ spec 02 §6).
 24. [24 — Declarative overlays](24-declarative-overlays.md) — write areas and key bindings: the gated COW write gate, `TEBAKO_OVERLAYS` / `TEBAKO_DECRYPT`, the record-mode fold-in, exit 68 (PARTIAL)
 25. [25 — Trace observability](25-trace-observability.md) — the interception bus, `tebako trace run|explain|cover|import`, the escapes correlation (PARTIAL — all four phases' code shipped: the bus + `trace run` (T1), the spawn/resolve emission (T2), `trace cover` + the procmon converter `trace import` (T3), `trace explain` (T4); the remainder is the §8 dogfood legs, not code)
 26. [26 — Payload checks](26-payload-checks.md) — the in-image self-validation contract: the `checks:` manifest block, `tebako check` at press/install/discovery moments, SKIP discipline, exit 79 (PARTIAL — the block + the engine shipped; the §3 press/install gate wiring remains)
+27. [27 — Benchmarks](27-benchmarks.md) — the tebako-bench harness contract: the three arms (v1-exe / v2-press / v2-managed), suite/platforms/result documents + versioned schemas, the in-process sampler semantics (RUSAGE_CHILDREN discipline, ru_maxrss normalization), warm/cold modes and the cache-wipe set, named-gap records, statistical rules; CI tooling, never shipped (PLANNED)
 
 ## Locked invariants (all specs subordinate to these)
 

--- a/docs/spec/27-benchmarks.md
+++ b/docs/spec/27-benchmarks.md
@@ -1,0 +1,414 @@
+# Spec 27 — Benchmarks: the tebako-bench harness contract
+
+Status: PLANNED (spec-first per spec 14; slice 0 spikes executed
+2026-08-25 — §9 records the evidence; the suite/platforms documents,
+schemas, and the `tebako-bench validate` surface land with this spec's
+implementation slice; the sampler, acquisition, run engine, report
+renderer, and workflow are later slices)
+Depends on: 00 (locked invariants), 02 (tpkg wire format), 05
+(resolution and cache), 14 (engineering process), 16 (distribution —
+slim/fat), 17 (runtime driver contract), 19 (bootstrap distribution),
+20 (limnifs backend)
+
+Tebako's benchmark harness answers one question with numbers a third
+party can audit: **how does the v2 tebako stack compare to the v1
+packed-mn release executables on the same document, on the same
+machine, in wall time, CPU time, and peak memory?** The harness is a
+Rust binary (`tebako-bench`, crate `crates/tebako-bench`), three
+authored documents (`benchmarks/suite.yaml`, `benchmarks/platforms.yaml`,
+plus vendored fixtures), two versioned JSON Schemas
+(`schema/tebako-bench-suite-v1.schema.json`,
+`schema/tebako-bench-result-v1.schema.json`), and one GitHub workflow
+(`.github/workflows/benchmark.yml`). This spec is the contract those
+artifacts implement.
+
+## 0. Frame — what the harness is, and is not
+
+- **CI tooling, never shipped.** `tebako-bench` is a workspace crate
+  that builds and runs in CI (and locally for development) and is
+  NEVER a shipped artifact: it is not added to `.github/workflows/release.yml`'s
+  binary set, not published to any release page, not installed by any
+  installer. The crate root carries a comment stating this boundary.
+  The audience law (§root AGENTS.md) is unaffected: nothing a user or a
+  payload developer runs ever involves this crate.
+- **The no-shell-out law applies to tooling too** (invariant 1 is
+  written about shipped artifacts; the harness obeys it by choice,
+  because that uniformity is exactly what lets one implementation serve
+  all seven triplets, musl and Windows included). All downloads are
+  in-process HTTP (the workspace's HTTP crate), all archive handling is
+  in-process (`flate2`/`tar`), all measurement is in-process FFI
+  (§4). The harness never shells out to `time`, `curl`, `git`,
+  `Measure-Command`, or any platform tool.
+- **No vcpkg, no TFS dependency.** The crate is pure Rust. It must
+  build in the pure-Rust CI legs (the `test-windows` package set) —
+  it never links dwarfs-t, sqfs, or rnp. It *drives* the product
+  binaries; it does not link them.
+- **Never per-PR.** Benchmarks run on `workflow_dispatch` and on
+  `release: published` only. A per-PR benchmark would be noise (shared
+  runners) and a cost bomb, and it would put the harness on the merge
+  critical path where it does not belong.
+- The harness **reports**; it does not gate. There is no performance
+  regression refusal in this spec. Named gaps (§6) are data, not
+  failures of the product under test.
+
+## 1. The three arms (targets)
+
+Every benchmark row is one **target** — a way of obtaining and running
+the payload. Three kinds exist; a suite declares one target of each
+kind unless an arm is genuinely meaningless for the suite.
+
+| kind | What it is | The contract it represents |
+|------|-----------|---------------------------|
+| `v1-exe` | A packed-mn release asset (per-triplet `.tgz` or `.exe`), sha256-verified against its `.sha256.txt` sidecar, executed directly | "Download one file, run it, zero install" — the old world |
+| `v2-press` | A fat tpkg assembled in-leg from published, sha256-verified artifacts: bootstrap + payload image slot + runtime slot | The v2 artifact with the same one-file contract (spec 16's fat form) |
+| `v2-managed` | `tebako install <name>@<version>` from a registry, dispatched through the shim with a warm store | v2's primary distribution form (slim/managed, spec 16) |
+
+**Structural asymmetries are part of the report, never hidden:**
+
+- The v1 stack merges env+app in one embedded image and extracts to the
+  host at run time; v2 mounts the env image and the payload image as
+  two co-mounted images (spec 17). The comparison is apples-to-apples
+  at the *user contract* level (one file, one command, one document),
+  not at the mechanism level.
+- packed-mn's Windows asset is aibika-packed, not tebako-v1; the
+  platforms document carries a `v1_note` saying so, and the report
+  labels the row "old world (aibika)". It is included because it is
+  what users actually downloaded.
+- **Version skew is accepted and documented**: the old world is frozen
+  at the packed-mn tag's metanorma-cli (v1.14.4 ↔ metanorma-cli 1.14.4)
+  while the v2 payload is current (1.16.9). Rebuilding a v1 package of
+  a current metanorma resurrects retired tooling and is forbidden
+  (AGENTS.md §10). Every report footer carries the skew note.
+- The v2 image format (`dwarfs` today, `limnifs` when the writer can
+  carry the tree — §9 spike b) is recorded per result
+  (`versions.image_format`); numbers across formats are never mixed in
+  one statistic.
+
+## 2. The suite document (`benchmarks/suite.yaml`)
+
+The suite is the authored SSOT for *what runs*. YAML (invariant 6),
+`schema_version: 1`, validated against
+`schema/tebako-bench-suite-v1.schema.json` by `tebako-bench validate`
+and cross-checked against the crate's serde model in unit tests (the
+tpkg pattern: schema and model kept MECE by the cross-check).
+
+```yaml
+schema_version: 1
+name: metanorma-v1-vs-v2
+workloads:
+  - id: compile-small-iso                 # ^[a-z0-9][a-z0-9-]*$
+    source: {kind: vendored, path: benchmarks/fixtures/test-iso.adoc}
+    argv: ["compile", "{doc}", "--type", "iso", "--agree-to-terms"]
+    expect: {exit: 0, files: ["test-iso.xml"]}
+    timeout_s: 600
+  - id: compile-medium-rice
+    source: {kind: git, url: https://github.com/metanorma/mn-samples-iso,
+             ref: <40-hex pinned commit>, path: sources/.../document-en.adoc}
+    argv: ["compile", "{doc}", "--agree-to-terms"]
+    expect: {exit: 0, files: ["document-en.xml"]}
+    timeout_s: 900
+targets:
+  - {id: v1-packed-mn, kind: v1-exe}
+  - {id: v2-shim, kind: v2-managed, payload: "metanorma@1.16.9",
+     registries: ["tfs:github:tebako-packages/metanorma"]}
+  - {id: v2-fat, kind: v2-press, payload: "metanorma@1.16.9", fat: true,
+     registries: ["tfs:github:tebako-packages/metanorma"]}
+run_policy: {warmup: 1, repetitions: 5, cold_repetitions: 2, interleave: true}
+```
+
+Contract rules:
+
+- **workloads** — a document to compile plus the expectation. `source`
+  is one of:
+  - `kind: vendored` — a file committed in the repo (`path` relative to
+    the repo root). For tiny, CI-proven fixtures only.
+  - `kind: git` — a public git-hosted tree at a **pinned 40-hex
+    commit** (`ref`). The harness fetches the host's archive-of-commit
+    over HTTPS in-process and extracts it in-process (never a `git`
+    shell-out — invariant 1); `path` selects the document inside the
+    tree. Floating refs (branch names, tags) are a named error:
+    reproducibility is the point of the pin.
+- `{doc}` is the ONE argv substitution: the workload document's path in
+  the run's scratch directory. Anything else is literal. (The spec 26
+  checks contract's `{scratch}` rule, applied to the document itself.)
+- `expect`: `exit` (default 0) and `files` — scratch-relative outputs
+  that must exist and be non-empty (the spec 26 §1 `expect.files`
+  rule). A run that misses its expectation is recorded with
+  `status: "failed"` (§6); it is not retried silently and never
+  enters statistics.
+- `timeout_s` is per single run. Expiry kills the child (process group
+  on POSIX, job object on Windows — §4) and records
+  `status: "timeout"`. A benchmark run may be slow; it may never hang
+  the leg.
+- `opt_in: true` workloads are skipped unless the run explicitly opts
+  in (e.g. a dispatch input). Use for workloads needing credentials —
+  the OIML r060 document (Futura PT fonts live in the private
+  fontist-formulas repo) is the canonical case. A skipped opt-in
+  workload emits NO rows at all (it is not a gap — nothing was asked).
+- **targets** — see §1. `v2-managed`/`v2-press` carry `payload`
+  (`name@version`) and `registries` (spec 04 references). `v1-exe`
+  takes its asset from the platforms document (§3).
+- **run_policy** — `warmup` full runs per (workload × target) before
+  any measurement (primes the fontist/relaton/OS caches);
+  `repetitions` measured warm runs per (workload × target);
+  `cold_repetitions` measured cold runs (§5); `interleave: true`
+  rotates targets A/B/C per iteration so runner drift decorrelates
+  across arms. `interleave: false` runs each target to completion in
+  turn (debugging only).
+
+## 3. The platforms document (`benchmarks/platforms.yaml`)
+
+The triplet → runner + asset mapping lives here, not in the workflow —
+the workflow's matrix is generated FROM this document, so a platform
+change is one authored edit. YAML, `schema_version: 1` (its structural
+gate is the crate's serde model; a versioned JSON Schema may follow in
+a later schema revision).
+
+```yaml
+schema_version: 1
+packed_mn: {repo: metanorma/packed-mn, tag: v1.14.4}
+triplets:
+  linux-gnu-x86_64:  {runner: ubuntu-24.04,     v1_asset: metanorma-linux-x86_64.tgz,      v2_payload: true}
+  linux-gnu-arm64:   {runner: ubuntu-24.04-arm, v1_asset: metanorma-linux-aarch64.tgz,     v2_payload: false}
+  linux-musl-x86_64: {runner: ubuntu-24.04, container: alpine:3.21, v1_asset: metanorma-linux-musl-x86_64.tgz, v2_payload: false}
+  linux-musl-arm64:  {runner: ubuntu-24.04-arm, container: alpine:3.21, v1_asset: null,    v2_payload: false}   # gap both sides
+  macos-arm64:       {runner: macos-14,         v1_asset: metanorma-darwin-arm64.tgz,      v2_payload: true}
+  macos-x86_64:      {runner: macos-15-intel,   v1_asset: null,                            v2_payload: false}   # gap both sides (v1 dropped after ~v1.13)
+  windows-ucrt64:    {runner: windows-latest,   v1_asset: metanorma-windows-x86_64.exe,    v2_payload: true, v1_note: aibika-packed}
+```
+
+- The seven triplets are the release workflow's platform vocabulary —
+  the same spelling, so a benchmark row joins against a release row
+  without a translation table.
+- `v1_asset: null` and/or `v2_payload: false` are not skips: each
+  produces an explicit `unavailable` row per workload (§6) with the
+  reason named. Gaps are data.
+- `container` (musl legs) names the image the leg builds and runs
+  inside — the harness itself is one pure-Rust implementation, so the
+  container is the whole difference.
+- The packed-mn POSIX `.tgz` layout is a **single-member gzipped tar
+  carrying one executable** named `metanorma-<platform>` at the root
+  (§9 spike c) — extraction is: decompress, take the one member, mark
+  it executable. The Windows asset is the aibika `.exe` itself
+  (optionally zip-wrapped per the release page).
+
+## 4. The sampler semantics
+
+One in-process sampler spawns the target and records the run. Platform
+shell tools are forbidden (they are absent or flavor-divergent exactly
+where the matrix needs uniformity: no `/usr/bin/time -v` on macOS,
+busybox `time` on alpine, no peak working set in `Measure-Command`).
+FFI is quarantined in `src/sys/{posix,windows}.rs` per the workspace
+rule (unsafe only inside FFI boundary modules).
+
+- **Wall time** — `std::time::Instant` around the spawn→wait span.
+  Unit: seconds, f64, recorded as `wall_s`.
+- **CPU time** —
+  - POSIX: `libc::getrusage(RUSAGE_CHILDREN)` sampled immediately
+    before the spawn and immediately after the `wait` returns; the
+    recorded user/sys CPU is the DELTA. **`RUSAGE_CHILDREN` is
+    cumulative over all waited-on children of the process** — therefore
+    the sampler runs exactly ONE measured child at a time, and no
+    unrelated child of the harness may be reaped between the two
+    samples. This discipline is the whole accuracy story; concurrent
+    measured runs are forbidden even when workloads are independent.
+  - Windows: `CreateProcessW` + `GetProcessTimes` on the child's
+    process handle after wait; user/kernel 100-ns FILETIME intervals
+    converted to seconds. Recorded as `cpu_user_s` / `cpu_sys_s`;
+    statistics use their sum as `cpu_s`.
+- **Peak RSS** —
+  - POSIX: `ru_maxrss` from the same getrusage delta span. **Unit
+    normalization at record time**: Linux/musl report KiB, macOS
+    reports bytes — the sampler multiplies the Linux value by 1024 and
+    every run record carries `peak_rss_bytes`, bytes, always. A result
+    file with un-normalized units is a bug, not a platform difference.
+  - Windows: `K32GetProcessMemoryInfo` → `PeakWorkingSetSize` (bytes,
+    already normalized).
+  - `ru_maxrss`/`PeakWorkingSetSize` are high-water marks of the
+    child — per-run peak, not a sample series. That is the metric
+    (process comparison), and it is deliberately not a Ruby-heap
+    profiler: the comparison target is the process, not the
+    interpreter's allocator.
+- **Timeouts** kill the whole child tree (POSIX: the child's process
+    group; Windows: the job object) and record `status: "timeout"`.
+- One sampler process = one child at a time = one leg's sequential
+  matrix. Cross-leg parallelism is the workflow matrix's job, never
+  the sampler's.
+
+## 5. Modes: warm and cold
+
+- **warm** — the steady-state compile: store primed (v2 runtime +
+  payload installed/resolved), payload caches primed by the warmup
+  run(s). Warm runs measure *the compile*, and only warm runs enter
+  the compile statistics.
+- **cold** — the first-boot experience: before EACH cold run the
+  harness wipes the per-stack caches and measures the whole thing
+  (acquisition included). The wipe set:
+  - `~/.tebako` — the v2 store (runtimes, payloads, registries).
+    Wiping it forces re-download + re-verification; that cost IS the
+    cold metric for the v2 arms. (v2-managed only — v2-press fat
+    packages carry their runtime and never touch the store; v1-exe
+    never either.)
+  - The v1 stack's host extraction root (the v1 memfs unpacks under
+    `$TMPDIR` — observed 2026-08-25 as `$TMPDIR/<content-hash>/` plus
+    `tebako-runtime-*` staging dirs): v1's analog of the store, wiped
+    for v1 cold runs so "cold" means first-boot on both stacks.
+  - `~/.metanorma` and `~/.relaton` — the payload-side caches (fontist
+    fonts, relaton bibliographic cache), present for BOTH stacks, wiped
+    for every cold run of every target. Same paths both stacks: parity
+    holds.
+- Cold results are reported SEPARATELY as install/first-boot metrics
+  and are never mixed into warm medians. `mode` on every run record is
+  `"warm"` or `"cold"` (§6), and statistics are computed per mode.
+- The wipe set is fixed by this spec, not by the suite: an ad-hoc
+  per-suite wipe list would make cross-suite numbers incomparable.
+  (If a payload-side cache outside the three named paths proves to
+  matter — e.g. a legacy `~/.fontist` — it is added HERE by spec
+  amendment, applied to every target alike.)
+
+## 6. The result document (`results.json`)
+
+One result file per triplet per run is the leg's artifact. JSON (the
+results format is machine-written, machine-merged — the authored-YAML
+rule covers authored documents; schemas are versioned JSON Schema per
+invariant 6). Validated against
+`schema/tebako-bench-result-v1.schema.json`; the schema and the crate's
+serde model are cross-checked in unit tests.
+
+```json
+{"schema_version": 1, "suite": "metanorma-v1-vs-v2", "triplet": "linux-gnu-x86_64",
+ "runner": {"runs_on": "ubuntu-24.04", "arch": "x86_64", "cpus": 4, "ram_bytes": 16777216000},
+ "versions": {"tebako": "0.2.4", "runtime": "0.16.9-3.3.12", "payload": "1.16.9-3",
+              "packed_mn": "v1.14.4 (metanorma-cli 1.14.4)", "image_format": "dwarfs"},
+ "runs": [{"workload": "compile-small-iso", "target": "v2-shim", "mode": "warm",
+           "iteration": 3, "status": "ok",
+           "wall_s": 12.34, "cpu_user_s": 11.8, "cpu_sys_s": 0.4,
+           "peak_rss_bytes": 123456789, "exit": 0}],
+ "stats": [{"workload": "compile-small-iso", "target": "v2-shim", "mode": "warm", "n": 5,
+            "median_wall_s": 12.3, "min_wall_s": 11.9, "max_wall_s": 13.1,
+            "stdev_wall_s": 0.4, "mean_wall_s": 12.4,
+            "median_cpu_s": 12.1, "median_peak_rss_bytes": 123000000}]}
+```
+
+Contract rules:
+
+- **Run records** carry `status`:
+  - `"ok"` — expectation met; all metric fields present.
+  - `"failed"` — ran, expectation missed (exit mismatch, missing/empty
+    output); `exit` and whatever metrics exist are present, `error`
+    names the miss. Never enters statistics.
+  - `"timeout"` — killed at `timeout_s`; `wall_s` ≈ timeout, other
+    metrics absent. Never enters statistics.
+  - `"unavailable"` — **the named-gap record**: the arm was never
+    attempted on this triplet (no v1 asset, no published payload, a
+    spike-proven platform incapacity). `reason` is mandatory and
+    human-readable; `mode`/`iteration`/metrics are absent. A gap is
+    explicit data — silent omission is a schema violation (invariant 9:
+    named, never silent).
+- **`runner` metadata is mandatory on every result** — `runs_on` (the
+  GitHub runner label), `arch`, `cpus`, `ram_bytes`. Numbers without
+  their environment are not numbers.
+- **`versions`** records what actually ran — resolved versions, not
+  requested ones (the runtime line resolves to `0.16.9-3.3.12`, the
+  payload to `1.16.9-3`). `image_format` is the v2 arms' backend
+  (`dwarfs` today; §9 spike b).
+- **stats** are computed per (workload × target × mode) over `status:
+  "ok"` runs only, and only when `n ≥ 1`; `stdev` is the sample
+  standard deviation (n−1), absent when `n < 2`. An arm whose runs all
+  failed has NO stats row — the failed run records tell the story.
+
+## 7. Statistical and reporting rules
+
+- Defaults (the suite pins them): warmup 1, warm repetitions 5, cold
+  repetitions 2, interleaved. Repetition counts below these are
+  development shortcuts; CI runs use the suite values.
+- Report median (headline), min, max, stdev, mean for wall; median CPU;
+  median peak RSS. **min is the cross-noise-comparable figure** on
+  shared runners (noise inflates, it does not deflate); the report
+  labels it so.
+- Speedup columns are always "vs v1-exe on the same triplet ×
+  workload × mode"; a missing v1 arm (named gap) renders as "—", never
+  as an invented ratio.
+- The report footer carries: the runner metadata block per triplet, the
+  shared-runner noise caveat ("GitHub-hosted runners are shared,
+  multi-tenant machines; treat differences under ~10% as noise and read
+  min alongside median"), and the version-skew note (§1).
+- One result file per triplet; the report merges N triplet files into
+  one markdown document + one site-ingestible dashboard JSON. Merging
+  never recomputes run-level data — stats are re-derived from the
+  merged run records, so a hand-edited run record cannot smuggle a
+  stale stat past the report.
+
+## 8. The tool surface and its named errors
+
+```text
+tebako-bench run --suite <suite.yaml> --platforms <platforms.yaml>
+                 --triplet <t> --out <dir> [--opt-in <workload-id>]...
+tebako-bench report <results.json>... --md <report.md> --json <dashboard.json>
+tebako-bench validate --kind suite|result <file>
+```
+
+Exit codes (the tool is not the product; its codes are the plain CLI
+shape, never the spec 06/17 contract codes):
+
+- `0` — success; for `validate`: the document is VALID.
+- `1` — for `validate`: the document is INVALID (every violation listed
+  on stderr, one per line, path-prefixed). For `run`/`report`: the
+  benchmark or merge completed with every arm failed/unavailable (the
+  artifacts still written — a red matrix is a deliverable, not a
+  crash).
+- `2` — operational error: unreadable/unparseable input, unknown
+  `--kind`, schema/model disagreement, unimplemented surface (the
+  run/report stubs before their slices land return exit 2 with a named
+  "not implemented" error), I/O failure.
+
+Errors are named on stderr (`tebako-bench: <what> [<detail>]`), one
+line, never a bare exit (invariant 9).
+
+`validate` checks the input against BOTH gates: the versioned JSON
+Schema (structure) and the crate's serde model (the same shape the run
+engine consumes) — a file passing one and failing the other is a bug
+in the harness, and the cross-check unit tests exist to make that
+impossible.
+
+## 9. Spike evidence (2026-08-25, macos-arm64, macOS 14.1.1)
+
+The slice-0 spikes this design rests on, executed before this spec
+landed:
+
+- **(a) Fat press works on macos-arm64 — with `--format dwarfs`, not
+  the default.** `tebako press -r <metanorma-cli 1.16.9 app> -e main.rb
+  -m fat --format dwarfs` (v0.2.4 release binary) produced a 393.8 MB
+  fat package that boots and compiles the small ISO fixture to the full
+  output set (exit 0). The DEFAULT press format (`--format limnifs`)
+  fails at image build: the limnifs writer refuses the staged tree's
+  symlink (`git-5.1.0/.claude/skills -> ../.github/skills`,
+  "unsupported file type", exit 255). v2-fat CI legs therefore press
+  (or bundle) with dwarfs until the limnifs writer grows symlink
+  support AND the size ceiling lifts.
+- **(b) limnifs cannot carry the metanorma payload tree today.**
+  `tfs mkimage --format limnifs` on the extracted 1.16.9 payload
+  (29,846 files, 643 MB, zero symlinks) fails: the tree's metadata
+  externalizes at **6,952,795 bytes** — the writer's inline threshold
+  is 1 MiB − 24 KiB and the readers' hard ceiling is 1 MiB
+  (`limnifs-core 0.2.61`'s `DEFAULT_INLINE_METADATA_MAX_BYTES`; the
+  writer's `metadata_externalize_threshold` knob, limnifs#187, can
+  raise the WRITE side but every published v0.16.x-era runtime reads
+  with the default, so lifting it produces images the field cannot
+  read). limnifs-write 0.2.61 (2026-08-24) is the newest published —
+  upstream has NOT lifted the ceiling. Consequence: v2 arms report
+  dwarfs-backend numbers for metanorma; a limnifs arm is a named gap
+  until a small-payload suite or a lifted ceiling changes the facts.
+  Never fake it.
+- **(c) packed-mn v1.14.4 `metanorma-darwin-arm64.tgz` is a
+  single-member gzipped tar** (343.8 MB → one 355.4 MB Mach-O arm64
+  executable, mode 0755, member name `metanorma-darwin-arm64`), sha256
+  verified against its `.sha256.txt` (bare-hash format). **The v1 exe
+  does not run on this machine**: exec → v1 runtime extracts its memfs
+  to `$TMPDIR/<content-hash>/` → AMFI kills the process loading the
+  extracted `nokogiri.bundle` (`cs_invalid_page ... final status
+  0x23020200, denying page sending SIGKILL`, exit 137; reproduced with
+  a fresh TMPDIR). Whether the `macos-14` CI runner behaves the same is
+  an empirical question the leg answers; if it does, the v1 macOS arm
+  becomes a named gap with this reason. The harness records the
+  outcome; it does not work around it.

--- a/schema/tebako-bench-result-v1.schema.json
+++ b/schema/tebako-bench-result-v1.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tebako.org/schemas/tebako-bench-result-v1.schema.json",
+  "title": "tebako-bench result v1",
+  "description": "One benchmark leg's result document (spec 27 §6): runner metadata + resolved versions + per-run records + per-(workload × target × mode) statistics. Machine-written by `tebako-bench run`, machine-merged by `tebako-bench report`. This schema is the STRUCTURAL contract; the crate's serde model is the same shape (MECE cross-check in unit tests). Unknown keys are tolerated at every level for forward compatibility; schema_version pins the version.",
+  "type": "object",
+  "required": ["schema_version", "suite", "triplet", "runner", "versions", "runs", "stats"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "suite": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The suite document's `name` — the report merges only same-suite results."
+    },
+    "triplet": {
+      "enum": ["linux-gnu-x86_64", "linux-gnu-arm64", "linux-musl-x86_64", "linux-musl-arm64", "macos-arm64", "macos-x86_64", "windows-ucrt64"],
+      "description": "The release workflow's platform vocabulary — a result row joins against a release row without a translation table."
+    },
+    "runner": {
+      "type": "object",
+      "required": ["runs_on", "arch", "cpus", "ram_bytes"],
+      "properties": {
+        "runs_on": { "type": "string", "minLength": 1, "description": "The CI runner label (e.g. ubuntu-24.04, macos-14, windows-latest)." },
+        "arch": { "type": "string", "minLength": 1 },
+        "cpus": { "type": "integer", "minimum": 1 },
+        "ram_bytes": { "type": "integer", "minimum": 1 }
+      },
+      "description": "Mandatory environment metadata — numbers without their environment are not numbers."
+    },
+    "versions": {
+      "type": "object",
+      "properties": {
+        "tebako": { "type": "string", "minLength": 1 },
+        "runtime": { "type": "string", "minLength": 1, "description": "The RESOLVED runtime (e.g. 0.16.9-3.3.12), never the requested line." },
+        "payload": { "type": "string", "minLength": 1, "description": "The resolved payload release (e.g. 1.16.9-3)." },
+        "packed_mn": { "type": "string", "minLength": 1, "description": "e.g. \"v1.14.4 (metanorma-cli 1.14.4)\" — the version-skew record." },
+        "image_format": { "enum": ["dwarfs", "limnifs"], "description": "The v2 arms' image backend; numbers across formats never mix in one statistic." }
+      },
+      "description": "What actually ran. Fields may be absent when no arm of that world ran on the triplet (all-gap results stay honest)."
+    },
+    "runs": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/run" },
+      "description": "One record per attempted run AND one per named gap. Gaps are explicit data — silent omission is a schema violation (invariant 9)."
+    },
+    "stats": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/stats" },
+      "description": "Per (workload × target × mode) statistics over status \"ok\" runs only. Absent for arms with zero ok runs."
+    }
+  },
+  "$defs": {
+    "run": {
+      "type": "object",
+      "required": ["workload", "target", "status"],
+      "properties": {
+        "workload": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "target": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "mode": { "enum": ["warm", "cold"] },
+        "iteration": { "type": "integer", "minimum": 0 },
+        "status": {
+          "enum": ["ok", "failed", "timeout", "unavailable"],
+          "description": "ok: expectation met, all metrics present. failed: ran, expectation missed — never enters statistics. timeout: killed at the workload's timeout_s. unavailable: the named-gap record — the arm was never attempted on this triplet; reason is mandatory."
+        },
+        "wall_s": { "type": "number", "minimum": 0, "description": "Instant-elapsed seconds around spawn→wait." },
+        "cpu_user_s": { "type": "number", "minimum": 0, "description": "POSIX: getrusage(RUSAGE_CHILDREN) delta; Windows: GetProcessTimes user. spec 27 §4." },
+        "cpu_sys_s": { "type": "number", "minimum": 0, "description": "Same span, system CPU." },
+        "peak_rss_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Bytes, ALWAYS — the sampler normalizes ru_maxrss's KiB (Linux/musl) vs bytes (macOS) at record time. Windows: PeakWorkingSetSize."
+        },
+        "exit": { "type": "integer", "description": "The child's process exit status." },
+        "error": { "type": "string", "minLength": 1, "description": "failed runs: names the missed expectation." },
+        "reason": { "type": "string", "minLength": 1, "description": "unavailable rows: the human-readable gap reason." }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "ok" } }, "required": ["status"] },
+          "then": { "required": ["mode", "iteration", "wall_s", "cpu_user_s", "cpu_sys_s", "peak_rss_bytes", "exit"] }
+        },
+        {
+          "if": { "properties": { "status": { "const": "failed" } }, "required": ["status"] },
+          "then": { "required": ["mode", "iteration", "exit", "error"] }
+        },
+        {
+          "if": { "properties": { "status": { "const": "timeout" } }, "required": ["status"] },
+          "then": { "required": ["mode", "iteration", "wall_s"] }
+        },
+        {
+          "if": { "properties": { "status": { "const": "unavailable" } }, "required": ["status"] },
+          "then": { "required": ["reason"] }
+        }
+      ]
+    },
+    "stats": {
+      "type": "object",
+      "required": ["workload", "target", "mode", "n", "median_wall_s", "min_wall_s", "max_wall_s", "mean_wall_s", "median_cpu_s", "median_peak_rss_bytes"],
+      "properties": {
+        "workload": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "target": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "mode": { "enum": ["warm", "cold"] },
+        "n": { "type": "integer", "minimum": 1, "description": "Count of status \"ok\" runs in this cell." },
+        "median_wall_s": { "type": "number", "minimum": 0, "description": "The headline figure." },
+        "min_wall_s": { "type": "number", "minimum": 0, "description": "The cross-noise-comparable figure on shared runners (noise inflates, never deflates)." },
+        "max_wall_s": { "type": "number", "minimum": 0 },
+        "stdev_wall_s": { "type": "number", "minimum": 0, "description": "Sample standard deviation (n−1); absent when n < 2." },
+        "mean_wall_s": { "type": "number", "minimum": 0 },
+        "median_cpu_s": { "type": "number", "minimum": 0, "description": "Median of (cpu_user_s + cpu_sys_s)." },
+        "median_peak_rss_bytes": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/schema/tebako-bench-suite-v1.schema.json
+++ b/schema/tebako-bench-suite-v1.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tebako.org/schemas/tebako-bench-suite-v1.schema.json",
+  "title": "tebako-bench suite v1",
+  "description": "The benchmark suite document (spec 27 §2): workloads + targets + run_policy. This schema is the STRUCTURAL contract; the tebako-bench crate's serde model is the same shape (kept MECE by the unit-test cross-check). Semantic rules beyond shape — {doc} arity, git ref pinning to a 40-hex commit (pattern-checked here), registries being spec-04 references — are the model's/run engine's. Unknown keys are tolerated at every level for forward compatibility; schema_version pins the version.",
+  "type": "object",
+  "required": ["schema_version", "name", "workloads", "targets", "run_policy"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "name": { "type": "string", "minLength": 1 },
+    "workloads": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/workload" },
+      "description": "The documents to compile. Order is not semantic; ids are unique (checked semantically)."
+    },
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/target" },
+      "description": "The arms under test (spec 27 §1). A full suite declares one target of each kind unless an arm is genuinely meaningless."
+    },
+    "run_policy": { "$ref": "#/$defs/runPolicy" }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "description": "DNS-label-ish identifier, used as a key in result records."
+    },
+    "workload": {
+      "type": "object",
+      "required": ["id", "source", "argv", "expect", "timeout_s"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "opt_in": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true the workload runs only on explicit opt-in (e.g. needs credentials — the OIML r060 private-fonts case). A skipped opt-in workload emits NO result rows."
+        },
+        "source": { "$ref": "#/$defs/source" },
+        "argv": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "The argument vector passed to the target's entrypoint. '{doc}' is the ONE substitution — the workload document's path in the run scratch; every other token is literal."
+        },
+        "expect": { "$ref": "#/$defs/expect" },
+        "timeout_s": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Per-run timeout in seconds. Expiry kills the child tree and records status \"timeout\" — a benchmark may be slow, never hung."
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": ["kind", "path"],
+      "properties": {
+        "kind": { "enum": ["vendored", "git"] },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "vendored: file path relative to the repo root. git: the document's path inside the pinned tree."
+        },
+        "url": { "type": "string", "minLength": 1 },
+        "ref": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "The pinned 40-hex commit. Floating refs (branches, tags) are invalid: reproducibility is the point of the pin. Fetched as the host's in-process HTTPS archive — never a git shell-out."
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "const": "git" } }, "required": ["kind"] },
+          "then": { "required": ["url", "ref"] }
+        }
+      ]
+    },
+    "expect": {
+      "type": "object",
+      "required": ["files"],
+      "properties": {
+        "exit": {
+          "type": "integer",
+          "default": 0,
+          "description": "Expected process exit status (the spec 26 §1 expect rule)."
+        },
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Scratch-relative output paths that must exist and be non-empty after the run."
+        }
+      }
+    },
+    "target": {
+      "type": "object",
+      "required": ["id", "kind"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "kind": {
+          "enum": ["v1-exe", "v2-managed", "v2-press"],
+          "description": "v1-exe: the packed-mn release asset (asset from platforms.yaml). v2-managed: registry install + shim dispatch, warm store. v2-press: fat tpkg assembled in-leg from verified published artifacts."
+        },
+        "payload": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]*@\\S+$",
+          "description": "name@version — the registry payload reference (v2 kinds)."
+        },
+        "registries": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "description": "spec 04 registry references the v2 arms resolve the payload through."
+        },
+        "fat": {
+          "type": "boolean",
+          "description": "v2-press: carry the runtime as a slot (the one-file contract). v2 packages are fat in this harness by definition; the flag exists for the suite author's explicitness."
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "enum": ["v2-managed", "v2-press"] } }, "required": ["kind"] },
+          "then": { "required": ["payload", "registries"] }
+        }
+      ]
+    },
+    "runPolicy": {
+      "type": "object",
+      "required": ["warmup", "repetitions", "cold_repetitions", "interleave"],
+      "properties": {
+        "warmup": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Unmeasured runs per (workload × target) priming the fontist/relaton/OS caches before measurement."
+        },
+        "repetitions": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Measured warm runs per (workload × target). The statistics live or die on this N."
+        },
+        "cold_repetitions": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Measured cold runs — each preceded by the spec 27 §5 cache wipe; reported separately as install/first-boot metrics, never mixed into warm statistics."
+        },
+        "interleave": {
+          "type": "boolean",
+          "description": "true: rotate targets A/B/C per iteration to decorrelate runner drift. false: each target to completion in turn (debugging only)."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Spec 27 + tebako-bench skeleton (benchmark harness, slices 0–2)

The v2-vs-v1 benchmark system (plan + locked decisions: `PROGRESS/13-benchmarks.md` + `13-benchmarks-plan-full.md`). **CI tooling — never shipped**; release.yml untouched (its five binaries build by explicit `-p` lists).

### Spike results (recorded normatively in spec §9)

- **Fat press of metanorma 1.16.9: PASS with `--format dwarfs`** (393.8 MB exe; `--version` and a full `compile` of the vendored ISO fixture verified, rc=0) — **FAIL with default limnifs**: the writer rejects a symlink shipped by the git gem → filed **limnifs/limnifs#190**.
- **limnifs cannot carry the published 643 MB metanorma payload tree** (metadata externalizes 6.63 MiB vs the ~1000 KiB threshold; the #187 writer knob is write-side only and every published reader floors at 1 MiB) → filed **limnifs/limnifs#191**. Consequence per decision 1: dwarfs-backend numbers for metanorma + a named-gap limnifs arm.
- **packed-mn v1.14.4 `metanorma-darwin-arm64.tgz`** is a single-member tar.gz (355.4 MB Mach-O, sha256 verified); extraction rule recorded. **The v1 exe does not run on macOS 14.1.1** — `Killed: 9`, `cs_invalid_page` on its extracted `nokogiri.bundle`. If macos-14 runners behave alike, the v1 macOS arm is a named gap; the suite models that.

### Contents

- `docs/spec/27-benchmarks.md` + `docs/spec/00-INDEX.md` row (contracts, sampler semantics, warm/cold modes, named gaps, stats rules, CI-tooling boundary, spike evidence).
- `benchmarks/suite.yaml` + `benchmarks/platforms.yaml` + vendored `benchmarks/fixtures/test-iso.adoc` (byte-identical from metanorma-feedstock @ 79bddb4; rice doc + opt-in OIML r060 pinned by sha).
- `schema/tebako-bench-{suite,result}-v1.schema.json` (draft 2020-12, tpkg cross-check pattern).
- `crates/tebako-bench`: clap dispatch `run|report|validate`; serde models; `validate` fully implemented (schema + model + semantic gates); `run`/`report` named-error stubs; pure Rust, no vcpkg/tfs deps. `ci.yml` test+clippy legs gain `-p tebako-bench`.

### Verification

`cargo build/test/clippy/fmt` all green in debug (6/6 tests incl. the repo's own suite.yaml validating clean); binary smoke: valid→0, invalid→1 naming every violation, stubs→2 named. Rebased onto the v0.2.5 bump.

### Next slices (stacked follow-up PRs)

Sampler (getrusage/CreateProcessW, FFI-quarantined) → acquisition (sha256-verified fetch/install) → run engine → report renderer → benchmark.yml workflow.
