### PR TITLE
chore(deps): raise the limnifs floor to 0.2.62

### DIFF
--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -41,7 +41,7 @@ serde_yml = "0.0.12"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
 # — pure Rust, no `limni` binary anywhere.
-limnifs-write = "0.2.61"
+limnifs-write = "0.2.62"
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -34,7 +34,7 @@ serde_yaml = "0.9"
 dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
 # §6) — pure Rust, no `limni` binary anywhere.
-limnifs-write = "0.2.61"
+limnifs-write = "0.2.62"
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is
@@ -64,4 +64,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # The floor-recipe structural test parses the emitted metadata through
 # the reader (spec 20 §5 constraint 1: no SharedInline handle anywhere)
 # — test-only, never linked into the shipped binary.
-limnifs-core = "0.2.61"
+limnifs-core = "0.2.62"

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -54,7 +54,7 @@ sqfs-sys = { version = "0.2.1", path = "../sqfs-sys", optional = true }
 # §5's floor recipe is lz4-only (metadata lz4-hc, content lz4-or-store),
 # and the 0.2.54 writer self-check refuses to emit un-decodable zstd
 # frames regardless.
-limnifs-core = { version = "0.2.61", optional = true }
+limnifs-core = { version = "0.2.62", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
@@ -102,5 +102,5 @@ rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
 crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —
 # test-only, never linked into the shipped library.
-limnifs-write = "0.2.57"
+limnifs-write = "0.2.62"
 

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -26,4 +26,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 # The limnifs backend-pair golden class builds its fixture image
 # in-process (spec 20 §8) — never a `limni` binary.
-limnifs-write = "0.2.57"
+limnifs-write = "0.2.62"


### PR DESCRIPTION
# chore(deps): raise the limnifs floor to 0.2.62

Raises every limnifs pin in the workspace from 0.2.57/0.2.61 to **0.2.62**
— the line carrying the symlink press-from-source fix and the big-tree
externalized-metadata read-back fix. The pins are minimum floors (caret);
a fresh resolution today lands 0.2.64.

Pin sites (6):

- `crates/tfs/Cargo.toml` — `limnifs-core` (the backend dep) 0.2.61 →
  0.2.62; `limnifs-write` (dev, golden fixtures) 0.2.57 → 0.2.62
- `crates/tfs-cli/Cargo.toml` — `limnifs-write` (mkimage) 0.2.61 →
  0.2.62; `limnifs-core` (dev, floor-recipe structural test) 0.2.61 →
  0.2.62
- `crates/tebako-cli/Cargo.toml` — `limnifs-write` (press) 0.2.61 →
  0.2.62
- `tests/contract/Cargo.toml` — `limnifs-write` (dev, golden pair)
  0.2.57 → 0.2.62

No spec delta: spec 20 §5's floor recipe (lz4-only, metadata inlined under
the readers' 1 MiB ceiling, shared-inline off) is untouched — the press
path's externalization refusal stands exactly as written.

## Verification (local, debug; resolution landed 0.2.64)

- `tfs`, `tfs-cli`, `tebako-contract-tests` suites + `tebako-cli --lib`:
  553 tests, 0 failed (incl. the limnifs backend tests, the mkimage
  limnifs legs, the floor-recipe structural test, the golden backend-pair
  class).
- `tebako-cli` integration: cli_e2e 13/13 (all four network presses green
  this run), install 9/9, info 29/29.
