### PR TITLE
tebako-bench slices 3–5: sampler, acquisition, run engine (spec 27)

### DIFF
--- a/crates/tebako-bench/Cargo.toml
+++ b/crates/tebako-bench/Cargo.toml
@@ -27,6 +27,18 @@ clap = { version = "4", features = ["derive"] }
 # `validate`'s schema gate (the same jsonschema the tpkg cross-checks use).
 jsonschema = "0.30"
 
+# Acquisition (slice 4): downloads ride the workspace's HTTP crate
+# (in-process ureq+rustls, webpki-roots bundled — the no-shell-out rule);
+# the fat tpkg assembles through tpkg, the L0 wire-format owner (pure
+# Rust, forbid(unsafe)); the packed-mn .tgz and the git source archives
+# extract in-process via flate2 (rust backend) + tar (the workspace's
+# established versions — tebako-cli's RuntimeSdk provisioning uses the
+# same pair).
+tebako-http = { version = "0.2.1", path = "../tebako-http" }
+tpkg = { version = "0.2.1", path = "../tpkg" }
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+tar = { version = "0.4", default-features = false }
+
 # The sampler's POSIX backend (sys/posix.rs): wait4 rusage, killpg,
 # sysconf — FFI quarantined in that one module (workspace unsafe rule).
 [target.'cfg(unix)'.dependencies]

--- a/crates/tebako-bench/Cargo.toml
+++ b/crates/tebako-bench/Cargo.toml
@@ -27,5 +27,22 @@ clap = { version = "4", features = ["derive"] }
 # `validate`'s schema gate (the same jsonschema the tpkg cross-checks use).
 jsonschema = "0.30"
 
+# The sampler's POSIX backend (sys/posix.rs): wait4 rusage, killpg,
+# sysconf — FFI quarantined in that one module (workspace unsafe rule).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+# The sampler's Windows backend (sys/windows.rs): OpenProcess +
+# WaitForSingleObject polling, GetProcessTimes / K32GetProcessMemoryInfo,
+# the timeout job object, GlobalMemoryStatusEx.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_ProcessStatus",
+    "Win32_System_JobObjects",
+    "Win32_System_SystemInformation",
+] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tebako-bench/Cargo.toml
+++ b/crates/tebako-bench/Cargo.toml
@@ -17,7 +17,11 @@ categories = ["development-tools"]
 # manifest convention); result documents are machine-written JSON.
 serde = { version = "1", features = ["derive"] }
 serde_yml = "0.0.12"
-serde_json = "1"
+# float_roundtrip: results.json is machine-merged by `report` — an emitted
+# f64 (a measured wall, a computed stat) must parse back bit-exact, or the
+# report's re-derived stats could drift 1 ulp from the leg's (spec 27 §7's
+# merge rule). serde_json's default float parse does not guarantee it.
+serde_json = { version = "1", features = ["float_roundtrip"] }
 # SHA-256 for artifact verification (the acquisition slice); spec 00's
 # trust-anchor rule applies to every downloaded byte.
 sha2 = "0.10"

--- a/crates/tebako-bench/src/acquire.rs
+++ b/crates/tebako-bench/src/acquire.rs
@@ -749,6 +749,36 @@ pub fn prime_runtime(
     read_runtime_entry(layout, triplet, &payload.mirror)
 }
 
+/// The dispatcher path for the payload's first entrypoint — the managed
+/// arm's measured program (the engine re-runs it after `prime_runtime`
+/// staged the store).
+pub fn shim_path(
+    layout: &BenchLayout,
+    triplet: &str,
+    payload: &PayloadHome,
+) -> Result<PathBuf, BenchError> {
+    let entrypoint = app_entrypoints(&payload.mirror)
+        .first()
+        .map(|e| e.name.clone())
+        .ok_or_else(|| {
+            BenchError::operational(format!(
+                "acquire: the {} {} manifest declares no entrypoints — nothing to dispatch",
+                payload.name, payload.version
+            ))
+        })?;
+    let shim = layout
+        .store()
+        .join("shims")
+        .join(format!("{entrypoint}{}", exe_suffix(triplet)));
+    if !shim.is_file() {
+        return Err(BenchError::operational(format!(
+            "acquire: the install left no dispatcher {} in the store",
+            shim.display()
+        )));
+    }
+    Ok(shim)
+}
+
 /// Scan `runtimes/<engine>-<lv>-<ver>-<triplet>/` for THE cached runtime.
 /// Zero entries (the priming failed) or several (ambiguity) are named
 /// errors — never a guess (invariant 9).

