### PR TITLE
fix(tfs): the TEBAKO_TFS_MOUNTS slot form — package slots survive the spawn hand-off — #455

### DIFF
--- a/crates/libtfs-preload/Cargo.toml
+++ b/crates/libtfs-preload/Cargo.toml
@@ -26,6 +26,10 @@ crate-type = ["cdylib", "rlib"]
 # mount a payload payload-side (ENOTSUP) is a shim that cannot do its
 # job. squashfs stays opt-in via the tfs crate's own features.
 tfs = { version = "0.2.1", path = "../tfs", default-features = false, features = ["vendored-dwarfs", "backend-limnifs"] }
+# The slot form of TEBAKO_TFS_MOUNTS (spec 17 §2.1) resolves slot → byte
+# region against the tpkg trailer — the wire format's owner crate (pure
+# safe Rust, no engine dependency).
+tpkg = { version = "0.2.5", path = "../tpkg" }
 libc = "0.2"
 
 [dev-dependencies]

--- a/crates/libtfs-preload/src/lib.rs
+++ b/crates/libtfs-preload/src/lib.rs
@@ -11,9 +11,10 @@
 //!
 //! On init (library constructor, before the program's `main`):
 //!
-//! 1. `TEBAKO_TFS_MOUNTS=image:mount,image:mount,…` — mount each image
-//!    through the engine (see [`spec`] for the grammar). Absent/empty →
-//!    the shim is fully inert.
+//! 1. `TEBAKO_TFS_MOUNTS=image[:slot]:mount,image[:slot]:mount,…` — mount
+//!    each image through the engine (see [`spec`] for the grammar; the
+//!    slot form mounts a package slot's region, spec 17 §2.1).
+//!    Absent/empty → the shim is fully inert.
 //! 2. `TEBAKO_JAIL=<spec 08 env form>` — install the `host_policy`
 //!    (`open`/`deny`, docker-`-v` grants, `@` argument files; see
 //!    [`tfs::policy::JailSpec`]). Installed AFTER the mounts — the mount

--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -342,6 +342,47 @@ pub fn initialize() -> Result<(), String> {
     RESULT.get_or_init(init_inner).clone()
 }
 
