### PR TITLE
fix(resolve): the release-index filename is the authoritative runtime asset spelling — #456

### DIFF
--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -164,6 +164,40 @@ pub struct RuntimeRef {
     pub abi: String,
 }
 
+/// The identity triple a release-index entry is matched by (spec 05 §2):
+/// the runtime_ref's tebako abi + language version + the host platform.
+/// The authoritative asset spellings flow from the matched entry, never
+/// from consumer-side synthesis (tebako#456).
+pub struct ReleaseIdentity<'a> {
+    pub runtime_type: &'a str,
+    pub lang_version: &'a str,
+    pub tebako_version: &'a str,
+    pub platform: &'a str,
+}
+
+impl<'a> ReleaseIdentity<'a> {
+    /// The identity of the runtime `rr` on this host.
+    pub fn of(rr: &'a RuntimeRef, platform: &'a str) -> ReleaseIdentity<'a> {
+        ReleaseIdentity {
+            runtime_type: &rr.r#type,
+            lang_version: &rr.version,
+            tebako_version: &rr.abi,
+            platform,
+        }
+    }
+
+    /// The matching release-index entry, when the index declares one.
+    fn entry<'m>(&self, manifest_text: &'m str) -> Option<ManifestEntry<'m>> {
+        manifest_entry_for_runtime(
+            manifest_text,
+            self.runtime_type,
+            self.lang_version,
+            self.tebako_version,
+            self.platform,
+        )
+    }
+}
+
 /// Parse a runtime_ref (exact C++ `parse_runtime_ref` semantics; the
 /// components become path/URL parts, so `/\\ \t\r\n` are refused).
 pub fn parse_runtime_ref(ref_: &str) -> Result<RuntimeRef, BootError> {
@@ -701,6 +735,37 @@ fn fetch_url(url: &str, local: bool, out: &Path) -> Result<(), ()> {
     }
 }
 