--- a/crates/tebako-bench/src/acquire.rs
+++ b/crates/tebako-bench/src/acquire.rs
@@ -1,0 +1,1278 @@
+//! Acquisition (spec 27 §1/§3/§5): everything the run engine needs before
+//! the matrix starts — the downloaded product tools, the v1 packed-mn
+//! executable, the v2-managed store contents, the v2-press fat package, and
+//! the workload source documents — plus the per-mode cache wiping.
+//!
+//! **The dogfood rule (task-level decision, recorded here and in the
+//! commit):** anything the PRODUCT already does with its own verification
+//! rides the product — `tebako add-registry` / `tebako install` populate
+//! the bench home's store by SPAWNING the downloaded CLI (in-process
+//! re-implementation would duplicate the spec 05 store + registry-pin
+//! verification logic), and the runtime download rides the shim/bootstrap
+//! dispatch (release-index manifest.json / SHA256SUMS.txt verification is
+//! the product's own download path, tebako-shim/src/runtime.rs). The
+//! harness itself verifies exactly the bytes IT downloads: the tebako
+//! release assets against the release `SHA256SUMS`, and the packed-mn
+//! asset against its bare-hash `.sha256.txt` sidecar. The fat package's
+//! runtime slot is the store's verified exe, pinned byte-for-byte by the
+//! trailer's `;sha256=` (re-verified by the bootstrap at every run).
+//!
+//! **No shell-outs to platform tools** (spec 27 §0): downloads are
+//! tebako-http, archives are flate2/tar in-process. The ONE exception is
+//! macOS ad-hoc re-signing of the assembled fat package — `codesign` has
+//! no in-process form (it is a Mach-O load-command rewrite) and the
+//! product's own press does exactly the same, best-effort and loud on
+//! failure (tebako-cli::resign_if_needed).
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use sha2::Digest;
+
+use crate::error::BenchError;
+use crate::platforms::PlatformFile;
+use crate::result::ImageFormat;
+use crate::suite::{SourceKind, Target, TargetKind, Workload};
+
+/// The triplet spellings are the release vocabulary (spec 27 §3) — the
+/// Windows legs carry the `.exe` suffix in their release asset names.
+pub fn exe_suffix(triplet: &str) -> &'static str {
+    if triplet.starts_with("windows") {
+        ".exe"
+    } else {
+        ""
+    }
+}
+
+/// The `--out` directory's internal layout (spec 27 §5's hermetic bench
+/// home lives here — a cold run never touches the host's real caches).
+#[derive(Debug, Clone)]
+pub struct BenchLayout {
+    /// `<out>` itself.
+    pub root: PathBuf,
+    /// `<out>/bin` — the downloaded product tools under their BARE names
+    /// (the CLI locates the dispatcher next to its own current_exe).
+    pub bin: PathBuf,
+    /// `<out>/assets` — raw downloads (kept for audit).
+    pub assets: PathBuf,
+    /// `<out>/home` — the hermetic bench home (the child's HOME; its
+    /// `.tebako` is the v2 store; `.metanorma`/`.relaton` the payload
+    /// caches).
+    pub home: PathBuf,
+    /// `<out>/tmp/<target>` — the per-target TMPDIR (the v1 stack's
+    /// extraction root is its TMPDIR, spec 27 §9 spike c).
+    pub tmp: PathBuf,
+    /// `<out>/sources/<workload>` — materialized workload source trees.
+    pub sources: PathBuf,
+    /// `<out>/targets/<target>` — the acquired executables (v1 exe, fat
+    /// package).
+    pub targets: PathBuf,
+    /// `<out>/scratch/<workload>/<target>/<mode>-<iteration>` — per-run
+    /// scratch (the child's cwd; `{doc}` and expectations live here).
+    pub scratch: PathBuf,
+    /// `<out>/logs` — one log per run plus the acquisition logs.
+    pub logs: PathBuf,
+}
+
+impl BenchLayout {
+    pub fn new(out: &Path) -> Result<Self, BenchError> {
+        let layout = BenchLayout {
+            root: out.to_path_buf(),
+            bin: out.join("bin"),
+            assets: out.join("assets"),
+            home: out.join("home"),
+            tmp: out.join("tmp"),
+            sources: out.join("sources"),
+            targets: out.join("targets"),
+            scratch: out.join("scratch"),
+            logs: out.join("logs"),
+        };
+        for dir in [
+            &layout.root,
+            &layout.bin,
+            &layout.assets,
+            &layout.home,
+            &layout.tmp,
+            &layout.sources,
+            &layout.targets,
+            &layout.scratch,
+            &layout.logs,
+        ] {
+            std::fs::create_dir_all(dir).map_err(|e| {
+                BenchError::operational(format!("acquire: cannot create {}: {e}", dir.display()))
+            })?;
+        }
+        Ok(layout)
+    }
+
+    /// The bench home's store root (`<out>/home/.tebako`, TEBAKO_HOME).
+    pub fn store(&self) -> PathBuf {
+        self.home.join(".tebako")
+    }
+
+    /// The hermetic environment every spawned child rides (spec 27 §5):
+    /// HOME + TEBAKO_HOME under `<out>/home`, TMPDIR per target. On
+    /// Windows the USERPROFILE/TEMP/TMP equivalents come along (the leg's
+    /// platform IS the host — `cfg!(windows)` is the triplet's truth).
+    pub fn child_env(&self, target: &str) -> Vec<(String, String)> {
+        let tmp = self.tmp.join(target);
+        let mut env = vec![
+            ("HOME".to_string(), self.home.to_string_lossy().into_owned()),
+            (
+                "TEBAKO_HOME".to_string(),
+                self.store().to_string_lossy().into_owned(),
+            ),
+            ("TMPDIR".to_string(), tmp.to_string_lossy().into_owned()),
+        ];
+        if cfg!(windows) {
+            env.push((
+                "USERPROFILE".to_string(),
+                self.home.to_string_lossy().into_owned(),
+            ));
+            env.push(("TEMP".to_string(), tmp.to_string_lossy().into_owned()));
+            env.push(("TMP".to_string(), tmp.to_string_lossy().into_owned()));
+        }
+        env
+    }
+
+    /// The spec 27 §5 cold-run wipe for one target: the payload caches
+    /// (`~/.metanorma`, `~/.relaton` — both stacks, parity holds) always;
+    /// then per arm:
+    ///
+    /// - v1-exe: the per-target TMPDIR (the v1 memfs extraction root) —
+    ///   first-boot means re-extraction inside the measured span.
+    /// - v2-managed: the whole store — the payload re-installs
+    ///   (UNMEASURED, spec 27 §5's cold flow) and the runtime download
+    ///   lands inside the measured span.
+    /// - v2-press: the store's `runtimes/` — the fat package carries the
+    ///   runtime EXE but NOT the env image (§9 spike a), so the env-image
+    ///   download lands inside the measured span. The package never
+    ///   touches the store's payload side, so the payload record survives
+    ///   (and the next v2-managed cold rep re-installs anyway).
+    pub fn wipe_cold_caches(&self, target: &str, kind: TargetKind) -> Result<(), BenchError> {
+        let mut wipes = vec![self.home.join(".metanorma"), self.home.join(".relaton")];
+        match kind {
+            TargetKind::V1Exe => wipes.push(self.tmp.join(target)),
+            TargetKind::V2Managed => wipes.push(self.store()),
+            TargetKind::V2Press => wipes.push(self.store().join("runtimes")),
+        }
+        for dir in &wipes {
+            remove_tree(dir)?;
+        }
+        // The wiped TMPDIR must exist again for the next child.
+        std::fs::create_dir_all(self.tmp.join(target)).map_err(|e| {
+            BenchError::operational(format!(
+                "acquire: cannot recreate {}: {e}",
+                self.tmp.join(target).display()
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+fn remove_tree(dir: &Path) -> Result<(), BenchError> {
+    match std::fs::remove_dir_all(dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(BenchError::operational(format!(
+            "acquire: cannot wipe {}: {e}",
+            dir.display()
+        ))),
+    }
+}
+
+// ---------------------------------------------------------------------
+// downloads + sha256 verification (the bytes the HARNESS downloads)
+// ---------------------------------------------------------------------
+
+/// sha256 of a file's bytes, lowercase hex.
+pub fn sha256_file_hex(path: &Path) -> Result<String, BenchError> {
+    let mut f = std::fs::File::open(path).map_err(|e| {
+        BenchError::operational(format!("acquire: cannot open {}: {e}", path.display()))
+    })?;
+    let mut hasher = sha2::Sha256::new();
+    std::io::copy(&mut f, &mut hasher).map_err(|e| {
+        BenchError::operational(format!("acquire: cannot read {}: {e}", path.display()))
+    })?;
+    Ok(hex_lower(&hasher.finalize()))
+}
+
+pub fn sha256_bytes_hex(bytes: &[u8]) -> String {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(bytes);
+    hex_lower(&hasher.finalize())
+}
+
+fn hex_lower(digest: &[u8]) -> String {
+    digest.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// One `SHA256SUMS` line: `<64-hex><space(s)>[*]<name>` (the coreutils
+/// format). Returns the lowercase digest for `asset`, if listed.
+pub fn parse_sha256sums(text: &str, asset: &str) -> Option<String> {
+    text.lines().find_map(|line| {
+        let mut parts = line.split_whitespace();
+        let hex = parts.next()?;
+        let name = parts.next()?.trim_start_matches('*');
+        if name == asset && is_hex64(hex) {
+            Some(hex.to_lowercase())
+        } else {
+            None
+        }
+    })
+}
+
+/// The packed-mn `.sha256.txt` sidecar is a BARE hash (spec 27 §9 spike
+/// c): one 64-hex token, optionally with trailing whitespace/filename.
+pub fn parse_bare_hash(text: &str) -> Option<String> {
+    let token = text.split_whitespace().next()?;
+    is_hex64(token).then(|| token.to_lowercase())
+}
+
+fn is_hex64(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// GET `url` (tebako-http — in-process, HTTPS-only) → BenchError with the
+/// URL named.
+fn get(url: &str) -> Result<Vec<u8>, BenchError> {
+    tebako_http::get(url)
+        .map_err(|e| BenchError::operational(format!("acquire: download failed for {url}: {e}")))
+}
+
+/// Download `url` to `dest` (tmp + rename — a partial download is
+/// invisible), verifying against the expected lowercase hex digest.
+pub fn download_verified(url: &str, dest: &Path, expected_sha256: &str) -> Result<(), BenchError> {
+    let bytes = get(url)?;
+    let actual = sha256_bytes_hex(&bytes);
+    if actual != expected_sha256.to_lowercase() {
+        return Err(BenchError::operational(format!(
+            "acquire: SHA256 mismatch for {url}\n  expected: {}\n  actual:   {actual}\n  the download was NOT written (the trust anchor is the checksum, spec 00 §8)",
+            expected_sha256.to_lowercase()
+        )));
+    }
+    let tmp = dest.with_extension("part");
+    std::fs::write(&tmp, &bytes).map_err(|e| {
+        BenchError::operational(format!("acquire: cannot write {}: {e}", tmp.display()))
+    })?;
+    std::fs::rename(&tmp, dest).map_err(|e| {
+        BenchError::operational(format!("acquire: cannot publish {}: {e}", dest.display()))
+    })?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------
+// the product tools (tebako release assets, SHA256SUMS-verified)
+// ---------------------------------------------------------------------
+
+/// The downloaded product trio under their bare names, plus the resolved
+/// tebako version (the binary's own report — never the requested tag).
+pub struct TebakoTools {
+    pub cli: PathBuf,
+    pub shim: PathBuf,
+    pub bootstrap: PathBuf,
+    /// The RESOLVED tebako version (e.g. "0.2.5"), from the binary itself.
+    pub version: String,
+}
+
+/// The tools the harness drives: `tebako` (add-registry/install), its
+/// sibling dispatcher `tebako-shim`, and `tebako-bootstrap` (the fat
+/// package's part A). `release`: a tag ("v0.2.5") or None for the latest
+/// release (`releases/latest/download/...` — the version is learned from
+/// the release's own SHA256SUMS, never guessed).
+pub fn fetch_tebako_tools(
+    layout: &BenchLayout,
+    release: Option<&str>,
+    triplet: &str,
+) -> Result<TebakoTools, BenchError> {
+    let base = match release {
+        Some(tag) => format!("https://github.com/tamatebako/tebako/releases/download/{tag}"),
+        None => "https://github.com/tamatebako/tebako/releases/latest/download".to_string(),
+    };
+    let sums_url = format!("{base}/SHA256SUMS");
+    let sums_bytes = get(&sums_url)?;
+    let sums = String::from_utf8(sums_bytes)
+        .map_err(|e| BenchError::operational(format!("acquire: {sums_url} is not UTF-8: {e}")))?;
+
+    let suffix = exe_suffix(triplet);
+    let version = match release {
+        Some(tag) => tag.strip_prefix('v').unwrap_or(tag).to_string(),
+        None => version_from_sums(&sums, triplet).ok_or_else(|| {
+            BenchError::operational(format!(
+                "acquire: {sums_url} lists no tebako-<ver>-{triplet}{suffix} asset — cannot learn the release version"
+            ))
+        })?,
+    };
+
+    let mut tools = TebakoTools {
+        cli: PathBuf::new(),
+        shim: PathBuf::new(),
+        bootstrap: PathBuf::new(),
+        version: version.clone(),
+    };
+    for (tool, slot) in [
+        ("tebako", &mut tools.cli),
+        ("tebako-shim", &mut tools.shim),
+        ("tebako-bootstrap", &mut tools.bootstrap),
+    ] {
+        let asset = format!("{tool}-{version}-{triplet}{suffix}");
+        let expected = parse_sha256sums(&sums, &asset).ok_or_else(|| {
+            BenchError::operational(format!(
+                "acquire: {asset} is not in {sums_url} (typo in the triplet or the release is incomplete)"
+            ))
+        })?;
+        let dest = layout.assets.join(&asset);
+        download_verified(&format!("{base}/{asset}"), &dest, &expected)?;
+        let bare = layout.bin.join(format!("{tool}{suffix}"));
+        std::fs::copy(&dest, &bare).map_err(|e| {
+            BenchError::operational(format!(
+                "acquire: cannot stage {} as {}: {e}",
+                dest.display(),
+                bare.display()
+            ))
+        })?;
+        chmod_0755(&bare)?;
+        *slot = bare;
+    }
+
+    // The resolved version is the binary's own report (spec 27 §6:
+    // resolved, never requested). This doubles as an exec smoke test of
+    // the downloaded CLI on this triplet.
+    tools.version = tebako_cli_version(&tools.cli).unwrap_or(version);
+    Ok(tools)
+}
+
+/// The `tebako-<ver>-<triplet>` line in a SHA256SUMS reveals the version
+/// of a `latest` download: the middle must be a bare version (digits and
+/// dots — "shim-0.2.5" / "bootstrap-0.2.5" / "pkg-0.2.5" are rejected by
+/// construction).
+///
+/// The scan itself stays out of the public surface; the unit tests pin
+/// its grammar through this wrapper.
+#[doc(hidden)]
+pub fn testonly_version_from_sums(sums: &str, triplet: &str) -> Option<String> {
+    version_from_sums(sums, triplet)
+}
+
+fn version_from_sums(sums: &str, triplet: &str) -> Option<String> {
+    let suffix = format!("-{triplet}{}", exe_suffix(triplet));
+    sums.lines()
+        .filter_map(|line| line.split_whitespace().nth(1))
+        .find_map(|name| {
+            let name = name.trim_start_matches('*');
+            let rest = name.strip_prefix("tebako-")?.strip_suffix(&suffix)?;
+            if !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit() || b == b'.') {
+                Some(rest.to_string())
+            } else {
+                None
+            }
+        })
+}
+
+/// `tebako --version` → "Tebako executable packager version 0.2.5" → the
+/// trailing version token. None on any surprise (the caller keeps the
+/// SHA256SUMS-learned version).
+fn tebako_cli_version(cli: &Path) -> Option<String> {
+    let out = std::process::Command::new(cli)
+        .arg("--version")
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let token = text.split_whitespace().last()?;
+    if token.bytes().next()?.is_ascii_digit() {
+        Some(token.to_string())
+    } else {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------
+// the v1 arm: the packed-mn release executable
+// ---------------------------------------------------------------------
+
+/// Download + verify + (for POSIX) extract the packed-mn asset named by
+/// the platforms document. Returns the runnable executable's path.
+pub fn acquire_v1_exe(
+    layout: &BenchLayout,
+    platforms: &PlatformFile,
+    triplet: &str,
+) -> Result<PathBuf, BenchError> {
+    let entry = platforms.triplets.get(triplet).ok_or_else(|| {
+        BenchError::operational(format!(
+            "acquire: platforms.yaml has no triplet '{triplet}'"
+        ))
+    })?;
+    let asset = entry.v1_asset.as_deref().ok_or_else(|| {
+        BenchError::operational(format!(
+            "acquire: v1-exe on {triplet} is a named gap (v1_asset: null) — the caller must not attempt acquisition"
+        ))
+    })?;
+    let (repo, tag) = (&platforms.packed_mn.repo, &platforms.packed_mn.tag);
+    let base = format!("https://github.com/{repo}/releases/download/{tag}");
+    let sidecar = get(&format!("{base}/{asset}.sha256.txt"))?;
+    let expected = parse_bare_hash(&String::from_utf8_lossy(&sidecar)).ok_or_else(|| {
+        BenchError::operational(format!(
+            "acquire: {base}/{asset}.sha256.txt is not a bare 64-hex sha256 (spec 27 §9 spike c)"
+        ))
+    })?;
+    let dest = layout.assets.join(asset);
+    download_verified(&format!("{base}/{asset}"), &dest, &expected)?;
+
+    let target_dir = layout.targets.join("v1-packed-mn");
+    std::fs::create_dir_all(&target_dir).map_err(|e| {
+        BenchError::operational(format!(
+            "acquire: cannot create {}: {e}",
+            target_dir.display()
+        ))
+    })?;
+    if asset.ends_with(".tgz") {
+        // The single-member rule (spec 27 §3/§9 spike c): decompress,
+        // take the ONE member, mark it executable.
+        let bytes = std::fs::read(&dest).map_err(|e| {
+            BenchError::operational(format!("acquire: cannot read {}: {e}", dest.display()))
+        })?;
+        let exe = extract_single_member_tgz(&bytes, &target_dir)?;
+        chmod_0755(&exe)?;
+        Ok(exe)
+    } else if asset.ends_with(".exe") {
+        let exe = target_dir.join(asset);
+        std::fs::copy(&dest, &exe).map_err(|e| {
+            BenchError::operational(format!("acquire: cannot stage {}: {e}", exe.display()))
+        })?;
+        chmod_0755(&exe)?;
+        Ok(exe)
+    } else {
+        Err(BenchError::operational(format!(
+            "acquire: unsupported packed-mn asset form '{asset}' (.tgz single-member or .exe expected — spec 27 §3)"
+        )))
+    }
+}
+
+/// The packed-mn POSIX layout (spec 27 §9 spike c): a gzipped tar with
+/// exactly ONE regular-file member (the executable). Anything else —
+/// zero members, several members, a path that would escape `dest_dir` —
+/// is a named error, never a guess.
+pub fn extract_single_member_tgz(bytes: &[u8], dest_dir: &Path) -> Result<PathBuf, BenchError> {
+    let gz = flate2::read::GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(gz);
+    let mut member: Option<(String, Vec<u8>)> = None;
+    let entries = archive
+        .entries()
+        .map_err(|e| BenchError::operational(format!("acquire: tgz read failed: {e}")))?;
+    for entry in entries {
+        let mut entry =
+            entry.map_err(|e| BenchError::operational(format!("acquire: tgz entry: {e}")))?;
+        if !entry.header().entry_type().is_file() {
+            continue; // pax headers, dirs — not the payload
+        }
+        let name = entry
+            .path()
+            .map_err(|e| BenchError::operational(format!("acquire: tgz entry path: {e}")))?
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .ok_or_else(|| {
+                BenchError::operational("acquire: tgz member has no file name".to_string())
+            })?;
+        if member.is_some() {
+            return Err(BenchError::operational(format!(
+                "acquire: the packed-mn tgz carries more than one file member (at least '{name}' and one other) — the single-member rule (spec 27 §3) is violated"
+            )));
+        }
+        let mut buf = Vec::new();
+        entry
+            .read_to_end(&mut buf)
+            .map_err(|e| BenchError::operational(format!("acquire: tgz member read: {e}")))?;
+        member = Some((name, buf));
+    }
+    let (name, buf) = member.ok_or_else(|| {
+        BenchError::operational(
+            "acquire: the packed-mn tgz carries NO file member — single-member rule violated"
+                .to_string(),
+        )
+    })?;
+    let dest = dest_dir.join(&name);
+    std::fs::write(&dest, &buf).map_err(|e| {
+        BenchError::operational(format!("acquire: cannot write {}: {e}", dest.display()))
+    })?;
+    Ok(dest)
+}
+
+// ---------------------------------------------------------------------
+// the v2 arms: store population via the downloaded CLI (the dogfood path)
+// ---------------------------------------------------------------------
+
+/// The payload records read back from the bench home's store after
+/// `tebako install` (the store is the SSOT — the harness never parses the
+/// image itself).
+pub struct PayloadHome {
+    pub name: String,
+    pub version: String,
+    /// The resolved feedstock release tag (e.g. "1.16.9-3"), from the
+    /// store's registry cache (the L3 mirror the resolution used).
+    pub release_tag: String,
+    /// The store's payload image (byte-identical with the registry
+    /// artifact — the CLI sha256-verified it at install).
+    pub image: PathBuf,
+    /// The dispatcher-visible manifest mirror (the embedded manifest,
+    /// authoritative).
+    pub mirror: tpkg::PayloadManifest,
+    /// The image backend (sniffed from the payload's magic bytes — the
+    /// tebako-pkg sniff rule) for `versions.image_format`.
+    pub image_format: ImageFormat,
+}
+
+/// `tebako add-registry <ref>...` + `tebako install <name@version>` in
+/// the bench home, then read the store records back. Payload bytes are
+/// sha256-verified by the PRODUCT against the registry pin (spec 05) —
+/// that verification is deliberately not re-implemented here.
+pub fn install_payload(
+    layout: &BenchLayout,
+    tools: &TebakoTools,
+    target: &Target,
+) -> Result<PayloadHome, BenchError> {
+    let payload = target.payload.as_deref().ok_or_else(|| {
+        BenchError::operational(format!(
+            "acquire: v2 target '{}' carries no payload reference",
+            target.id
+        ))
+    })?;
+    let (name, version) = payload.split_once('@').ok_or_else(|| {
+        BenchError::operational(format!(
+            "acquire: payload reference '{payload}' is not name@version"
+        ))
+    })?;
+    let registries = target.registries.as_deref().unwrap_or(&[]);
+    if registries.is_empty() {
+        return Err(BenchError::operational(format!(
+            "acquire: v2 target '{}' carries no registries",
+            target.id
+        )));
+    }
+    for r in registries {
+        run_admin(
+            layout,
+            &tools.cli,
+            &["add-registry", r],
+            "acquire-add-registry.log",
+        )?;
+    }
+    run_admin(
+        layout,
+        &tools.cli,
+        &["install", payload],
+        "acquire-install.log",
+    )?;
+
+    let record_dir = layout.store().join("payloads").join(name);
+    let image = record_dir.join(format!("{version}.tfs"));
+    if !image.is_file() {
+        return Err(BenchError::operational(format!(
+            "acquire: `tebako install {payload}` left no {} in the store — the install log names why",
+            image.display()
+        )));
+    }
+    if !record_dir.join(format!("{version}.tfs.sha256")).is_file() {
+        return Err(BenchError::operational(format!(
+            "acquire: the store's {} has no .sha256 trust anchor — the payload record is incomplete",
+            image.display()
+        )));
+    }
+    let mirror_path = record_dir.join(format!("{version}.manifest.yaml"));
+    let mirror_text = std::fs::read_to_string(&mirror_path).map_err(|e| {
+        BenchError::operational(format!(
+            "acquire: cannot read the manifest mirror {}: {e}",
+            mirror_path.display()
+        ))
+    })?;
+    let mirror = tpkg::PayloadManifest::from_yaml(&mirror_text).map_err(|e| {
+        BenchError::operational(format!(
+            "acquire: the manifest mirror {} does not parse: {e}",
+            mirror_path.display()
+        ))
+    })?;
+    let release_tag = registry_release_tag(layout, name, version)?;
+    let image_format = sniff_image_format(&image)?;
+    Ok(PayloadHome {
+        name: name.to_string(),
+        version: version.to_string(),
+        release_tag,
+        image,
+        mirror,
+        image_format,
+    })
+}
+
+/// The feedstock release tag the installed payload came from, read from
+/// the store's registry cache (`registries/*.yaml` — the verbatim fetched
+/// L3 mirror): `release.ref`'s trailing `:tag`.
+fn registry_release_tag(
+    layout: &BenchLayout,
+    name: &str,
+    version: &str,
+) -> Result<String, BenchError> {
+    #[derive(serde::Deserialize)]
+    struct Registry {
+        payloads: Vec<RegPayload>,
+    }
+    #[derive(serde::Deserialize)]
+    struct RegPayload {
+        name: String,
+        versions: Vec<RegVersion>,
+    }
+    #[derive(serde::Deserialize)]
+    struct RegVersion {
+        version: serde_yml::Value,
+        release: Option<RegRelease>,
+    }
+    #[derive(serde::Deserialize)]
+    struct RegRelease {
+        #[serde(rename = "ref")]
+        reference: String,
+    }
+
+    let dir = layout.store().join("registries");
+    let entries = std::fs::read_dir(&dir).map_err(|e| {
+        BenchError::operational(format!(
+            "acquire: cannot list the registry cache {}: {e}",
+            dir.display()
+        ))
+    })?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("yaml") {
+            continue;
+        }
+        let text = match std::fs::read_to_string(&path) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let Ok(registry) = serde_yml::from_str::<Registry>(&text) else {
+            continue;
+        };
+        for payload in &registry.payloads {
+            if payload.name != name {
+                continue;
+            }
+            for v in &payload.versions {
+                let vtext = match &v.version {
+                    serde_yml::Value::String(s) => s.clone(),
+                    other => format!("{other:?}").trim_matches('"').to_string(),
+                };
+                if vtext == version {
+                    if let Some(release) = &v.release {
+                        if let Some(tag) = release.reference.rsplit(':').next() {
+                            return Ok(tag.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Err(BenchError::operational(format!(
+        "acquire: no registry in the store cache names {name} {version} with a release ref — cannot record versions.payload (resolved, never requested)"
+    )))
+}
+
+/// The image backend from the payload's magic bytes (the tebako-pkg
+/// `sniff_format` rule — the bench reads bytes, never links a backend).
+fn sniff_image_format(image: &Path) -> Result<ImageFormat, BenchError> {
+    let mut f = std::fs::File::open(image).map_err(|e| {
+        BenchError::operational(format!("acquire: cannot open {}: {e}", image.display()))
+    })?;
+    let mut magic = [0u8; 8];
+    let n = f.read(&mut magic).map_err(|e| {
+        BenchError::operational(format!("acquire: cannot read {}: {e}", image.display()))
+    })?;
+    let magic = &magic[..n];
+    if magic.starts_with(b"DWARFS") {
+        Ok(ImageFormat::Dwarfs)
+    } else if magic.starts_with(b"LMFS") {
+        Ok(ImageFormat::Limnifs)
+    } else {
+        Err(BenchError::operational(format!(
+            "acquire: {} is neither dwarfs- nor limnifs-format (versions.image_format has no spelling for it)",
+            image.display()
+        )))
+    }
+}
+
+// ---------------------------------------------------------------------
+// the runtime: resolved by the PRODUCT, read back from the store
+// ---------------------------------------------------------------------
+
+/// The runtime cache entry the priming dispatch resolved (dir name +
+/// trust marker parse — resolution logic is the product's, never
+/// duplicated here).
+pub struct RuntimeEntry {
+    pub engine: String,
+    /// The language version (e.g. "3.3.7").
+    pub lang_version: String,
+    /// The tebako runtime release (e.g. "0.16.9").
+    pub tebako_version: String,
+    /// The cached interpreter exe (the fat package's runtime slot).
+    pub exe: PathBuf,
+    /// The exe's verified digest (the store's `sha256` marker) — pinned
+    /// into the fat package's runtime_ref.
+    pub exe_sha256: String,
+}
+
+/// Force the runtime resolution once (UNMEASURED — acquisition, not a
+/// benchmark run): dispatch the installed payload's shim with `--version`
+/// and read the resolved runtime back from the store. The child's exit
+/// code is irrelevant — the runtime download happens before the payload's
+/// argv matters — so the check is the cache entry's existence, never the
+/// exit status.
+pub fn prime_runtime(
+    layout: &BenchLayout,
+    triplet: &str,
+    payload: &PayloadHome,
+) -> Result<RuntimeEntry, BenchError> {
+    let entrypoint = app_entrypoints(&payload.mirror)
+        .first()
+        .map(|e| e.name.clone())
+        .ok_or_else(|| {
+            BenchError::operational(format!(
+                "acquire: the {} {} manifest declares no entrypoints — nothing to prime with",
+                payload.name, payload.version
+            ))
+        })?;
+    let shim = layout
+        .store()
+        .join("shims")
+        .join(format!("{entrypoint}{}", exe_suffix(triplet)));
+    // Best-effort: a dispatch failure is fine as long as the runtime
+    // landed in the store (the read-back below is the real check).
+    let _ = run_admin(layout, &shim, &["--version"], "acquire-prime-runtime.log");
+    read_runtime_entry(layout, triplet, &payload.mirror)
+}
+
+/// Scan `runtimes/<engine>-<lv>-<ver>-<triplet>/` for THE cached runtime.
+/// Zero entries (the priming failed) or several (ambiguity) are named
+/// errors — never a guess (invariant 9).
+fn read_runtime_entry(
+    layout: &BenchLayout,
+    triplet: &str,
+    mirror: &tpkg::PayloadManifest,
+) -> Result<RuntimeEntry, BenchError> {
+    let engine = app_entrypoints(mirror)
+        .first()
+        .and_then(|e| e.runtime_requirement.as_ref())
+        .map(|r| r.engine.clone())
+        .unwrap_or_else(|| "ruby".to_string());
+    let dir = layout.store().join("runtimes");
+    let mut found: Vec<PathBuf> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                found.push(p);
+            }
+        }
+    }
+    let entry_dir = match found.len() {
+        1 => found.remove(0),
+        0 => {
+            return Err(BenchError::operational(format!(
+                "acquire: the priming dispatch left no runtime in {} — see logs/acquire-prime-runtime.log",
+                dir.display()
+            )))
+        }
+        n => {
+            return Err(BenchError::operational(format!(
+                "acquire: {} runtime entries in {} — the bench home is shared or stale; refusing to guess",
+                n,
+                dir.display()
+            )))
+        }
+    };
+    let dir_name = entry_dir
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    // "<engine>-<lv>-<ver>-<triplet>": strip the known prefix/suffix, then
+    // split the remainder at its first '-' (neither version carries '-').
+    let middle = dir_name
+        .strip_prefix(&format!("{engine}-"))
+        .and_then(|s| s.strip_suffix(&format!("-{triplet}")))
+        .ok_or_else(|| {
+            BenchError::operational(format!(
+                "acquire: runtime cache entry '{dir_name}' is not {engine}-<lang-ver>-<tebako-ver>-{triplet}"
+            ))
+        })?;
+    let (lang_version, tebako_version) = middle.split_once('-').ok_or_else(|| {
+        BenchError::operational(format!(
+            "acquire: runtime cache entry '{dir_name}' does not carry <lang-ver>-<tebako-ver>"
+        ))
+    })?;
+    let asset = format!(
+        "tebako-runtime-{tebako_version}-{lang_version}-{triplet}{}",
+        exe_suffix(triplet)
+    );
+    let exe = entry_dir.join(&asset);
+    if !exe.is_file() {
+        return Err(BenchError::operational(format!(
+            "acquire: the runtime cache entry {} has no {asset}",
+            entry_dir.display()
+        )));
+    }
+    let marker = std::fs::read_to_string(entry_dir.join("sha256")).map_err(|e| {
+        BenchError::operational(format!(
+            "acquire: the runtime cache entry {} has no readable sha256 marker: {e}",
+            entry_dir.display()
+        ))
+    })?;
+    let exe_sha256 = parse_bare_hash(&marker).ok_or_else(|| {
+        BenchError::operational(format!(
+            "acquire: the sha256 marker of {} is not a 64-hex digest",
+            entry_dir.display()
+        ))
+    })?;
+    Ok(RuntimeEntry {
+        engine,
+        lang_version: lang_version.to_string(),
+        tebako_version: tebako_version.to_string(),
+        exe,
+        exe_sha256,
+    })
+}
+
+// ---------------------------------------------------------------------
+// the v2-press arm: the fat package, assembled in-process through tpkg
+// ---------------------------------------------------------------------
+
+/// Assemble the fat tpkg (spec 27 §1: bootstrap + payload image slot +
+/// runtime slot) from the verified published artifacts. The wire format
+/// is written through `tpkg` — the L0 owner crate — mirroring
+/// tebako-cli's `stitch` byte-for-byte in shape: TPKG_FLAG_LEAN set
+/// (every press writes it; fatness is the runtime slot's presence, the
+/// bootstrap never branches on the flag), launcher ABI 1 (spec 17), the
+/// type-2 package manifest naming entries[0] + the union mount at "/"
+/// (the shim's mount rule, tebako-shim/src/dispatch.rs).
+///
+/// `;sha256=` in the runtime_ref pins the runtime EXE's verified digest
+/// (the store's trust marker) — the bootstrap re-verifies the slot
+/// against it at every run, so the package's runtime half is anchored to
+/// the same bytes the managed arm resolved.
+pub fn assemble_fat_package(
+    layout: &BenchLayout,
+    tools: &TebakoTools,
+    payload: &PayloadHome,
+    runtime: &RuntimeEntry,
+    target: &Target,
+) -> Result<PathBuf, BenchError> {
+    let entrypoint = app_entrypoints(&payload.mirror).first().ok_or_else(|| {
+        BenchError::operational(format!(
+            "acquire: the {} {} manifest declares no entrypoints",
+            payload.name, payload.version
+        ))
+    })?;
+    let runtime_ref = format!(
+        "{}@{};tebako={};image;sha256={}",
+        runtime.engine, runtime.lang_version, runtime.tebako_version, runtime.exe_sha256
+    );
+
+    let target_dir = layout.targets.join(&target.id);
+    std::fs::create_dir_all(&target_dir).map_err(|e| {
+        BenchError::operational(format!(
+            "acquire: cannot create {}: {e}",
+            target_dir.display()
+        ))
+    })?;
+    // The package rides the leg's platform; cfg! is that truth in-leg.
+    let suffix = if cfg!(windows) { ".exe" } else { "" };
+    let package = target_dir.join(format!("{}-fat{suffix}", payload.name));
+
+    let stem = format!("{}-fat", payload.name);
+    let manifest = tpkg::PackageManifest {
+        schema_version: tpkg::PACKAGE_SCHEMA_VERSION,
+        package: tpkg::PackageIdentity {
+            name: stem,
+            version: "0.0.0".to_string(),
+            producer: tpkg::Producer {
+                tool: "tebako-bench".to_string(),
+                tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            },
+            created: rfc3339_now(),
+        },
+        entries: vec![tpkg::PackageEntry {
+            name: entrypoint.name.clone(),
+            slot: 0,
+            entrypoint: entrypoint.path.clone(),
+            runtime_ref: runtime_ref.clone(),
+        }],
+        jail: None,
+        env: Default::default(),
+        mounts: vec![tpkg::PackageMount {
+            slot: 0,
+            point: "/".to_string(),
+            mode: tpkg::MountMode::Union,
+            precedence: Some(tpkg::Precedence::AfterEnv),
+        }],
+    };
+
+    let slots: [(&Path, &str, u32); 2] = [
+        // The payload slot auto-detects (format_id 0 = auto): the wire
+        // field answers "how do I read these bytes" and the magic says
+        // it (the orthogonality law, spec 00 §4).
+        (&payload.image, "/", tpkg::TPKG_FORMAT_AUTO),
+        // The runtime exe rides as a role slot (never mounted).
+        (&runtime.exe, "", tpkg::TPKG_FORMAT_RUNTIME),
+    ];
+    write_package(&tools.bootstrap, &slots, &runtime_ref, &manifest, &package)?;
+    chmod_0755(&package)?;
+    resign_ad_hoc_if_macos(&package);
+
+    // Read-back gate: the assembled package must parse and carry exactly
+    // what was written (the wire owner validates its own bytes).
+    let mut f = std::fs::File::open(&package).map_err(|e| {
+        BenchError::operational(format!(
+            "acquire: cannot re-open the assembled package {}: {e}",
+            package.display()
+        ))
+    })?;
+    let m = tpkg::read_from(&mut f).map_err(|e| {
+        BenchError::operational(format!(
+            "acquire: the assembled package {} failed the trailer read-back: {}",
+            package.display(),
+            tpkg::strerror(e.code())
+        ))
+    })?;
+    if m.slots.len() != 2 || m.slots[1].format_id != tpkg::TPKG_FORMAT_RUNTIME {
+        return Err(BenchError::operational(format!(
+            "acquire: the assembled package {} read back with {} slots / runtime slot format {} (expected 2 / {})",
+            package.display(),
+            m.slots.len(),
+            m.slots.get(1).map(|s| s.format_id).unwrap_or(0),
+            tpkg::TPKG_FORMAT_RUNTIME
+        )));
+    }
+    Ok(package)
+}
+
+/// The package writer, mirroring tebako-pkg's `assemble` on the unsigned
+/// path: bootstrap bytes, then each slot's bytes, then the ext blocks +
+/// trailer through tpkg (the L0 owner). `;sha256=` digests ride the
+/// runtime_ref, not a signing block (signing stays opt-in, spec 00 §7 —
+/// the benchmark assembles unsigned packages exactly like the dogfood
+/// press).
+fn write_package(
+    bootstrap: &Path,
+    slots: &[(&Path, &str, u32)],
+    runtime_ref: &str,
+    manifest: &tpkg::PackageManifest,
+    output: &Path,
+) -> Result<(), BenchError> {
+    if runtime_ref.len() >= tpkg::TPKG_RUNTIME_REF_LEN {
+        return Err(BenchError::operational(format!(
+            "acquire: runtime_ref exceeds {} bytes: {runtime_ref}",
+            tpkg::TPKG_RUNTIME_REF_LEN - 1
+        )));
+    }
+    let mut m = tpkg::Manifest {
+        package_flags: tpkg::TPKG_FLAG_LEAN,
+        launcher_abi: 1, // spec 17's launcher ABI version 1
+        ..Default::default()
+    };
+    m.set_runtime_ref(runtime_ref.as_bytes());
+    m.set_package_manifest(manifest)
+        .map_err(|e| BenchError::operational(format!("acquire: invalid package manifest: {e}")))?;
+
+    let tmp = output.with_extension("part");
+    let result = (|| -> Result<(), BenchError> {
+        let mut out = std::fs::File::create(&tmp).map_err(|e| {
+            BenchError::operational(format!("acquire: cannot create {}: {e}", tmp.display()))
+        })?;
+        let mut total = stream_into(&mut out, bootstrap)?;
+        for (path, mount, format_id) in slots {
+            let written = stream_into(&mut out, path)?;
+            m.slots
+                .push(tpkg::Slot::new(total, written, *format_id, mount));
+            total += written;
+        }
+        out.flush().map_err(|e| {
+            BenchError::operational(format!("acquire: write failed for {}: {e}", tmp.display()))
+        })?;
+        tpkg::write_to(&mut out, &m).map_err(|e| {
+            BenchError::operational(format!(
+                "acquire: tpkg trailer write failed: {}",
+                tpkg::strerror(e.code())
+            ))
+        })?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result?;
+    std::fs::rename(&tmp, output).map_err(|e| {
+        BenchError::operational(format!("acquire: cannot publish {}: {e}", output.display()))
+    })?;
+    Ok(())
+}
+
+fn stream_into(out: &mut std::fs::File, path: &Path) -> Result<u64, BenchError> {
+    let mut f = std::fs::File::open(path).map_err(|e| {
+        BenchError::operational(format!("acquire: cannot open {}: {e}", path.display()))
+    })?;
+    std::io::copy(&mut f, out).map_err(|e| {
+        BenchError::operational(format!(
+            "acquire: cannot stream {} into the package: {e}",
+            path.display()
+        ))
+    })
+}
+
+/// macOS ad-hoc re-sign after appending the trailer (the product's own
+/// press does exactly this — tebako-cli::resign_if_needed — best-effort,
+/// loud on failure, the package kept either way). The ONE platform-tool
+/// spawn in the harness: codesign has no in-process form, and the
+/// no-shell-out uniformity argument (one implementation serving all
+/// triplets) does not apply to a macOS-only Mach-O post-step.
+#[cfg(target_os = "macos")]
+fn resign_ad_hoc_if_macos(package: &Path) {
+    match std::process::Command::new("codesign")
+        .args(["--force", "--sign", "-"])
+        .arg(package)
+        .output()
+    {
+        Ok(out) if out.status.success() => {}
+        other => {
+            eprintln!(
+                "tebako-bench: warning: ad-hoc re-sign of {} failed ({:?}); keeping the package (tebako-cli parity: it still executes on macOS)",
+                package.display(),
+                other.map(|o| o.status)
+            );
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn resign_ad_hoc_if_macos(_package: &Path) {}
+
+/// The app PROVIDES entrypoints of a payload manifest (empty for non-app
+/// kinds — tebako-shim's manifest.rs dispatchables rule).
+fn app_entrypoints(mirror: &tpkg::PayloadManifest) -> &[tpkg::Entrypoint] {
+    match &mirror.provides {
+        tpkg::Provides::App(app) => &app.entrypoints,
+        _ => &[],
+    }
+}
+
+// ---------------------------------------------------------------------
+// workload sources
+// ---------------------------------------------------------------------
+
+/// A materialized workload source: `root` is copied into each run's
+/// scratch (the whole tree — the document's relative includes must
+/// resolve), `doc_rel` selects the document inside it.
+pub struct MaterializedSource {
+    pub root: PathBuf,
+    pub doc_rel: PathBuf,
+}
+
+/// Materialize a workload's source document (spec 27 §2). Vendored: copy
+/// the repo file. Git: fetch the host's archive-of-commit over HTTPS
+/// in-process (never a `git` shell-out — invariant 1) and extract the
+/// whole tree in-process.
+pub fn materialize_source(
+    workload: &Workload,
+    layout: &BenchLayout,
+    repo_root: &Path,
+) -> Result<MaterializedSource, BenchError> {
+    let dest = layout.sources.join(&workload.id);
+    remove_tree(&dest)?;
+    std::fs::create_dir_all(&dest).map_err(|e| {
+        BenchError::operational(format!("acquire: cannot create {}: {e}", dest.display()))
+    })?;
+    match workload.source.kind {
+        SourceKind::Vendored => {
+            let src = repo_root.join(&workload.source.path);
+            let name = Path::new(&workload.source.path)
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .ok_or_else(|| {
+                    BenchError::operational(format!(
+                        "acquire: vendored source '{}' has no file name",
+                        workload.source.path
+                    ))
+                })?;
+            std::fs::copy(&src, dest.join(&name)).map_err(|e| {
+                BenchError::operational(format!(
+                    "acquire: cannot vendor {} (run from the repo root): {e}",
+                    src.display()
+                ))
+            })?;
+            Ok(MaterializedSource {
+                root: dest,
+                doc_rel: PathBuf::from(name),
+            })
+        }
+        SourceKind::Git => fetch_git_source(workload, dest),
+    }
+}
+
+/// GitHub's archive-of-commit (`codeload .../tar.gz/<40-hex>`), extracted
+/// in-process. The suite's semantic gate already pinned a 40-hex ref; a
+/// non-github host is a named error here (MECE reference syntax — never
+/// a guessed host grammar).
+fn fetch_git_source(workload: &Workload, dest: PathBuf) -> Result<MaterializedSource, BenchError> {
+    let url = workload.source.url.as_deref().ok_or_else(|| {
+        BenchError::operational(format!(
+            "acquire: git workload '{}' carries no url",
+            workload.id
+        ))
+    })?;
+    let git_ref = workload.source.git_ref.as_deref().ok_or_else(|| {
+        BenchError::operational(format!(
+            "acquire: git workload '{}' carries no pinned ref",
+            workload.id
+        ))
+    })?;
+    let path = url
+        .strip_prefix("https://github.com/")
+        .ok_or_else(|| {
+            BenchError::operational(format!(
+                "acquire: workload '{}' url '{url}' is not a GitHub repo URL (the archive-of-commit fetch speaks codeload only)",
+                workload.id
+            ))
+        })?
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .to_string();
+    let archive_url = format!("https://codeload.github.com/{path}/tar.gz/{git_ref}");
+    let bytes = get(&archive_url)?;
+    let gz = flate2::read::GzDecoder::new(&bytes[..]);
+    let mut archive = tar::Archive::new(gz);
+    archive.unpack(&dest).map_err(|e| {
+        BenchError::operational(format!(
+            "acquire: cannot extract the {archive_url} archive: {e}"
+        ))
+    })?;
+    // The archive's single top-level dir is "<repo>-<sha>/".
+    let mut tops: Vec<PathBuf> = std::fs::read_dir(&dest)
+        .map_err(|e| {
+            BenchError::operational(format!("acquire: cannot list {}: {e}", dest.display()))
+        })?
+        .flatten()
+        .map(|e| e.path())
+        .collect();
+    if tops.len() != 1 {
+        return Err(BenchError::operational(format!(
+            "acquire: the {archive_url} archive holds {} top-level entries (one expected)",
+            tops.len()
+        )));
+    }
+    let root = tops.remove(0);
+    let doc_rel = PathBuf::from(&workload.source.path);
+    if doc_rel.is_absolute() || doc_rel.to_string_lossy().contains("..") {
+        return Err(BenchError::operational(format!(
+            "acquire: workload '{}' path '{}' must be tree-relative without '..'",
+            workload.id, workload.source.path
+        )));
+    }
+    if !root.join(&doc_rel).is_file() {
+        return Err(BenchError::operational(format!(
+            "acquire: the pinned tree holds no '{}' for workload '{}'",
+            workload.source.path, workload.id
+        )));
+    }
+    Ok(MaterializedSource { root, doc_rel })
+}
+
+// ---------------------------------------------------------------------
+// shared helpers
+// ---------------------------------------------------------------------
+
+/// Run an UNMEASURED product command in the bench home (the dogfood
+/// install path): the hermetic env, output appended to logs/<log_name>,
+/// nonzero exit → named error pointing at the log. This spawns the
+/// downloaded product binaries — never platform tools (spec 27 §0).
+pub fn run_admin(
+    layout: &BenchLayout,
+    program: &Path,
+    args: &[&str],
+    log_name: &str,
+) -> Result<(), BenchError> {
+    let log_path = layout.logs.join(log_name);
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|e| {
+            BenchError::operational(format!("acquire: cannot open {}: {e}", log_path.display()))
+        })?;
+    let log_err = log.try_clone().map_err(|e| {
+        BenchError::operational(format!("acquire: cannot clone the log handle: {e}"))
+    })?;
+    let mut cmd = std::process::Command::new(program);
+    cmd.args(args)
+        .current_dir(&layout.home)
+        // The store location for admin commands is target-independent —
+        // the tmp override uses a fixed "admin" slot so v1's TMPDIR rules
+        // never leak into v2 store population.
+        .envs(layout.child_env("admin"))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(log))
+        .stderr(std::process::Stdio::from(log_err));
+    let status = cmd.status().map_err(|e| {
+        BenchError::operational(format!("acquire: cannot spawn {}: {e}", program.display()))
+    })?;
+    if !status.success() {
+        return Err(BenchError::operational(format!(
+            "acquire: `{} {}` failed ({}) — see {}",
+            program.display(),
+            args.join(" "),
+            status
+                .code()
+                .map(|c| format!("exit {c}"))
+                .unwrap_or_else(|| "signal".to_string()),
+            log_path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn chmod_0755(path: &Path) -> Result<(), BenchError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(path)
+            .map_err(|e| {
+                BenchError::operational(format!("acquire: cannot stat {}: {e}", path.display()))
+            })?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).map_err(|e| {
+            BenchError::operational(format!("acquire: cannot chmod {}: {e}", path.display()))
+        })?;
+    }
+    let _ = path;
+    Ok(())
+}
+
+/// RFC 3339 UTC now, for the package manifest's `created` (the metadata
+/// convention — no chrono in the tree; the civil-from-days algorithm is
+/// Howard Hinnant's, same as tebako-cli's).
+fn rfc3339_now() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+    let (h, mi, s) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 3) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}

--- a/crates/tebako-bench/src/bin/tebako-bench-child.rs
+++ b/crates/tebako-bench/src/bin/tebako-bench-child.rs
@@ -1,0 +1,101 @@
+//! tebako-bench-child — the golden-test measured child for the spec 27
+//! sampler/run-engine tests. TEST TOOLING inside the never-shipped
+//! tebako-bench crate (the crate-root boundary comment applies): it exists
+//! so the golden tests exercise one identical child on every triplet —
+//! no `sleep`/`busybox`/PowerShell flavor divergence, no platform tool at
+//! all (the harness's no-shell-out uniformity rule, spec 27 §0).
+//!
+//! ```text
+//! tebako-bench-child [--sleep-ms N] [--busy-ms N] [--alloc-mb N]
+//!                    [--touch PATH]... [--print TEXT] [--print-env VAR]
+//!                    [--exit N]
+//! ```
+//!
+//! Order of operations: alloc → busy → sleep → touch/print → exit.
+
+use std::time::{Duration, Instant};
+
+fn take_value(args: &[String], i: &mut usize, flag: &str) -> String {
+    match args.get(*i + 1) {
+        Some(v) => {
+            *i += 1;
+            v.clone()
+        }
+        None => {
+            eprintln!("tebako-bench-child: missing value for {flag}");
+            std::process::exit(64);
+        }
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut sleep_ms = 0u64;
+    let mut busy_ms = 0u64;
+    let mut alloc_mb = 0usize;
+    let mut touches: Vec<String> = Vec::new();
+    let mut prints: Vec<String> = Vec::new();
+    let mut print_envs: Vec<String> = Vec::new();
+    let mut exit = 0i32;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--sleep-ms" => sleep_ms = take_value(&args, &mut i, "--sleep-ms").parse().unwrap_or(0),
+            "--busy-ms" => busy_ms = take_value(&args, &mut i, "--busy-ms").parse().unwrap_or(0),
+            "--alloc-mb" => alloc_mb = take_value(&args, &mut i, "--alloc-mb").parse().unwrap_or(0),
+            "--touch" => touches.push(take_value(&args, &mut i, "--touch")),
+            "--print" => prints.push(take_value(&args, &mut i, "--print")),
+            "--print-env" => print_envs.push(take_value(&args, &mut i, "--print-env")),
+            "--exit" => exit = take_value(&args, &mut i, "--exit").parse().unwrap_or(0),
+            other => {
+                eprintln!("tebako-bench-child: unknown flag {other}");
+                std::process::exit(64);
+            }
+        }
+        i += 1;
+    }
+
+    // Allocated and page-touched, then HELD until the end (the peak-RSS
+    // golden test reads ru_maxrss / PeakWorkingSetSize — a freed-before-
+    // exit allocation still counts against the high-water mark, but
+    // holding it keeps the intent obvious).
+    let mut held: Vec<Vec<u8>> = Vec::new();
+    for _ in 0..alloc_mb {
+        let mut block = vec![0u8; 1024 * 1024];
+        for page in block.chunks_mut(4096) {
+            page[0] = 1;
+        }
+        held.push(block);
+    }
+
+    if busy_ms > 0 {
+        let deadline = Instant::now() + Duration::from_millis(busy_ms);
+        let mut acc = 0u64;
+        while Instant::now() < deadline {
+            acc = acc.wrapping_add(1);
+        }
+        std::hint::black_box(acc);
+    }
+
+    if sleep_ms > 0 {
+        std::thread::sleep(Duration::from_millis(sleep_ms));
+    }
+
+    for path in &touches {
+        if let Err(e) = std::fs::write(path, b"tebako-bench-child\n") {
+            eprintln!("tebako-bench-child: cannot touch {path}: {e}");
+            std::process::exit(74);
+        }
+    }
+    for text in &prints {
+        println!("{text}");
+        eprintln!("{text}");
+    }
+    for var in &print_envs {
+        println!("{}={}", var, std::env::var(var).unwrap_or_default());
+    }
+
+    std::hint::black_box(&held);
+    std::process::exit(exit);
+}

--- a/crates/tebako-bench/src/engine.rs
+++ b/crates/tebako-bench/src/engine.rs
@@ -1,0 +1,858 @@
+//! The run engine (spec 27 §5–§7): the acquisition orchestration that
+//! turns suite targets into prepared programs, the measured matrix loop
+//! (warmup → warm, interleaved → cold-with-wipe), the expectation check,
+//! and the statistics over the run records. Network access lives ONLY in
+//! [`prepare_targets`] (it drives the acquisition slice); the matrix
+//! itself — [`execute_matrix`] — is offline given prepared targets, which
+//! is how the tests drive it with the `tebako-bench-child` golden child.
+//!
+//! Run-shape conventions (the engine owns these; the suite/fixtures were
+//! authored against them):
+//!
+//! - Per-run scratch cell: `scratch/<workload>/<target>/<mode>-<iter>/`
+//!   (warmups: `warmup-<k>`). The materialized source tree is copied in
+//!   whole (relative includes must resolve); the run's working directory
+//!   is the document's own directory inside the cell and `{doc}`
+//!   substitutes the document's file NAME — so "scratch-relative"
+//!   `expect.files` resolve against the directory the compile's outputs
+//!   land in, for the vendored (flat) and git (deep tree) cases alike.
+//! - Warmup runs are unmeasured priming. A warmup that misses its
+//!   expectation is recorded `failed` with `iteration: 0` (named, never
+//!   retried — spec 27 §2) and the cell is SKIPPED (no measured runs on
+//!   an arm that cannot compile once); a warmup timeout is recorded
+//!   `timeout` the same way. A warmup that cannot even START (spawn
+//!   failure — e.g. the AMFI-killed v1 exe of §9 spike c) makes the arm
+//!   a named gap: one `unavailable` row whose reason carries the spawn
+//!   error, the "platform incapacity" clause of §6 applied at run time.
+//! - Cold runs follow the §5 per-arm flow: wipe the arm's cache set,
+//!   then (v2-managed only) an UNMEASURED re-`install` — the caller's
+//!   `cold_reprime` callback — and the measured run (the runtime/env
+//!   download lands inside the measured span).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::acquire::{self, BenchLayout, MaterializedSource, TebakoTools};
+use crate::error::BenchError;
+use crate::platforms::PlatformFile;
+use crate::result::{ResultFile, RunMode, RunRecord, RunStatus, RunnerMeta, StatRecord, Versions};
+use crate::sampler::{ChildSpec, Sample, Sampler};
+use crate::suite::{Expect, SuiteFile, Target, TargetKind, Workload};
+use crate::{exit, validate, DocKind};
+
+/// The `run` subcommand's input: both documents parsed (main owns the
+/// file I/O), the triplet this leg runs, and the run options.
+pub struct RunRequest {
+    pub suite: SuiteFile,
+    pub platforms: PlatformFile,
+    pub triplet: String,
+    pub out: PathBuf,
+    pub opt_in: Vec<String>,
+    /// `--tebako-release <tag>`: the pinned tools release; None = latest.
+    pub tebako_release: Option<String>,
+    /// Vendored source paths resolve against this root (the repo root).
+    pub repo_root: PathBuf,
+}
+
+/// One target after acquisition: either its measured program is staged
+/// or the arm is a named gap (§6: explicit data, never a silent skip).
+pub enum Prepared {
+    Ready { program: PathBuf },
+    Unavailable { reason: String },
+}
+
+pub struct PreparedTarget {
+    pub target: Target,
+    pub state: Prepared,
+}
+
+/// The `run` surface: acquire, execute, emit, and return the exit code
+/// (spec 27 §8 — 0, or 1 when every arm failed/unavailable; a red matrix
+/// is a deliverable, the artifacts are written either way).
+pub fn run(request: &RunRequest) -> Result<u8, BenchError> {
+    let violations = request
+        .suite
+        .semantic_violations()
+        .into_iter()
+        .map(|v| format!("suite: {v}"))
+        .chain(
+            request
+                .platforms
+                .semantic_violations()
+                .into_iter()
+                .map(|v| format!("platforms: {v}")),
+        )
+        .collect::<Vec<_>>();
+    if !violations.is_empty() {
+        return Err(BenchError::operational(format!(
+            "run: the input documents are invalid — validate them first:\n  {}",
+            violations.join("\n  ")
+        )));
+    }
+
+    let layout = BenchLayout::new(&request.out)?;
+    let (prepared, versions, tools) = prepare_targets(
+        &layout,
+        &request.suite,
+        &request.platforms,
+        &request.triplet,
+        request.tebako_release.as_deref(),
+    )?;
+
+    // The §5 cold flow's unmeasured half: the engine calls this only for
+    // v2-managed targets — re-install the payload after the store wipe
+    // (install does not fetch the runtime — that download lands in the
+    // measured span).
+    let mut cold_reprime = |layout: &BenchLayout, target: &Target| -> Result<(), BenchError> {
+        let tools = tools.as_ref().ok_or_else(|| {
+            BenchError::operational(format!(
+                "engine: v2-managed target '{}' is ready but the tebako tools were never fetched (harness bug)",
+                target.id
+            ))
+        })?;
+        acquire::install_payload(layout, tools, target).map(|_| ())
+    };
+    let runs = execute_matrix(
+        &layout,
+        &request.suite,
+        &request.opt_in,
+        &prepared,
+        &request.repo_root,
+        &mut cold_reprime,
+    )?;
+
+    let result = assemble_result(
+        &request.suite,
+        &request.triplet,
+        runner_meta(&request.platforms, &request.triplet)?,
+        versions,
+        runs,
+    );
+    emit_result(&request.out, &result)?;
+
+    let any_ok = result.runs.iter().any(|r| r.status == RunStatus::Ok);
+    if any_ok || result.runs.is_empty() {
+        Ok(exit::OK)
+    } else {
+        Ok(exit::INVALID)
+    }
+}
+
+/// The acquisition half: stage every target's measured program (or name
+/// its gap) and collect the resolved versions (§6: what actually ran,
+/// never what was requested). Acquisition FAILURES degrade the arm to a
+/// named gap whose reason carries the error — one broken download never
+/// costs the other arms their numbers.
+fn prepare_targets(
+    layout: &BenchLayout,
+    suite: &SuiteFile,
+    platforms: &PlatformFile,
+    triplet: &str,
+    tebako_release: Option<&str>,
+) -> Result<(Vec<PreparedTarget>, Versions, Option<TebakoTools>), BenchError> {
+    let entry = platforms.triplets.get(triplet).ok_or_else(|| {
+        BenchError::operational(format!(
+            "engine: platforms.yaml has no triplet '{triplet}' (known: {})",
+            platforms
+                .triplets
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    })?;
+
+    let mut tools: Option<TebakoTools> = None;
+    let mut versions = Versions::default();
+    let mut prepared = Vec::new();
+    for target in &suite.targets {
+        let state = match target.kind {
+            TargetKind::V1Exe => match &entry.v1_asset {
+                None => Prepared::Unavailable {
+                    reason: format!(
+                        "platforms.yaml: v1_asset is null for {triplet} — packed-mn shipped no asset for this triplet{}",
+                        entry
+                            .v1_note
+                            .as_ref()
+                            .map(|n| format!(" ({n})"))
+                            .unwrap_or_default()
+                    ),
+                },
+                Some(_) => match acquire::acquire_v1_exe(layout, platforms, triplet) {
+                    Ok(exe) => {
+                        let tag = &platforms.packed_mn.tag;
+                        versions.packed_mn =
+                            Some(format!("{tag} (metanorma-cli {})", tag.trim_start_matches('v')));
+                        Prepared::Ready { program: exe }
+                    }
+                    Err(e) => Prepared::Unavailable {
+                        reason: format!("v1 acquisition failed: {e}"),
+                    },
+                },
+            },
+            TargetKind::V2Managed | TargetKind::V2Press => {
+                if !entry.v2_payload {
+                    Prepared::Unavailable {
+                        reason: format!(
+                            "platforms.yaml: v2_payload is false for {triplet} — no published payload"
+                        ),
+                    }
+                } else {
+                    match prepare_v2(layout, triplet, tebako_release, &mut tools, target) {
+                        Ok(staged) => {
+                            versions.tebako = Some(staged.tools_version);
+                            versions.runtime = Some(format!(
+                                "{}-{}",
+                                staged.runtime_tebako_version, staged.runtime_lang_version
+                            ));
+                            versions.payload = Some(staged.payload_release_tag);
+                            versions.image_format = Some(staged.image_format);
+                            Prepared::Ready {
+                                program: staged.program,
+                            }
+                        }
+                        Err(e) => Prepared::Unavailable {
+                            reason: format!("v2 acquisition failed: {e}"),
+                        },
+                    }
+                }
+            }
+        };
+        prepared.push(PreparedTarget {
+            target: target.clone(),
+            state,
+        });
+    }
+    Ok((prepared, versions, tools))
+}
+
+/// What a staged v2 arm reports upward (the measured program plus the
+/// resolved-version records the result document carries).
+struct StagedV2 {
+    program: PathBuf,
+    tools_version: String,
+    runtime_tebako_version: String,
+    runtime_lang_version: String,
+    payload_release_tag: String,
+    image_format: crate::result::ImageFormat,
+}
+
+/// Stage one v2 arm through the dogfood path (spec 27 §5): the
+/// downloaded CLI installs the payload, a shim dispatch primes the
+/// runtime, and the arm's program is the shim (managed) or the
+/// in-process-assembled fat package (press).
+fn prepare_v2(
+    layout: &BenchLayout,
+    triplet: &str,
+    tebako_release: Option<&str>,
+    tools: &mut Option<TebakoTools>,
+    target: &Target,
+) -> Result<StagedV2, BenchError> {
+    if tools.is_none() {
+        *tools = Some(acquire::fetch_tebako_tools(
+            layout,
+            tebako_release,
+            triplet,
+        )?);
+    }
+    let tools_ref = tools.as_ref().ok_or_else(|| {
+        BenchError::operational(
+            "engine: the tools slot is empty right after the fetch (harness bug)",
+        )
+    })?;
+    let payload = acquire::install_payload(layout, tools_ref, target)?;
+    let runtime = acquire::prime_runtime(layout, triplet, &payload)?;
+    let program = match target.kind {
+        TargetKind::V2Managed => acquire::shim_path(layout, triplet, &payload)?,
+        TargetKind::V2Press => {
+            acquire::assemble_fat_package(layout, tools_ref, &payload, &runtime, target)?
+        }
+        TargetKind::V1Exe => {
+            return Err(BenchError::operational(format!(
+                "engine: prepare_v2 called for the v1 target '{}' (harness bug)",
+                target.id
+            )))
+        }
+    };
+    Ok(StagedV2 {
+        program,
+        tools_version: tools_ref.version.clone(),
+        runtime_tebako_version: runtime.tebako_version,
+        runtime_lang_version: runtime.lang_version,
+        payload_release_tag: payload.release_tag,
+        image_format: payload.image_format,
+    })
+}
+
+/// The measured matrix (spec 27 §5): per selected workload, the named
+/// gaps first (explicit rows), warmups per ready target, the warm
+/// repetitions (targets interleaved per iteration when the policy says
+/// so — drift decorrelation), then the cold repetitions (wipe → the
+/// v2-managed-only unmeasured reprime → measured run). Returns every run
+/// record in execution order.
+pub fn execute_matrix(
+    layout: &BenchLayout,
+    suite: &SuiteFile,
+    opt_in: &[String],
+    prepared: &[PreparedTarget],
+    repo_root: &Path,
+    cold_reprime: &mut dyn FnMut(&BenchLayout, &Target) -> Result<(), BenchError>,
+) -> Result<Vec<RunRecord>, BenchError> {
+    // An --opt-in id naming nothing (or a non-opt-in workload) is a
+    // typo; named, never silent (invariant 9).
+    for id in opt_in {
+        match suite.workloads.iter().find(|w| &w.id == id) {
+            Some(w) if w.opt_in => {}
+            Some(_) => {
+                return Err(BenchError::operational(format!(
+                    "engine: --opt-in '{id}' names a workload that is not opt_in"
+                )))
+            }
+            None => {
+                return Err(BenchError::operational(format!(
+                    "engine: --opt-in '{id}' names no workload in suite '{}'",
+                    suite.name
+                )))
+            }
+        }
+    }
+    let workloads: Vec<&Workload> = suite
+        .workloads
+        .iter()
+        .filter(|w| !w.opt_in || opt_in.contains(&w.id))
+        .collect();
+
+    let mut sampler = Sampler::new();
+    let mut runs = Vec::new();
+    for w in workloads {
+        let source = acquire::materialize_source(w, layout, repo_root)?;
+
+        // Named gaps are explicit rows, one per workload (§6).
+        for pt in prepared {
+            if let Prepared::Unavailable { reason } = &pt.state {
+                runs.push(RunRecord {
+                    workload: w.id.clone(),
+                    target: pt.target.id.clone(),
+                    mode: None,
+                    iteration: None,
+                    status: RunStatus::Unavailable,
+                    wall_s: None,
+                    cpu_user_s: None,
+                    cpu_sys_s: None,
+                    peak_rss_bytes: None,
+                    exit: None,
+                    error: None,
+                    reason: Some(reason.clone()),
+                });
+            }
+        }
+
+        // Warmups: unmeasured priming. A missed expectation or a timeout
+        // kills the cell (the failed/timeout row at iteration 0 tells the
+        // story); a spawn failure makes the arm a named gap.
+        let mut dead: BTreeSet<usize> = BTreeSet::new();
+        for (t_idx, pt) in prepared.iter().enumerate() {
+            let Prepared::Ready { program } = &pt.state else {
+                continue;
+            };
+            for k in 1..=suite.run_policy.warmup {
+                match run_once(
+                    &mut sampler,
+                    layout,
+                    &source,
+                    w,
+                    &pt.target,
+                    program,
+                    RunMode::Warm,
+                    k,
+                    true,
+                ) {
+                    Ok((sample, cwd)) => {
+                        if let Some(record) = warmup_outcome(w, &pt.target, &sample, &cwd) {
+                            runs.push(record);
+                            dead.insert(t_idx);
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        runs.push(RunRecord {
+                            workload: w.id.clone(),
+                            target: pt.target.id.clone(),
+                            mode: None,
+                            iteration: None,
+                            status: RunStatus::Unavailable,
+                            wall_s: None,
+                            cpu_user_s: None,
+                            cpu_sys_s: None,
+                            peak_rss_bytes: None,
+                            exit: None,
+                            error: None,
+                            reason: Some(format!(
+                                "the staged program could not start on this triplet: {e}"
+                            )),
+                        });
+                        dead.insert(t_idx);
+                        break;
+                    }
+                }
+            }
+        }
+
+        // The warm repetitions.
+        for (t_idx, iteration) in warm_schedule(
+            prepared.len(),
+            suite.run_policy.repetitions,
+            suite.run_policy.interleave,
+        ) {
+            let pt = &prepared[t_idx];
+            let Prepared::Ready { program } = &pt.state else {
+                continue;
+            };
+            if dead.contains(&t_idx) {
+                continue;
+            }
+            let (sample, cwd) = run_once(
+                &mut sampler,
+                layout,
+                &source,
+                w,
+                &pt.target,
+                program,
+                RunMode::Warm,
+                iteration,
+                false,
+            )?;
+            runs.push(measured_record(
+                w,
+                &pt.target,
+                RunMode::Warm,
+                iteration,
+                &sample,
+                &cwd,
+            ));
+        }
+
+        // The cold repetitions: wipe → unmeasured reprime → measured run.
+        for (t_idx, pt) in prepared.iter().enumerate() {
+            let Prepared::Ready { program } = &pt.state else {
+                continue;
+            };
+            if dead.contains(&t_idx) {
+                continue;
+            }
+            for iteration in 1..=suite.run_policy.cold_repetitions {
+                layout.wipe_cold_caches(&pt.target.id, pt.target.kind)?;
+                // The §5 cold flow's unmeasured re-install is v2-managed's
+                // alone (v1 re-extracts in-span; the fat package needs no
+                // store) — the engine owns WHEN, the callback owns HOW.
+                if pt.target.kind == TargetKind::V2Managed {
+                    cold_reprime(layout, &pt.target)?;
+                }
+                let (sample, cwd) = run_once(
+                    &mut sampler,
+                    layout,
+                    &source,
+                    w,
+                    &pt.target,
+                    program,
+                    RunMode::Cold,
+                    iteration,
+                    false,
+                )?;
+                runs.push(measured_record(
+                    w,
+                    &pt.target,
+                    RunMode::Cold,
+                    iteration,
+                    &sample,
+                    &cwd,
+                ));
+            }
+        }
+    }
+    Ok(runs)
+}
+
+/// One child execution: fresh scratch cell (the source tree copied in),
+/// cwd = the document's directory, `{doc}` = the document's file name,
+/// the hermetic bench-home env, output to `logs/`. Warmup cells are
+/// named `warmup-<k>` so priming outputs never pollute a measured cell.
+#[allow(clippy::too_many_arguments)]
+fn run_once(
+    sampler: &mut Sampler,
+    layout: &BenchLayout,
+    source: &MaterializedSource,
+    workload: &Workload,
+    target: &Target,
+    program: &Path,
+    mode: RunMode,
+    iteration: u32,
+    warmup: bool,
+) -> Result<(Sample, PathBuf), BenchError> {
+    let cell_name = if warmup {
+        format!("warmup-{iteration}")
+    } else {
+        format!("{}-{iteration}", mode_str(mode))
+    };
+    let cell = layout
+        .scratch
+        .join(&workload.id)
+        .join(&target.id)
+        .join(&cell_name);
+    if cell.exists() {
+        std::fs::remove_dir_all(&cell).map_err(|e| {
+            BenchError::operational(format!("engine: cannot clear {}: {e}", cell.display()))
+        })?;
+    }
+    copy_tree(&source.root, &cell)?;
+    // The hermetic per-target TMPDIR must EXIST before the child boots
+    // (the v1 bootstrap's temp_directory_path aborts on a missing dir —
+    // the cold wipe recreates it; the first run must too).
+    let target_tmp = layout.tmp.join(&target.id);
+    std::fs::create_dir_all(&target_tmp).map_err(|e| {
+        BenchError::operational(format!(
+            "engine: cannot create {}: {e}",
+            target_tmp.display()
+        ))
+    })?;
+    let cwd = cell
+        .join(source.doc_rel.parent().unwrap_or_else(|| Path::new("")))
+        .canonicalize()
+        .map_err(|e| {
+            BenchError::operational(format!(
+                "engine: the document directory for workload '{}' is missing under {}: {e}",
+                workload.id,
+                cell.display()
+            ))
+        })?;
+    let doc_name = source
+        .doc_rel
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .ok_or_else(|| {
+            BenchError::operational(format!(
+                "engine: workload '{}' document path has no file name",
+                workload.id
+            ))
+        })?;
+    let mut argv = vec![program.to_string_lossy().into_owned()];
+    argv.extend(workload.argv.iter().map(|a| {
+        if a == "{doc}" {
+            doc_name.clone()
+        } else {
+            a.clone()
+        }
+    }));
+    let spec = ChildSpec {
+        argv,
+        cwd: cwd.clone(),
+        env: layout.child_env(&target.id),
+        log_path: layout
+            .logs
+            .join(format!("{}--{}--{}.log", workload.id, target.id, cell_name)),
+        timeout: Duration::from_secs(workload.timeout_s),
+    };
+    let sample = sampler.run(&spec)?;
+    Ok((sample, cwd))
+}
+
+/// The warmup verdict: None on success, else the one row that closes the
+/// cell (failed = expectation missed; timeout = killed at timeout_s).
+fn warmup_outcome(
+    workload: &Workload,
+    target: &Target,
+    sample: &Sample,
+    cwd: &Path,
+) -> Option<RunRecord> {
+    if sample.timed_out {
+        return Some(timeout_record(workload, target, RunMode::Warm, 0, sample));
+    }
+    check_expect(cwd, &workload.expect, sample.exit).map(|miss| RunRecord {
+        workload: workload.id.clone(),
+        target: target.id.clone(),
+        mode: Some(RunMode::Warm),
+        iteration: Some(0),
+        status: RunStatus::Failed,
+        wall_s: Some(sample.wall_s),
+        cpu_user_s: Some(sample.cpu_user_s),
+        cpu_sys_s: Some(sample.cpu_sys_s),
+        peak_rss_bytes: Some(sample.peak_rss_bytes),
+        exit: Some(sample.exit),
+        error: Some(format!("warmup: {miss}")),
+        reason: None,
+    })
+}
+
+/// The measured-run record (§6): timeout carries wall only; failed
+/// carries the exit, whatever metrics exist, and the named miss; ok
+/// carries everything.
+fn measured_record(
+    workload: &Workload,
+    target: &Target,
+    mode: RunMode,
+    iteration: u32,
+    sample: &Sample,
+    cwd: &Path,
+) -> RunRecord {
+    if sample.timed_out {
+        return timeout_record(workload, target, mode, iteration, sample);
+    }
+    let base = RunRecord {
+        workload: workload.id.clone(),
+        target: target.id.clone(),
+        mode: Some(mode),
+        iteration: Some(iteration),
+        status: RunStatus::Ok,
+        wall_s: Some(sample.wall_s),
+        cpu_user_s: Some(sample.cpu_user_s),
+        cpu_sys_s: Some(sample.cpu_sys_s),
+        peak_rss_bytes: Some(sample.peak_rss_bytes),
+        exit: Some(sample.exit),
+        error: None,
+        reason: None,
+    };
+    match check_expect(cwd, &workload.expect, sample.exit) {
+        None => base,
+        Some(miss) => RunRecord {
+            status: RunStatus::Failed,
+            error: Some(miss),
+            ..base
+        },
+    }
+}
+
+fn timeout_record(
+    workload: &Workload,
+    target: &Target,
+    mode: RunMode,
+    iteration: u32,
+    sample: &Sample,
+) -> RunRecord {
+    RunRecord {
+        workload: workload.id.clone(),
+        target: target.id.clone(),
+        mode: Some(mode),
+        iteration: Some(iteration),
+        status: RunStatus::Timeout,
+        wall_s: Some(sample.wall_s),
+        cpu_user_s: None,
+        cpu_sys_s: None,
+        peak_rss_bytes: None,
+        exit: None,
+        error: None,
+        reason: None,
+    }
+}
+
+/// The expectation check (§2): exit status, then every `expect.files`
+/// entry existing and non-empty. The first miss is returned, named.
+pub fn check_expect(cwd: &Path, expect: &Expect, exit_code: i32) -> Option<String> {
+    if exit_code != expect.exit {
+        return Some(format!("exit {exit_code} (expected {})", expect.exit));
+    }
+    for f in &expect.files {
+        let p = cwd.join(f);
+        match std::fs::metadata(&p) {
+            Ok(m) if m.len() > 0 => {}
+            Ok(_) => return Some(format!("expect.files '{f}' is empty")),
+            Err(e) => return Some(format!("expect.files '{f}' is missing ({e})")),
+        }
+    }
+    None
+}
+
+/// The warm-run order (§2's run_policy): interleaved — rotate targets
+/// per iteration so runner drift decorrelates across arms; otherwise
+/// each target to completion in turn (debugging only). Pure: the
+/// ordering is pinned by unit tests.
+pub fn warm_schedule(n_targets: usize, repetitions: u32, interleave: bool) -> Vec<(usize, u32)> {
+    if interleave {
+        (1..=repetitions)
+            .flat_map(|i| (0..n_targets).map(move |t| (t, i)))
+            .collect()
+    } else {
+        (0..n_targets)
+            .flat_map(|t| (1..=repetitions).map(move |i| (t, i)))
+            .collect()
+    }
+}
+
+/// The statistics (§6/§7): one StatRecord per (workload × target ×
+/// mode) over status-ok runs only, n ≥ 1. An arm whose runs all failed
+/// has no row — the run records tell the story.
+pub fn compute_stats(runs: &[RunRecord]) -> Vec<StatRecord> {
+    let mut cells: BTreeMap<(&str, &str, RunMode), Vec<&RunRecord>> = BTreeMap::new();
+    for r in runs.iter().filter(|r| r.status == RunStatus::Ok) {
+        if let Some(mode) = r.mode {
+            cells
+                .entry((&r.workload, &r.target, mode))
+                .or_default()
+                .push(r);
+        }
+    }
+    cells
+        .into_iter()
+        .map(|((workload, target, mode), cell)| {
+            let mut walls: Vec<f64> = cell.iter().filter_map(|r| r.wall_s).collect();
+            walls.sort_by(|a, b| a.total_cmp(b));
+            let mut cpus: Vec<f64> = cell
+                .iter()
+                .filter_map(|r| Some(r.cpu_user_s? + r.cpu_sys_s?))
+                .collect();
+            cpus.sort_by(|a, b| a.total_cmp(b));
+            let mut rss: Vec<u64> = cell.iter().filter_map(|r| r.peak_rss_bytes).collect();
+            rss.sort_unstable();
+            let n = cell.len() as u32;
+            let mean = walls.iter().sum::<f64>() / walls.len() as f64;
+            StatRecord {
+                workload: workload.to_string(),
+                target: target.to_string(),
+                mode,
+                n,
+                median_wall_s: median_f64(&walls),
+                min_wall_s: walls.first().copied().unwrap_or(0.0),
+                max_wall_s: walls.last().copied().unwrap_or(0.0),
+                stdev_wall_s: stdev_sample(&walls, mean),
+                mean_wall_s: mean,
+                median_cpu_s: median_f64(&cpus),
+                median_peak_rss_bytes: median_u64(&rss),
+            }
+        })
+        .collect()
+}
+
+/// Median of a sorted f64 slice (even counts average the two middles).
+fn median_f64(sorted: &[f64]) -> f64 {
+    let n = sorted.len();
+    if n == 0 {
+        return 0.0;
+    }
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+    }
+}
+
+/// Median of a sorted u64 slice, integer-rounded.
+fn median_u64(sorted: &[u64]) -> u64 {
+    let n = sorted.len();
+    if n == 0 {
+        return 0;
+    }
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+    }
+}
+
+/// Sample standard deviation (n−1); absent under n < 2 (§6).
+fn stdev_sample(sorted: &[f64], mean: f64) -> Option<f64> {
+    if sorted.len() < 2 {
+        return None;
+    }
+    let var =
+        sorted.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>() / (sorted.len() - 1) as f64;
+    Some(var.sqrt())
+}
+
+/// The §6 runner metadata: the runner label flows from platforms.yaml,
+/// the rest is read off the machine (numbers without their environment
+/// are not numbers).
+pub fn runner_meta(platforms: &PlatformFile, triplet: &str) -> Result<RunnerMeta, BenchError> {
+    let entry = platforms.triplets.get(triplet).ok_or_else(|| {
+        BenchError::operational(format!("engine: platforms.yaml has no triplet '{triplet}'"))
+    })?;
+    Ok(RunnerMeta {
+        runs_on: entry.runner.clone(),
+        arch: std::env::consts::ARCH.to_string(),
+        cpus: std::thread::available_parallelism()
+            .map(|n| n.get() as u32)
+            .unwrap_or(1),
+        ram_bytes: crate::ram_total_bytes()?,
+    })
+}
+
+/// Assemble the result document (statistics derived from the run
+/// records, never authored).
+pub fn assemble_result(
+    suite: &SuiteFile,
+    triplet: &str,
+    runner: RunnerMeta,
+    versions: Versions,
+    runs: Vec<RunRecord>,
+) -> ResultFile {
+    let stats = compute_stats(&runs);
+    ResultFile {
+        schema_version: 1,
+        suite: suite.name.clone(),
+        triplet: triplet.to_string(),
+        runner,
+        versions,
+        runs,
+        stats,
+    }
+}
+
+/// Write `<out>/results.json`, self-checked: the emitted text re-enters
+/// BOTH validation gates (the versioned schema + the serde model +
+/// semantics). A violation here is a harness bug, surfaced operationally
+/// instead of shipping a bad artifact.
+pub fn emit_result(out: &Path, result: &ResultFile) -> Result<PathBuf, BenchError> {
+    let text = result.to_json().map_err(|e| {
+        BenchError::operational(format!(
+            "engine: the result document does not serialize: {e}"
+        ))
+    })?;
+    let violations = validate::validate_text(DocKind::Result, &text)?;
+    if !violations.is_empty() {
+        return Err(BenchError::operational(format!(
+            "engine: the emitted results.json fails validation (harness bug):\n  {}",
+            violations.join("\n  ")
+        )));
+    }
+    let dest = out.join("results.json");
+    std::fs::write(&dest, format!("{text}\n")).map_err(|e| {
+        BenchError::operational(format!("engine: cannot write {}: {e}", dest.display()))
+    })?;
+    Ok(dest)
+}
+
+fn mode_str(mode: RunMode) -> &'static str {
+    match mode {
+        RunMode::Warm => "warm",
+        RunMode::Cold => "cold",
+    }
+}
+
+/// Recursive copy of the materialized source tree into a run cell
+/// (files + dirs; symlinks are not expected in suite sources — a
+/// non-file/non-dir entry is copied as its file bytes or named).
+fn copy_tree(src: &Path, dst: &Path) -> Result<(), BenchError> {
+    std::fs::create_dir_all(dst).map_err(|e| {
+        BenchError::operational(format!("engine: cannot create {}: {e}", dst.display()))
+    })?;
+    let entries = std::fs::read_dir(src).map_err(|e| {
+        BenchError::operational(format!("engine: cannot list {}: {e}", src.display()))
+    })?;
+    for entry in entries.flatten() {
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let ft = entry.file_type().map_err(|e| {
+            BenchError::operational(format!("engine: cannot stat {}: {e}", from.display()))
+        })?;
+        if ft.is_dir() {
+            copy_tree(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to).map_err(|e| {
+                BenchError::operational(format!(
+                    "engine: cannot copy {} into the run scratch: {e}",
+                    from.display()
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}

--- a/crates/tebako-bench/src/lib.rs
+++ b/crates/tebako-bench/src/lib.rs
@@ -20,6 +20,7 @@
 //!   (including the not-implemented stubs).
 
 pub mod acquire;
+pub mod engine;
 pub mod error;
 pub mod platforms;
 pub mod result;

--- a/crates/tebako-bench/src/lib.rs
+++ b/crates/tebako-bench/src/lib.rs
@@ -19,6 +19,7 @@
 //!   spec 27 §8 — 0 success/valid, 1 invalid/all-arms-failed, 2 operational
 //!   (including the not-implemented stubs).
 
+pub mod acquire;
 pub mod error;
 pub mod platforms;
 pub mod result;

--- a/crates/tebako-bench/src/lib.rs
+++ b/crates/tebako-bench/src/lib.rs
@@ -22,7 +22,9 @@
 pub mod error;
 pub mod platforms;
 pub mod result;
+pub mod sampler;
 pub mod suite;
+mod sys;
 pub mod validate;
 
 pub use error::BenchError;
@@ -30,6 +32,12 @@ pub use platforms::{PlatformFile, Triplet};
 pub use result::{ResultFile, RunRecord, StatRecord};
 pub use suite::{RunPolicy, SuiteFile, Target, TargetKind, Workload};
 pub use validate::{validate_file, validate_text, DocKind};
+
+/// Total physical RAM of the runner in bytes (`runner.ram_bytes`, spec 27
+/// §6). The platform mechanics live in `crate::sys` (FFI-quarantined).
+pub fn ram_total_bytes() -> Result<u64, BenchError> {
+    sys::ram_total_bytes()
+}
 
 /// The process exit codes (spec 27 §8).
 pub mod exit {

--- a/crates/tebako-bench/src/main.rs
+++ b/crates/tebako-bench/src/main.rs
@@ -32,8 +32,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// Execute the benchmark matrix for one triplet (planned: the sampler,
-    /// acquisition, and run-engine slices of the spec 27 plan).
+    /// Execute the benchmark matrix for one triplet (spec 27 §5–§7:
+    /// acquire, warmup → warm interleaved → cold-with-wipe, results.json).
     Run {
         /// The suite document (benchmarks/suite.yaml).
         #[arg(long)]
@@ -50,6 +50,13 @@ enum Command {
         /// Opt an opt-in workload in (repeatable; e.g. --opt-in compile-medium-oiml-r060).
         #[arg(long = "opt-in")]
         opt_in: Vec<String>,
+        /// Pin the tebako tools release (default: the latest release; the
+        /// resolved version is learned from the release's SHA256SUMS).
+        #[arg(long = "tebako-release")]
+        tebako_release: Option<String>,
+        /// Vendored source paths resolve against this root (the repo root).
+        #[arg(long = "repo-root", default_value = ".")]
+        repo_root: PathBuf,
     },
     /// Merge N triplet result files into a markdown report + dashboard JSON
     /// (planned: the report-renderer slice).
@@ -105,10 +112,38 @@ fn run(cli: Cli) -> Result<u8, BenchError> {
                 Ok(exit::INVALID)
             }
         }
-        Command::Run { .. } => Err(BenchError::not_implemented(
-            "run",
-            "slices 3–5 (sampler, acquisition, run engine)",
-        )),
+        Command::Run {
+            suite,
+            platforms,
+            triplet,
+            out,
+            opt_in,
+            tebako_release,
+            repo_root,
+        } => {
+            let suite_text = std::fs::read_to_string(&suite).map_err(|e| {
+                BenchError::operational(format!("cannot read {}: {e}", suite.display()))
+            })?;
+            let suite = tebako_bench::SuiteFile::from_yaml(&suite_text).map_err(|e| {
+                BenchError::operational(format!("cannot parse {}: {e}", suite.display()))
+            })?;
+            let platforms_text = std::fs::read_to_string(&platforms).map_err(|e| {
+                BenchError::operational(format!("cannot read {}: {e}", platforms.display()))
+            })?;
+            let platforms =
+                tebako_bench::PlatformFile::from_yaml(&platforms_text).map_err(|e| {
+                    BenchError::operational(format!("cannot parse {}: {e}", platforms.display()))
+                })?;
+            tebako_bench::engine::run(&tebako_bench::engine::RunRequest {
+                suite,
+                platforms,
+                triplet,
+                out,
+                opt_in,
+                tebako_release,
+                repo_root,
+            })
+        }
         Command::Report { .. } => Err(BenchError::not_implemented(
             "report",
             "slice 6 (report renderer)",

--- a/crates/tebako-bench/src/result.rs
+++ b/crates/tebako-bench/src/result.rs
@@ -70,8 +70,8 @@ pub struct RunRecord {
     /// Instant-elapsed seconds around spawn→wait.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wall_s: Option<f64>,
-    /// POSIX getrusage(RUSAGE_CHILDREN) delta / Windows GetProcessTimes
-    /// (spec 27 §4 — one measured child at a time, the delta is exact).
+    /// POSIX wait4 rusage of the reaped child / Windows GetProcessTimes
+    /// (spec 27 §4 — one measured child at a time, attributed exactly).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cpu_user_s: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/tebako-bench/src/sampler.rs
+++ b/crates/tebako-bench/src/sampler.rs
@@ -1,0 +1,87 @@
+//! The benchmark sampler (spec 27 §4): spawn one child, measure wall /
+//! CPU / peak RSS, enforce the timeout. Platform mechanics live in
+//! `crate::sys` (FFI-quarantined); this module is the neutral surface.
+//!
+//! **The one-child-at-a-time discipline.** A `Sampler` measures exactly
+//! one child at a time, and a benchmark process holds exactly one
+//! `Sampler` (the run engine's). The rusage numbers are per-child
+//! (POSIX `wait4` reaps the measured child itself — see
+//! `sys::posix` for why not `RUSAGE_CHILDREN`), but the discipline still
+//! stands: it keeps wall-time/timeout semantics clean, makes cross-run
+//! attribution impossible by construction, and matches the Windows
+//! handle model. Concurrent measured runs are forbidden even when
+//! workloads are independent — cross-leg parallelism is the workflow
+//! matrix's job, never the sampler's.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::error::BenchError;
+
+/// What to run and how to bound it.
+#[derive(Debug, Clone)]
+pub struct ChildSpec {
+    /// argv[0] is the program; the rest are passed verbatim.
+    pub argv: Vec<String>,
+    /// The child's working directory (the per-run scratch dir).
+    pub cwd: PathBuf,
+    /// Overrides on the inherited environment (HOME/TMPDIR/… — the bench
+    /// hermetic home, spec 27 §5).
+    pub env: Vec<(String, String)>,
+    /// stdout+stderr are appended to this file (one log per run).
+    pub log_path: PathBuf,
+    /// The workload's timeout. Expiry kills the child's tree
+    /// (POSIX: the child's process group; Windows: the job object,
+    /// falling back to the direct child) and records `timed_out`.
+    pub timeout: Duration,
+}
+
+/// One measured run.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Sample {
+    /// Instant-elapsed seconds around spawn→reap.
+    pub wall_s: f64,
+    /// User CPU seconds attributed to the child.
+    pub cpu_user_s: f64,
+    /// System CPU seconds attributed to the child.
+    pub cpu_sys_s: f64,
+    /// Peak RSS in BYTES, always (unit-normalized at record time —
+    /// `ru_maxrss` is KiB on Linux/musl, bytes on macOS; Windows's
+    /// `PeakWorkingSetSize` is bytes).
+    pub peak_rss_bytes: u64,
+    /// The process exit status; 128+signal when signal-killed (the shell
+    /// convention — a timeout kill records 137).
+    pub exit: i32,
+    /// True when the run was killed at the spec's timeout.
+    pub timed_out: bool,
+}
+
+/// The one-per-process measured-run surface. Not `Clone`/`Sync`: the
+/// discipline above is a type-level fact, not a comment.
+pub struct Sampler {
+    _seal: std::marker::PhantomData<*const ()>,
+}
+
+impl Sampler {
+    pub fn new() -> Self {
+        Sampler {
+            _seal: std::marker::PhantomData,
+        }
+    }
+
+    /// Run the child to completion (or timeout) and return its sample.
+    pub fn run(&mut self, spec: &ChildSpec) -> Result<Sample, BenchError> {
+        if spec.argv.is_empty() {
+            return Err(BenchError::operational(
+                "sampler: empty argv (argv[0] is the program)",
+            ));
+        }
+        crate::sys::run_child(spec)
+    }
+}
+
+impl Default for Sampler {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/tebako-bench/src/sys/mod.rs
+++ b/crates/tebako-bench/src/sys/mod.rs
@@ -1,0 +1,14 @@
+//! The platform mechanics of the sampler — the crate's FFI boundary
+//! (workspace rule: `unsafe` only inside boundary modules). `posix.rs`
+//! and `windows.rs` export the same two functions; the sampler calls the
+//! alias, never a platform module directly.
+
+#[cfg(unix)]
+pub mod posix;
+#[cfg(windows)]
+pub mod windows;
+
+#[cfg(unix)]
+pub(crate) use posix::{ram_total_bytes, run_child};
+#[cfg(windows)]
+pub(crate) use windows::{ram_total_bytes, run_child};

--- a/crates/tebako-bench/src/sys/posix.rs
+++ b/crates/tebako-bench/src/sys/posix.rs
@@ -1,0 +1,199 @@
+//! The sampler's POSIX mechanics — one of the crate's two FFI boundary
+//! modules (all `unsafe` lives here and in `sys::windows`).
+//!
+//! **Why `wait4`, not `RUSAGE_CHILDREN` (spec 27 §4, amended).** The spec
+//! originally read "rusage delta around each run". That is wrong for a
+//! benchmark: `getrusage(RUSAGE_CHILDREN).ru_maxrss` is a *running
+//! maximum* over every child the process has ever reaped, so after one
+//! big child the (after − before) RSS delta is 0 forever — runs 2..N
+//! would report garbage RSS. `wait4(pid, …)` instead returns the reaped
+//! child's OWN rusage (utime/stime exact, maxrss the child's own peak),
+//! so every run is attributed correctly no matter what ran before it. We
+//! poll `wait4(WNOHANG)` on a ~2 ms tick against an `Instant` deadline;
+//! on expiry the child's process group (the child is made a group leader
+//! via `CommandExt::process_group(0)`, safe std) gets `SIGKILL`, then a
+//! blocking `wait4` reaps it for the rusage. The std `Child` is dropped,
+//! never `wait()`ed — wait4 already reaped it.
+//!
+//! Unit note: `ru_maxrss` is BYTES on macOS and KIBIBYTES on Linux/musl —
+//! normalized to bytes at record time (`maxrss_to_bytes`).
+
+use std::fs::OpenOptions;
+use std::os::unix::process::CommandExt;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::error::BenchError;
+use crate::sampler::{ChildSpec, Sample};
+
+/// Poll granularity of the WNOHANG loop. 2 ms keeps wall-time overshoot
+/// far below any metanorma workload's runtime while adding negligible
+/// scheduler noise.
+const POLL_INTERVAL: Duration = Duration::from_millis(2);
+
+/// Run the child to completion (or timeout) and return its sample.
+pub(crate) fn run_child(spec: &ChildSpec) -> Result<Sample, BenchError> {
+    let log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&spec.log_path)
+        .map_err(|e| {
+            BenchError::operational(format!(
+                "sampler: cannot open log {}: {e}",
+                spec.log_path.display()
+            ))
+        })?;
+    let log_err = log.try_clone().map_err(|e| {
+        BenchError::operational(format!(
+            "sampler: cannot clone log handle {}: {e}",
+            spec.log_path.display()
+        ))
+    })?;
+
+    let mut cmd = Command::new(&spec.argv[0]);
+    cmd.args(&spec.argv[1..])
+        .current_dir(&spec.cwd)
+        .envs(spec.env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(log_err))
+        // Own process group: the timeout kill must reach the child's whole
+        // tree (metanorma shells out to sub-tools), not just the direct
+        // child. Group id == child pid.
+        .process_group(0);
+
+    // Wall time spans spawn→reap: the exec cost is part of what the user
+    // pays. The deadline is anchored at the same instant.
+    let start = Instant::now();
+    let deadline = start + spec.timeout;
+
+    let child = cmd.spawn().map_err(|e| {
+        BenchError::operational(format!(
+            "sampler: cannot spawn {:?} in {}: {e}",
+            spec.argv[0],
+            spec.cwd.display()
+        ))
+    })?;
+    let pid = child.id() as libc::pid_t;
+
+    let mut status: libc::c_int = 0;
+    // SAFETY: `usage` is plain-old-data filled by wait4 before any read.
+    let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+
+    let (exit, timed_out) = loop {
+        // SAFETY: `status`/`usage` are valid out-params; `pid` is our own
+        // spawned, not-yet-reaped child.
+        let rc = unsafe { libc::wait4(pid, &mut status, libc::WNOHANG, &mut usage) };
+        if rc == pid {
+            break (decode_exit(status), false);
+        }
+        if rc == 0 {
+            // Still running.
+            if Instant::now() >= deadline {
+                // SAFETY: pid is the child's group leader id; the group is
+                // ours (created by this spawn). ESRCH (already exited) is
+                // harmless — the blocking wait4 below reaps either way.
+                unsafe {
+                    libc::kill(-pid, libc::SIGKILL);
+                }
+                reap_blocking(pid, &mut status, &mut usage)?;
+                break (decode_exit(status), true);
+            }
+            std::thread::sleep(POLL_INTERVAL);
+            continue;
+        }
+        let err = std::io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(libc::EINTR) => continue,
+            _ => {
+                return Err(BenchError::operational(format!(
+                    "sampler: wait4({pid}) failed: {err}"
+                )))
+            }
+        }
+    };
+    let wall_s = start.elapsed().as_secs_f64();
+
+    // wait4 reaped the child; std's Child must never be wait()ed now (its
+    // Drop does not reap — safe to drop).
+    drop(child);
+
+    Ok(Sample {
+        wall_s,
+        cpu_user_s: timeval_to_s(&usage.ru_utime),
+        cpu_sys_s: timeval_to_s(&usage.ru_stime),
+        peak_rss_bytes: maxrss_to_bytes(usage.ru_maxrss),
+        exit,
+        timed_out,
+    })
+}
+
+/// Blocking reap after the timeout SIGKILL; loops on EINTR.
+fn reap_blocking(
+    pid: libc::pid_t,
+    status: &mut libc::c_int,
+    usage: &mut libc::rusage,
+) -> Result<(), BenchError> {
+    loop {
+        // SAFETY: same as the poll loop; options 0 = block until the child
+        // exits (SIGKILL guarantees it does).
+        let rc = unsafe { libc::wait4(pid, status, 0, usage) };
+        if rc == pid {
+            return Ok(());
+        }
+        let err = std::io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(libc::EINTR) => continue,
+            _ => {
+                return Err(BenchError::operational(format!(
+                    "sampler: wait4({pid}) after SIGKILL failed: {err}"
+                )))
+            }
+        }
+    }
+}
+
+/// The shell convention: exit status, or 128+signal when signal-killed
+/// (a timeout SIGKILL therefore records 137).
+fn decode_exit(status: libc::c_int) -> i32 {
+    if libc::WIFEXITED(status) {
+        libc::WEXITSTATUS(status)
+    } else if libc::WIFSIGNALED(status) {
+        128 + libc::WTERMSIG(status)
+    } else {
+        // Stopped/continued — wait4 without WUNTRACED/WCONTINUED never
+        // reports those.
+        -1
+    }
+}
+
+fn timeval_to_s(tv: &libc::timeval) -> f64 {
+    tv.tv_sec as f64 + (tv.tv_usec as f64) / 1_000_000.0
+}
+
+/// `ru_maxrss` is bytes on macOS, KiB everywhere else we run
+/// (linux-gnu/musl). Normalized to BYTES at record time.
+fn maxrss_to_bytes(ru_maxrss: libc::c_long) -> u64 {
+    let v = u64::try_from(ru_maxrss).unwrap_or(0);
+    if cfg!(target_os = "macos") {
+        v
+    } else {
+        v.saturating_mul(1024)
+    }
+}
+
+/// Total physical RAM in bytes (`runner.ram_bytes` in the result
+/// document).
+pub(crate) fn ram_total_bytes() -> Result<u64, BenchError> {
+    // SAFETY: sysconf on these two names is always safe; errors surface
+    // as -1.
+    let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if pages <= 0 || page_size <= 0 {
+        return Err(BenchError::operational(format!(
+            "sampler: sysconf(_SC_PHYS_PAGES/_SC_PAGESIZE) failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok((pages as u64).saturating_mul(page_size as u64))
+}

--- a/crates/tebako-bench/src/sys/windows.rs
+++ b/crates/tebako-bench/src/sys/windows.rs
@@ -24,8 +24,9 @@ use std::fs::OpenOptions;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
+use windows_sys::core::BOOL;
 use windows_sys::Win32::Foundation::{
-    CloseHandle, BOOL, FILETIME, HANDLE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+    CloseHandle, FILETIME, HANDLE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
 };
 use windows_sys::Win32::System::JobObjects::{
     AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,

--- a/crates/tebako-bench/src/sys/windows.rs
+++ b/crates/tebako-bench/src/sys/windows.rs
@@ -22,7 +22,7 @@
 
 use std::fs::OpenOptions;
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use windows_sys::core::BOOL;
 use windows_sys::Win32::Foundation::{
@@ -282,9 +282,8 @@ fn create_armed_job() -> Result<HANDLE, BenchError> {
             std::io::Error::last_os_error()
         )));
     }
-    set_job_kill_on_close(job, true).map_err(|e| {
+    set_job_kill_on_close(job, true).inspect_err(|_| {
         close_handle_quiet(job);
-        e
     })?;
     Ok(job)
 }

--- a/crates/tebako-bench/src/sys/windows.rs
+++ b/crates/tebako-bench/src/sys/windows.rs
@@ -1,0 +1,351 @@
+//! The sampler's Windows mechanics — one of the crate's two FFI boundary
+//! modules (all `unsafe` lives here and in `sys::posix`).
+//!
+//! Spawn is std (`Command` gets argv quoting right for free). Metrics ride
+//! a handle we `OpenProcess` ourselves (std's `Child` does not expose
+//! its handle): `WaitForSingleObject` on a 50 ms tick against an
+//! `Instant` deadline, then `GetProcessTimes` (user/kernel FILETIMEs —
+//! separate, mapping straight onto cpu_user/cpu_sys) and
+//! `K32GetProcessMemoryInfo` (`PeakWorkingSetSize`, already bytes). Both
+//! stay queryable after the child exits because the handle is held open.
+//!
+//! The timeout kill is a JOB OBJECT armed with
+//! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`: on expiry we close it, which
+//! takes the child's whole tree (metanorma spawns sub-tools). On a normal
+//! exit the job is disarmed (LimitFlags=0) BEFORE its handle is closed —
+//! closing an armed job would kill the (already exited) tree. CI runners
+//! may nest us in a job that forbids assignment (GitHub windows-2019
+//! does): then we run without a job and the timeout kill degrades to
+//! `TerminateProcess` on the direct child — loud on stderr, never silent
+//! (invariant 9). Either way a timeout records exit 137 (the shell
+//! convention, matching the POSIX SIGKILL path).
+
+use std::fs::OpenOptions;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use windows_sys::Win32::Foundation::{
+    CloseHandle, BOOL, FILETIME, HANDLE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+};
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+use windows_sys::Win32::System::ProcessStatus::{K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS};
+use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+use windows_sys::Win32::System::Threading::{
+    GetProcessTimes, OpenProcess, TerminateProcess, WaitForSingleObject, PROCESS_QUERY_INFORMATION,
+    PROCESS_SET_QUOTA, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, PROCESS_VM_READ,
+};
+
+use crate::error::BenchError;
+use crate::sampler::{ChildSpec, Sample};
+
+/// Poll granularity of the WaitForSingleObject loop (see posix.rs).
+const POLL_INTERVAL_MS: u32 = 50;
+
+/// The rights our metrics/timeout handle needs: query times + memory,
+/// wait for exit, terminate, and (for the job) set quota.
+const CHILD_RIGHTS: u32 = PROCESS_QUERY_INFORMATION
+    | PROCESS_VM_READ
+    | PROCESS_TERMINATE
+    | PROCESS_SET_QUOTA
+    | PROCESS_SYNCHRONIZE;
+
+/// Run the child to completion (or timeout) and return its sample.
+pub(crate) fn run_child(spec: &ChildSpec) -> Result<Sample, BenchError> {
+    let log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&spec.log_path)
+        .map_err(|e| {
+            BenchError::operational(format!(
+                "sampler: cannot open log {}: {e}",
+                spec.log_path.display()
+            ))
+        })?;
+    let log_err = log.try_clone().map_err(|e| {
+        BenchError::operational(format!(
+            "sampler: cannot clone log handle {}: {e}",
+            spec.log_path.display()
+        ))
+    })?;
+
+    let mut cmd = Command::new(&spec.argv[0]);
+    cmd.args(&spec.argv[1..])
+        .current_dir(&spec.cwd)
+        .envs(spec.env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(log_err));
+
+    // The timeout job is created before spawn so a later failure to arm it
+    // cannot leave a spawned child unbounded.
+    let job = create_armed_job()?;
+
+    // Wall time spans spawn→reap (see posix.rs).
+    let start = Instant::now();
+    let deadline = start + spec.timeout;
+
+    let mut child = cmd.spawn().map_err(|e| {
+        close_job(job, false);
+        BenchError::operational(format!(
+            "sampler: cannot spawn {:?} in {}: {e}",
+            spec.argv[0],
+            spec.cwd.display()
+        ))
+    })?;
+    let pid = child.id();
+
+    // SAFETY: pid is our own freshly spawned child, so the access rights
+    // are grantable; null-checked right after.
+    let h: HANDLE = unsafe { OpenProcess(CHILD_RIGHTS, 0, pid) };
+    if h.is_null() {
+        let err = std::io::Error::last_os_error();
+        close_job(job, false);
+        return Err(BenchError::operational(format!(
+            "sampler: OpenProcess({pid}) failed: {err}"
+        )));
+    }
+
+    // Join the timeout job. Fails on CI runners that nest us in a job
+    // that forbids assignment — degrade to direct-child TerminateProcess,
+    // LOUDLY (never a silent fallback, invariant 9).
+    // SAFETY: both handles are valid and ours.
+    let job = if unsafe { AssignProcessToJobObject(job, h) } == 0 {
+        let err = std::io::Error::last_os_error();
+        eprintln!(
+            "tebako-bench: warning: AssignProcessToJobObject({pid}) failed: {err}; \
+             the timeout kill is direct-child only for this run"
+        );
+        close_job(job, false);
+        std::ptr::null_mut()
+    } else {
+        job
+    };
+
+    let result = poll_child(h, deadline, job.is_null());
+    let timed_out = matches!(result, PollOutcome::TimedOut);
+    // The job close IS the tree kill on timeout; otherwise disarm first
+    // (closing an armed job would kill the tree).
+    close_job(job, timed_out);
+
+    // Reap via std (our OpenProcess handle is separate). On timeout the
+    // exit code is forced to 137 per the shell convention, matching the
+    // POSIX SIGKILL path.
+    let wait = child.wait();
+    let wall_s = start.elapsed().as_secs_f64();
+
+    let sample = match result {
+        PollOutcome::Exited {
+            cpu_user_s,
+            cpu_sys_s,
+            peak_rss_bytes,
+        } => match wait {
+            Ok(status) => Ok(Sample {
+                wall_s,
+                cpu_user_s,
+                cpu_sys_s,
+                peak_rss_bytes,
+                exit: status.code().unwrap_or(-1),
+                timed_out: false,
+            }),
+            Err(e) => Err(BenchError::operational(format!(
+                "sampler: child wait() failed: {e}"
+            ))),
+        },
+        PollOutcome::TimedOut => {
+            // The job close (or the TerminateProcess fallback in
+            // poll_child) already killed the child; drain the wait so no
+            // zombie handle lingers, ignore its code.
+            let _ = wait;
+            query_metrics(h).map(|(cpu_user_s, cpu_sys_s, peak_rss_bytes)| Sample {
+                wall_s,
+                cpu_user_s,
+                cpu_sys_s,
+                peak_rss_bytes,
+                exit: 137,
+                timed_out: true,
+            })
+        }
+        PollOutcome::Failed(e) => {
+            let _ = wait;
+            Err(e)
+        }
+    };
+    close_handle_quiet(h);
+    sample
+}
+
+enum PollOutcome {
+    Exited {
+        cpu_user_s: f64,
+        cpu_sys_s: f64,
+        peak_rss_bytes: u64,
+    },
+    TimedOut,
+    Failed(BenchError),
+}
+
+/// WaitForSingleObject polling against the deadline; on expiry the caller
+/// kills via the job close — here we only terminate directly when there
+/// is no job.
+fn poll_child(h: HANDLE, deadline: Instant, no_job: bool) -> PollOutcome {
+    loop {
+        // SAFETY: h is our valid process handle.
+        let rc = unsafe { WaitForSingleObject(h, POLL_INTERVAL_MS) };
+        if rc == WAIT_OBJECT_0 {
+            return match query_metrics(h) {
+                Ok((cpu_user_s, cpu_sys_s, peak_rss_bytes)) => PollOutcome::Exited {
+                    cpu_user_s,
+                    cpu_sys_s,
+                    peak_rss_bytes,
+                },
+                Err(e) => PollOutcome::Failed(e),
+            };
+        }
+        if rc == WAIT_FAILED {
+            return PollOutcome::Failed(BenchError::operational(format!(
+                "sampler: WaitForSingleObject failed: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        debug_assert_eq!(rc, WAIT_TIMEOUT);
+        if Instant::now() >= deadline {
+            if no_job {
+                // SAFETY: h is our valid process handle; failing that, the
+                // sample is a timeout either way.
+                unsafe {
+                    TerminateProcess(h, 137);
+                }
+            }
+            return PollOutcome::TimedOut;
+        }
+    }
+}
+
+/// user/kernel CPU seconds + peak RSS bytes from the (still open)
+/// process handle. Queryable after the child has exited.
+fn query_metrics(h: HANDLE) -> Result<(f64, f64, u64), BenchError> {
+    let mut creation: FILETIME = unsafe { std::mem::zeroed() };
+    let mut exit: FILETIME = unsafe { std::mem::zeroed() };
+    let mut kernel: FILETIME = unsafe { std::mem::zeroed() };
+    let mut user: FILETIME = unsafe { std::mem::zeroed() };
+    // SAFETY: h is our valid process handle; the FILETIMEs are valid
+    // out-params filled before any read.
+    if unsafe { GetProcessTimes(h, &mut creation, &mut exit, &mut kernel, &mut user) } == 0 {
+        return Err(BenchError::operational(format!(
+            "sampler: GetProcessTimes failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    let mut counters: PROCESS_MEMORY_COUNTERS = unsafe { std::mem::zeroed() };
+    // SAFETY: h is our valid process handle; `counters` is a valid
+    // out-param of the passed size, filled before any read.
+    if unsafe {
+        K32GetProcessMemoryInfo(
+            h,
+            &mut counters,
+            std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32,
+        )
+    } == 0
+    {
+        return Err(BenchError::operational(format!(
+            "sampler: K32GetProcessMemoryInfo failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok((
+        filetime_to_s(&user),
+        filetime_to_s(&kernel),
+        counters.PeakWorkingSetSize as u64,
+    ))
+}
+
+/// A FILETIME is 100-ns intervals; convert to seconds.
+fn filetime_to_s(ft: &FILETIME) -> f64 {
+    let ticks = (u64::from(ft.dwHighDateTime) << 32) | u64::from(ft.dwLowDateTime);
+    ticks as f64 / 10_000_000.0
+}
+
+/// A job object armed with KILL_ON_JOB_CLOSE. Creation failure is an
+/// operational error (an unbounded child is worse than a named failure).
+fn create_armed_job() -> Result<HANDLE, BenchError> {
+    // SAFETY: null attributes/name create an unnamed job with default
+    // security; null-checked right after.
+    let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+    if job.is_null() {
+        return Err(BenchError::operational(format!(
+            "sampler: CreateJobObjectW failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    set_job_kill_on_close(job, true).map_err(|e| {
+        close_handle_quiet(job);
+        e
+    })?;
+    Ok(job)
+}
+
+fn set_job_kill_on_close(job: HANDLE, armed: bool) -> Result<(), BenchError> {
+    let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+    info.BasicLimitInformation.LimitFlags = if armed {
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    } else {
+        0
+    };
+    // SAFETY: job is our valid job handle; `info` points at a valid
+    // struct of the passed size for the ExtendedLimitInformation class.
+    let ok: BOOL = unsafe {
+        SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &info as *const JOBOBJECT_EXTENDED_LIMIT_INFORMATION as *const _,
+            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        )
+    };
+    if ok == 0 {
+        return Err(BenchError::operational(format!(
+            "sampler: SetInformationJobObject(KILL_ON_JOB_CLOSE={armed}) failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(())
+}
+
+/// Close the job, disarming first unless the close is meant to kill.
+fn close_job(job: HANDLE, kill: bool) {
+    if job.is_null() {
+        return;
+    }
+    if !kill {
+        // A failure to disarm must not leak a kill: if disarm fails we
+        // still close, and the (already exited) child is unaffected.
+        let _ = set_job_kill_on_close(job, false);
+    }
+    close_handle_quiet(job);
+}
+
+fn close_handle_quiet(h: HANDLE) {
+    // SAFETY: h is a handle we opened; CloseHandle failure leaves nothing
+    // to do here.
+    unsafe {
+        CloseHandle(h);
+    }
+}
+
+/// Total physical RAM in bytes (`runner.ram_bytes` in the result
+/// document).
+pub(crate) fn ram_total_bytes() -> Result<u64, BenchError> {
+    // SAFETY: `status` is a valid out-param; dwLength must be set first.
+    let mut status: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+    status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+    if unsafe { GlobalMemoryStatusEx(&mut status) } == 0 {
+        return Err(BenchError::operational(format!(
+            "sampler: GlobalMemoryStatusEx failed: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(status.ullTotalPhys)
+}

--- a/crates/tebako-bench/tests/acquire.rs
+++ b/crates/tebako-bench/tests/acquire.rs
@@ -1,0 +1,347 @@
+//! Acquisition tests (spec 27 slices 4): checksum parsing, the
+//! single-member tgz rule, file://-backed verified downloads, the
+//! SHA256SUMS version-learning rule, the cold-wipe set per arm, the
+//! hermetic child env — and the fat package's WIRE round-trip through
+//! tpkg's own reader (the L0 owner validates the bytes the bench wrote).
+//! Everything here is offline; the networked flows are the CI legs'.
+
+use std::path::Path;
+
+use tebako_bench::acquire::{self, BenchLayout};
+use tebako_bench::suite::{Target, TargetKind};
+
+fn make_tgz(members: &[(&str, &[u8], bool)]) -> Vec<u8> {
+    let enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    let mut builder = tar::Builder::new(enc);
+    for (name, bytes, is_dir) in members {
+        if *is_dir {
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Directory);
+            header.set_size(0);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, name, std::io::empty())
+                .unwrap();
+        } else {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append_data(&mut header, name, *bytes).unwrap();
+        }
+    }
+    builder.into_inner().unwrap().finish().unwrap()
+}
+
+#[test]
+fn sha256sums_parses_the_coreutils_format() {
+    let sums = "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3  tebako-0.2.5-macos-arm64\n\
+                b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c *tebako-shim-0.2.5-macos-arm64\n";
+    assert_eq!(
+        acquire::parse_sha256sums(sums, "tebako-0.2.5-macos-arm64").as_deref(),
+        Some("a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3")
+    );
+    // the binary-marker form (`sha256sum -b`) is accepted
+    assert_eq!(
+        acquire::parse_sha256sums(sums, "tebako-shim-0.2.5-macos-arm64").as_deref(),
+        Some("b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c")
+    );
+    assert!(acquire::parse_sha256sums(sums, "tfs-0.2.5-macos-arm64").is_none());
+    // uppercase digests normalize to lowercase
+    let upper = "A665A45920422F9D417E4867EFDC4FB8A04A1F3FFF1FA07E998E86F7F7A27AE3  x\n";
+    assert_eq!(
+        acquire::parse_sha256sums(upper, "x").as_deref(),
+        Some("a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3")
+    );
+}
+
+#[test]
+fn bare_hash_sidecar_parses() {
+    let h = "e82157502615d12ca61a9558c7e10c6f52215d9b5ee3695aaf4852c27408bbb4";
+    assert_eq!(
+        acquire::parse_bare_hash(&format!("{h}\n")).as_deref(),
+        Some(h)
+    );
+    // a trailing filename (some sidecars carry one) is tolerated
+    assert_eq!(
+        acquire::parse_bare_hash(&format!("{h}  metanorma.tgz\n")).as_deref(),
+        Some(h)
+    );
+    assert!(acquire::parse_bare_hash("not-a-hash\n").is_none());
+    assert!(acquire::parse_bare_hash("").is_none());
+}
+
+#[test]
+fn sha256_matches_the_known_vector() {
+    // sha256("abc") — the canonical test vector.
+    assert_eq!(
+        acquire::sha256_bytes_hex(b"abc"),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+}
+
+#[test]
+fn single_member_tgz_extracts_the_one_executable() {
+    let dir = tempfile::tempdir().unwrap();
+    let tgz = make_tgz(&[("metanorma-darwin-arm64", b"\xcf\xfaMach-O fake", false)]);
+    let exe = acquire::extract_single_member_tgz(&tgz, dir.path()).unwrap();
+    assert_eq!(
+        exe.file_name().unwrap().to_string_lossy(),
+        "metanorma-darwin-arm64"
+    );
+    assert_eq!(std::fs::read(&exe).unwrap(), b"\xcf\xfaMach-O fake");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // the caller chmods; here the member must at least be a file
+        assert!(exe.is_file());
+        let _ = exe.metadata().unwrap().permissions().mode();
+    }
+}
+
+#[test]
+fn tgz_with_dirs_still_has_one_member() {
+    let dir = tempfile::tempdir().unwrap();
+    let tgz = make_tgz(&[
+        ("./", b"", true),
+        ("metanorma-linux-x86_64", b"ELF fake", false),
+    ]);
+    let exe = acquire::extract_single_member_tgz(&tgz, dir.path()).unwrap();
+    assert_eq!(std::fs::read(&exe).unwrap(), b"ELF fake");
+}
+
+#[test]
+fn multi_member_tgz_is_a_named_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let tgz = make_tgz(&[("a", b"1", false), ("b", b"2", false)]);
+    let err = acquire::extract_single_member_tgz(&tgz, dir.path()).unwrap_err();
+    assert!(
+        err.message.contains("single-member"),
+        "named error expected: {}",
+        err.message
+    );
+}
+
+#[test]
+fn empty_tgz_is_a_named_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let tgz = make_tgz(&[]);
+    let err = acquire::extract_single_member_tgz(&tgz, dir.path()).unwrap_err();
+    assert!(
+        err.message.contains("NO file member"),
+        "named error expected: {}",
+        err.message
+    );
+}
+
+#[test]
+fn download_verified_via_file_url() {
+    let dir = tempfile::tempdir().unwrap();
+    let asset = dir.path().join("asset.bin");
+    std::fs::write(&asset, b"verified bytes").unwrap();
+    let sha = acquire::sha256_file_hex(&asset).unwrap();
+    let dest = dir.path().join("out").join("asset.bin");
+    std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+    let file_url = format!("file://{}", asset.display());
+    acquire::download_verified(&file_url, &dest, &sha).unwrap();
+    assert_eq!(std::fs::read(&dest).unwrap(), b"verified bytes");
+    // a mismatch writes NOTHING (the trust anchor is the checksum)
+    let err =
+        acquire::download_verified(&file_url, &dest.with_file_name("nope.bin"), &"0".repeat(64))
+            .unwrap_err();
+    assert!(err.message.contains("SHA256 mismatch"), "{}", err.message);
+    assert!(!dest.with_file_name("nope.bin").exists());
+}
+
+#[test]
+fn version_from_sums_learns_the_latest_release_version() {
+    let sums = "\
+d34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33f  tebako-0.2.5-macos-arm64\n\
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  tebako-shim-0.2.5-macos-arm64\n\
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  tebako-bootstrap-0.2.5-macos-arm64\n\
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  tebako-pkg-0.2.5-macos-arm64\n\
+dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd  tfs-0.2.5-macos-arm64\n\
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee  tebako-0.2.5-linux-gnu-x86_64\n";
+    // the version is the middle of the tebako-<ver>-<triplet> line ONLY —
+    // shim/bootstrap/pkg/tfs lines must not leak into it.
+    let learned = acquire::testonly_version_from_sums(sums, "macos-arm64");
+    assert_eq!(learned.as_deref(), Some("0.2.5"));
+    let learned = acquire::testonly_version_from_sums(sums, "linux-gnu-x86_64");
+    assert_eq!(learned.as_deref(), Some("0.2.5"));
+    assert!(acquire::testonly_version_from_sums(sums, "windows-ucrt64").is_none());
+}
+
+// ---------------------------------------------------------------------
+// the fat package wire round-trip (tpkg reads what the bench wrote)
+// ---------------------------------------------------------------------
+
+fn fake_payload_home(dir: &Path) -> acquire::PayloadHome {
+    let image = dir.join("metanorma-1.16.9-macos-arm64.tfs");
+    std::fs::write(&image, b"DWARFS-fake-payload-bytes").unwrap();
+    let mirror_yaml = "identity:\n  schema_version: 1\n  kind: app\n  name: metanorma\n  version: \"1.16.9\"\n  producer: {tool: test, tool_version: \"1\"}\n  created: \"2026-08-25T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n    blob_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n  signing: {state: unsigned}\n  encryption: {state: none}\nprovides:\n  entrypoints:\n    - name: metanorma\n      path: /__tebako__/bin/metanorma\n      runtime_requirement: {engine: ruby, constraint: \"~> 3.3.0\", abi: arm64-darwin-23}\n  platforms: universal\n  capabilities: {exec: true, read: true}\n";
+    acquire::PayloadHome {
+        name: "metanorma".to_string(),
+        version: "1.16.9".to_string(),
+        release_tag: "1.16.9-3".to_string(),
+        image,
+        mirror: tpkg::PayloadManifest::from_yaml(mirror_yaml).unwrap(),
+        image_format: tebako_bench::result::ImageFormat::Dwarfs,
+    }
+}
+
+#[test]
+fn fat_package_round_trips_through_tpkg() {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = BenchLayout::new(dir.path()).unwrap();
+
+    // The three verified inputs: a bootstrap, the payload image (fake
+    // home), the runtime exe + its trust-marker digest.
+    let bootstrap = dir.path().join("tebako-bootstrap");
+    std::fs::write(&bootstrap, b"BOOTSTRAP-BYTES").unwrap();
+    let runtime_exe = dir.path().join("tebako-runtime-0.16.9-3.3.7-macos-arm64");
+    std::fs::write(&runtime_exe, b"RUNTIME-EXE-BYTES").unwrap();
+    let runtime_sha = acquire::sha256_file_hex(&runtime_exe).unwrap();
+    let tools = acquire::TebakoTools {
+        cli: bootstrap.clone(),
+        shim: bootstrap.clone(),
+        bootstrap: bootstrap.clone(),
+        version: "0.2.5".to_string(),
+    };
+    let payload = fake_payload_home(dir.path());
+    let runtime = acquire::RuntimeEntry {
+        engine: "ruby".to_string(),
+        lang_version: "3.3.7".to_string(),
+        tebako_version: "0.16.9".to_string(),
+        exe: runtime_exe,
+        exe_sha256: runtime_sha.clone(),
+    };
+    let target = Target {
+        id: "v2-fat".to_string(),
+        kind: TargetKind::V2Press,
+        payload: Some("metanorma@1.16.9".to_string()),
+        registries: Some(vec!["tfs:github:tebako-packages/metanorma".to_string()]),
+        fat: Some(true),
+    };
+
+    let package = acquire::assemble_fat_package(&layout, &tools, &payload, &runtime, &target)
+        .unwrap_or_else(|e| panic!("assemble: {e}"));
+
+    // The wire check rides the L0 owner's reader.
+    let mut f = std::fs::File::open(&package).unwrap();
+    let m = tpkg::read_from(&mut f).unwrap();
+    assert_eq!(m.slots.len(), 2, "payload slot + runtime slot");
+    // slot 0: the payload image at "/", bytes intact after the bootstrap.
+    assert_eq!(m.slots[0].mount_point_str(), Some("/"));
+    assert_eq!(
+        m.slots[0].offset as usize,
+        b"BOOTSTRAP-BYTES".len(),
+        "the payload follows the bootstrap bytes"
+    );
+    assert_eq!(m.slots[0].size as usize, b"DWARFS-fake-payload-bytes".len());
+    // slot 1: the runtime exe, role format, never mounted.
+    assert_eq!(m.slots[1].format_id, tpkg::TPKG_FORMAT_RUNTIME);
+    assert_eq!(m.slots[1].mount_point_str(), Some(""));
+    // the trailer's runtime_ref pins the verified exe digest (the fat
+    // package's runtime trust anchor, spec 27 §4's acquisition rule).
+    let rr = m.runtime_ref_str().unwrap();
+    assert_eq!(
+        rr,
+        format!("ruby@3.3.7;tebako=0.16.9;image;sha256={runtime_sha}")
+    );
+    // the type-2 package manifest rode along and names the entrypoint
+    // (the payload mirror's authoritative path) + the "/" union mount.
+    let pm = m.package_manifest().unwrap().expect("type-2 block present");
+    assert_eq!(pm.entries.len(), 1);
+    assert_eq!(pm.entries[0].name, "metanorma");
+    assert_eq!(pm.entries[0].entrypoint, "/__tebako__/bin/metanorma");
+    assert_eq!(pm.entries[0].runtime_ref, rr);
+    assert_eq!(pm.mounts.len(), 1);
+    assert_eq!(pm.mounts[0].point, "/");
+    assert_eq!(pm.mounts[0].mode, tpkg::MountMode::Union);
+    // the assembled bytes carry the parts verbatim (the exe slot bytes
+    // land where the trailer says they do).
+    let bytes = std::fs::read(&package).unwrap();
+    let slot1 = &bytes[m.slots[1].offset as usize..(m.slots[1].offset + m.slots[1].size) as usize];
+    assert_eq!(slot1, b"RUNTIME-EXE-BYTES");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            package.metadata().unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// the cold-wipe set + the hermetic env (spec 27 §5)
+// ---------------------------------------------------------------------
+
+#[test]
+fn cold_wipe_matches_the_arm() {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = BenchLayout::new(dir.path()).unwrap();
+    let mark = |p: &Path| {
+        std::fs::create_dir_all(p).unwrap();
+        std::fs::write(p.join("marker"), b"x").unwrap();
+    };
+    for d in [
+        layout.home.join(".metanorma"),
+        layout.home.join(".relaton"),
+        layout.store(),
+        layout.store().join("runtimes"),
+        layout.tmp.join("t1"),
+    ] {
+        mark(&d);
+    }
+    // v1-exe: the payload caches + the per-target TMPDIR go; the store stays.
+    layout.wipe_cold_caches("t1", TargetKind::V1Exe).unwrap();
+    assert!(!layout.home.join(".metanorma/marker").exists());
+    assert!(!layout.home.join(".relaton/marker").exists());
+    assert!(!layout.tmp.join("t1/marker").exists());
+    assert!(layout.tmp.join("t1").is_dir(), "the TMPDIR is recreated");
+    assert!(
+        layout.store().join("marker").exists(),
+        "v1 never wipes the store"
+    );
+
+    // v2-press: runtimes/ goes (the env image re-downloads in-span); the
+    // store's payload side survives (the fat package never uses it).
+    layout.wipe_cold_caches("t1", TargetKind::V2Press).unwrap();
+    assert!(!layout.store().join("runtimes/marker").exists());
+    assert!(layout.store().join("marker").exists());
+
+    // v2-managed: the whole store goes (payload re-install is unmeasured,
+    // the runtime download lands in the measured span).
+    layout
+        .wipe_cold_caches("t1", TargetKind::V2Managed)
+        .unwrap();
+    assert!(!layout.store().join("marker").exists());
+}
+
+#[test]
+fn child_env_is_the_hermetic_bench_home() {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = BenchLayout::new(dir.path()).unwrap();
+    let env: std::collections::BTreeMap<String, String> =
+        layout.child_env("v2-shim").into_iter().collect();
+    assert_eq!(
+        env.get("HOME").map(String::as_str),
+        Some(layout.home.to_string_lossy().as_ref())
+    );
+    assert_eq!(
+        env.get("TEBAKO_HOME").map(String::as_str),
+        Some(layout.store().to_string_lossy().as_ref())
+    );
+    assert_eq!(
+        env.get("TMPDIR").map(String::as_str),
+        Some(layout.tmp.join("v2-shim").to_string_lossy().as_ref())
+    );
+    #[cfg(windows)]
+    {
+        assert!(env.contains_key("USERPROFILE"));
+        assert!(env.contains_key("TEMP"));
+        assert!(env.contains_key("TMP"));
+    }
+}

--- a/crates/tebako-bench/tests/engine.rs
+++ b/crates/tebako-bench/tests/engine.rs
@@ -1,0 +1,598 @@
+//! Run-engine tests (spec 27 slices 5): the pure ordering/statistics/
+//! expectation rules, and the matrix loop end-to-end against the
+//! `tebako-bench-child` golden child — acquisition is injected as
+//! prepared targets (Ready with the child bin as the program), so the
+//! whole file is offline. The emitted results.json re-enters BOTH
+//! validation gates (the engine's own emit path does this; the tests
+//! assert it stays true).
+
+use std::path::{Path, PathBuf};
+
+use tebako_bench::engine::{self, Prepared, PreparedTarget};
+use tebako_bench::platforms::{PackedMn, PlatformFile, Triplet};
+use tebako_bench::result::{ResultFile, RunMode, RunRecord, RunStatus, RunnerMeta, Versions};
+use tebako_bench::suite::{
+    Expect, RunPolicy, Source, SourceKind, SuiteFile, Target, TargetKind, Workload,
+};
+use tebako_bench::{acquire::BenchLayout, validate, DocKind};
+
+/// The test-helper binary's path (the same idiom as tests/sampler.rs:
+/// CARGO_BIN_FILE_<name> at run time, the debug-profile path otherwise).
+fn child_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("CARGO_BIN_FILE_tebako-bench-child") {
+        return PathBuf::from(p);
+    }
+    let name = if cfg!(windows) {
+        "tebako-bench-child.exe"
+    } else {
+        "tebako-bench-child"
+    };
+    let dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../target")));
+    dir.join("debug").join(name)
+}
+
+/// A one-workload suite whose vendored source lives in `repo_root` (the
+/// caller writes `fixtures/doc.adoc` there).
+fn test_suite(argv: &[&str], files: &[&str], policy: RunPolicy) -> SuiteFile {
+    SuiteFile {
+        schema_version: 1,
+        name: "engine-test".to_string(),
+        workloads: vec![Workload {
+            id: "w-small".to_string(),
+            opt_in: false,
+            source: Source {
+                kind: SourceKind::Vendored,
+                path: "fixtures/doc.adoc".to_string(),
+                url: None,
+                git_ref: None,
+            },
+            argv: argv.iter().map(|s| s.to_string()).collect(),
+            expect: Expect {
+                exit: 0,
+                files: files.iter().map(|s| s.to_string()).collect(),
+            },
+            timeout_s: 30,
+        }],
+        targets: Vec::new(),
+        run_policy: policy,
+    }
+}
+
+fn repo_root_with_doc(dir: &Path) -> PathBuf {
+    let fixtures = dir.join("fixtures");
+    std::fs::create_dir_all(&fixtures).unwrap();
+    std::fs::write(fixtures.join("doc.adoc"), b"= Title\n\nbody\n").unwrap();
+    dir.to_path_buf()
+}
+
+fn ready(id: &str, kind: TargetKind) -> PreparedTarget {
+    PreparedTarget {
+        target: Target {
+            id: id.to_string(),
+            kind,
+            payload: None,
+            registries: None,
+            fat: None,
+        },
+        state: Prepared::Ready {
+            program: child_path(),
+        },
+    }
+}
+
+fn unavailable(id: &str, kind: TargetKind, reason: &str) -> PreparedTarget {
+    PreparedTarget {
+        target: Target {
+            id: id.to_string(),
+            kind,
+            payload: None,
+            registries: None,
+            fat: None,
+        },
+        state: Prepared::Unavailable {
+            reason: reason.to_string(),
+        },
+    }
+}
+
+fn noop_reprime(_: &BenchLayout, _: &Target) -> Result<(), tebako_bench::BenchError> {
+    Ok(())
+}
+
+fn test_platforms(triplet: &str) -> PlatformFile {
+    PlatformFile {
+        schema_version: 1,
+        packed_mn: PackedMn {
+            repo: "metanorma/packed-mn".to_string(),
+            tag: "v1.14.4".to_string(),
+        },
+        triplets: [(
+            triplet.to_string(),
+            Triplet {
+                runner: "test-runner".to_string(),
+                container: None,
+                v1_asset: None,
+                v2_payload: false,
+                v1_note: None,
+            },
+        )]
+        .into_iter()
+        .collect(),
+    }
+}
+
+// ---------------------------------------------------------------------
+// the pure rules
+// ---------------------------------------------------------------------
+
+#[test]
+fn warm_schedule_rotates_targets_per_iteration() {
+    assert_eq!(
+        engine::warm_schedule(3, 2, true),
+        vec![(0, 1), (1, 1), (2, 1), (0, 2), (1, 2), (2, 2)],
+        "interleaved: A/B/C per iteration so drift decorrelates"
+    );
+    assert_eq!(
+        engine::warm_schedule(3, 2, false),
+        vec![(0, 1), (0, 2), (1, 1), (1, 2), (2, 1), (2, 2)],
+        "non-interleaved: each target to completion in turn (debugging)"
+    );
+    assert!(engine::warm_schedule(2, 0, true).is_empty());
+}
+
+fn ok_run(w: &str, t: &str, mode: RunMode, wall: f64, cpu: f64, rss: u64) -> RunRecord {
+    RunRecord {
+        workload: w.to_string(),
+        target: t.to_string(),
+        mode: Some(mode),
+        iteration: Some(1),
+        status: RunStatus::Ok,
+        wall_s: Some(wall),
+        cpu_user_s: Some(cpu / 2.0),
+        cpu_sys_s: Some(cpu / 2.0),
+        peak_rss_bytes: Some(rss),
+        exit: Some(0),
+        error: None,
+        reason: None,
+    }
+}
+
+#[test]
+fn stats_math_matches_the_spec_rules() {
+    let mut runs = vec![
+        ok_run("w", "t", RunMode::Warm, 14.0, 12.0, 300),
+        ok_run("w", "t", RunMode::Warm, 10.0, 8.0, 100),
+        ok_run("w", "t", RunMode::Warm, 12.0, 10.0, 200),
+        ok_run("w", "t", RunMode::Cold, 30.0, 20.0, 500),
+        // failed + timeout runs never enter statistics
+        RunRecord {
+            status: RunStatus::Failed,
+            wall_s: Some(999.0),
+            error: Some("missed".to_string()),
+            ..ok_run("w", "t", RunMode::Warm, 999.0, 999.0, 999)
+        },
+        RunRecord {
+            status: RunStatus::Timeout,
+            wall_s: Some(60.0),
+            cpu_user_s: None,
+            cpu_sys_s: None,
+            peak_rss_bytes: None,
+            exit: None,
+            ..ok_run("w", "t", RunMode::Warm, 60.0, 0.0, 0)
+        },
+    ];
+    let stats = engine::compute_stats(&runs);
+    assert_eq!(stats.len(), 2, "one row per (workload × target × mode)");
+    let warm = &stats[0];
+    assert_eq!((warm.mode, warm.n), (RunMode::Warm, 3));
+    assert_eq!(warm.median_wall_s, 12.0);
+    assert_eq!(warm.min_wall_s, 10.0);
+    assert_eq!(warm.max_wall_s, 14.0);
+    assert_eq!(warm.mean_wall_s, 12.0);
+    // sample stdev (n−1): deviations ±2, 0 → sqrt(8/2) = 2.0
+    assert_eq!(warm.stdev_wall_s, Some(2.0));
+    assert_eq!(warm.median_cpu_s, 10.0);
+    assert_eq!(warm.median_peak_rss_bytes, 200);
+    let cold = &stats[1];
+    assert_eq!((cold.mode, cold.n), (RunMode::Cold, 1));
+    assert_eq!(cold.stdev_wall_s, None, "stdev absent under n < 2");
+
+    // Even counts average the two middles.
+    runs.retain(|r| r.status == RunStatus::Ok && r.mode == Some(RunMode::Warm));
+    runs.pop();
+    let stats = engine::compute_stats(&runs);
+    assert_eq!(stats[0].median_wall_s, 12.0, "(10+14)/2");
+    assert_eq!(stats[0].median_peak_rss_bytes, 200, "(100+300)/2");
+
+    // An arm whose runs all failed has NO stats row.
+    let failed_only = vec![RunRecord {
+        status: RunStatus::Failed,
+        error: Some("missed".to_string()),
+        ..ok_run("w", "t", RunMode::Warm, 1.0, 1.0, 1)
+    }];
+    assert!(engine::compute_stats(&failed_only).is_empty());
+}
+
+#[test]
+fn check_expect_names_each_miss() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("out.xml"), b"<xml/>").unwrap();
+    std::fs::write(dir.path().join("empty.xml"), b"").unwrap();
+    let expect = Expect {
+        exit: 0,
+        files: vec!["out.xml".to_string()],
+    };
+    assert_eq!(engine::check_expect(dir.path(), &expect, 0), None);
+    assert_eq!(
+        engine::check_expect(dir.path(), &expect, 3),
+        Some("exit 3 (expected 0)".to_string())
+    );
+    let missing = Expect {
+        exit: 0,
+        files: vec!["nope.xml".to_string()],
+    };
+    let miss = engine::check_expect(dir.path(), &missing, 0).unwrap();
+    assert!(
+        miss.contains("expect.files 'nope.xml' is missing"),
+        "{miss}"
+    );
+    let empty = Expect {
+        exit: 0,
+        files: vec!["empty.xml".to_string()],
+    };
+    assert_eq!(
+        engine::check_expect(dir.path(), &empty, 0),
+        Some("expect.files 'empty.xml' is empty".to_string())
+    );
+}
+
+// ---------------------------------------------------------------------
+// the matrix loop, driven by the golden child
+// ---------------------------------------------------------------------
+
+#[test]
+fn engine_runs_the_matrix_end_to_end() {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = BenchLayout::new(&dir.path().join("out")).unwrap();
+    let repo_root = repo_root_with_doc(dir.path());
+    let policy = RunPolicy {
+        warmup: 1,
+        repetitions: 2,
+        cold_repetitions: 1,
+        interleave: true,
+    };
+    let suite = test_suite(
+        &["--sleep-ms", "10", "--touch", "out.txt"],
+        &["out.txt"],
+        policy,
+    );
+    // v1-exe + v2-managed kinds exercise both cold-wipe paths.
+    let prepared = vec![
+        ready("t-one", TargetKind::V1Exe),
+        ready("t-two", TargetKind::V2Managed),
+    ];
+    let mut reprimed: Vec<String> = Vec::new();
+    let mut reprime = |_: &BenchLayout, t: &Target| {
+        reprimed.push(t.id.clone());
+        Ok(())
+    };
+    let runs =
+        engine::execute_matrix(&layout, &suite, &[], &prepared, &repo_root, &mut reprime).unwrap();
+
+    // 2 targets × (2 warm + 1 cold) ok runs; warmup rows are not recorded.
+    assert_eq!(runs.len(), 6);
+    assert!(runs.iter().all(|r| r.status == RunStatus::Ok));
+    for r in &runs {
+        assert!(r.wall_s.unwrap() > 0.0);
+        assert!(r.cpu_user_s.is_some() && r.cpu_sys_s.is_some());
+        assert!(r.peak_rss_bytes.unwrap() > 0);
+        assert_eq!(r.exit, Some(0));
+    }
+    // The interleave: targets rotate per warm iteration (A/B, A/B).
+    let warm: Vec<(&str, u32)> = runs
+        .iter()
+        .filter(|r| r.mode == Some(RunMode::Warm))
+        .map(|r| (r.target.as_str(), r.iteration.unwrap()))
+        .collect();
+    assert_eq!(
+        warm,
+        vec![("t-one", 1), ("t-two", 1), ("t-one", 2), ("t-two", 2)]
+    );
+    // Cold: v2-managed was reprimed (the unmeasured re-install) exactly
+    // once — before its single cold run; v1-exe never is.
+    assert_eq!(reprimed, vec!["t-two".to_string()]);
+    let cold: Vec<(&str, u32)> = runs
+        .iter()
+        .filter(|r| r.mode == Some(RunMode::Cold))
+        .map(|r| (r.target.as_str(), r.iteration.unwrap()))
+        .collect();
+    assert_eq!(cold, vec![("t-one", 1), ("t-two", 1)]);
+
+    // Scratch cells + per-run logs exist.
+    assert!(layout
+        .scratch
+        .join("w-small/t-one/warm-1/out.txt")
+        .is_file());
+    assert!(layout.logs.join("w-small--t-one--warm-1.log").is_file());
+
+    // The emitted results.json passes both validation gates.
+    let triplet = "macos-arm64";
+    let runner = engine::runner_meta(&test_platforms(triplet), triplet).unwrap();
+    assert_eq!(runner.runs_on, "test-runner");
+    assert!(runner.cpus >= 1 && runner.ram_bytes > 0);
+    let result = engine::assemble_result(&suite, triplet, runner, Versions::default(), runs);
+    assert_eq!(result.stats.len(), 4, "2 targets × 2 modes");
+    let dest = engine::emit_result(&layout.root, &result).unwrap();
+    let text = std::fs::read_to_string(&dest).unwrap();
+    let violations = validate::validate_text(DocKind::Result, &text).unwrap();
+    assert!(violations.is_empty(), "{violations:?}");
+    let parsed = ResultFile::from_json(&text).unwrap();
+    assert_eq!(parsed, result);
+}
+
+#[test]
+fn unavailable_arms_emit_named_gap_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = BenchLayout::new(&dir.path().join("out")).unwrap();
+    let repo_root = repo_root_with_doc(dir.path());
+    let suite = test_suite(
+        &["--touch", "out.txt"],
+        &["out.txt"],
+        RunPolicy {
+            warmup: 1,
+            repetitions: 1,
+            cold_repetitions: 1,
+            interleave: true,
+        },
+    );
+    let prepared = vec![
+        ready("t-one", TargetKind::V1Exe),
+        unavailable(
+            "t-two",
+            TargetKind::V2Managed,
+            "no published payload for this triplet",
+        ),
+    ];
+    let runs = engine::execute_matrix(
+        &layout,
+        &suite,
+        &[],
+        &prepared,
+        &repo_root,
+        &mut noop_reprime,
+    )
+    .unwrap();
+    let gaps: Vec<&RunRecord> = runs
+        .iter()
+        .filter(|r| r.status == RunStatus::Unavailable)
+        .collect();
+    assert_eq!(gaps.len(), 1);
+    assert_eq!(gaps[0].target, "t-two");
+    assert_eq!(
+        gaps[0].reason.as_deref(),
+        Some("no published payload for this triplet")
+    );
+    assert!(gaps[0].mode.is_none() && gaps[0].iteration.is_none());
+    // The ready arm ran; the gap enters no statistics.
+    assert_eq!(runs.iter().filter(|r| r.status == RunStatus::Ok).count(), 2);
+    let result = engine::assemble_result(
+        &suite,
+        "macos-arm64",
+        RunnerMeta {
+            runs_on: "test".to_string(),
+            arch: "test".to_string(),
+            cpus: 1,
+            ram_bytes: 1,
+        },
+        Versions::default(),
+        runs,
+    );
+    assert!(result.stats.iter().all(|s| s.target == "t-one"));
+    let violations = result.semantic_violations();
+    assert!(violations.is_empty(), "{violations:?}");
+}
+
+#[test]
+fn failed_warmup_is_recorded_once_and_the_cell_is_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = BenchLayout::new(&dir.path().join("out")).unwrap();
+    let repo_root = repo_root_with_doc(dir.path());
+    let policy = RunPolicy {
+        warmup: 1,
+        repetitions: 2,
+        cold_repetitions: 1,
+        interleave: true,
+    };
+    let suite = test_suite(&["--exit", "3"], &[], policy);
+    // Two broken arms: each must get exactly ONE failed warmup row
+    // (iteration 0) and no measured runs — a broken compile is named,
+    // never retried (spec 27 §2), and the skip is cell-scoped.
+    let prepared = vec![
+        ready("t-bad", TargetKind::V1Exe),
+        ready("t-also-bad", TargetKind::V2Managed),
+    ];
+    let runs = engine::execute_matrix(
+        &layout,
+        &suite,
+        &[],
+        &prepared,
+        &repo_root,
+        &mut noop_reprime,
+    )
+    .unwrap();
+    // Each arm: exactly ONE failed warmup row (iteration 0), no measured
+    // runs — a broken compile is named, never retried (spec 27 §2).
+    assert_eq!(runs.len(), 2);
+    for r in &runs {
+        assert_eq!(r.status, RunStatus::Failed);
+        assert_eq!(r.mode, Some(RunMode::Warm));
+        assert_eq!(r.iteration, Some(0));
+        assert_eq!(r.exit, Some(3));
+        assert!(
+            r.error.as_deref().unwrap().contains("exit 3 (expected 0)"),
+            "{:?}",
+            r.error
+        );
+    }
+    assert!(engine::compute_stats(&runs).is_empty());
+    // The failed rows are schema-shaped (mode/iteration/exit/error).
+    let result = engine::assemble_result(
+        &suite,
+        "macos-arm64",
+        RunnerMeta {
+            runs_on: "test".to_string(),
+            arch: "test".to_string(),
+            cpus: 1,
+            ram_bytes: 1,
+        },
+        Versions::default(),
+        runs,
+    );
+    let violations = result.semantic_violations();
+    assert!(violations.is_empty(), "{violations:?}");
+}
+
+#[test]
+fn warmup_timeout_is_recorded_and_the_cell_is_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = BenchLayout::new(&dir.path().join("out")).unwrap();
+    let repo_root = repo_root_with_doc(dir.path());
+    let mut suite = test_suite(
+        &["--sleep-ms", "3000"],
+        &[],
+        RunPolicy {
+            warmup: 1,
+            repetitions: 1,
+            cold_repetitions: 0,
+            interleave: true,
+        },
+    );
+    suite.workloads[0].timeout_s = 1;
+    let prepared = vec![ready("t-slow", TargetKind::V1Exe)];
+    let runs = engine::execute_matrix(
+        &layout,
+        &suite,
+        &[],
+        &prepared,
+        &repo_root,
+        &mut noop_reprime,
+    )
+    .unwrap();
+    assert_eq!(runs.len(), 1);
+    let r = &runs[0];
+    assert_eq!(r.status, RunStatus::Timeout);
+    assert_eq!(r.mode, Some(RunMode::Warm));
+    assert_eq!(r.iteration, Some(0));
+    let wall = r.wall_s.unwrap();
+    assert!(
+        wall > 0.5 && wall < 2.9,
+        "killed near the 1 s timeout: {wall}"
+    );
+    assert!(r.cpu_user_s.is_none() && r.peak_rss_bytes.is_none() && r.exit.is_none());
+}
+
+#[test]
+fn doc_substitution_and_the_scratch_layout() {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = BenchLayout::new(&dir.path().join("out")).unwrap();
+    let repo_root = repo_root_with_doc(dir.path());
+    // {doc} substitutes the document's file NAME (the exact token;
+    // anything else is literal — spec 27 §2); the run's cwd is the
+    // document's directory (the vendored flat case: the cell root).
+    let suite = test_suite(
+        &["--touch", "{doc}"],
+        &["doc.adoc"],
+        RunPolicy {
+            warmup: 0,
+            repetitions: 1,
+            cold_repetitions: 0,
+            interleave: true,
+        },
+    );
+    let prepared = vec![ready("t-one", TargetKind::V1Exe)];
+    let runs = engine::execute_matrix(
+        &layout,
+        &suite,
+        &[],
+        &prepared,
+        &repo_root,
+        &mut noop_reprime,
+    )
+    .unwrap();
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].status, RunStatus::Ok, "{:?}", runs[0].error);
+    let cell = layout.scratch.join("w-small/t-one/warm-1");
+    // The child overwrote the COPIED document via the substituted path —
+    // the repo-root original is untouched (runs never mutate sources).
+    assert_eq!(
+        std::fs::read(cell.join("doc.adoc")).unwrap(),
+        b"tebako-bench-child\n"
+    );
+    assert_eq!(
+        std::fs::read(repo_root.join("fixtures/doc.adoc")).unwrap(),
+        b"= Title\n\nbody\n"
+    );
+}
+
+#[test]
+fn opt_in_gating_is_explicit() {
+    let dir = tempfile::tempdir().unwrap();
+    let layout = BenchLayout::new(&dir.path().join("out")).unwrap();
+    let repo_root = repo_root_with_doc(dir.path());
+    let mut suite = test_suite(
+        &["--touch", "out.txt"],
+        &["out.txt"],
+        RunPolicy {
+            warmup: 0,
+            repetitions: 1,
+            cold_repetitions: 0,
+            interleave: true,
+        },
+    );
+    suite.workloads[0].opt_in = true;
+    let prepared = vec![ready("t-one", TargetKind::V1Exe)];
+
+    // Skipped silently-by-design: nothing was asked, so NO rows at all.
+    let runs = engine::execute_matrix(
+        &layout,
+        &suite,
+        &[],
+        &prepared,
+        &repo_root,
+        &mut noop_reprime,
+    )
+    .unwrap();
+    assert!(runs.is_empty());
+
+    // An unknown --opt-in id is a named operational error (a typo is
+    // never silent); so is a non-opt-in id.
+    let err = engine::execute_matrix(
+        &layout,
+        &suite,
+        &["nope".to_string()],
+        &prepared,
+        &repo_root,
+        &mut noop_reprime,
+    )
+    .unwrap_err();
+    assert!(
+        err.message.contains("--opt-in 'nope' names no workload"),
+        "{}",
+        err.message
+    );
+
+    // Opted in: the workload runs.
+    let runs = engine::execute_matrix(
+        &layout,
+        &suite,
+        &["w-small".to_string()],
+        &prepared,
+        &repo_root,
+        &mut noop_reprime,
+    )
+    .unwrap();
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].status, RunStatus::Ok);
+}

--- a/crates/tebako-bench/tests/sampler.rs
+++ b/crates/tebako-bench/tests/sampler.rs
@@ -1,0 +1,257 @@
+//! Golden tests for the spec 27 §4 sampler: the measured child is the
+//! crate's own `tebako-bench-child` helper (one identical child on every
+//! triplet — no platform `time`/`sleep` flavor divergence). Assertions:
+//! wall/cpu/rss nonzero, ordered (a busy child burns more CPU than a
+//! sleeping one), unit-consistent (`peak_rss_bytes` is BYTES everywhere —
+//! a KiB-confused Linux value fails the floors below by three orders of
+//! magnitude), the timeout kill records 137, and the child's cwd/env/log
+//! plumbing works (the run engine's expectation checks ride on it).
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tebako_bench::sampler::{ChildSpec, Sampler};
+
+/// The test-helper binary's path. Cargo exports CARGO_BIN_FILE_<name> to
+/// integration tests at RUN time (not compile time); the debug-profile
+/// fallback keeps `cargo test` usable from any cargo version.
+fn child_path() -> PathBuf {
+    if let Some(p) = std::env::var_os("CARGO_BIN_FILE_tebako-bench-child") {
+        return PathBuf::from(p);
+    }
+    let name = if cfg!(windows) {
+        "tebako-bench-child.exe"
+    } else {
+        "tebako-bench-child"
+    };
+    let dir = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../../target")));
+    dir.join("debug").join(name)
+}
+
+fn spec(dir: &std::path::Path, name: &str, args: &[&str], timeout_s: u64) -> ChildSpec {
+    let mut argv = vec![child_path().to_string_lossy().into_owned()];
+    argv.extend(args.iter().map(|s| s.to_string()));
+    ChildSpec {
+        argv,
+        cwd: dir.to_path_buf(),
+        env: Vec::new(),
+        log_path: dir.join(format!("{name}.log")),
+        timeout: Duration::from_secs(timeout_s),
+    }
+}
+
+fn rss_sane(bytes: u64) -> bool {
+    // Unit consistency: a byte-denominated RSS of any real process clears
+    // 100 KiB; a KiB-confused value (the Linux/musl normalization bug the
+    // spec calls out) reads ~1–4 THOUSAND here and fails the floor.
+    (100_000..16 * 1024 * 1024 * 1024).contains(&bytes)
+}
+
+#[test]
+fn sleep_child_measures_wall_cpu_rss() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut sampler = Sampler::new();
+    let sample = sampler
+        .run(&spec(dir.path(), "sleep", &["--sleep-ms", "300"], 30))
+        .unwrap();
+    assert_eq!(sample.exit, 0);
+    assert!(!sample.timed_out);
+    assert!(
+        sample.wall_s >= 0.25,
+        "wall {}s must cover the 300ms sleep",
+        sample.wall_s
+    );
+    let cpu = sample.cpu_user_s + sample.cpu_sys_s;
+    assert!(cpu > 0.0, "cpu must be attributed, got 0");
+    assert!(
+        cpu < sample.wall_s,
+        "a sleeping child cannot burn {cpu}s cpu in {}s wall",
+        sample.wall_s
+    );
+    assert!(
+        rss_sane(sample.peak_rss_bytes),
+        "peak_rss_bytes {} fails the byte-unit sanity band",
+        sample.peak_rss_bytes
+    );
+}
+
+#[test]
+fn busy_child_burns_more_cpu_than_a_sleeping_one() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut sampler = Sampler::new();
+    let busy = sampler
+        .run(&spec(dir.path(), "busy", &["--busy-ms", "1500"], 30))
+        .unwrap();
+    let sleepy = sampler
+        .run(&spec(dir.path(), "sleepy", &["--sleep-ms", "400"], 30))
+        .unwrap();
+    let busy_cpu = busy.cpu_user_s + busy.cpu_sys_s;
+    let sleepy_cpu = sleepy.cpu_user_s + sleepy.cpu_sys_s;
+    // The spin is wall-anchored inside the child; on a loaded machine the
+    // child is descheduled and the attributed CPU is its on-core share
+    // only (observed: 0.13s of a 400ms spin under a full parallel cargo
+    // build, 0.06s at load average 160 — the developer machine this suite
+    // was written on). Absolute duty-cycle floors are therefore noise
+    // traps; the golden claims are ATTRIBUTION (nonzero, and the busy
+    // child out-burns the sleeping one) — sleepy cpu is the millisecond
+    // startup cost, busy is the spin's on-core share, and the 3x margin
+    // survives even a 6% duty cycle.
+    assert!(
+        busy_cpu > 0.005,
+        "a 1500ms spin must attribute real cpu even starved, got {busy_cpu}s"
+    );
+    assert!(
+        busy.wall_s >= 1.4,
+        "wall {}s must cover the 1500ms spin",
+        busy.wall_s
+    );
+    assert!(
+        busy_cpu > sleepy_cpu * 3.0,
+        "ordering: busy cpu {busy_cpu}s vs sleepy cpu {sleepy_cpu}s"
+    );
+    assert!(rss_sane(busy.peak_rss_bytes));
+}
+
+#[test]
+fn peak_rss_tracks_the_allocation_in_bytes() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut sampler = Sampler::new();
+    let big = sampler
+        .run(&spec(
+            dir.path(),
+            "alloc",
+            &["--alloc-mb", "32", "--sleep-ms", "50"],
+            30,
+        ))
+        .unwrap();
+    // 32 MiB touched and held: the high-water mark must show it. A
+    // KiB-confused record reads 32768 here — the floor is 500x that.
+    assert!(
+        big.peak_rss_bytes >= 16 * 1024 * 1024,
+        "peak_rss_bytes {} must reflect the held 32 MiB",
+        big.peak_rss_bytes
+    );
+}
+
+#[test]
+fn timeout_kills_the_child_and_records_137() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut sampler = Sampler::new();
+    let start = std::time::Instant::now();
+    let sample = sampler
+        .run(&spec(dir.path(), "stuck", &["--sleep-ms", "60000"], 1))
+        .unwrap();
+    let outer = start.elapsed();
+    assert!(sample.timed_out, "the 60s child must hit the 1s timeout");
+    assert_eq!(
+        sample.exit, 137,
+        "a timeout SIGKILL records 137 (the shell convention)"
+    );
+    assert!(
+        sample.wall_s >= 1.0 && sample.wall_s < 15.0,
+        "wall {}s should hug the 1s timeout",
+        sample.wall_s
+    );
+    assert!(
+        outer < Duration::from_secs(20),
+        "the kill must actually land (outer elapsed {outer:?})"
+    );
+}
+
+#[test]
+fn exit_status_propagates_verbatim() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut sampler = Sampler::new();
+    let sample = sampler
+        .run(&spec(dir.path(), "exit3", &["--exit", "3"], 30))
+        .unwrap();
+    assert_eq!(sample.exit, 3);
+    assert!(!sample.timed_out);
+}
+
+#[test]
+fn cwd_env_and_log_plumbing() {
+    let dir = tempfile::tempdir().unwrap();
+    let scratch = dir.path().join("scratch");
+    std::fs::create_dir_all(&scratch).unwrap();
+    let mut s = spec(
+        &scratch,
+        "plumbing",
+        &[
+            "--touch",
+            "out.txt",
+            "--print",
+            "hello-bench",
+            "--print-env",
+            "TEBAKO_BENCH_PROBE",
+        ],
+        30,
+    );
+    s.env = vec![("TEBAKO_BENCH_PROBE".to_string(), "probe-value".to_string())];
+    let mut sampler = Sampler::new();
+    let sample = sampler.run(&s).unwrap();
+    assert_eq!(sample.exit, 0);
+    // cwd: the relative --touch landed inside the scratch dir.
+    let touched = scratch.join("out.txt");
+    assert!(touched.is_file(), "cwd-relative touch must land in scratch");
+    assert!(
+        std::fs::metadata(&touched).unwrap().len() > 0,
+        "the expectation file must be non-empty (spec 27 §2)"
+    );
+    // log: stdout+stderr were appended to the log file.
+    let log = std::fs::read_to_string(&s.log_path).unwrap();
+    assert!(
+        log.contains("hello-bench"),
+        "log must capture stdout: {log}"
+    );
+    // env: the override flowed to the child.
+    assert!(
+        log.contains("TEBAKO_BENCH_PROBE=probe-value"),
+        "env override must reach the child: {log}"
+    );
+}
+
+#[test]
+fn empty_argv_is_a_named_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut sampler = Sampler::new();
+    let err = sampler
+        .run(&ChildSpec {
+            argv: Vec::new(),
+            cwd: dir.path().to_path_buf(),
+            env: Vec::new(),
+            log_path: PathBuf::from(dir.path()).join("never.log"),
+            timeout: Duration::from_secs(1),
+        })
+        .unwrap_err();
+    assert!(
+        err.message.contains("empty argv"),
+        "named error expected, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn spawn_failure_is_a_named_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut s = spec(dir.path(), "nope", &[], 1);
+    s.argv = vec!["tebako-bench-definitely-not-a-binary-9x7".to_string()];
+    let mut sampler = Sampler::new();
+    let err = sampler.run(&s).unwrap_err();
+    assert!(
+        err.message.contains("cannot spawn"),
+        "named error expected, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn ram_total_bytes_reports_a_sane_figure() {
+    let ram = tebako_bench::ram_total_bytes().unwrap();
+    assert!(
+        ram >= 512 * 1024 * 1024,
+        "runner.ram_bytes {ram} below any CI runner"
+    );
+}

--- a/crates/tebako-bench/tests/sampler.rs
+++ b/crates/tebako-bench/tests/sampler.rs
@@ -1,11 +1,14 @@
 //! Golden tests for the spec 27 §4 sampler: the measured child is the
 //! crate's own `tebako-bench-child` helper (one identical child on every
 //! triplet — no platform `time`/`sleep` flavor divergence). Assertions:
-//! wall/cpu/rss nonzero, ordered (a busy child burns more CPU than a
-//! sleeping one), unit-consistent (`peak_rss_bytes` is BYTES everywhere —
-//! a KiB-confused Linux value fails the floors below by three orders of
-//! magnitude), the timeout kill records 137, and the child's cwd/env/log
-//! plumbing works (the run engine's expectation checks ride on it).
+//! wall/rss nonzero, cpu nonzero on POSIX (windows charges CPU in
+//! timer-tick quanta — a sleeping child can legitimately read exactly 0
+//! there; the busy child carries the attribution claim on every
+//! platform), ordered (a busy child burns more CPU than a sleeping one),
+//! unit-consistent (`peak_rss_bytes` is BYTES everywhere — a KiB-confused
+//! Linux value fails the floors below by three orders of magnitude), the
+//! timeout kill records 137, and the child's cwd/env/log plumbing works
+//! (the run engine's expectation checks ride on it).
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -64,6 +67,14 @@ fn sleep_child_measures_wall_cpu_rss() {
         sample.wall_s
     );
     let cpu = sample.cpu_user_s + sample.cpu_sys_s;
+    // Windows charges process CPU in timer-tick quanta: a sleeping child
+    // whose whole on-core life fits between ticks legitimately reports
+    // exactly 0 (observed on windows-latest, run 32884882108 —
+    // GetProcessTimes returned 0/0 with the 100-ns→s conversion verified
+    // correct in sys/windows.rs). The attribution-nonzero claim is carried
+    // by the BUSY child below, whose 1500ms spin cannot round to zero on
+    // any platform.
+    #[cfg(not(windows))]
     assert!(cpu > 0.0, "cpu must be attributed, got 0");
     assert!(
         cpu < sample.wall_s,

--- a/docs/spec/27-benchmarks.md
+++ b/docs/spec/27-benchmarks.md
@@ -2,9 +2,9 @@
 
 Status: PLANNED (spec-first per spec 14; slice 0 spikes executed
 2026-08-25 — §9 records the evidence; the suite/platforms documents,
-schemas, and the `tebako-bench validate` surface land with this spec's
-implementation slice; the sampler, acquisition, run engine, report
-renderer, and workflow are later slices)
+schemas, the `tebako-bench validate` surface, the sampler, the
+acquisition slice, and the run engine have landed; the report renderer
+and workflow are later slices)
 Depends on: 00 (locked invariants), 02 (tpkg wire format), 05
 (resolution and cache), 14 (engineering process), 16 (distribution —
 slim/fat), 17 (runtime driver contract), 19 (bootstrap distribution),

--- a/docs/spec/27-benchmarks.md
+++ b/docs/spec/27-benchmarks.md
@@ -204,20 +204,26 @@ rule (unsafe only inside FFI boundary modules).
 - **Wall time** — `std::time::Instant` around the spawn→wait span.
   Unit: seconds, f64, recorded as `wall_s`.
 - **CPU time** —
-  - POSIX: `libc::getrusage(RUSAGE_CHILDREN)` sampled immediately
-    before the spawn and immediately after the `wait` returns; the
-    recorded user/sys CPU is the DELTA. **`RUSAGE_CHILDREN` is
-    cumulative over all waited-on children of the process** — therefore
-    the sampler runs exactly ONE measured child at a time, and no
-    unrelated child of the harness may be reaped between the two
-    samples. This discipline is the whole accuracy story; concurrent
-    measured runs are forbidden even when workloads are independent.
+  - POSIX: `libc::wait4(pid, …)` reaps the measured child itself, so
+    the returned `rusage` is the child's OWN (utime/stime exact).
+    This replaces the originally drafted `getrusage(RUSAGE_CHILDREN)`
+    delta — **amended 2026-08-25, when the sampler landed**: that
+    counter's `ru_maxrss` is a *running maximum* over every child the
+    process has ever reaped, so after one big child the
+    (after − before) RSS delta is 0 forever and runs 2..N would record
+    garbage peak RSS. `wait4` has no such contamination and still
+    gives exact per-child CPU. The sampler polls `wait4(WNOHANG)` on a
+    ~2 ms tick against the deadline. The one-measured-child-at-a-time
+    discipline still stands (it keeps wall/timeout semantics clean and
+    matches the Windows handle model), even though wait4 makes
+    cross-child CPU/RSS contamination impossible by construction.
   - Windows: `CreateProcessW` + `GetProcessTimes` on the child's
     process handle after wait; user/kernel 100-ns FILETIME intervals
     converted to seconds. Recorded as `cpu_user_s` / `cpu_sys_s`;
     statistics use their sum as `cpu_s`.
 - **Peak RSS** —
-  - POSIX: `ru_maxrss` from the same getrusage delta span. **Unit
+  - POSIX: `ru_maxrss` from the same `wait4` reap (the measured
+    child's own high-water mark). **Unit
     normalization at record time**: Linux/musl report KiB, macOS
     reports bytes — the sampler multiplies the Linux value by 1024 and
     every run record carries `peak_rss_bytes`, bytes, always. A result

--- a/docs/spec/27-benchmarks.md
+++ b/docs/spec/27-benchmarks.md
@@ -249,20 +249,40 @@ rule (unsafe only inside FFI boundary modules).
   the compile statistics.
 - **cold** — the first-boot experience: before EACH cold run the
   harness wipes the per-stack caches and measures the whole thing
-  (acquisition included). The wipe set:
-  - `~/.tebako` — the v2 store (runtimes, payloads, registries).
+  (acquisition included).
+- **The hermetic bench home** (amended 2026-08-25 from the original
+  host-home wording — same wipe set, hermetic location): every spawned
+  child runs with `HOME` (and `USERPROFILE` on Windows) set to
+  `<out>/home`, `TEBAKO_HOME` set to `<out>/home/.tebako`, and
+  `TMPDIR` (plus `TEMP`/`TMP` on Windows) set to a per-target
+  `<out>/tmp/<target>`. "The caches" below therefore mean the named
+  directories UNDER the bench home: a cold run never evicts the host's
+  real store, a developer's caches, or a sibling job's files, and the
+  run needs no privilege to touch them. The wipe set:
+  - `<bench-home>/.tebako` — the v2 store (runtimes, payloads,
+    registries).
     Wiping it forces re-download + re-verification; that cost IS the
     cold metric for the v2 arms. (v2-managed only — v2-press fat
     packages carry their runtime and never touch the store; v1-exe
     never either.)
-  - The v1 stack's host extraction root (the v1 memfs unpacks under
-    `$TMPDIR` — observed 2026-08-25 as `$TMPDIR/<content-hash>/` plus
-    `tebako-runtime-*` staging dirs): v1's analog of the store, wiped
-    for v1 cold runs so "cold" means first-boot on both stacks.
-  - `~/.metanorma` and `~/.relaton` — the payload-side caches (fontist
+  - The v1 stack's extraction root, `<bench-tmp>/<target>/` (the v1
+    memfs unpacks under its `TMPDIR` — observed 2026-08-25 as
+    `<content-hash>/` plus `tebako-runtime-*` staging dirs): v1's
+    analog of the store, wiped per-target for v1 cold runs so "cold"
+    means first-boot on both stacks.
+  - `<bench-home>/.metanorma` and `<bench-home>/.relaton` — the
+    payload-side caches (fontist
     fonts, relaton bibliographic cache), present for BOTH stacks, wiped
     for every cold run of every target. Same paths both stacks: parity
     holds.
+- **The cold flow per arm**: v2-managed = wipe → UNMEASURED
+  `tebako install` (payload acquisition is excluded from the metric;
+  install does not fetch the runtime) → measured compile run (the
+  runtime download lands inside the measured span); v2-press = wipe →
+  measured package run (the fat package carries the runtime exe but
+  NOT the env image — §9 spike a — so the env-image download lands
+  inside the measured span); v1-exe = wipe → measured exe run
+  (re-extraction inside the span).
 - Cold results are reported SEPARATELY as install/first-boot metrics
   and are never mixed into warm medians. `mode` on every run record is
   `"warm"` or `"cold"` (§6), and statistics are computed per mode.

--- a/schema/tebako-bench-result-v1.schema.json
+++ b/schema/tebako-bench-result-v1.schema.json
@@ -63,7 +63,7 @@
           "description": "ok: expectation met, all metrics present. failed: ran, expectation missed — never enters statistics. timeout: killed at the workload's timeout_s. unavailable: the named-gap record — the arm was never attempted on this triplet; reason is mandatory."
         },
         "wall_s": { "type": "number", "minimum": 0, "description": "Instant-elapsed seconds around spawn→wait." },
-        "cpu_user_s": { "type": "number", "minimum": 0, "description": "POSIX: getrusage(RUSAGE_CHILDREN) delta; Windows: GetProcessTimes user. spec 27 §4." },
+        "cpu_user_s": { "type": "number", "minimum": 0, "description": "POSIX: wait4 rusage of the reaped child; Windows: GetProcessTimes user. spec 27 §4." },
         "cpu_sys_s": { "type": "number", "minimum": 0, "description": "Same span, system CPU." },
         "peak_rss_bytes": {
           "type": "integer",


### PR DESCRIPTION
## Summary

Bench slices 3–5 of spec 27 (`tebako-bench` crate — pure Rust CI tooling, never shipped):

- **Slice 3 — the §4 sampler** (`src/sampler.rs`, `src/sys/{mod,posix,windows}.rs`): wait4 rusage on POSIX, GetProcessTimes + job object on Windows (FFI quarantined in the sys modules), timeout kill; `src/bin/tebako-bench-child.rs` golden child; 9 tests. Spec 27 §4 amendment: wait4 replaces the RUSAGE_CHILDREN delta (running-max contamination).
- **Slice 4 — §5 acquisition** (`src/acquire.rs`, ~1300 lines): verified downloads (SHA256SUMS / manifest anchors), dogfooded product installs, in-process fat press via `tpkg`; 12 tests. §5 amendment: hermetic per-target bench home + per-arm cold flow.
- **Slice 5 — §5–§7 run engine** (`src/engine.rs`, ~850 lines): the cell matrix runner with named gaps per arm; `run` subcommand wired (`--tebako-release`, `--repo-root`); 9 tests. `serde_json/float_roundtrip` for bit-exact stat re-reads (§7 merge rule). `report` stub remains for slice 6.

## Verification

- `cargo test -p tebako-bench` (debug, mandated vcpkg/git-cli env): **36/36 pass** (12 acquire + 9 engine + 9 sampler + 6 validate); clippy `-D warnings` clean; fmt clean. Never `--release` (the libtfs.rlib collision rule).
- **Live dogfood smoke** (real suite, macos-arm64): harness downloaded + sha-verified the tebako tools and the packed-mn asset, registered the registry, recorded the machine truth — v1 warmup exit 137 (the §9 spike-c AMFI kill, recorded failed-at-iteration-0, cell skipped), v2 arms named gaps, exit 1 with `results.json` written per §8's red-matrix contract. The smoke caught and fixed a real harness bug: per-target hermetic TMPDIR must exist before first boot.

## Product-side findings (filed separately, not this crate's to fix)

- `tebako install metanorma@1.16.9` exits 65 ("register one with add-registry") immediately after a successful `add-registry` in the same `TEBAKO_HOME` — install doesn't see the freshly registered registry.
- packed-mn darwin-arm64 v1 asset SIGKILLed on macOS 14 (spike c, second data point — recorded as a named gap by design).

Spec 27 §4/§5 amendments ride the commits (documented in the spec's status line).