+/// Build the mount for one `TEBAKO_TFS_MOUNTS` declaration. The slot form
+/// (`image:slot:mount`, spec 17 §2.1) resolves the slot's byte region
+/// against the file's tpkg trailer first, so a packaged payload mounts its
+/// region — never the whole package file (whose trailer the format sniff
+/// would reject). The established mount carries the slot identity so a
+/// re-export to a spawned child keeps the slot form.
+fn build_decl(d: &spec::MountDecl) -> Result<tfs::context::Mount, String> {
+    let mount_error = |e: i32| {
+        format!(
+            "TEBAKO_TFS_MOUNTS: cannot mount {} at {}: {}",
+            d.image,
+            d.mount,
+            errno_text(e)
+        )
+    };
+    let Some(slot) = d.slot else {
+        return tfs::mount::build_from_file(&d.image, &d.mount).map_err(mount_error);
+    };
+    let mut file = std::fs::File::open(&d.image)
+        .map_err(|e| mount_error(e.raw_os_error().unwrap_or(libc::EIO)))?;
+    match tpkg::resolve_slot_region(&mut file, slot).map_err(|e| {
+        format!(
+            "TEBAKO_TFS_MOUNTS: cannot mount slot {slot} of {} at {}: {e}",
+            d.image, d.mount
+        )
+    })? {
+        // Slot 0 on a bare image IS the whole file; the mount stays
+        // slot-less, so the re-exported form is the two-field spelling
+        // (spec 17 §2.1's emit rule).
+        tpkg::SlotRegion::Whole => {
+            tfs::mount::build_from_file(&d.image, &d.mount).map_err(mount_error)
+        }
+        tpkg::SlotRegion::Region { offset, len } => {
+            let mut mount = tfs::mount::build_from_file_at(&d.image, offset, len, &d.mount)
+                .map_err(mount_error)?;
+            mount.slot = Some(slot);
+            Ok(mount)
+        }
+    }
+}
+
 fn init_inner() -> Result<(), String> {
     // The trace bus (spec 25 §2): `TEBAKO_TRACE` arms the channel for ANY
     // tfs consumer — the preload delivery included; the driver is not the
@@ -360,14 +401,7 @@ fn init_inner() -> Result<(), String> {
         let decls =
             spec::parse_mounts(&mounts_spec).map_err(|e| format!("TEBAKO_TFS_MOUNTS: {e}"))?;
         for d in &decls {
-            let mount = tfs::mount::build_from_file(&d.image, &d.mount).map_err(|e| {
-                format!(
-                    "TEBAKO_TFS_MOUNTS: cannot mount {} at {}: {}",
-                    d.image,
-                    d.mount,
-                    errno_text(e)
-                )
-            })?;
+            let mount = build_decl(d)?;
             context()
                 .write()
                 .unwrap()

--- a/crates/libtfs-preload/src/spec.rs
+++ b/crates/libtfs-preload/src/spec.rs
@@ -32,6 +32,7 @@ mod tests {
         let _ = MountSpecError("x".to_string());
         let _ = MountDecl {
             image: "/a".to_string(),
+            slot: None,
             mount: "/t".to_string(),
         };
     }

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -9,6 +9,9 @@
 //! - the spec 08 jail (deny → EPERM; memfs unaffected; ro grant → EROFS
 //!   on writes; rw grant passes),
 //! - the grandchild staying in the VFS (env propagation),
+//! - the slot form of `TEBAKO_TFS_MOUNTS` (spec 17 §2.1): a packaged
+//!   payload's slot mounts its region, the child hand-off preserves it,
+//!   and resolution failures are named EX_CONFIG errors,
 //! - dlopen of a memfs library via the dlmap2file host cache,
 //! - the linux LFS64+fortify surface the JDK needs (lseek64 SEEK_END
 //!   probe, __read_chk fortified read, __fxstat64, anonymous mmap with
@@ -43,6 +46,9 @@ struct Fixtures {
     dir: PathBuf,
     /// The test image (zip backend).
     zip: PathBuf,
+    /// The stitched package: the zip image as slot 0 plus a tpkg trailer
+    /// (spec 17 §2.1's slot-form proofs).
+    pkg: PathBuf,
     /// The fork-exec test image (DWARFS backend — the fork/exec
     /// regression needs a backend with a worker pool; zip has none).
     dwarfs: PathBuf,
@@ -245,6 +251,24 @@ fn build_fixtures() -> Option<Fixtures> {
         zw.finish().unwrap();
     }
 
+    // The stitched-package fixture (spec 17 §2.1): the zip image bytes as
+    // slot 0 of a tpkg package. The slot form mounts the region — the
+    // whole-file spelling would leave the trailer inside the sniffed
+    // bytes (tebako#455).
+    let pkg_path = dir.join("pkg.tebako");
+    {
+        let zip_len = std::fs::copy(&zip_path, &pkg_path).unwrap();
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&pkg_path)
+            .unwrap();
+        let manifest = tpkg::Manifest {
+            slots: vec![tpkg::Slot::new(0, zip_len, tpkg::TPKG_FORMAT_ZIP, "/tfs")],
+            ..Default::default()
+        };
+        tpkg::write_to(&mut file, &manifest).unwrap();
+    }
+
     // The fork-exec image (DWARFS backend — its block-cache worker pool is
     // the fork hazard the guard exists for). Contents matter: an in-image
     // `__tpkg__/manifest.yaml` WITHOUT the java_home annotation (the exec
@@ -288,6 +312,7 @@ fn build_fixtures() -> Option<Fixtures> {
     Some(Fixtures {
         dir,
         zip: zip_path,
+        pkg: pkg_path,
         dwarfs: dwarfs_path,
         shim,
         work,
@@ -320,10 +345,23 @@ struct Run {
 /// Run a fixture tool under the shim. `jail` is the TEBAKO_JAIL value
 /// (None = unset). The preload/mount env is set ONLY on the child.
 fn run(f: &Fixtures, tool: &str, args: &[&str], jail: Option<&str>) -> Run {
+    let mounts = format!("{}:{MOUNT}", f.zip.display());
+    run_with_mounts(f, tool, args, &mounts, jail)
+}
+
+/// [`run`] with an explicit `TEBAKO_TFS_MOUNTS` value (the slot-form
+/// proofs).
+fn run_with_mounts(
+    f: &Fixtures,
+    tool: &str,
+    args: &[&str],
+    mounts: &str,
+    jail: Option<&str>,
+) -> Run {
     let mut cmd = Command::new(f.dir.join("bin").join(tool));
     cmd.args(args)
         .env(preload_var(), &f.shim)
-        .env("TEBAKO_TFS_MOUNTS", format!("{}:{MOUNT}", f.zip.display()))
+        .env("TEBAKO_TFS_MOUNTS", mounts)
         // Determinism: no inherited preload env from the test harness.
         .env_remove("DYLD_PRINT_LIBRARIES");
     match jail {
@@ -553,6 +591,67 @@ fn grandchild_stays_in_vfs() {
     // …and the preload env propagated (the process tree stays in the VFS).
     assert!(r.stdout.contains("CHILD-ENV:ok"), "stdout: {}", r.stdout);
     assert!(r.stdout.contains("SPAWN-RC:0"), "stdout: {}", r.stdout);
+}
+
+// ---------------------------------------------------------------------
+// spec 17 §2.1: the slot form of TEBAKO_TFS_MOUNTS (tebako#455)
+// ---------------------------------------------------------------------
+
+/// The consume side: a packaged payload's slot mounts its REGION. (The
+/// whole-file spelling of a package leaves the appended trailer inside
+/// the sniffed bytes — the packed-mn PDF leg's EINVAL/78.)
+#[test]
+fn slot_form_mounts_the_package_region() {
+    let Some(f) = fixtures() else { return };
+    let mounts = format!("{}:0:{MOUNT}", f.pkg.display());
+    let r = run_with_mounts(
+        f,
+        "print-data",
+        &[&format!("{MOUNT}/data/secret.txt")],
+        &mounts,
+        None,
+    );
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.matches(SECRET).count(), 1, "stdout: {}", r.stdout);
+}
+
+/// The issue's acceptance shape: a process holding a slot mount spawns a
+/// child that reads a file through the mount — the slot form survives the
+/// hand-off, so the child mounts the same region, never the whole
+/// package file.
+#[test]
+fn slot_form_grandchild_reads_through_the_mount() {
+    let Some(f) = fixtures() else { return };
+    let mounts = format!("{}:0:{MOUNT}", f.pkg.display());
+    let r = run_with_mounts(
+        f,
+        "spawn-self",
+        &[&format!("{MOUNT}/data/secret.txt")],
+        &mounts,
+        None,
+    );
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.matches(SECRET).count(), 2, "stdout: {}", r.stdout);
+    assert!(r.stdout.contains("CHILD-ENV:ok"), "stdout: {}", r.stdout);
+    assert!(r.stdout.contains("SPAWN-RC:0"), "stdout: {}", r.stdout);
+}
+
+/// Slot-resolution failures are named errors (spec 17 §2.1), exit 78 —
+/// never a silent whole-file fallback.
+#[test]
+fn slot_form_failures_are_named_errors() {
+    let Some(f) = fixtures() else { return };
+    // Out of range on a packaged file.
+    let mounts = format!("{}:1:{MOUNT}", f.pkg.display());
+    let r = run_with_mounts(f, "print-data", &["/etc/hosts"], &mounts, None);
+    assert_eq!(r.rc, tfs_preload::spec::EX_CONFIG, "stderr: {}", r.stderr);
+    assert!(r.stderr.contains("slot 1"), "stderr: {}", r.stderr);
+    assert!(r.stderr.contains("out of range"), "stderr: {}", r.stderr);
+    // A non-zero slot on a bare image (no slot table).
+    let mounts = format!("{}:3:{MOUNT}", f.zip.display());
+    let r = run_with_mounts(f, "print-data", &["/etc/hosts"], &mounts, None);
+    assert_eq!(r.rc, tfs_preload::spec::EX_CONFIG, "stderr: {}", r.stderr);
+    assert!(r.stderr.contains("no slot table"), "stderr: {}", r.stderr);
 }
 
 #[test]

--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -669,10 +669,14 @@ fn mount_image(
                 }
                 ResolvedRegion::Region(offset, size) => {
                     let what = format!("failed to mount own slot {n} at '{}'", spec.mount);
-                    let mount = build_error(
+                    let mut mount = build_error(
                         tfs::mount::build_from_file_at(&display, offset, size, &spec.mount),
                         &what,
                     )?;
+                    // The slot identity rides the mount so a spawned
+                    // child's TEBAKO_TFS_MOUNTS re-mounts this region —
+                    // never the whole package (spec 17 §2.1's emit rule).
+                    mount.slot = Some(*n);
                     mount_at_point(
                         mount,
                         spec,
@@ -689,7 +693,7 @@ fn mount_image(
             let display = path.display().to_string();
             let resolved = resolve_image(path, *slot, &display, &spec.mount)?;
             let what = format!("failed to mount image '{display}' at '{}'", spec.mount);
-            let mount = match resolved.region {
+            let mut mount = match resolved.region {
                 ResolvedRegion::Whole => {
                     build_error(tfs::mount::build_from_file(&display, &spec.mount), &what)?
                 }
@@ -698,6 +702,11 @@ fn mount_image(
                     &what,
                 )?,
             };
+            // A slot-mounted package region carries its slot identity so
+            // the respawn env keeps the slot form (spec 17 §2.1).
+            if let (SlotRef::Slot(n), Some(_)) = (slot, &resolved.trailer) {
+                mount.slot = Some(*n);
+            }
             mount_at_point(
                 mount,
                 spec,

--- a/crates/tebako-driver/src/injection.rs
+++ b/crates/tebako-driver/src/injection.rs
@@ -53,7 +53,7 @@ pub const PRELOAD_SHIM_VAR: &str = "TEBAKO_PRELOAD_SHIM";
 /// exclusion (spec 22 §2.1; spec 17 §2's handoff-env row).
 pub const RUNTIME_DLL_VAR: &str = "TEBAKO_RUNTIME_DLL";
 
-/// The mounts list the shim rebuilds the namespace from (spec 17 §2).
+/// The mounts list the shim rebuilds the namespace from (spec 17 §2.1).
 const MOUNTS_VAR: &str = "TEBAKO_TFS_MOUNTS";
 
 /// The platform's injection variable (ELF / macOS; none elsewhere).

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -682,6 +682,36 @@ fn packaged_file_mounts_the_slot_region() {
 }
 
 #[test]
+fn a_slot_mounts_respawn_env_carries_the_slot_form() {
+    // spec 17 §2.1's emit rule (tebako#455): a mount established from a
+    // package slot serializes as image:slot:mount in TEBAKO_TFS_MOUNTS,
+    // so a spawned child re-mounts the region — never the whole package
+    // file (whose trailer the child's format sniff would hit).
+    let g = guard("pkg-slot-env");
+    let payload = write_payload_image(g.path());
+    package_in_place(&payload, tpkg::TPKG_FORMAT_ZIP);
+    let env = MapEnv::new();
+
+    boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:0:/", payload.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap();
+    let mounts = context().read().unwrap().mounts_env().unwrap();
+    assert_eq!(
+        mounts.to_string_lossy(),
+        format!("{}:0:/", payload.display())
+    );
+}
+
+#[test]
 fn no_entry_starts_the_interpreter_with_its_own_args() {
     let g = guard("no-entry");
     let payload = write_payload_image(g.path());

--- a/crates/tfs-cli/src/lib.rs
+++ b/crates/tfs-cli/src/lib.rs
@@ -1258,6 +1258,7 @@ pub fn cmd_exec(opts: &ExecOptions) -> Result<(), (String, i32)> {
         }
         decls.push(tfs::mount_spec::MountDecl {
             image: canon.to_string_lossy().into_owned(),
+            slot: d.slot,
             mount: d.mount,
         });
     }

--- a/crates/tfs/src/c_api.rs
+++ b/crates/tfs/src/c_api.rs
@@ -1129,10 +1129,11 @@ pub unsafe extern "C" fn tebako_fs_mount_of(path: *const c_char) -> *mut c_char 
 }
 
 /// `tebako_fs_mounts`: the mount table in the `TEBAKO_TFS_MOUNTS`
-/// grammar ("image:mount,image:mount,…"), heap-allocated with libc
-/// malloc (the caller `free()`s it); NULL when nothing file-backed is
-/// mounted. A spawned child re-establishes the namespace from this —
-/// the spawn hook writes it into the child's environment.
+/// grammar ("image[:slot]:mount,image[:slot]:mount,…" — spec 17 §2.1),
+/// heap-allocated with libc malloc (the caller `free()`s it); NULL when
+/// nothing file-backed is mounted. A spawned child re-establishes the
+/// namespace from this — the spawn hook writes it into the child's
+/// environment.
 ///
 /// # Safety
 /// C ABI entry point; the returned string must be freed with libc

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -78,6 +78,11 @@ pub struct Mount {
     pub mount_point_c: Box<std::ffi::CString>,
     /// Archive path on disk, when mounted from a file.
     pub archive_path: Option<Box<std::ffi::CString>>,
+    /// The package slot the mount was established from, when the archive
+    /// is a stitched tpkg package and a slot region was mounted (spec 17
+    /// §2.1); `None` for a whole-file mount. Serialized into
+    /// `TEBAKO_TFS_MOUNTS` so a spawned child re-mounts the same region.
+    pub slot: Option<u32>,
     /// The backend.
     pub backend: Box<dyn Backend>,
     /// Mount mode (spec 11 §3; writes on RO mounts fail with EROFS).
@@ -1288,27 +1293,32 @@ impl FsContext {
     }
 
     /// The mount table in the `TEBAKO_TFS_MOUNTS` grammar
-    /// ("image:mount,image:mount,…") — the env a spawned child needs to
-    /// re-establish this namespace through the preload shim. Only
-    /// file-backed mounts serialize; memory mounts have no image path
-    /// and are skipped (a child cannot remount them anyway).
+    /// ("image[:slot]:mount,image[:slot]:mount,…" — spec 17 §2.1) — the
+    /// env a spawned child needs to re-establish this namespace through
+    /// the preload shim. Only file-backed mounts serialize; memory mounts
+    /// have no image path and are skipped (a child cannot remount them
+    /// anyway). A mount established from a package slot carries its slot
+    /// field, so the child mounts the same region — never the whole
+    /// package file.
     pub fn mounts_env(&self) -> Option<std::ffi::CString> {
-        let mut out = String::new();
-        for mount in self.mounts.values() {
-            let Some(archive) = &mount.archive_path else {
-                continue;
-            };
-            if !out.is_empty() {
-                out.push(',');
-            }
-            out.push_str(&archive.to_string_lossy());
-            out.push(':');
-            out.push_str(&mount.mount_point);
-        }
-        if out.is_empty() {
+        let decls: Vec<crate::mount_spec::MountDecl> = self
+            .mounts
+            .values()
+            .filter_map(|mount| {
+                mount
+                    .archive_path
+                    .as_ref()
+                    .map(|archive| crate::mount_spec::MountDecl {
+                        image: archive.to_string_lossy().into_owned(),
+                        slot: mount.slot,
+                        mount: mount.mount_point.clone(),
+                    })
+            })
+            .collect();
+        if decls.is_empty() {
             None
         } else {
-            std::ffi::CString::new(out).ok()
+            std::ffi::CString::new(crate::mount_spec::to_env_spec(&decls)).ok()
         }
     }
 
@@ -2707,6 +2717,7 @@ mod tests {
             mount_point: "/tfs".to_string(),
             mount_point_c: Box::new(std::ffi::CString::new("/tfs").unwrap()),
             archive_path: None,
+            slot: None,
             backend: Box::new(backend),
             mode: crate::mount::MountMode::ReadOnly,
         };
@@ -3148,10 +3159,47 @@ mod tests {
             mount_point: point.to_string(),
             mount_point_c: Box::new(std::ffi::CString::new(point).unwrap()),
             archive_path: None,
+            slot: None,
             backend: Box::new(backend),
             mode: crate::mount::MountMode::ReadOnly,
         };
         ctx.mount_checked(mount).unwrap();
+    }
+
+    #[test]
+    fn mounts_env_carries_the_slot_field_for_package_slot_mounts() {
+        // spec 17 §2.1's emit rule: a mount established from a package
+        // slot serializes as image:slot:mount; a whole-file mount stays
+        // image:mount. The child re-mounts the same region, never the
+        // whole package file.
+        let dir = std::env::temp_dir().join(format!("tfs-mounts-env-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let pkg = dir.join("pkg.tebako");
+        let img = dir.join("img.tfs");
+        let mut ctx = FsContext::new();
+        for (archive, slot, point) in [(pkg.clone(), Some(0), "/app"), (img.clone(), None, "/data")]
+        {
+            let backend = crate::backends_hostdir::HostDirBackend::new(&dir).unwrap();
+            let mount = Mount {
+                handle: 0,
+                mount_point: point.to_string(),
+                mount_point_c: Box::new(std::ffi::CString::new(point).unwrap()),
+                archive_path: Some(Box::new(
+                    std::ffi::CString::new(archive.to_string_lossy().into_owned()).unwrap(),
+                )),
+                slot,
+                backend: Box::new(backend),
+                mode: crate::mount::MountMode::ReadOnly,
+            };
+            ctx.mount_checked(mount).unwrap();
+        }
+        let env = ctx.mounts_env().unwrap();
+        assert_eq!(
+            env.to_string_lossy(),
+            format!("{}:0:/app,{}:/data", pkg.display(), img.display())
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/tfs/src/mount.rs
+++ b/crates/tfs/src/mount.rs
@@ -110,6 +110,7 @@ fn make_mount(
         mount_point: mount_point.to_string(),
         mount_point_c: cstring(mount_point),
         archive_path: archive_path.map(cstring),
+        slot: None,
         backend,
         mode,
     }

--- a/crates/tfs/src/mount_spec.rs
+++ b/crates/tfs/src/mount_spec.rs
@@ -1,19 +1,23 @@
-//! The `TEBAKO_TFS_MOUNTS` mount-spec grammar (spec 07 §8 tier 1) — the
-//! env form that seeds a process's mount table, shared by the preload
-//! shim (which parses the env var at init) and `tfs exec` (which
-//! validates and re-serializes it for the exec'd child). One grammar,
-//! one parser, one serializer.
+//! The `TEBAKO_TFS_MOUNTS` mount-spec grammar (spec 07 §8 tier 1, spec 17
+//! §2.1) — the env form that seeds a process's mount table, shared by the
+//! preload shim (which parses the env var at init) and `tfs exec` (which
+//! validates and re-serializes it for the exec'd child). One grammar, one
+//! parser, one serializer.
 //!
 //! Pure safe Rust; named errors on malformed input (spec 14 §3).
 
 use std::fmt;
 use std::path::Path;
 
-/// One `image:mount` declaration.
+/// One `image[:slot]:mount` declaration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MountDecl {
     /// Absolute path of the image file on the host.
     pub image: String,
+    /// The package slot to mount when the image is a stitched tpkg
+    /// package; `None` mounts the whole file (a bare image). Parsed from
+    /// an all-digits field; `-` on the wire means the same as absent.
+    pub slot: Option<u32>,
     /// Absolute virtual mount point (never `/` — see [`parse_mount_entry`]).
     pub mount: String,
 }
@@ -31,8 +35,39 @@ impl fmt::Display for MountSpecError {
 
 impl std::error::Error for MountSpecError {}
 
-/// Validate one `image:mount` pair (shared tail of the env and CLI forms).
-fn validate(image: &str, mount: &str, context: &str) -> Result<MountDecl, MountSpecError> {
+/// Split one entry from the RIGHT (spec 17 §2.1): the mount is the field
+/// after the last ':'; a slot is recognized only when the remainder's
+/// rightmost field is all digits or exactly '-' — anything else stays
+/// part of the image path, which may itself contain colons (and, on
+/// windows, a drive colon). `-` parses to `None` (whole file).
+fn split_entry(entry: &str) -> Result<(&str, Option<u32>, &str), MountSpecError> {
+    let Some((rest, mount)) = entry.rsplit_once(':') else {
+        return Err(MountSpecError(format!(
+            "entry {entry:?} needs the image[:slot]:mount shape"
+        )));
+    };
+    if let Some((image, field)) = rest.rsplit_once(':') {
+        if field == "-" {
+            return Ok((image, None, mount));
+        }
+        if !field.is_empty() && field.bytes().all(|b| b.is_ascii_digit()) {
+            let slot = field.parse::<u32>().map_err(|_| {
+                MountSpecError(format!("slot {field:?} out of range in entry {entry:?}"))
+            })?;
+            return Ok((image, Some(slot), mount));
+        }
+    }
+    Ok((rest, None, mount))
+}
+
+/// Validate one `image[:slot]:mount` triple (shared tail of the env and
+/// CLI forms).
+fn validate(
+    image: &str,
+    slot: Option<u32>,
+    mount: &str,
+    context: &str,
+) -> Result<MountDecl, MountSpecError> {
     let err = |msg: &str| MountSpecError(format!("{msg} in {context:?}"));
     if image.is_empty() {
         return Err(err("empty image path"));
@@ -51,25 +86,24 @@ fn validate(image: &str, mount: &str, context: &str) -> Result<MountDecl, MountS
     // the passthrough decision moots that.)
     Ok(MountDecl {
         image: image.to_string(),
+        slot,
         mount: mount.to_string(),
     })
 }
 
-/// Parse one `image:mount` entry. Split at the LAST ':' so image paths
-/// containing ':' survive.
+/// Parse one `image[:slot]:mount` entry. Split at the LAST ':' so image
+/// paths containing ':' survive; the slot field is recognized only on an
+/// exact all-digits (or `-`) rightmost remainder (spec 17 §2.1).
 pub fn parse_mount_entry(entry: &str) -> Result<MountDecl, MountSpecError> {
     if entry.is_empty() {
         return Err(MountSpecError("empty entry".to_string()));
     }
-    let Some((image, mount)) = entry.rsplit_once(':') else {
-        return Err(MountSpecError(format!(
-            "entry {entry:?} needs the image:mount shape"
-        )));
-    };
-    validate(image, mount, entry)
+    let (image, slot, mount) = split_entry(entry)?;
+    validate(image, slot, mount, entry)
 }
 
-/// Parse the `TEBAKO_TFS_MOUNTS` env form: `image:mount,image:mount,…`.
+/// Parse the `TEBAKO_TFS_MOUNTS` env form:
+/// `image[:slot]:mount,image[:slot]:mount,…`.
 pub fn parse_mounts(spec: &str) -> Result<Vec<MountDecl>, MountSpecError> {
     if spec.trim().is_empty() {
         return Err(MountSpecError("empty spec".to_string()));
@@ -87,11 +121,16 @@ pub fn parse_mounts(spec: &str) -> Result<Vec<MountDecl>, MountSpecError> {
 }
 
 /// Serialize mount declarations to the `TEBAKO_TFS_MOUNTS` env form (the
-/// inverse of [`parse_mounts`]).
+/// inverse of [`parse_mounts`]). The slot field is emitted iff the mount
+/// was established from a package slot; `-` is never spelled (spec 17
+/// §2.1's emit rule).
 pub fn to_env_spec(decls: &[MountDecl]) -> String {
     decls
         .iter()
-        .map(|d| format!("{}:{}", d.image, d.mount))
+        .map(|d| match d.slot {
+            Some(slot) => format!("{}:{}:{}", d.image, slot, d.mount),
+            None => format!("{}:{}", d.image, d.mount),
+        })
         .collect::<Vec<_>>()
         .join(",")
 }
@@ -99,15 +138,16 @@ pub fn to_env_spec(decls: &[MountDecl]) -> String {
 /// Parse the `tfs exec` CLI form of one image argument: `image[:mount]`,
 /// default mount `/mnt` (the tfs-cli convention). The ':' is a delimiter
 /// only when what follows it looks like a mount point (starts with '/'),
-/// so a bare image path containing ':' is still accepted.
+/// so a bare image path containing ':' is still accepted. The CLI form
+/// has no slot field (`slot` is always `None`).
 pub fn parse_cli_image_mount(token: &str) -> Result<MountDecl, MountSpecError> {
     match token.rsplit_once(':') {
-        Some((image, mount)) if mount.starts_with('/') => validate(image, mount, token),
+        Some((image, mount)) if mount.starts_with('/') => validate(image, None, mount, token),
         _ => {
             if token.is_empty() {
                 return Err(MountSpecError("empty image argument".to_string()));
             }
-            validate(token, "/mnt", token)
+            validate(token, None, "/mnt", token)
         }
     }
 }
@@ -116,20 +156,22 @@ pub fn parse_cli_image_mount(token: &str) -> Result<MountDecl, MountSpecError> {
 mod tests {
     use super::*;
 
+    fn decl(image: &str, slot: Option<u32>, mount: &str) -> MountDecl {
+        MountDecl {
+            image: image.to_string(),
+            slot,
+            mount: mount.to_string(),
+        }
+    }
+
     #[test]
     fn parses_env_form() {
         let decls = parse_mounts("/a/img.zip:/tfs,/b/other.zip:/data").unwrap();
         assert_eq!(
             decls,
             vec![
-                MountDecl {
-                    image: "/a/img.zip".to_string(),
-                    mount: "/tfs".to_string(),
-                },
-                MountDecl {
-                    image: "/b/other.zip".to_string(),
-                    mount: "/data".to_string(),
-                },
+                decl("/a/img.zip", None, "/tfs"),
+                decl("/b/other.zip", None, "/data"),
             ]
         );
     }
@@ -144,7 +186,61 @@ mod tests {
     fn image_path_may_contain_colons() {
         let d = parse_mount_entry("/Volumes/a:b/img.zip:/tfs").unwrap();
         assert_eq!(d.image, "/Volumes/a:b/img.zip");
+        assert_eq!(d.slot, None);
         assert_eq!(d.mount, "/tfs");
+    }
+
+    #[test]
+    fn parses_slot_form() {
+        let d = parse_mount_entry("/a/pkg.tebako:0:/tfs").unwrap();
+        assert_eq!(d, decl("/a/pkg.tebako", Some(0), "/tfs"));
+        let d = parse_mount_entry("/b/pkg.tebako:12:/data").unwrap();
+        assert_eq!(d, decl("/b/pkg.tebako", Some(12), "/data"));
+    }
+
+    #[test]
+    fn slot_round_trip_is_identity() {
+        let spec = "/a/pkg.tebako:0:/tfs,/b/img.zip:/data";
+        assert_eq!(to_env_spec(&parse_mounts(spec).unwrap()), spec);
+    }
+
+    #[test]
+    fn dash_slot_means_whole_file() {
+        // '-' on the wire is the same as absent, and is never re-spelled.
+        let d = parse_mount_entry("/a/img.zip:-:/tfs").unwrap();
+        assert_eq!(d, decl("/a/img.zip", None, "/tfs"));
+        assert_eq!(to_env_spec(&[d]), "/a/img.zip:/tfs");
+    }
+
+    #[test]
+    fn slot_field_recognized_only_on_exact_match() {
+        // A non-digit, non-'-' field stays part of the image path (spec
+        // 17 §2.1: paths may contain colons; the grammar never rejects
+        // them).
+        let d = parse_mount_entry("/a.tfs:q:/mnt").unwrap();
+        assert_eq!(d, decl("/a.tfs:q", None, "/mnt"));
+    }
+
+    #[test]
+    fn slot_overflow_is_a_named_error() {
+        let e = parse_mount_entry("/a.zip:99999999999999999999:/mnt").unwrap_err();
+        assert!(
+            e.0.contains("slot") && e.0.contains("out of range"),
+            "unexpected error: {e:?}"
+        );
+    }
+
+    #[test]
+    fn windows_drive_shapes_split_from_the_right() {
+        // split_entry is validation-free, so the windows shapes parse
+        // identically on every host (spec 17 §2.1's examples).
+        let (image, slot, mount) = split_entry("C:\\pkg.tebako:0:/__tfs__").unwrap();
+        assert_eq!(
+            (image, slot, mount),
+            ("C:\\pkg.tebako", Some(0), "/__tfs__")
+        );
+        let (image, slot, mount) = split_entry("C:\\image.tfs:/data").unwrap();
+        assert_eq!((image, slot, mount), ("C:\\image.tfs", None, "/data"));
     }
 
     #[test]
@@ -152,7 +248,7 @@ mod tests {
         for (spec, frag) in [
             ("", "empty spec"),
             ("  ", "empty spec"),
-            ("/a.zip", "image:mount"),
+            ("/a.zip", "image[:slot]:mount"),
             ("relative.zip:/tfs", "not absolute"),
             ("/a.zip:tfs", "not absolute"),
             ("/a.zip:/tfs,", "empty entry"),
@@ -179,6 +275,7 @@ mod tests {
     fn cli_form_defaults_mount_to_mnt() {
         let d = parse_cli_image_mount("/a/img.zip").unwrap();
         assert_eq!(d.mount, "/mnt");
+        assert_eq!(d.slot, None);
         let d = parse_cli_image_mount("/a/img.zip:/tfs").unwrap();
         assert_eq!(d.image, "/a/img.zip");
         assert_eq!(d.mount, "/tfs");

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -154,6 +154,7 @@ pub mod merkle;
 pub mod merkle_host;
 mod model;
 mod package;
+mod region;
 
 pub use codec::{
     encode_ext_blocks, encode_trailer, parse_ext_blocks, parse_trailer, trailer_len,
@@ -185,6 +186,7 @@ pub use package::{
     MountMode, PackageEntry, PackageIdentity, PackageManifest, PackageManifestError, PackageMount,
     Precedence, PACKAGE_SCHEMA_VERSION,
 };
+pub use region::{resolve_slot_region, SlotRegion, SlotRegionError};
 
 /// Manifest format version (stays 1: the chain-of-trust extension is
 /// flagged via `TPKG_FLAG_SIGNED_V2`, not a version bump, so v1-era

--- a/crates/tpkg/src/region.rs
+++ b/crates/tpkg/src/region.rs
@@ -1,0 +1,196 @@
+//! Slot → byte-region resolution (spec 17 §2.1): given a seekable package
+//! file and a numeric slot, answer the region to mount. The rules mirror
+//! the driver's `resolve_image` exactly — the driver's traced copy stays
+//! the boot path's owner (it needs the trailer for mount modes and the
+//! trace events); this helper serves the preload shim's
+//! `TEBAKO_TFS_MOUNTS` consumption, where slot references arrive by env
+//! and no trace bus exists yet.
+
+use std::fmt;
+use std::io::{Read, Seek};
+
+use crate::error::TpkgError;
+use crate::TPKG_FORMAT_RUNTIME;
+
+/// What a slot reference resolves to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotRegion {
+    /// Mount the whole file: a bare image (slot 0 on a trailer-less
+    /// file — the same answer `build_from_file_at`'s
+    /// `offset == 0 && len == 0` convention gives).
+    Whole,
+    /// Mount `len` bytes at `offset` (a package slot).
+    Region {
+        /// Absolute file offset of the slot's image.
+        offset: u64,
+        /// Image length in bytes.
+        len: u64,
+    },
+}
+
+/// A named slot-resolution failure (spec 17 §2.1's named errors).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotRegionError {
+    /// The file could not be read (seek/read failure).
+    Io,
+    /// The file is a bare image (no slot table) but a non-zero slot was
+    /// requested.
+    NoSlotTable(u32),
+    /// A trailer is present but does not parse.
+    CorruptTrailer(TpkgError),
+    /// The slot index is beyond the manifest's slot count.
+    SlotOutOfRange {
+        /// The requested slot.
+        slot: u32,
+        /// The manifest's slot count.
+        slots: usize,
+    },
+    /// The slot is a runtime payload slot (`TPKG_FORMAT_RUNTIME`) —
+    /// runtime payload slots are never mounted.
+    RuntimeSlot(u32),
+}
+
+impl fmt::Display for SlotRegionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SlotRegionError::Io => write!(f, "cannot read the package file"),
+            SlotRegionError::NoSlotTable(slot) => write!(
+                f,
+                "slot {slot} is out of range (a bare image file — no slot table; use slot 0 or -)"
+            ),
+            SlotRegionError::CorruptTrailer(e) => {
+                write!(f, "corrupt tpkg manifest trailer ({e})")
+            }
+            SlotRegionError::SlotOutOfRange { slot, slots } => {
+                write!(
+                    f,
+                    "slot {slot} is out of range ({slots} slot(s) in its manifest)"
+                )
+            }
+            SlotRegionError::RuntimeSlot(slot) => write!(
+                f,
+                "slot {slot} is a runtime payload slot — payload slots are never mounted"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SlotRegionError {}
+
+/// Resolve a numeric slot against the file's tpkg trailer (spec 17 §2.1):
+/// a bare file answers [`SlotRegion::Whole`] for slot 0 only; a packaged
+/// file answers its slot's region, with out-of-range and runtime-role
+/// slots as named errors.
+pub fn resolve_slot_region<R: Read + Seek>(
+    r: &mut R,
+    slot: u32,
+) -> Result<SlotRegion, SlotRegionError> {
+    let manifest = match crate::io::read_from(r) {
+        Ok(m) => m,
+        Err(TpkgError::NoTrailer) => {
+            return if slot == 0 {
+                Ok(SlotRegion::Whole)
+            } else {
+                Err(SlotRegionError::NoSlotTable(slot))
+            };
+        }
+        Err(TpkgError::Io) => return Err(SlotRegionError::Io),
+        Err(e) => return Err(SlotRegionError::CorruptTrailer(e)),
+    };
+    let Some(s) = manifest.slots.get(slot as usize) else {
+        return Err(SlotRegionError::SlotOutOfRange {
+            slot,
+            slots: manifest.slots.len(),
+        });
+    };
+    if s.format_id == TPKG_FORMAT_RUNTIME {
+        return Err(SlotRegionError::RuntimeSlot(slot));
+    }
+    Ok(SlotRegion::Region {
+        offset: s.offset,
+        len: s.size,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Manifest, Slot};
+    use std::io::Cursor;
+
+    /// A 100-byte payload region carrying two slots ([0,40) and [40,100))
+    /// plus the appended trailer.
+    fn packaged(slots: Vec<Slot>) -> Cursor<Vec<u8>> {
+        let mut cur = Cursor::new(vec![0u8; 100]);
+        let manifest = Manifest {
+            slots,
+            ..Default::default()
+        };
+        crate::io::write_to(&mut cur, &manifest).unwrap();
+        cur
+    }
+
+    #[test]
+    fn resolves_slot_regions() {
+        let mut cur = packaged(vec![
+            Slot::new(0, 40, crate::TPKG_FORMAT_ZIP, "/a"),
+            Slot::new(40, 60, crate::TPKG_FORMAT_DWARFS, "/b"),
+        ]);
+        assert_eq!(
+            resolve_slot_region(&mut cur, 0).unwrap(),
+            SlotRegion::Region { offset: 0, len: 40 }
+        );
+        assert_eq!(
+            resolve_slot_region(&mut cur, 1).unwrap(),
+            SlotRegion::Region {
+                offset: 40,
+                len: 60
+            }
+        );
+    }
+
+    #[test]
+    fn out_of_range_is_named() {
+        let mut cur = packaged(vec![Slot::new(0, 40, crate::TPKG_FORMAT_ZIP, "/a")]);
+        assert_eq!(
+            resolve_slot_region(&mut cur, 1).unwrap_err(),
+            SlotRegionError::SlotOutOfRange { slot: 1, slots: 1 }
+        );
+    }
+
+    #[test]
+    fn runtime_slot_is_never_mounted() {
+        let mut cur = packaged(vec![Slot::new(0, 40, crate::TPKG_FORMAT_RUNTIME, "/r")]);
+        assert_eq!(
+            resolve_slot_region(&mut cur, 0).unwrap_err(),
+            SlotRegionError::RuntimeSlot(0)
+        );
+    }
+
+    #[test]
+    fn bare_file_answers_whole_for_slot_zero_only() {
+        let mut cur = Cursor::new(vec![0u8; 100]);
+        assert_eq!(resolve_slot_region(&mut cur, 0).unwrap(), SlotRegion::Whole);
+        assert_eq!(
+            resolve_slot_region(&mut cur, 3).unwrap_err(),
+            SlotRegionError::NoSlotTable(3)
+        );
+    }
+
+    #[test]
+    fn corrupt_trailer_is_named() {
+        // The magic PREFIX present but the full magic wrong: corrupt,
+        // never absent (a bare zero/garbage file is legitimately
+        // trailer-less — NoTrailer is not corruption).
+        let mut bytes = vec![0xAAu8; 2048];
+        let trailer_at = bytes.len() - crate::TPKG_HEADER_SIZE;
+        bytes[trailer_at..trailer_at + crate::TPKG_MAGIC_PREFIX_LEN]
+            .copy_from_slice(&crate::TPKG_MAGIC[..crate::TPKG_MAGIC_PREFIX_LEN]);
+        let mut cur = Cursor::new(bytes);
+        let err = resolve_slot_region(&mut cur, 0).unwrap_err();
+        assert!(
+            matches!(err, SlotRegionError::CorruptTrailer(_)),
+            "unexpected error: {err:?}"
+        );
+    }
+}

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -131,7 +131,7 @@ The locked model is three tiers — **interposition-first, never FUSE**:
    `DYLD_INSERT_LIBRARIES` (Mach-O), or DLL injection (Windows), mapping
    the libc/dyld file-IO family (open/stat/opendir/pread/dlopen…) onto
    `tebako_fs_*`. The launcher seeds the mount table via env
-   (`TEBAKO_TFS_MOUNTS=image:mount,…`); the binary AND its whole dynamic
+   (`TEBAKO_TFS_MOUNTS=image[:slot]:mount,…` — grammar in spec 17 §2.1); the binary AND its whole dynamic
    chain see the mounted image — **no extraction, no chain problem**.
    retrace (in-family: linux/macOS/windows CI, v2 config-driven
    interception) is the reference technique. Bonus: interposed IO flows

--- a/docs/spec/17-runtime-driver-contract.md
+++ b/docs/spec/17-runtime-driver-contract.md
@@ -103,7 +103,7 @@ exact contract (roadmap 22's "add a language" playbook).
 | var | meaning |
 |-----|---------|
 | `TEBAKO_RUNTIME_IMAGE` | image-era: absolute path of the runtime's own `.tfs` (driver mounts it instead of any embedded image) |
-| `TEBAKO_TFS_MOUNTS` | `image:mount,…` — mounts to establish (preload-shim path) |
+| `TEBAKO_TFS_MOUNTS` | `image[:slot]:mount,…` — mounts to establish (preload-shim path); grammar in §2.1 |
 | `TEBAKO_JAIL` | jail policy env form (spec 08) — the driver/preload enforces it |
 | `TEBAKO_JAIL_SOURCE` | audit label of the policy's origin (`manifest` / `user` / `manifest+user`, or the exporting surface) — journaled with every denial (spec 08 §2) |
 | `TEBAKO_JAIL_JOURNAL` | explicit audit-journal path (default: `$TEBAKO_HOME/journal.log`) |
@@ -114,6 +114,44 @@ exact contract (roadmap 22's "add a language" playbook).
 | `TEBAKO_MOUNT_<SLUG>` | spec 22 §6 + v2-1/20: per co-mounted payload image, its physical mount point (drive-qualified on windows). SLUG is the mount's mechanical uppercase form: `/tools/inkscape` → `TEBAKO_MOUNT_TOOLS_INKSCAPE`; two mounts slugging alike is a named boot error (65). The root mount `/` exports nothing — `TEBAKO_MOUNT_ROOT` stays the mount-root override (§1) |
 | `PATH` | spec 22 §3.2: led by the launcher dir (`<exec-cache-leaf>/wrap-bin/`) when the env image delivers the preload shim — every declared dependency executable materialized as a self-injecting wrapper (unix; the SIP-strip answer) — then every co-mounted DEPENDENCY image's declared bin dirs (the dirname of each `provides.entrypoints[].path` / `provides.executables[].path` in the image's own `/__tpkg__/manifest.yaml`, joined under its mount, in triple order). The first triple (the app payload) never contributes; an image without a readable manifest declares no bins; a corrupt manifest or an unmaterializable declared executable is a named 65. On windows the boot-materialized library-alias directories complete the same lead (spec 22 §2.1's bare-name rule) — every co-mounted image contributing, the env image and the app payload included; the lead order is locked: launcher dir → dependency bin dirs → alias dirs → the inherited `PATH` |
 | `SSL_CERT_FILE` | spec 22 §4 (the cert convention's env surface — driver-owned, the driver being the single owner of the materialized host path): when a mounted image declares a `materialize:` entry ending `ssl/cert.pem`, the driver exports the cert's materialized HOST path at boot, in both boot shapes. An unset/empty value is set; a value lexically under the effective runtime mount root (a stale in-VFS spelling — `A:/t/ssl/cert.pem` — resolved by the patched IO but unreadable by libcrypto's native CRT IO) is rewritten; a real host path is the user's own configuration and always wins. No declared cert → nothing is set (the POSIX no-op) |
+
+### 2.1 The `TEBAKO_TFS_MOUNTS` grammar (the preload re-mount wire form)
+
+```
+mounts     = entry *( "," entry )
+entry      = image-ref ":" mount
+image-ref  = image-path [ ":" slot ]
+image-path = absolute host path (may itself contain colons)
+slot       = 1*DIGIT / "-"
+mount      = "/" *path-char              ; a VFS-absolute mount point
+```
+
+- **Parse from the right.** Per entry: the mount is the field after the
+  last `:` (it MUST start with `/`); the slot is recognized ONLY when the
+  remainder's rightmost field is all digits or exactly `-` — then the
+  image path is what is left. Anything else after a colon stays part of
+  the image path: host paths may contain colons, and the grammar never
+  rejects them.
+- **Slot meaning.** Absent ≡ `-` ≡ the whole file (a bare image — the
+  pre-slot behavior, unchanged). A numeric slot names a package slot: the
+  consumer resolves slot → byte region against the file's tpkg trailer
+  (spec 04). On a trailer-less file a numeric slot is a named error; a
+  slot out of range is a named error; a runtime-role slot
+  (`format_id == 4`) is never mounted — a named error.
+- **Windows.** Right-parsing keeps drive colons intact:
+  `C:\pkg.tebako:0:/__tfs__` is package `C:\pkg.tebako`, slot 0, mount
+  `/__tfs__`; `C:\image.tfs:/data` is the bare image `C:\image.tfs`,
+  whole file, mount `/data`.
+- **No `<self>`.** The CLI triple form's `<self>` token (§1) is NOT
+  meaningful in the env form — the consuming process is a different
+  executable from the one that was stitched. The emit side always spells
+  the package's absolute host path.
+- **Emit rule.** A mount established from a whole bare image serializes
+  as `image:mount`; a mount established from a package slot serializes as
+  `image:slot:mount`. Consumers re-exporting their mount table to a
+  spawned child MUST preserve the slot form, so the child mounts the same
+  region — never the whole package file (mounting a packaged file whole
+  sniffs the trailer and fails; spec 22's spawn re-entry is the victim).
 
 ## 3. File IO semantics
 

--- a/docs/spec/18-contract-set.md
+++ b/docs/spec/18-contract-set.md
@@ -271,8 +271,11 @@ Owner: `tpkg::jail` + the driver. Malformed → exit 73 (unchanged);
 unknown jail directive → named error (no silent drops).
 
 ### C18 · preload shim ↔ driver (spawn re-entry)
-Owner: the driver (`TEBAKO_TFS_MOUNTS` grammar). Verify: unparseable →
-fail closed, never a half-mounted child.
+Owner: the driver (`TEBAKO_TFS_MOUNTS` grammar — the slot form included,
+spec 17 §2.1; the trailer data source is `tpkg::read_from`). Verify:
+unparseable → fail closed, never a half-mounted child; a packaged
+payload's slot survives the hand-off (the child mounts the slot region,
+never the whole package file).
 
 ### C19 · vcpkg baseline → consumers
 Owner: dwarfs-t. Grammar: tag + canonical-root map (the restore script


### PR DESCRIPTION
# fix(tfs): the TEBAKO_TFS_MOUNTS slot form — a packaged payload's slot survives the spawn hand-off — #455

Closes #455.

## The bug

`TEBAKO_TFS_MOUNTS` serialized mounts as `image:mount,…` with no slot
field. A standalone stitched package whose slot payload spawned a child
(the spec-22 preload path — first victim: packed-mn's PDF leg, fontist's
`git clone` child) re-mounted slot payloads as the WHOLE package file;
the child's format sniff hit the appended tpkg trailer → EINVAL / exit 78.

## The fix (spec-first, spec 14)

**Spec** — the grammar is amended before the code:

- `docs/spec/17-runtime-driver-contract.md` — new §2.1 with the normative
  grammar (`entry = image-ref ":" mount`, `image-ref = image-path [ ":"
  slot ]`, `slot = 1*DIGIT / "-"`): parse from the RIGHT (the mount after
  the last `:`; a slot is recognized only on an exact all-digits or `-`
  rightmost remainder, so paths containing colons — windows drive colons
  included — stay paths); slot absent ≡ `-` ≡ whole file; a numeric slot
  resolves against the file's tpkg trailer (trailer-less → named error,
  out-of-range → named error, runtime-role slot → named error); `<self>`
  is NOT meaningful in the env form (the consumer is a different
  executable — the emit side always spells the absolute host path); the
  emit rule serializes the slot iff the mount was established from a
  package slot. The §2 env table row points at §2.1.
- `docs/spec/18-contract-set.md` — C18's owner note now names the slot
  form (trailer data source: `tpkg::read_from`) and adds the slot
  hand-off to the verify clause.
- `docs/spec/07-shims-and-dispatch.md` — §8's env spelling updated to
  `image[:slot]:mount,…`.

**Parse/serialize** (`crates/tfs/src/mount_spec.rs`): `MountDecl` gains
`slot: Option<u32>`; `parse_mount_entry` right-parses per the grammar
(`-` → `None`; all-digits → the slot, u32 overflow is a named parse
error; anything else stays image path); `to_env_spec` emits
`image:slot:mount` iff `slot` is `Some` (`-` is never re-spelled). The
`tfs exec` CLI form is unchanged (no slot field; always `None`).

**Mount identity** (`crates/tfs/src/context.rs`, `mount.rs`): `Mount`
gains `slot: Option<u32>` (default `None`); `mounts_env` — the single
composer the driver's child-injection exports — now routes through
`mount_spec::to_env_spec` and carries the slot field, so a spawned child
re-mounts the same region.

**Slot → region** (`crates/tpkg/src/region.rs`, new): `resolve_slot_region`
answers `Whole` (bare file, slot 0) or `Region { offset, len }`, with the
driver's exact named rules — `NoSlotTable`, `CorruptTrailer`,
`SlotOutOfRange`, `RuntimeSlot`. The driver's traced `resolve_image`
stays the boot path's owner; this helper serves the env-form consumer
(the preload shim), per C18's SSOT note.

**Consume** (`crates/libtfs-preload/src/route.rs`): a slot declaration
resolves the region via `tpkg::resolve_slot_region` and mounts it with
`build_from_file_at`; the established mount carries the slot identity so
the re-export keeps the slot form. Failures are named
`TEBAKO_TFS_MOUNTS:` errors (exit 78), never a whole-file fallback.
`tpkg` added as a dependency (pure safe Rust, no cycle).

**Emit** (`crates/tebako-driver/src/driver.rs`): both slot-mount build
sites (`<self>` slot and file triple) set `mount.slot = Some(n)`, so the
driver's exported `TEBAKO_TFS_MOUNTS` carries the slot form.

## Tests

- `tfs` mount_spec: slot round-trip, windows drive shapes
  (`C:\pkg.tebako:0:/__tfs__` vs `C:\image.tfs:/data`), `-` ≡ absent and
  never re-spelled, non-digit field stays path (`/a.tfs:q:/mnt`), slot
  overflow named error; context: `mounts_env` carries the slot field.
- `tpkg` region: region resolution, out-of-range, runtime-slot, bare-file
  whole/zero-only, corrupt trailer — 5 tests.
- `tebako-driver` boot: a slot mount's respawn env carries the slot form.
- `libtfs-preload` e2e (the issue's acceptance shape): a stitched package
  fixture (zip as slot 0 + tpkg trailer) — a process holding the slot
  mount spawns a child that reads the file through the mount
  (`spawn-self` grandchild proof); slot out-of-range and bare-file
  non-zero slot are named EX_CONFIG errors.

Local runs (debug): `tfs` lib incl. mount_spec+mounts_env tests green;
`tpkg` 5/5; `libtfs-preload` 16 lib + 22 e2e green (incl. the 3 new
slot-form proofs, macOS arm64); `tebako-driver` + `tfs-cli` suites green.
CI covers linux-gnu and windows-ucrt64.

## Follow-ups (not this PR)

- packed-mn#251's PDF leg flips to enforced once a product release
  carries this fix.