+/// fetch_url's in-memory sibling for the small index documents
+/// (manifest.json): the same local/remote rules and the same
+/// retry/throttle budget, no staging file.
+#[allow(clippy::result_unit_err)] // C-style -1 error by design
+fn fetch_text(url: &str, local: bool) -> Result<String, ()> {
+    if local {
+        return std::fs::read_to_string(Path::new(url)).map_err(|_| ());
+    }
+    let mut attempts = 0;
+    let mut throttles = 0;
+    loop {
+        match tebako_http::get(url) {
+            Ok(bytes) => return String::from_utf8(bytes).map_err(|_| ()),
+            Err(tebako_http::FetchError::IndexUnavailable(_)) => return Err(()),
+            Err(tebako_http::FetchError::Throttled { retry_after, .. }) => {
+                throttles += 1;
+                if throttles >= tebako_http::THROTTLE_ROUNDS {
+                    return Err(());
+                }
+                std::thread::sleep(tebako_http::throttle_backoff(throttles, retry_after));
+            }
+            Err(tebako_http::FetchError::DownloadFailed(_)) => {
+                attempts += 1;
+                if attempts >= 3 {
+                    return Err(());
+                }
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------
 // progress UX (spec 06 §5, locked): phases + bar on stderr, never stdout
 // ---------------------------------------------------------------------
@@ -934,7 +999,18 @@ fn contract_mismatch_error(runtime_ref: &str, declared: u32) -> BootError {
 /// A declared era or contract_version newer than this bootstrap speaks
 /// is refused with both numbers named. Returns the negotiation error to
 /// propagate, or `None` when the entry is acceptable.
-fn contract_gate(runtime_ref: &str, manifest_text: &str, asset: &str) -> Option<BootError> {
+///
+/// `asset` is the resolved spelling — the identity-matched entry's
+/// `filename` when the index declares one (spec 05 §2), the synthesized
+/// fallback otherwise; `id` names the identity triple the entry was
+/// matched by, so the no-entry refusal diagnoses the mis-lookup as what
+/// it is (tebako#456) instead of parroting a hand-invented name.
+fn contract_gate(
+    runtime_ref: &str,
+    manifest_text: &str,
+    asset: &str,
+    id: &ReleaseIdentity,
+) -> Option<BootError> {
     let pre_era = |detail: &str| {
         BootError::new(
             EX_TEBAKO_CONTRACT,
@@ -944,7 +1020,10 @@ fn contract_gate(runtime_ref: &str, manifest_text: &str, asset: &str) -> Option<
         )
     };
     if !contract_entry_present(manifest_text, asset) {
-        return Some(pre_era(&format!("no entry for {asset}")));
+        return Some(pre_era(&format!(
+            "no entry for tebako_version={} {}_version={} platform={} (asset spelling {asset})",
+            id.tebako_version, id.runtime_type, id.lang_version, id.platform
+        )));
     }
     let era = era_from_manifest_json(manifest_text, asset);
     let contract = contract_from_manifest_json(manifest_text, asset);
@@ -1049,6 +1128,224 @@ pub fn dll_install_as_from_manifest(text: &str, dll_asset: &str) -> Result<Strin
 }
 
 // ---------------------------------------------------------------------
+// release index: entry matching by the identity triple (spec 05 §2)
+// ---------------------------------------------------------------------
+
+/// A release-index entry located by the identity triple: the verbatim
+/// `filename` (the ONLY authoritative asset spelling — flowed into the
+/// download URL, the cache layout, and the contract gate, never
+/// synthesized) plus the entry's object body for the facet readers.
+pub struct ManifestEntry<'a> {
+    pub filename: String,
+    body: &'a str,
+}
+
+/// The index of the closing quote of the JSON string opening at `open`
+/// (`b[open] == b'"'`); `\\` and `\"` are the only escapes the factory
+/// spellings can carry.
+fn json_string_end(b: &[u8], open: usize) -> Option<usize> {
+    let mut i = open + 1;
+    while i < b.len() {
+        match b[i] {
+            b'\\' => i += 2,
+            b'"' => return Some(i),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// The top-level `{…}` object bodies of a JSON array (the release index
+/// shape), depth-tracked with string literals skipped. Malformed input
+/// yields fewer bodies — the caller's no-match fallback covers it.
+fn top_level_object_bodies(text: &str) -> Vec<&str> {
+    let b = text.as_bytes();
+    let mut bodies = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < b.len() {
+        match b[i] {
+            b'"' => {
+                let Some(end) = json_string_end(b, i) else {
+                    break;
+                };
+                i = end + 1;
+            }
+            b'{' => {
+                if depth == 0 {
+                    start = i + 1;
+                }
+                depth += 1;
+                i += 1;
+            }
+            b'}' => {
+                if depth == 0 {
+                    break; // unbalanced — stop, yield what we have
+                }
+                depth -= 1;
+                if depth == 0 {
+                    bodies.push(&text[start..i]);
+                }
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    bodies
+}
+
+/// The depth-1 `"key": "string"` fields of a JSON object body (non-string
+/// and deeper-nested values are skipped). A string token is a key when a
+/// `:` follows it, else the pending key's value.
+fn depth1_string_fields(body: &str) -> Vec<(&str, &str)> {
+    let b = body.as_bytes();
+    let mut fields = Vec::new();
+    let mut depth = 0usize;
+    let mut pending: Option<&str> = None;
+    let mut i = 0usize;
+    while i < b.len() {
+        match b[i] {
+            b'"' => {
+                let Some(end) = json_string_end(b, i) else {
+                    break;
+                };
+                let s = &body[i + 1..end];
+                if depth == 0 {
+                    let mut j = end + 1;
+                    while j < b.len() && b[j].is_ascii_whitespace() {
+                        j += 1;
+                    }
+                    if j < b.len() && b[j] == b':' {
+                        pending = Some(s);
+                    } else if let Some(k) = pending.take() {
+                        fields.push((k, s));
+                    }
+                }
+                i = end + 1;
+            }
+            b'{' | b'[' => {
+                depth += 1;
+                i += 1;
+            }
+            b'}' | b']' => {
+                depth = depth.saturating_sub(1);
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    fields
+}
+
+/// The body of the object value of a depth-1 key (`"image": { … }` → the
+/// inner `…`) — an entry's additive facets (`image`, `dll`).
+fn depth1_object_body<'a>(body: &'a str, key: &str) -> Option<&'a str> {
+    let b = body.as_bytes();
+    let mut depth = 0usize;
+    let mut i = 0usize;
+    while i < b.len() {
+        match b[i] {
+            b'"' => {
+                let end = json_string_end(b, i)?;
+                if depth == 0 && &body[i + 1..end] == key {
+                    let mut j = end + 1;
+                    while j < b.len() && b[j].is_ascii_whitespace() {
+                        j += 1;
+                    }
+                    if j < b.len() && b[j] == b':' {
+                        j += 1;
+                        while j < b.len() && b[j].is_ascii_whitespace() {
+                            j += 1;
+                        }
+                        if j < b.len() && b[j] == b'{' {
+                            let mut d = 1usize;
+                            let mut k = j + 1;
+                            while k < b.len() {
+                                match b[k] {
+                                    b'"' => {
+                                        k = json_string_end(b, k)? + 1;
+                                    }
+                                    b'{' => {
+                                        d += 1;
+                                        k += 1;
+                                    }
+                                    b'}' => {
+                                        d -= 1;
+                                        if d == 0 {
+                                            return Some(&body[j + 1..k]);
+                                        }
+                                        k += 1;
+                                    }
+                                    _ => k += 1,
+                                }
+                            }
+                            return None;
+                        }
+                    }
+                }
+                i = end + 1;
+            }
+            b'{' | b'[' => {
+                depth += 1;
+                i += 1;
+            }
+            b'}' | b']' => {
+                depth = depth.saturating_sub(1);
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// spec 05 §2 (SSOT, tebako#456): the release-index entry is matched by
+/// the identity triple (`tebako_version`, `<type>_version`, `platform`)
+/// — never by a synthesized asset name. The matched entry's `filename`
+/// is the authoritative exe spelling (the factory publishes the windows
+/// exe SUFFIX-LESS). `None` when no entry carries the triple (a
+/// pre-identity index) or none matches — the caller falls back to the
+/// synthesized spelling (the SHA256SUMS-only era) and names the triple
+/// in its refusal.
+pub fn manifest_entry_for_runtime<'a>(
+    text: &'a str,
+    runtime_type: &str,
+    lang_version: &str,
+    tebako_version: &str,
+    platform: &str,
+) -> Option<ManifestEntry<'a>> {
+    let lang_key = format!("{runtime_type}_version");
+    for body in top_level_object_bodies(text) {
+        let fields = depth1_string_fields(body);
+        let get = |key: &str| fields.iter().find(|(k, _)| *k == key).map(|(_, v)| *v);
+        let matches = get("tebako_version") == Some(tebako_version)
+            && get(&lang_key) == Some(lang_version)
+            && get("platform") == Some(platform);
+        if matches {
+            if let Some(filename) = get("filename") {
+                return Some(ManifestEntry {
+                    filename: filename.to_string(),
+                    body,
+                });
+            }
+        }
+    }
+    None
+}
+
+/// The verbatim `filename` of an entry's additive facet (`image`, `dll`)
+/// — the authoritative spelling of that facet's asset (spec 05 §2).
+/// `None` when the entry declares no such facet or no filename in it.
+pub fn manifest_entry_facet_filename(entry: &ManifestEntry, facet: &str) -> Option<String> {
+    let body = depth1_object_body(entry.body, facet)?;
+    depth1_string_fields(body)
+        .into_iter()
+        .find(|(k, _)| *k == "filename")
+        .map(|(_, v)| v.to_string())
+}
+
+// ---------------------------------------------------------------------
 // fat package: install the runtime payload slot
 // ---------------------------------------------------------------------
 
@@ -1087,9 +1384,15 @@ struct CacheLayout {
     root: PathBuf,
     entry_dir: PathBuf,
     exe_path: PathBuf,
+    /// The resolved exe spelling: the identity-matched index entry's
+    /// `filename` when one is known (the cached index on the hit path —
+    /// spec 05 §2), the synthesized `<asset_base><exe_suffix>` fallback
+    /// otherwise.
     asset: String,
-    /// The asset name without the platform executable suffix; the runtime
-    /// image is `<asset_base>.tfs` (item 30b).
+    /// The asset name without the platform executable suffix; the
+    /// synthesized fallback spellings (`<asset_base>.tfs`,
+    /// `<asset_base>.dll`) derive from it when no index entry declares
+    /// the facet (item 30b, tebako-runtime-ruby#40).
     asset_base: String,
     entry: String,
 }
@@ -1686,23 +1989,27 @@ fn resolve_runtime(
     m: &tpkg::Manifest,
 ) -> Result<(PathBuf, Option<PathBuf>), BootError> {
     let platform = platform_string();
+    let id = ReleaseIdentity::of(rr, platform);
     let asset_base = format!("tebako-runtime-{}-{}-{platform}", rr.abi, rr.version);
+    let entry = format!("{}-{}-{}-{platform}", rr.r#type, rr.version, rr.abi);
+    let root = cache_root()?;
+    let entry_dir = root.join("runtimes").join(&entry);
+    // spec 05 §2 (tebako#456): the cache entry's exe file keeps the index
+    // entry's `filename` spelling (windows runtimes publish SUFFIX-LESS).
+    // A cached entry carries the verified index the lean install left
+    // behind — flow it. No cached index (a fat-payload install) → the
+    // synthesized fallback spelling.
+    let asset = std::fs::read_to_string(entry_dir.join("manifest.json"))
+        .ok()
+        .and_then(|text| id.entry(&text).map(|e| e.filename))
+        .unwrap_or_else(|| format!("{asset_base}{}", exe_suffix()));
     let layout = CacheLayout {
-        root: cache_root()?,
-        entry_dir: PathBuf::new(),
-        exe_path: PathBuf::new(),
-        asset: format!("{asset_base}{}", exe_suffix()),
+        exe_path: entry_dir.join(&asset),
+        asset,
+        root,
+        entry_dir,
         asset_base,
-        entry: format!("{}-{}-{}-{platform}", rr.r#type, rr.version, rr.abi),
-    };
-    let layout = CacheLayout {
-        entry_dir: layout.root.join("runtimes").join(&layout.entry),
-        exe_path: layout
-            .root
-            .join("runtimes")
-            .join(&layout.entry)
-            .join(&layout.asset),
-        ..layout
+        entry,
     };
 
     let mut ux = BootUx::new();
@@ -1756,18 +2063,11 @@ fn download_executable(
     layout: &CacheLayout,
     ux: &mut BootUx,
 ) -> Result<PathBuf, BootError> {
-    let (root, entry_dir, asset, entry) = (
-        &layout.root,
-        &layout.entry_dir,
-        &layout.asset,
-        &layout.entry,
-    );
+    let (root, entry_dir, entry) = (&layout.root, &layout.entry_dir, &layout.entry);
 
-    let exe_path = &layout.exe_path;
     let base_raw = releases_base();
     let base = skip_file_scheme(&base_raw).to_string();
     let local = base_is_local(&base_raw);
-    let asset_url = format!("{base}/v{}/{asset}", rr.abi);
     let manifest_url = format!("{base}/v{}/manifest.json", rr.abi);
     let sums_url = format!("{base}/v{}/SHA256SUMS.txt", rr.abi);
 
@@ -1775,32 +2075,24 @@ fn download_executable(
         return fail(
             EX_TEBAKO_UNAVAILABLE,
             format!(
-                "cannot resolve runtime \"{runtime_ref}\": not present in the cache and TEBAKO_OFFLINE is set\n  cache entry: {}\n  would fetch: {asset_url}\n  unset TEBAKO_OFFLINE, or set TEBAKO_RUNTIME_MIRROR to a reachable mirror",
-                entry_dir.display()
+                "cannot resolve runtime \"{runtime_ref}\": not present in the cache and TEBAKO_OFFLINE is set\n  cache entry: {}\n  would fetch: {base}/v{}/{}\n  unset TEBAKO_OFFLINE, or set TEBAKO_RUNTIME_MIRROR to a reachable mirror",
+                entry_dir.display(),
+                rr.abi,
+                layout.asset
             ),
         );
     }
 
     ux.resolving(runtime_ref);
 
-    let Some(ins) = begin_entry_install(root, entry, exe_path, asset, runtime_ref)? else {
-        ux.cached(rr);
-        return Ok(exe_path.clone());
-    };
-
-    // spec 18 C2: the release card gates BEFORE any asset download —
-    // a contract refusal never downloads a byte of the runtime. No
-    // readable manifest at all is the same pre-era signal (no old-path
-    // readers; the SHA256SUMS fallback covers checksums only).
-    let manifest_tmp = ins.tmp_dir.join("manifest.json");
-    let manifest_text = if fetch_url(&manifest_url, local, &manifest_tmp).is_ok() {
-        std::fs::read_to_string(&manifest_tmp).ok()
-    } else {
-        None
-    };
-    let Some(manifest_text) = manifest_text else {
-        cleanup_tmp_entry(&ins.tmp_dir, asset);
-        lock_release(ins.lock);
+    // spec 05 §2 (tebako#456): the index entry — matched by the identity
+    // triple, never by a synthesized name — carries the authoritative
+    // asset spelling, flowed verbatim into the URL, the cache layout, and
+    // the contract gate below. Fetched ahead of the install lock (a pure
+    // mirror read): the spelling decides the staging and cache paths. No
+    // readable manifest at all is the pre-era signal (spec 18 C2; the
+    // SHA256SUMS fallback covers checksums only, never the gate).
+    let Ok(manifest_text) = fetch_text(&manifest_url, local) else {
         return fail(
             EX_TEBAKO_CONTRACT,
             format!(
@@ -1808,14 +2100,44 @@ fn download_executable(
             ),
         );
     };
-    if let Some(e) = contract_gate(runtime_ref, &manifest_text, asset) {
-        cleanup_tmp_entry(&ins.tmp_dir, asset);
+    let id = ReleaseIdentity::of(rr, platform_string());
+    let asset = id
+        .entry(&manifest_text)
+        .map(|e| e.filename)
+        .unwrap_or_else(|| layout.asset.clone());
+    let exe_path = entry_dir.join(&asset);
+    let asset_url = format!("{base}/v{}/{asset}", rr.abi);
+
+    let Some(ins) = begin_entry_install(root, entry, &exe_path, &asset, runtime_ref)? else {
+        ux.cached(rr);
+        return Ok(exe_path);
+    };
+
+    // The gated index rides the install into the cache entry: the image /
+    // dll facets re-resolve from it offline (tebako-runtime-ruby#40), and
+    // the next run's cache-hit path flows its spellings (spec 05 §2).
+    if let Err(e) = write_small_file(&ins.tmp_dir.join("manifest.json"), &manifest_text) {
+        cleanup_tmp_entry(&ins.tmp_dir, &asset);
+        lock_release(ins.lock);
+        return Err(BootError::new(
+            EX_TEBAKO_IO,
+            format!(
+                "cannot stage the release manifest into {}: {e}",
+                ins.tmp_dir.display()
+            ),
+        ));
+    }
+
+    // spec 18 C2: the release card gates BEFORE any asset download —
+    // a contract refusal never downloads a byte of the runtime.
+    if let Some(e) = contract_gate(runtime_ref, &manifest_text, &asset, &id) {
+        cleanup_tmp_entry(&ins.tmp_dir, &asset);
         lock_release(ins.lock);
         return Err(e);
     }
 
-    if fetch_asset(&asset_url, local, &ins.tmp_asset, asset, &mut ux.prog).is_err() {
-        cleanup_tmp_entry(&ins.tmp_dir, asset);
+    if fetch_asset(&asset_url, local, &ins.tmp_asset, &asset, &mut ux.prog).is_err() {
+        cleanup_tmp_entry(&ins.tmp_dir, &asset);
         lock_release(ins.lock);
         return fail(
             EX_TEBAKO_UNAVAILABLE,
@@ -1838,7 +2160,7 @@ fn download_executable(
     ];
     let mut expected: Option<String> = None;
     let mut diag_manifest = 3;
-    if let Ok(sha) = sha_from_manifest_json(&manifest_text, asset) {
+    if let Ok(sha) = sha_from_manifest_json(&manifest_text, &asset) {
         diag_manifest = 4;
         expected = Some(sha);
     }
@@ -1850,7 +2172,7 @@ fn download_executable(
             diag_sums = 2;
             if let Ok(text) = std::fs::read_to_string(&sums_tmp) {
                 diag_sums = 3;
-                if let Ok(sha) = sha_from_sums(&text, asset) {
+                if let Ok(sha) = sha_from_sums(&text, &asset) {
                     diag_sums = 4;
                     expected = Some(sha);
                 }
@@ -1858,7 +2180,7 @@ fn download_executable(
         }
     }
     let Some(expected) = expected else {
-        cleanup_tmp_entry(&ins.tmp_dir, asset);
+        cleanup_tmp_entry(&ins.tmp_dir, &asset);
         lock_release(ins.lock);
         return fail(
             EX_TEBAKO_UNAVAILABLE,
@@ -1872,7 +2194,7 @@ fn download_executable(
     let actual = match sha256_file_hex(&ins.tmp_asset) {
         Ok(a) => a,
         Err(e) => {
-            cleanup_tmp_entry(&ins.tmp_dir, asset);
+            cleanup_tmp_entry(&ins.tmp_dir, &asset);
             lock_release(ins.lock);
             return Err(BootError::new(
                 EX_TEBAKO_IO,
@@ -1886,7 +2208,7 @@ fn download_executable(
 
     let expected = expected.to_lowercase();
     if expected != actual {
-        cleanup_tmp_entry(&ins.tmp_dir, asset);
+        cleanup_tmp_entry(&ins.tmp_dir, &asset);
         lock_release(ins.lock);
         return fail(
             EX_TEBAKO_SHA,
@@ -1898,7 +2220,7 @@ fn download_executable(
 
     let origin = format!("runtime_ref={runtime_ref}\nurl={asset_url}\nsha256={actual}\n");
     ux.prog.phase("installing (locked)");
-    let installed = publish_entry(ins, entry_dir, exe_path, asset, &actual, &origin)?;
+    let installed = publish_entry(ins, entry_dir, &exe_path, &asset, &actual, &origin)?;
     let size = std::fs::metadata(&installed).map(|m| m.len()).unwrap_or(0);
     ux.prog.line(&installed_line(entry, size, entry_dir));
     Ok(installed)
@@ -1908,11 +2230,18 @@ fn download_executable(
 // runtime image resolution (item 30b, the `;image` flag)
 // ---------------------------------------------------------------------
 
-/// Resolve the runtime image (`<asset_base>.tfs`) into the executable's
-/// cache entry: download (same mirror/offline rules), verify against the
-/// release index (manifest.json `image` key primary, SHA256SUMS line
-/// fallback), install read-only with `<image>.sha256`/`<image>.origin`
-/// trusted markers. The image is never extracted into the cache.
+/// Resolve the runtime image into the executable's cache entry: download
+/// (same mirror/offline rules), verify against the release index
+/// (manifest.json `image` key primary, SHA256SUMS line fallback),
+/// install read-only with `<image>.sha256`/`<image>.origin` trusted
+/// markers. The image is never extracted into the cache.
+///
+/// The image's spelling is the identity-matched entry's `image.filename`
+/// (spec 05 §2, flowed verbatim — from the entry's cached index on the
+/// fast path, from the fresh index on the download path); the
+/// synthesized `<asset_base>.tfs` is the fallback for index-less entries
+/// (a fat-payload install never fetches an index into the entry — its
+/// fast path derives the fallback spelling per run).
 fn resolve_image(
     runtime_ref: &str,
     rr: &RuntimeRef,
@@ -1920,9 +2249,15 @@ fn resolve_image(
     ux: &mut BootUx,
 ) -> Result<PathBuf, BootError> {
     let (root, entry_dir, entry) = (&layout.root, &layout.entry_dir, &layout.entry);
-    let image_asset = format!("{}.tfs", layout.asset_base);
-    let image_path = entry_dir.join(&image_asset);
-    let marker = entry_dir.join(format!("{image_asset}.sha256"));
+    let id = ReleaseIdentity::of(rr, platform_string());
+    let cached_index = std::fs::read_to_string(entry_dir.join("manifest.json")).ok();
+    let mut image_asset = cached_index
+        .as_deref()
+        .and_then(|text| id.entry(text))
+        .and_then(|e| manifest_entry_facet_filename(&e, "image"))
+        .unwrap_or_else(|| format!("{}.tfs", layout.asset_base));
+    let mut image_path = entry_dir.join(&image_asset);
+    let mut marker = entry_dir.join(format!("{image_asset}.sha256"));
 
     if file_exists(&image_path) && file_exists(&marker) {
         return Ok(image_path);
@@ -1931,7 +2266,6 @@ fn resolve_image(
     let base_raw = releases_base();
     let base = skip_file_scheme(&base_raw).to_string();
     let local = base_is_local(&base_raw);
-    let image_url = format!("{base}/v{}/{image_asset}", rr.abi);
     let manifest_url = format!("{base}/v{}/manifest.json", rr.abi);
     let sums_url = format!("{base}/v{}/SHA256SUMS.txt", rr.abi);
 
@@ -1939,8 +2273,9 @@ fn resolve_image(
         return fail(
             EX_TEBAKO_UNAVAILABLE,
             format!(
-                "cannot resolve runtime image \"{runtime_ref}\": not present in the cache and TEBAKO_OFFLINE is set\n  cache entry: {}\n  would fetch: {image_url}\n  unset TEBAKO_OFFLINE, or set TEBAKO_RUNTIME_MIRROR to a reachable mirror",
-                entry_dir.display()
+                "cannot resolve runtime image \"{runtime_ref}\": not present in the cache and TEBAKO_OFFLINE is set\n  cache entry: {}\n  would fetch: {base}/v{}/{image_asset}\n  unset TEBAKO_OFFLINE, or set TEBAKO_RUNTIME_MIRROR to a reachable mirror",
+                entry_dir.display(),
+                rr.abi
             ),
         );
     }
@@ -1987,7 +2322,6 @@ fn resolve_image(
     let tmp_dir = root
         .join("tmp")
         .join(format!("{entry}.{}.image", std::process::id()));
-    let tmp_image = tmp_dir.join(&image_asset);
     cleanup_tmp_entry(&tmp_dir, &image_asset);
     if let Err(e) = std::fs::create_dir(&tmp_dir) {
         lock_release(lock);
@@ -1997,8 +2331,8 @@ fn resolve_image(
         ));
     }
 
-    let fail_image = |lock: EntryLock, e: BootError| -> BootError {
-        cleanup_tmp_entry(&tmp_dir, &image_asset);
+    let fail_image = |lock: EntryLock, asset: &str, e: BootError| -> BootError {
+        cleanup_tmp_entry(&tmp_dir, asset);
         lock_release(lock);
         e
     };
@@ -2017,6 +2351,7 @@ fn resolve_image(
     let Some(manifest_text) = manifest_text else {
         return Err(fail_image(
             lock,
+            &image_asset,
             BootError::new(
                 EX_TEBAKO_CONTRACT,
                 format!(
@@ -2025,13 +2360,41 @@ fn resolve_image(
             ),
         ));
     };
-    if let Some(e) = contract_gate(runtime_ref, &manifest_text, &layout.asset) {
-        return Err(fail_image(lock, e));
+
+    // spec 05 §2: the identity-matched entry anchors the gate by ITS
+    // filename and carries the image's authoritative spelling — the fresh
+    // index wins over the cached/fast-path spelling.
+    let entry_match = id.entry(&manifest_text);
+    let gate_asset = entry_match
+        .as_ref()
+        .map(|e| e.filename.clone())
+        .unwrap_or_else(|| layout.asset.clone());
+    if let Some(e) = contract_gate(runtime_ref, &manifest_text, &gate_asset, &id) {
+        return Err(fail_image(lock, &image_asset, e));
     }
+    if let Some(flowed) = entry_match
+        .as_ref()
+        .and_then(|e| manifest_entry_facet_filename(e, "image"))
+    {
+        if flowed != image_asset {
+            image_asset = flowed;
+            image_path = entry_dir.join(&image_asset);
+            marker = entry_dir.join(format!("{image_asset}.sha256"));
+            // a raced install under the flowed spelling
+            if file_exists(&image_path) && file_exists(&marker) {
+                cleanup_tmp_entry(&tmp_dir, &image_asset);
+                lock_release(lock);
+                return Ok(image_path);
+            }
+        }
+    }
+    let image_url = format!("{base}/v{}/{image_asset}", rr.abi);
+    let tmp_image = tmp_dir.join(&image_asset);
 
     if fetch_asset(&image_url, local, &tmp_image, &image_asset, &mut ux.prog).is_err() {
         return Err(fail_image(
             lock,
+            &image_asset,
             BootError::new(
                 EX_TEBAKO_UNAVAILABLE,
                 format!(
@@ -2077,6 +2440,7 @@ fn resolve_image(
     let Some(expected) = expected else {
         return Err(fail_image(
             lock,
+            &image_asset,
             BootError::new(
                 EX_TEBAKO_UNAVAILABLE,
                 format!(
@@ -2092,6 +2456,7 @@ fn resolve_image(
         Err(e) => {
             return Err(fail_image(
                 lock,
+                &image_asset,
                 BootError::new(
                     EX_TEBAKO_IO,
                     format!("cannot hash downloaded file {}: {e}", tmp_image.display()),
@@ -2104,6 +2469,7 @@ fn resolve_image(
     if expected != actual {
         return Err(fail_image(
             lock,
+            &image_asset,
             BootError::new(
                 EX_TEBAKO_SHA,
                 format!(
@@ -2119,6 +2485,7 @@ fn resolve_image(
     if let Err(e) = os_rename(&tmp_image, &image_path) {
         return Err(fail_image(
             lock,
+            &image_asset,
             BootError::new(
                 EX_TEBAKO_IO,
                 format!(
@@ -2169,11 +2536,18 @@ fn resolve_dll(
     ux: &mut BootUx,
 ) -> Result<Option<PathBuf>, BootError> {
     let (root, entry_dir, entry) = (&layout.root, &layout.entry_dir, &layout.entry);
-    let dll_asset = format!("{}.dll", layout.asset_base);
 
     let Ok(manifest_text) = std::fs::read_to_string(entry_dir.join("manifest.json")) else {
         return Ok(None);
     };
+    // spec 05 §2: the identity-matched entry's `dll.filename` is the
+    // authoritative facet spelling (flowed verbatim); the synthesized
+    // `<asset_base>.dll` is the fallback for a pre-identity index.
+    let id = ReleaseIdentity::of(rr, platform_string());
+    let dll_asset = id
+        .entry(&manifest_text)
+        .and_then(|e| manifest_entry_facet_filename(&e, "dll"))
+        .unwrap_or_else(|| format!("{}.dll", layout.asset_base));
     let Ok(install_as) = dll_install_as_from_manifest(&manifest_text, &dll_asset) else {
         return Ok(None);
     };
@@ -2845,5 +3219,112 @@ mod dll_tests {
         let _ = std::fs::remove_dir_all(&home);
         let _ = std::fs::remove_dir_all(&home2);
         let _ = std::fs::remove_dir_all(&home3);
+    }
+}
+
+#[cfg(test)]
+mod manifest_identity_tests {
+    use super::*;
+
+    /// A multi-entry era-2 index: nested `image`/`dll`/`built_from`
+    /// objects, a non-string field (`contract_era: 2`), reordered keys —
+    /// the windows entry carries the factory's SUFFIX-LESS exe spelling
+    /// (tebako#456).
+    const INDEX: &str = r#"[
+  {
+    "tebako_version": "0.16.9",
+    "contract_era": 2,
+    "contract_version": 2,
+    "mount_root": "/__tfs__",
+    "ruby_version": "3.3.12",
+    "platform": "macos-arm64",
+    "filename": "tebako-runtime-0.16.9-3.3.12-macos-arm64",
+    "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "size_bytes": 24191976,
+    "built_from": {"scenario": "default", "toolchain": "clang"},
+    "image": {"filename": "tebako-runtime-0.16.9-3.3.12-macos-arm64.tfs", "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "size_bytes": 20410208}
+  },
+  {
+    "filename": "tebako-runtime-0.16.9-3.3.12-windows-ucrt64",
+    "platform": "windows-ucrt64",
+    "ruby_version": "3.3.12",
+    "tebako_version": "0.16.9",
+    "contract_era": 2,
+    "contract_version": 2,
+    "mount_root": "A:/t",
+    "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "size_bytes": 30000000,
+    "image": {"size_bytes": 40000000, "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "filename": "tebako-runtime-0.16.9-3.3.12-windows-ucrt64.tfs"},
+    "dll": {"filename": "tebako-runtime-0.16.9-3.3.12-windows-ucrt64.dll", "install_as": "x64-ucrt-ruby330.dll", "sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "size_bytes": 5000000}
+  }
+]"#;
+
+    #[test]
+    fn the_identity_triple_selects_the_entry_not_the_spelling() {
+        let win = manifest_entry_for_runtime(INDEX, "ruby", "3.3.12", "0.16.9", "windows-ucrt64")
+            .expect("the windows entry matches its identity triple");
+        // The flowed spelling is verbatim — NO synthesized `.exe`.
+        assert_eq!(win.filename, "tebako-runtime-0.16.9-3.3.12-windows-ucrt64");
+
+        let mac = manifest_entry_for_runtime(INDEX, "ruby", "3.3.12", "0.16.9", "macos-arm64")
+            .expect("the posix entry matches");
+        assert_eq!(mac.filename, "tebako-runtime-0.16.9-3.3.12-macos-arm64");
+    }
+
+    #[test]
+    fn a_wrong_triple_leg_is_no_match() {
+        assert!(
+            manifest_entry_for_runtime(INDEX, "ruby", "3.3.12", "0.16.9", "linux-x86_64").is_none()
+        );
+        assert!(
+            manifest_entry_for_runtime(INDEX, "ruby", "3.4.1", "0.16.9", "windows-ucrt64")
+                .is_none()
+        );
+        assert!(
+            manifest_entry_for_runtime(INDEX, "ruby", "3.3.12", "0.16.8", "windows-ucrt64")
+                .is_none()
+        );
+        // The language key composes from the runtime type.
+        assert!(
+            manifest_entry_for_runtime(INDEX, "python", "3.3.12", "0.16.9", "windows-ucrt64")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn facet_filenames_flow_verbatim() {
+        let win = manifest_entry_for_runtime(INDEX, "ruby", "3.3.12", "0.16.9", "windows-ucrt64")
+            .unwrap();
+        assert_eq!(
+            manifest_entry_facet_filename(&win, "image").as_deref(),
+            Some("tebako-runtime-0.16.9-3.3.12-windows-ucrt64.tfs")
+        );
+        assert_eq!(
+            manifest_entry_facet_filename(&win, "dll").as_deref(),
+            Some("tebako-runtime-0.16.9-3.3.12-windows-ucrt64.dll")
+        );
+        // A facet the entry does not declare is no answer.
+        let mac =
+            manifest_entry_for_runtime(INDEX, "ruby", "3.3.12", "0.16.9", "macos-arm64").unwrap();
+        assert!(manifest_entry_facet_filename(&mac, "dll").is_none());
+    }
+
+    #[test]
+    fn an_entry_without_filename_is_no_match() {
+        let text = r#"[{"tebako_version": "0.16.9", "ruby_version": "3.3.12", "platform": "macos-arm64", "sha256": "aaaa"}]"#;
+        assert!(
+            manifest_entry_for_runtime(text, "ruby", "3.3.12", "0.16.9", "macos-arm64").is_none()
+        );
+    }
+
+    #[test]
+    fn malformed_and_empty_indexes_are_no_match() {
+        for text in ["", "[]", "not json", "[{\"tebako_version\": ", "{}"] {
+            assert!(
+                manifest_entry_for_runtime(text, "ruby", "3.3.12", "0.16.9", "macos-arm64")
+                    .is_none(),
+                "{text:?} must be no match"
+            );
+        }
     }
 }

--- a/crates/tebako-bootstrap/src/platform.rs
+++ b/crates/tebako-bootstrap/src/platform.rs
@@ -23,13 +23,19 @@ use windows_sys::Win32::System::Console::{SetConsoleCtrlHandler, CTRL_BREAK_EVEN
 #[cfg(windows)]
 use windows_sys::Win32::System::IO::OVERLAPPED;
 
-/// Runtime-package platform string for asset-name construction.
-/// `tpkg::Platform` owns the vocabulary and host detection (spec 03 §3);
-/// this is the `&'static str` convenience over it.
+/// Runtime-package platform string — the `platform` leg of the release
+/// index's identity triple (spec 05 §2) and the fallback asset-name
+/// construction. `tpkg::Platform` owns the vocabulary and host detection
+/// (spec 03 §3); this is the `&'static str` convenience over it.
 pub fn platform_string() -> &'static str {
     tpkg::Platform::host().release_asset_name()
 }
 
+/// The platform executable suffix (`.exe` on Windows). Only for the
+/// SYNTHESIZED FALLBACK asset spelling — the release index entry's
+/// `filename` is the authoritative spelling, flowed verbatim whenever an
+/// identity-matched entry is in hand (spec 05 §2, tebako#456; the
+/// factory publishes the windows exe suffix-less).
 pub fn exe_suffix() -> &'static str {
     #[cfg(windows)]
     return ".exe";

--- a/crates/tebako-bootstrap/tests/harness/mod.rs
+++ b/crates/tebako-bootstrap/tests/harness/mod.rs
@@ -105,12 +105,26 @@ pub fn fake_runtime_path() -> PathBuf {
 
 impl Harness {
     pub fn new(bootstrap: PathBuf) -> Harness {
+        let plat = platform();
+        let exe = tebako_bootstrap::platform::exe_suffix();
+        Self::new_with_exe_asset(
+            bootstrap,
+            &format!("tebako-runtime-{TEBAKO_VER}-{RUBY_VER}-{plat}{exe}"),
+        )
+    }
+
+    /// [`new`] with an explicit exe asset spelling: the release index's
+    /// `filename` is the ONLY authoritative asset spelling (spec 05 §2
+    /// SSOT; tebako#456) — the factory publishes windows exe assets
+    /// SUFFIX-LESS, so the harness must carry any spelling the index
+    /// declares. The image keeps the exe's stem plus `.tfs`.
+    pub fn new_with_exe_asset(bootstrap: PathBuf, exe_name: &str) -> Harness {
         let tmp = TempDir::new("boot");
         let fake_runtime = fake_runtime_path();
 
         let plat = platform();
         let exe = tebako_bootstrap::platform::exe_suffix();
-        let asset = format!("tebako-runtime-{TEBAKO_VER}-{RUBY_VER}-{plat}{exe}");
+        let asset = exe_name.to_string();
         let entry = format!("ruby-{RUBY_VER}-{TEBAKO_VER}-{plat}");
         let runtime_ref = format!("ruby@{RUBY_VER};tebako={TEBAKO_VER}");
 

--- a/crates/tebako-bootstrap/tests/selftest.rs
+++ b/crates/tebako-bootstrap/tests/selftest.rs
@@ -816,3 +816,91 @@ fn s18_a_run_never_seeds_the_store() {
         "a plain run seeded the payloads store"
     );
 }
+
+// ---------------------------------------------------------------------
+// tebako#456: the release index's `filename` is the ONLY authoritative
+// asset spelling (spec 05 §2 SSOT) — the factory publishes windows exe
+// assets SUFFIX-LESS; the bootstrap matches the identity triple and
+// flows the declared names into the URL, the cache layout and the gate.
+// ---------------------------------------------------------------------
+
+#[test]
+fn s19_index_filename_is_the_authoritative_spelling() {
+    let plat = harness::platform();
+    // Two spellings: the real windows factory shape (suffix-less — equal
+    // to the synthesized name on posix) and one that diverges from the
+    // synthesized spelling on EVERY host.
+    for exe_name in [
+        format!("tebako-runtime-{TEBAKO_VER}-{RUBY_VER}-{plat}"),
+        format!("tebako-runtime-{TEBAKO_VER}-{RUBY_VER}-{plat}-renamed"),
+    ] {
+        let h = Harness::new_with_exe_asset(rust_bootstrap(), &exe_name);
+        let pkg = h.lean_pkg_image("imgapp");
+        let home = h.home("home");
+        let (rc, out, err) = h.run(&pkg, &home, &[], &["hello"]);
+        assert_eq!((rc, err.as_str()), (0, ""), "{exe_name}: {err}");
+        assert!(out.contains("FAKE-RUNTIME"), "{exe_name}: {out}");
+
+        // The cache holds the entry under the INDEX spelling, verbatim.
+        let entry_dir = home.join("runtimes").join(&h.entry);
+        let cached = entry_dir.join(&exe_name);
+        assert!(
+            cached.is_file(),
+            "{exe_name}: runtime not cached under the index spelling"
+        );
+        let sha_meta = std::fs::read_to_string(entry_dir.join("sha256")).unwrap();
+        assert_eq!(sha_meta, format!("{}  {exe_name}\n", h.sha), "{exe_name}");
+        assert!(
+            h.cache_image(&home).is_file(),
+            "{exe_name}: image not cached under the flowed spelling"
+        );
+
+        // The cached index flows on the hit path too: mirror gone +
+        // offline, the cache still serves (the exe found by identity).
+        std::fs::rename(&h.mirror_root, h.tmp.0.join("mirror-gone")).unwrap();
+        let (rc, out, err) = h.run(&pkg, &home, &[("TEBAKO_OFFLINE", "1")], &["hello"]);
+        assert_eq!(rc, 0, "{exe_name}: {err}");
+        assert!(out.contains("FAKE-RUNTIME"), "{exe_name}: {out}");
+    }
+}
+
+#[test]
+fn s20_missing_entry_names_the_identity() {
+    // No manifest entry matches the identity triple: the pre-era refusal
+    // names the triple alongside the spelling tried (exit 75, before any
+    // download — spec 05 §2's honest fallback error).
+    let h = h();
+    let manifest = h
+        .mirror_root
+        .join(format!("v{TEBAKO_VER}"))
+        .join("manifest.json");
+    let renamed = std::fs::read_to_string(&manifest)
+        .unwrap()
+        .replace(
+            &format!("\"ruby_version\": \"{RUBY_VER}\""),
+            "\"ruby_version\": \"0.0.0\"",
+        )
+        .replace(
+            &format!("\"filename\": \"{}\"", h.asset),
+            "\"filename\": \"tebako-runtime-9.9.9-0.0.0-nowhere\"",
+        );
+    std::fs::write(&manifest, renamed).unwrap();
+    let pkg = h.lean_pkg("myapp");
+    let home = h.home("home-no-entry");
+    let (rc, _, err) = h.run_raw(&pkg, &home, &[], &[]);
+    assert_eq!(rc, 75, "{err}");
+    assert!(err.contains("no entry"), "{err}");
+    assert!(err.contains(&format!("ruby_version={RUBY_VER}")), "{err}");
+    assert!(
+        err.contains(&format!("platform={}", harness::platform())),
+        "{err}"
+    );
+    assert!(
+        !err.contains("downloading "),
+        "the refusal must precede any download: {err}"
+    );
+    assert!(
+        !home.join("runtimes").join(&h.entry).exists(),
+        "a refused runtime entered the cache"
+    );
+}

--- a/crates/tebako-cli/src/resolve.rs
+++ b/crates/tebako-cli/src/resolve.rs
@@ -167,7 +167,13 @@ impl Resolver {
         tebako_version: &str,
     ) -> Result<Resolved, TebakoError> {
         let dir = self.entry_dir(ruby_version, platform, tebako_version);
-        let executable = dir.join(self.filename(ruby_version, platform, tebako_version));
+        // The entry's own cached index flows the asset spelling verbatim
+        // when it names this runtime (spec 05 §2 SSOT; tebako#456 — the
+        // factory publishes windows exe assets SUFFIX-LESS, and the
+        // bootstrap/shim install them under that spelling); the
+        // pre-identity fallback synthesizes `{name}[.exe]`.
+        let executable =
+            dir.join(self.cached_exe_name(&dir, ruby_version, platform, tebako_version));
         let image_marker = || self.read_image_marker(&dir, ruby_version, platform, tebako_version);
         if executable.is_file() && image_marker().is_some() {
             return Ok(Resolved {
@@ -180,8 +186,7 @@ impl Resolver {
             &self.entry_ref(ruby_version, platform, tebako_version),
             || {
                 if !executable.is_file() {
-                    let entry =
-                        self.install(&executable, ruby_version, platform, tebako_version)?;
+                    let entry = self.install(&dir, ruby_version, platform, tebako_version)?;
                     if let Some(image) = entry.image.clone() {
                         self.install_image(&dir, &image, tebako_version)?;
                     }
@@ -210,6 +215,10 @@ impl Resolver {
                 Ok(())
             },
         )?;
+        // The install placed the exe under the index spelling and the
+        // index rode into the entry — the name flows from it now.
+        let executable =
+            dir.join(self.cached_exe_name(&dir, ruby_version, platform, tebako_version));
         Ok(Resolved {
             executable,
             image: image_marker(),
@@ -233,7 +242,7 @@ impl Resolver {
         platform: &str,
         tebako_version: &str,
     ) -> Option<ImageRef> {
-        let filename = self.image_filename(ruby_version, platform, tebako_version);
+        let filename = self.cached_image_name(dir, ruby_version, platform, tebako_version);
         if !dir.join(&filename).is_file() {
             return None;
         }
@@ -484,6 +493,58 @@ impl Resolver {
         format!("tebako-runtime-{tebako_version}-{ruby_version}-{platform}{suffix}")
     }
 
+    /// The entry of the cache's own copy of the release index
+    /// (`manifest.json`) matching this (ruby, platform) — `None` when the
+    /// entry predates the cached index or never carried one (the
+    /// SHA256SUMS-era fallback spells the names instead, spec 05 §2).
+    fn cached_index_entry(
+        &self,
+        dir: &Path,
+        ruby_version: &str,
+        platform: &str,
+        tebako_version: &str,
+    ) -> Option<IndexEntry> {
+        let body = fs::read_to_string(dir.join("manifest.json")).ok()?;
+        let index = self.parse_manifest(&body, tebako_version).ok()?;
+        index.into_iter().find(|c| {
+            c.ruby_version.as_deref() == Some(ruby_version)
+                && c.platform.as_deref() == Some(platform)
+        })
+    }
+
+    /// The exe asset name of a cache entry: the cached release index's
+    /// `filename` flowed verbatim when the entry carries its index
+    /// (spec 05 §2 SSOT; tebako#456 — the factory publishes windows exe
+    /// assets SUFFIX-LESS), else the synthesized fallback.
+    fn cached_exe_name(
+        &self,
+        dir: &Path,
+        ruby_version: &str,
+        platform: &str,
+        tebako_version: &str,
+    ) -> String {
+        self.cached_index_entry(dir, ruby_version, platform, tebako_version)
+            .map(|e| e.filename)
+            .filter(|f| !f.is_empty())
+            .unwrap_or_else(|| self.filename(ruby_version, platform, tebako_version))
+    }
+
+    /// Same for the env image: the cached entry's `image.filename`
+    /// flowed verbatim, else the synthesized `<asset-minus-suffix>.tfs`.
+    fn cached_image_name(
+        &self,
+        dir: &Path,
+        ruby_version: &str,
+        platform: &str,
+        tebako_version: &str,
+    ) -> String {
+        self.cached_index_entry(dir, ruby_version, platform, tebako_version)
+            .and_then(|e| e.image)
+            .map(|i| i.filename)
+            .filter(|f| !f.is_empty())
+            .unwrap_or_else(|| self.image_filename(ruby_version, platform, tebako_version))
+    }
+
     fn entry_ref(&self, ruby_version: &str, platform: &str, tebako_version: &str) -> String {
         format!("ruby@{ruby_version} (tebako {tebako_version}, {platform})")
     }
@@ -492,7 +553,7 @@ impl Resolver {
 
     fn install(
         &self,
-        executable: &Path,
+        dir: &Path,
         ruby_version: &str,
         platform: &str,
         tebako_version: &str,
@@ -506,7 +567,18 @@ impl Resolver {
         let url = self.package_url(&entry.filename, tebako_version);
         let tmp = self.download(&url, &entry.filename)?;
         self.verify(&tmp, entry)?;
-        self.place(&tmp, executable, entry, &url)?;
+        // The exe installs under the index entry's `filename` verbatim
+        // (spec 05 §2 SSOT; tebako#456 — the factory publishes windows
+        // exe assets SUFFIX-LESS), and the index rides into the cache
+        // entry so every consumer flows the spelling from it.
+        let executable = dir.join(&entry.filename);
+        self.place(&tmp, &executable, entry, &url)?;
+        if let Some(card) = &card {
+            let card_path = dir.join("manifest.json");
+            fs::write(&card_path, card).map_err(|e| {
+                crate::error::plain_error(format!("{e} installing {}", card_path.display()))
+            })?;
+        }
         Ok(entry.clone())
     }
 
@@ -1710,6 +1782,67 @@ mod tests {
         r.resolve_runtime("3.3.12", "windows-ucrt64", "0.16.3")
             .unwrap();
         let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn resolve_runtime_flows_the_index_spelling() {
+        // tebako#456 (spec 05 §2 SSOT): the exe installs under the index
+        // entry's `filename` VERBATIM — the factory publishes the windows
+        // exe SUFFIX-LESS — the index rides into the cache entry, and a
+        // cache hit (mirror gone) finds the runtime by the flowed
+        // spelling again.
+        let dir = std::env::temp_dir().join(format!("tebako-resolve-flow-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let cache = dir.join("home");
+        let mirror = dir.join("mirror");
+        let release = mirror.join("v0.16.9");
+        fs::create_dir_all(&release).unwrap();
+        let exe = "tebako-runtime-0.16.9-3.3.12-windows-ucrt64";
+        let image = "tebako-runtime-0.16.9-3.3.12-windows-ucrt64.tfs";
+        fs::write(release.join(exe), b"fake runtime exe\n").unwrap();
+        fs::write(release.join(image), b"fake env image\n").unwrap();
+        fs::write(
+            release.join("manifest.json"),
+            format!(
+                "[{{\"tebako_version\":\"0.16.9\",\"contract_era\":2,\"contract_version\":2,\"mount_root\":\"A:/t\",\"ruby_version\":\"3.3.12\",\"platform\":\"windows-ucrt64\",\"filename\":\"{exe}\",\"sha256\":\"{}\",\"image\":{{\"filename\":\"{image}\",\"sha256\":\"{}\"}}}}]\n",
+                sha256_file_hex(&release.join(exe)).unwrap(),
+                sha256_file_hex(&release.join(image)).unwrap(),
+            ),
+        )
+        .unwrap();
+        let r = Resolver {
+            cache_root: cache.clone(),
+            mirror: format!("file://{}", mirror.display()),
+            lock_timeout: LOCK_TIMEOUT,
+        };
+
+        let resolved = r
+            .resolve_runtime("3.3.12", "windows-ucrt64", "0.16.9")
+            .unwrap();
+        assert_eq!(
+            resolved.executable.file_name().unwrap().to_string_lossy(),
+            exe,
+            "the cache holds the exe under the index spelling, verbatim"
+        );
+        let entry_dir = cache
+            .join("runtimes")
+            .join("ruby-3.3.12-0.16.9-windows-ucrt64");
+        assert!(entry_dir.join(exe).is_file());
+        assert!(entry_dir.join(image).is_file());
+        assert!(
+            entry_dir.join("manifest.json").is_file(),
+            "the index rides into the cache entry"
+        );
+
+        // a cache hit flows the cached index: the mirror is gone, the
+        // exe is found under the flowed spelling (no re-download).
+        fs::remove_dir_all(&mirror).unwrap();
+        let hit = r
+            .resolve_runtime("3.3.12", "windows-ucrt64", "0.16.9")
+            .unwrap();
+        assert_eq!(hit.executable, resolved.executable);
+        assert!(hit.image.is_some());
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/tebako-shim/src/runtime.rs
+++ b/crates/tebako-shim/src/runtime.rs
@@ -92,6 +92,78 @@ fn entry_exe_name(lv: &str, ver: &str, platform: &str) -> String {
     format!("tebako-runtime-{ver}-{lv}-{platform}{}", exe_suffix())
 }
 
+/// Synthesized env-image name (spec 05 §3's fallback spelling).
+fn synthesized_image_base(lv: &str, ver: &str, platform: &str) -> String {
+    format!("tebako-runtime-{ver}-{lv}-{platform}.tfs")
+}
+
+/// Match a release-index entry by the identity triple (spec 05 §2):
+/// `tebako_version` + `{engine}_version` + `platform` as strings.
+/// The runtime factory publishes windows exe assets SUFFIX-LESS, so the
+/// entry's `filename` is the ONLY authoritative asset spelling (spec 00
+/// §10 SSOT; tebako#456).
+fn release_index_entry<'m>(
+    manifest: &'m tebako_json::Value,
+    engine: &str,
+    lang_version: &str,
+    tebako_version: &str,
+    platform: &str,
+) -> Option<&'m tebako_json::Value> {
+    let tebako_json::Value::Array(entries) = manifest else {
+        return None;
+    };
+    let lang_key = format!("{engine}_version");
+    entries.iter().find(|e| {
+        [
+            ("tebako_version", tebako_version),
+            (lang_key.as_str(), lang_version),
+            ("platform", platform),
+        ]
+        .iter()
+        .all(|(k, want)| e.find(k).and_then(|v| v.as_string()).as_deref() == Some(*want))
+    })
+}
+
+/// `filename` of the entry itself (`facet: None`) or of a facet object
+/// (`image` / `dll`) — verbatim, including any platform suffix.
+fn entry_filename(entry: &tebako_json::Value, facet: Option<&str>) -> Option<String> {
+    let node = match facet {
+        Some(f) => entry.find(f)?,
+        None => entry,
+    };
+    node.find("filename")
+        .and_then(|v| v.as_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// The exe / env-image names for a cache entry: flow the cached release
+/// index verbatim when it names this identity, else the synthesized
+/// fallback (`{name}.exe` on windows, `{name}` on posix — spec 05 §2's
+/// pre-identity fallback).
+fn entry_asset_names(
+    entry_dir: &Path,
+    engine: &str,
+    lv: &str,
+    ver: &str,
+    platform: &str,
+) -> (String, String) {
+    let flowed = std::fs::read_to_string(entry_dir.join("manifest.json"))
+        .ok()
+        .and_then(|text| {
+            let parsed = tebako_json::parse(&text).ok()?;
+            let e = release_index_entry(&parsed, engine, lv, ver, platform)?;
+            Some((entry_filename(e, None), entry_filename(e, Some("image"))))
+        });
+    let exe = flowed
+        .as_ref()
+        .and_then(|(f, _)| f.clone())
+        .unwrap_or_else(|| entry_exe_name(lv, ver, platform));
+    let image = flowed
+        .and_then(|(_, i)| i)
+        .unwrap_or_else(|| synthesized_image_base(lv, ver, platform));
+    (exe, image)
+}
+
 /// The runtime's own `abi` string from the cached release index (the
 /// manifest.json entry whose `filename` is the exe): `None` when the
 /// entry or the key is absent (pre-abi releases — the compat window).
@@ -134,12 +206,11 @@ pub fn scan_cached(home: &Path, engine: &str) -> Vec<CachedRuntime> {
         if lang != engine {
             continue;
         }
-        let exe_name = entry_exe_name(&lv, &ver, platform);
+        let (exe_name, image_base) = entry_asset_names(&entry_dir, &lang, &lv, &ver, platform);
         let exe = entry_dir.join(&exe_name);
         if !exe.is_file() {
             continue;
         }
-        let image_base = format!("tebako-runtime-{ver}-{lv}-{platform}.tfs");
         let image = entry_dir.join(&image_base);
         let image = if image.is_file() && entry_dir.join(format!("{image_base}.sha256")).is_file() {
             Some(image)
@@ -179,12 +250,11 @@ pub fn scan_all_cached(home: &Path) -> Vec<CachedRuntime> {
         let Some((lang, lv, ver)) = parse_entry_name(&name, platform) else {
             continue;
         };
-        let exe_name = entry_exe_name(&lv, &ver, platform);
+        let (exe_name, image_base) = entry_asset_names(&entry_dir, &lang, &lv, &ver, platform);
         let exe = entry_dir.join(&exe_name);
         if !exe.is_file() {
             continue;
         }
-        let image_base = format!("tebako-runtime-{ver}-{lv}-{platform}.tfs");
         let image = entry_dir.join(&image_base);
         let image = if image.is_file() && entry_dir.join(format!("{image_base}.sha256")).is_file() {
             Some(image)
@@ -696,13 +766,6 @@ fn lock_release(lock: EntryLock) {
     }
 }
 
-fn cleanup_tmp_entry(dir: &Path, asset: &str) {
-    let _ = std::fs::remove_file(dir.join(asset));
-    let _ = std::fs::remove_file(dir.join("manifest.json"));
-    let _ = std::fs::remove_file(dir.join("SHA256SUMS.txt"));
-    let _ = std::fs::remove_dir(dir);
-}
-
 /// Fetch one URL (in-process HTTP; `file://`/local mirrors are copies).
 /// curl --retry 3 parity: transient failures get three attempts.
 #[allow(clippy::result_unit_err)]
@@ -834,14 +897,24 @@ fn fetch_manifest_text(base: &str, local: bool, abi: &str, tmp_dir: &Path) -> Op
 /// for the runtime exe must declare its contract set — tebako-resolve's
 /// reader owns the semantics (the shim links it); the refusal is exit 75
 /// with both sides named. An entry-less asset is undeclared by
-/// definition (no old-path readers).
-fn contract_gate(runtime_ref: &str, manifest_text: &str, asset: &str) -> Result<(), ShimError> {
+/// definition (no old-path readers) — the refusal names the identity
+/// triple alongside the asset spelling tried (spec 05 §2; tebako#456).
+#[allow(clippy::too_many_arguments)]
+fn contract_gate(
+    runtime_ref: &str,
+    manifest_text: &str,
+    asset: &str,
+    engine: &str,
+    lang_version: &str,
+    tebako_version: &str,
+    platform: &str,
+) -> Result<(), ShimError> {
     match tebako_resolve::contract::gate(manifest_text, asset) {
         Ok(Some(_)) => Ok(()),
         Ok(None) => fail(
             EX_TEBAKO_CONTRACT,
             format!(
-                "runtime \"{runtime_ref}\" is pre-era — its release manifest entry declares no contract set (no entry for {asset}) — refusing to install or execute\n  the release was built by a pre-contract factory; rebuild it with the current tebako-runtime-ruby (spec 18 C2), or pin a runtime that declares its contract"
+                "runtime \"{runtime_ref}\" is pre-era — its release manifest entry declares no contract set (no entry for tebako_version={tebako_version} {engine}_version={lang_version} platform={platform} (asset spelling {asset})) — refusing to install or execute\n  the release was built by a pre-contract factory; rebuild it with the current tebako-runtime-ruby (spec 18 C2), or pin a runtime that declares its contract"
             ),
         ),
         Err(e) => fail(
@@ -957,6 +1030,22 @@ fn install_asset(
     Ok(actual)
 }
 
+/// What the staging step produced: a fresh install (the staged names)
+/// or the discovery that another installer published the entry under
+/// the flowed spelling while the index was being fetched (use the
+/// cache as-is).
+enum StageOutcome {
+    Raced {
+        asset: String,
+        image_asset: String,
+    },
+    Installed {
+        has_image: bool,
+        asset: String,
+        image_asset: String,
+    },
+}
+
 /// Download the preferred runtime into the shared cache with the
 /// bootstrap's install discipline: per-entry flock (120 s), re-check
 /// under the lock, tmp staging, sha256-verified, tmp + rename publish,
@@ -971,12 +1060,13 @@ fn download_runtime(
     let runtime_ref = format!("{engine}@{};tebako={};image", pref.version, pref.tebako);
     let root = ctx.home.clone();
     let entry_dir = root.join("runtimes").join(&entry);
-    let asset = entry_exe_name(&pref.version, &pref.tebako, platform);
+    // The entry's own cached release index flows the asset spellings
+    // verbatim when it names this identity (spec 05 §2 SSOT; tebako#456
+    // — the factory publishes windows exe assets SUFFIX-LESS); the
+    // pre-identity fallback synthesizes `{name}.exe` / `{name}.tfs`.
+    let (asset, image_asset) =
+        entry_asset_names(&entry_dir, engine, &pref.version, &pref.tebako, platform);
     let exe_path = entry_dir.join(&asset);
-    let image_asset = format!(
-        "tebako-runtime-{}-{}-{platform}.tfs",
-        pref.tebako, pref.version
-    );
 
     if file_exists(&exe_path) {
         // Raced with another installer; use the cache.
@@ -1059,14 +1149,16 @@ fn download_runtime(
     let tmp_dir = root
         .join("tmp")
         .join(format!("{entry}.{}", std::process::id()));
-    cleanup_tmp_entry(&tmp_dir, &asset);
+    let _ = std::fs::remove_dir_all(&tmp_dir);
     let result = std::fs::create_dir(&tmp_dir).map_err(|e| {
         ShimError::new(
             EX_TEBAKO_IO,
             format!("cannot create {}: {e}", tmp_dir.display()),
         )
     });
-    let result = result.and_then(|()| {
+    let fallback_asset = asset.clone();
+    let fallback_image = image_asset.clone();
+    let result: Result<StageOutcome, ShimError> = result.and_then(|()| {
         // spec 18 C2: the release card gates BEFORE any asset download —
         // a contract refusal never downloads a byte of the runtime. No
         // readable manifest is the same pre-era signal (no old-path
@@ -1080,7 +1172,35 @@ fn download_runtime(
                 ),
             )
         })?;
-        contract_gate(&runtime_ref, &manifest_text, &asset)?;
+        // The entry's `filename` is the ONLY authoritative asset
+        // spelling (spec 05 §2 SSOT; tebako#456): match the identity
+        // triple (`tebako_version` + `{engine}_version` + `platform`)
+        // and flow `filename` / `image.filename` verbatim; the
+        // pre-identity fallback keeps the synthesized spelling.
+        let parsed = tebako_json::parse(&manifest_text).ok();
+        let entry_match = parsed
+            .as_ref()
+            .and_then(|m| release_index_entry(m, engine, &pref.version, &pref.tebako, platform));
+        let asset = entry_match
+            .and_then(|e| entry_filename(e, None))
+            .unwrap_or(fallback_asset);
+        let image_asset = entry_match
+            .and_then(|e| entry_filename(e, Some("image")))
+            .unwrap_or(fallback_image);
+        // Late re-check under the flowed spelling: another installer may
+        // have published the entry while the index was being fetched.
+        if file_exists(&entry_dir.join(&asset)) {
+            return Ok(StageOutcome::Raced { asset, image_asset });
+        }
+        contract_gate(
+            &runtime_ref,
+            &manifest_text,
+            &asset,
+            engine,
+            &pref.version,
+            &pref.tebako,
+            platform,
+        )?;
 
         // executable
         let exe_url = format!("{base}/v{}/{asset}", pref.tebako);
@@ -1117,7 +1237,15 @@ fn download_runtime(
         // serves and it installs alone — the s14 sums-fallback shape).
         // The contract gate is the same one (the exe entry governs its
         // additive image too).
-        contract_gate(&runtime_ref, &manifest_text, &asset)?;
+        contract_gate(
+            &runtime_ref,
+            &manifest_text,
+            &asset,
+            engine,
+            &pref.version,
+            &pref.tebako,
+            platform,
+        )?;
         let (image_sha, _) = expected_checksum(
             &base,
             local,
@@ -1179,13 +1307,37 @@ fn download_runtime(
             tmp_dir.join("origin"),
             format!("runtime_ref={runtime_ref}\nurl={exe_url}\nsha256={actual}\n"),
         );
-        Ok((actual, has_image))
+        Ok(StageOutcome::Installed {
+            has_image,
+            asset,
+            image_asset,
+        })
     });
 
     match result {
-        Ok((_, has_image)) => {
+        Ok(StageOutcome::Raced { asset, image_asset }) => {
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            lock_release(lock);
+            Ok(CachedRuntime {
+                engine: engine.to_string(),
+                lang_version: pref.version.clone(),
+                tebako_version: pref.tebako.clone(),
+                exe: entry_dir.join(&asset),
+                image: entry_dir
+                    .join(&image_asset)
+                    .is_file()
+                    .then(|| entry_dir.join(&image_asset)),
+                abi: entry_abi(&entry_dir, &asset),
+                dir: entry_dir,
+            })
+        }
+        Ok(StageOutcome::Installed {
+            has_image,
+            asset,
+            image_asset,
+        }) => {
             if file_exists(&entry_dir) {
-                cleanup_tmp_entry(&tmp_dir, &asset);
+                let _ = std::fs::remove_dir_all(&tmp_dir);
                 lock_release(lock);
                 return fail(
                     EX_TEBAKO_IO,
@@ -1196,7 +1348,7 @@ fn download_runtime(
                 );
             }
             if let Err(e) = std::fs::rename(&tmp_dir, &entry_dir) {
-                cleanup_tmp_entry(&tmp_dir, &asset);
+                let _ = std::fs::remove_dir_all(&tmp_dir);
                 lock_release(lock);
                 return fail(
                     EX_TEBAKO_IO,
@@ -1212,14 +1364,14 @@ fn download_runtime(
                 engine: engine.to_string(),
                 lang_version: pref.version.clone(),
                 tebako_version: pref.tebako.clone(),
-                exe: exe_path,
+                exe: entry_dir.join(&asset),
                 image: has_image.then(|| entry_dir.join(&image_asset)),
                 abi: entry_abi(&entry_dir, &asset),
                 dir: entry_dir,
             })
         }
         Err(e) => {
-            cleanup_tmp_entry(&tmp_dir, &asset);
+            let _ = std::fs::remove_dir_all(&tmp_dir);
             lock_release(lock);
             Err(e)
         }

--- a/crates/tebako-shim/tests/common/mod.rs
+++ b/crates/tebako-shim/tests/common/mod.rs
@@ -280,6 +280,37 @@ pub fn write_release_index(root: &Path, ver: &str, lvs: &[&str]) -> PathBuf {
     root.to_path_buf()
 }
 
+/// `write_release_index` with an explicit exe asset spelling (spec 05 §2
+/// SSOT; tebako#456): the release index's `filename` is the ONLY
+/// authoritative asset spelling — the factory publishes windows exe
+/// assets SUFFIX-LESS, so the fixture must carry any spelling the index
+/// declares. The image keeps the exe's stem plus `.tfs`.
+pub fn write_release_index_renamed(root: &Path, ver: &str, lv: &str, exe_name: &str) -> PathBuf {
+    let platform = platform();
+    let dir = root.join(format!("v{ver}"));
+    std::fs::create_dir_all(&dir).expect("mirror dir");
+    let stem = exe_name
+        .strip_suffix(tebako_shim::runtime::exe_suffix())
+        .unwrap_or(exe_name);
+    let image_name = format!("{stem}.tfs");
+    let exe_bytes = format!("mirrored runtime exe {lv}\n");
+    let image_bytes = format!("mirrored runtime image {lv}\n");
+    std::fs::write(dir.join(exe_name), &exe_bytes).expect("exe");
+    std::fs::write(dir.join(&image_name), &image_bytes).expect("image");
+    std::fs::write(
+        dir.join("manifest.json"),
+        // The era-2 factory shape (spec 18 C2) with the identity triple
+        // the matcher reads (spec 05 §2) — `filename` verbatim.
+        format!(
+            "[{{\"tebako_version\": \"{ver}\", \"contract_era\": 2, \"contract_version\": 2, \"mount_root\": \"/__tfs__\", \"ruby_version\": \"{lv}\", \"platform\": \"{platform}\", \"filename\": \"{exe_name}\", \"sha256\": \"{}\", \"image\": {{\"filename\": \"{image_name}\", \"sha256\": \"{}\"}}}}]\n",
+            sha256_hex(exe_bytes.as_bytes()),
+            sha256_hex(image_bytes.as_bytes())
+        ),
+    )
+    .expect("manifest.json");
+    root.to_path_buf()
+}
+
 /// `write_runtime` plus a release index manifest carrying the runtime's
 /// own `abi` string (spec 13's per-package `abi` key) — the field the
 /// abi-line filter reads.

--- a/crates/tebako-shim/tests/runtime.rs
+++ b/crates/tebako-shim/tests/runtime.rs
@@ -210,6 +210,105 @@ fn download_installs_verified_readonly_image_and_markers() {
 }
 
 #[test]
+fn the_index_filename_is_the_authoritative_spelling() {
+    // tebako#456 (spec 05 §2 SSOT): the exe/image spellings flow from the
+    // release index entry matched by the identity triple — the factory
+    // publishes windows exe assets SUFFIX-LESS, so a synthesized
+    // `{name}.exe` lookup misses them. A spelling that diverges from the
+    // synthesized name on EVERY host proves the flow.
+    let tmp = TempDir::new("index-spelling");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    let exe_name = format!("tebako-runtime-0.16.0-4.0.6-{}-renamed", platform());
+    write_release_index_renamed(&mirror, "0.16.0", "4.0.6", &exe_name);
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+
+    let rt = ready(runtime::resolve_runtime(Some(&req(">= 3.3, < 5.0")), true, &ctx).unwrap());
+    assert_eq!(rt.lang_version, "4.0.6");
+    assert_eq!(
+        rt.exe.file_name().unwrap().to_string_lossy(),
+        exe_name,
+        "the cache holds the entry under the index spelling, verbatim"
+    );
+    assert!(rt.exe.is_file());
+    let image = rt.image.clone().expect("image-era runtime");
+    assert_eq!(
+        image.file_name().unwrap().to_string_lossy(),
+        format!("{exe_name}.tfs"),
+        "the image spelling flows from the entry's image facet"
+    );
+    assert!(image.is_file());
+
+    // Second resolution is a cache hit under the flowed spelling: the
+    // mirror is gone, still Ready (scan_cached flows the cached index).
+    std::fs::remove_dir_all(&mirror).unwrap();
+    let rt2 = ready(runtime::resolve_runtime(Some(&req(">= 3.3, < 5.0")), true, &ctx).unwrap());
+    assert_eq!(rt2.exe, rt.exe);
+    assert_eq!(rt2.image, rt.image);
+}
+
+#[test]
+fn a_missing_index_entry_names_the_identity() {
+    // spec 05 §2's honest fallback error: the index entry carries no
+    // `tebako_version` (a pre-identity index — the availability probe
+    // selects it on `ruby_version` + `platform` alone), so the identity
+    // match misses at download time and the pre-era refusal names the
+    // triple alongside the synthesized spelling tried.
+    let tmp = TempDir::new("missing-entry");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    let dir = mirror.join("v0.16.0");
+    std::fs::create_dir_all(&dir).expect("mirror dir");
+    std::fs::write(
+        dir.join("manifest.json"),
+        format!(
+            "[{{\"contract_era\": 2, \"contract_version\": 2, \"mount_root\": \"/__tfs__\", \"ruby_version\": \"4.0.6\", \"platform\": \"{plat}\", \"filename\": \"tebako-runtime-0.16.0-4.0.6-{plat}-other\", \"sha256\": \"{}\"}}]\n",
+            "a".repeat(64),
+            plat = platform()
+        ),
+    )
+    .expect("manifest.json");
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+
+    let err = runtime::resolve_runtime(Some(&req(">= 3.3, < 5.0")), true, &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_CONTRACT);
+    assert!(
+        err.message
+            .contains("no entry for tebako_version=0.16.0 ruby_version=4.0.6"),
+        "{}",
+        err.message
+    );
+    assert!(
+        err.message.contains(&format!("platform={}", platform())),
+        "{}",
+        err.message
+    );
+    assert!(
+        !home
+            .join("runtimes")
+            .join(format!("ruby-4.0.6-0.16.0-{}", platform()))
+            .exists(),
+        "a refused runtime entered the cache"
+    );
+}
+
+#[test]
 fn sha_mismatch_is_exit_70_and_nothing_enters_the_cache() {
     let tmp = TempDir::new("sha-mismatch");
     let home = tmp.path().join("home");

--- a/docs/spec/05-resolution-and-cache.md
+++ b/docs/spec/05-resolution-and-cache.md
@@ -24,6 +24,20 @@ machine cache. Status: SHIPPED for runtimes (M6–M8); payload cache PARTIAL
 - `manifest.json` — machine index; per-asset entries plus the additive
   image-era key `image: {filename, sha256, size_bytes}` and the additive
   `contract_version` key (bootstrap↔runtime contract, spec 06 §6).
+- **The entry's `filename` is the ONLY authoritative asset spelling**
+  (spec 00 §10 SSOT; tebako#456). A consumer matches the entry by the
+  identity triple (`tebako_version`, `<lang>_version`, `platform`) —
+  never by a synthesized name — and flows `filename` /
+  `image.filename` / `dll.filename`+`install_as` verbatim into the
+  download URL, the cache layout, and the pre-download contract gate.
+  The `tebako-runtime-<ver>-<lv>-<triplet>[.exe]` grammar is the
+  factory's to declare, not the consumer's to derive (the factory
+  publishes the windows exe SUFFIX-LESS). When no entry matches the
+  identity triple (a pre-identity index), the synthesized spelling
+  remains the fallback for the SHA256SUMS-only era, and the
+  missing-entry refusal names the identity triple — the mis-lookup is
+  diagnosed as what it is, never as a contract refusal of a
+  hand-invented name.
 - `SHA256SUMS.txt` — line-index fallback (`<sha>  <file>`), carries the
   `<asset>.tfs` lines in the image era.
 - Base URL:
@@ -47,6 +61,13 @@ shims/                                        # spec 07
 config.yaml                                   # spec 07 (YAML — never JSON)
 keys/                                         # press-local signing keys (spec 09)
 ```
+
+The interpreter/image file names in a cache entry keep the index entry's
+`filename` / `image.filename` spellings verbatim (§2 — on windows the exe
+is suffix-less; the loader execs by full path and CreateProcess needs no
+`.exe`). The `[.exe]` diagram notation marks the synthesized fallback
+spelling, used only when no index entry is available (fat-payload
+installs, pre-identity manifests).
 
 ## 4. Install and trust rules (locked)
 


### PR DESCRIPTION
## What

Fixes #456.

On windows-ucrt64 the bootstrap synthesized the runtime asset name as
`tebako-runtime-<abi>-<ver>-<plat>.exe` and looked THAT up in the
factory's release index — but the factory publishes windows exe assets
SUFFIX-LESS (`"filename": "tebako-runtime-0.16.9-3.3.12-windows-ucrt64"`),
so the lookup missed and the run died with exit 75
("pre-era — no entry for tebako-runtime-…-windows-ucrt64.exe").

Per spec 00 §10 (SSOT), every consumer now matches the release index
entry by the identity triple (`tebako_version`, `<lang>_version`,
`platform`) — never by a synthesized name — and flows `filename` /
`image.filename` / `dll.filename`+`install_as` verbatim into the
download URL, the cache layout, and the pre-download contract gate.

## Why three components

The cache (`~/.tebako/runtimes/`) is shared machine-wide, so the
spelling rule has to hold in every consumer or they stop seeing each
other's entries on windows:

- **tebako-bootstrap** — the reported bug: synthesized the `.exe`
  spelling for the URL, the gate, and the cache layout.
- **tebako-shim** — the identical synthesis (`entry_exe_name`), and
  decisively: `scan_cached` would never see a bootstrap-installed
  suffix-less windows entry, so a bootstrap-only fix breaks
  cross-component cache sharing exactly where the bug lived.
- **tebako-cli** (press-time `Resolver`) — same cache-visibility gap on
  the read side (`resolve.rs` synthesized the exe path on a cache hit
  and placed fresh installs under the synthesized name): a windows
  press against a bootstrap-populated cache would re-download and
  double-install the runtime under `….exe`.

The SHA256SUMS-fallback / no-matching-entry path keeps the synthesized
spelling, and the missing-entry refusal now names the identity triple
alongside the spelling tried — the mis-lookup is diagnosed as what it
is, never as a contract refusal of a hand-invented name.

## Changes

- `docs/spec/05-resolution-and-cache.md` — §2: the
  `filename`-is-the-only-authoritative-spelling rule (identity-triple
  match, verbatim flow, the factory's suffix-less windows spelling, the
  honest missing-entry fallback error); §3: cache entries keep the
  index spelling verbatim, the `[.exe]` diagram notation marks the
  synthesized fallback only.
- `crates/tebako-bootstrap/src/lib.rs` — `ReleaseIdentity`,
  `ManifestEntry`, `manifest_entry_for_runtime`,
  `manifest_entry_facet_filename` (a depth-tracked scanner over the
  index shape; no new deps); `resolve_runtime` / `download_executable` /
  `resolve_image` / `resolve_dll` flow the matched spellings; the
  fetched index rides into the cache entry (`manifest.json`) so hit
  paths flow it too; the no-entry refusal (exit 75) names the identity
  triple.
- `crates/tebako-shim/src/runtime.rs` — `release_index_entry`,
  `entry_filename`, `entry_asset_names` (cached-index flow with the
  synthesized fallback); `scan_cached` / `scan_all_cached` /
  `download_runtime` use them; the contract gate names the triple; a
  raced install under the flowed spelling is recognized; tmp staging is
  swept wholesale (`remove_dir_all` — staged names are flowed, not known
  in advance), replacing name-keyed `cleanup_tmp_entry`.
- `crates/tebako-cli/src/resolve.rs` — `cached_index_entry` /
  `cached_exe_name` / `cached_image_name`; the cache-hit path and
  `read_image_marker` flow the cached index; `install` places the exe at
  `entry.filename` verbatim and writes the fetched `manifest.json` card
  into the entry.

## Tests

- bootstrap: 5 new lib unit tests (`manifest_identity_tests`:
  multi-entry fixture with nested `image`/`dll`/`built_from` objects,
  reordered keys, non-string values; wrong-triple no-match; facet
  filename extraction; entry-without-filename; malformed indexes) —
  23 lib total. New selftests: `s19_index_filename_is_the_authoritative_spelling`
  (suffix-less and host-diverging spellings end-to-end through download,
  cache layout, markers, and an offline cache hit) and
  `s20_missing_entry_names_the_identity` (exit 75 names
  `ruby_version=… platform=…`, before any download) — 29 selftest total.
  The `Harness` gained `new_with_exe_asset` (`new` delegates).
- shim: `write_release_index_renamed` fixture (identity triple +
  explicit exe spelling); `the_index_filename_is_the_authoritative_spelling`
  (download + cache-hit rescan under a spelling that diverges on every
  host) and `a_missing_index_entry_names_the_identity` — 27 runtime
  tests total. The existing `write_mirror` / `write_mirror_dll` fixtures
  carry no identity triple and exercise the fallback — unchanged, green.
- cli: `resolve_runtime_flows_the_index_spelling` (suffix-less windows
  spelling end-to-end through install + mirror-gone cache hit).
- Local (debug): `cargo test -p tebako-bootstrap -p tebako-shim` —
  161 passed, 0 failed (bootstrap lib 23 incl. the 5 new, selftest 29
  incl. s19/s20; shim runtime 27 incl. the 2 new). `cargo test -p
  tebako-cli` — lib 132 passed incl. the new test; `cli_e2e` 13/13 green
  (one earlier local run flaked 4 network-press tests under concurrent
  load; identical tree re-run green). `cargo clippy -p tebako-cli -p
  tebako-bootstrap -p tebako-shim --all-targets` — 0 warnings.

## Downstream

Once a release carries this fix, the metanorma/packed-mn#251 windows
smoke leg flips to enforced.
