### PR TITLE
test(cli): pin add-registry → install registry visibility at argv level (#459)

### DIFF
--- a/crates/tebako-cli/tests/registry_cli.rs
+++ b/crates/tebako-cli/tests/registry_cli.rs
@@ -3,6 +3,7 @@
 //! uninstall) against a file:// mirror and a temp TEBAKO_HOME.
 
 use std::fs;
+use std::io::Write as _;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -94,6 +95,129 @@ fn registry_install_uninstall_smoke() {
     assert!(text.contains("removed app (1.0)"), "{text}");
     assert!(!home.join("payloads/app").exists());
     assert!(!shim_path(&home, "app").exists());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+// ---------------------------------------------------------------------
+// #459 — add-registry → install in one home, no refresh (the bench
+// dogfood scenario): the registered set IS visible to install; a
+// `requires:` edge whose carrier is not registered is the named 65,
+// and registering the carrier lets the same home's retry proceed.
+// ---------------------------------------------------------------------
+
+/// A zip image with an embedded manifest (the tfs zip backend reads it)
+/// — the same fixture shape the library-level install tests use.
+fn zip_image(manifest_yaml: &str) -> Vec<u8> {
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let options = zip::write::SimpleFileOptions::default();
+    writer
+        .start_file("__tpkg__/manifest.yaml", options)
+        .unwrap();
+    writer.write_all(manifest_yaml.as_bytes()).unwrap();
+    writer.start_file("app/bin/app", options).unwrap();
+    writer.write_all(b"#!/bin/sh\n").unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+/// An app image whose embedded manifest carries one toolkit `requires:`
+/// edge (the metanorma → inkscape shape that #459 dogfooded).
+fn app_image_requiring(name: &str, version: &str, dep: &str, constraint: &str) -> Vec<u8> {
+    zip_image(&format!(
+        "identity:\n  schema_version: 1\n  kind: app\n  name: {name}\n  version: {version}\n  producer: {{tool: tebako, tool_version: 0.15.9}}\n  created: \"2026-07-26T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{}\"\n    blob_sha256: \"{}\"\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n  entrypoints:\n    - name: {name}\n      path: /app/bin/{name}\n      runtime_requirement: {{engine: ruby, constraint: \">= 3.3, < 5.0\"}}\n  platforms: universal\n  capabilities: {{exec: true, read: true}}\nrequires:\n  - kind: toolkit\n    name: {dep}\n    constraint: \"{constraint}\"\n    mount: /opt/{dep}\n",
+        "a".repeat(64),
+        "b".repeat(64)
+    ))
+}
+
+/// A toolkit image: an embedded kind:toolkit manifest with no
+/// executables (a pure mountable layer — nothing to materialize).
+fn toolkit_image(name: &str, version: &str) -> Vec<u8> {
+    zip_image(&format!(
+        "identity:\n  schema_version: 1\n  kind: toolkit\n  name: {name}\n  version: {version}\n  producer: {{tool: tebako, tool_version: 0.15.9}}\n  created: \"2026-07-26T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{}\"\n    blob_sha256: \"{}\"\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n  platforms: universal\n  capabilities: {{exec: false, read: true}}\n",
+        "a".repeat(64),
+        "b".repeat(64)
+    ))
+}
+
+#[test]
+fn add_registry_then_install_resolves_the_requires_closure_no_refresh() {
+    let dir = scratch("closure");
+    let home = dir.join("home");
+    let mirror = dir.join("mirror");
+    fs::create_dir_all(&mirror).unwrap();
+    let shim = dir.join("tebako-shim");
+    fs::write(&shim, b"#!/bin/sh\n").unwrap();
+
+    fs::write(
+        mirror.join("app-1.0.tfs"),
+        app_image_requiring("app", "1.0", "demotool", ">= 1.3"),
+    )
+    .unwrap();
+    let app_url = tebako_http::file_url(&mirror.join("app-1.0.tfs"));
+    fs::write(
+        mirror.join("app-registry.yaml"),
+        format!(
+            "schema_version: 1\npayloads:\n  - name: app\n    kind: app\n    versions:\n      - version: 1.0\n        platforms: universal\n        release: {{ref: {app_url}}}\n        runtime_requirement: {{engine: ruby, constraint: \">= 3.1\"}}\n        entrypoints: [app]\n    default: 1.0\n",
+        ),
+    )
+    .unwrap();
+    let app_reg = tebako_http::file_url(&mirror.join("app-registry.yaml"));
+
+    fs::write(
+        mirror.join("demotool-1.4.tfs"),
+        toolkit_image("demotool", "1.4"),
+    )
+    .unwrap();
+    let tool_url = tebako_http::file_url(&mirror.join("demotool-1.4.tfs"));
+    fs::write(
+        mirror.join("demotool-registry.yaml"),
+        format!(
+            "schema_version: 1\npayloads:\n  - name: demotool\n    kind: toolkit\n    versions:\n      - version: \"1.4\"\n        platforms: universal\n        release: {{ref: {tool_url}}}\n    default: \"1.4\"\n",
+        ),
+    )
+    .unwrap();
+    let tool_reg = tebako_http::file_url(&mirror.join("demotool-registry.yaml"));
+
+    // add-registry → install in one home, no refresh: the freshly
+    // registered registry IS seen (the #459 claim). The install fails on
+    // the DEPENDENCY nobody carries — the error names it and lists the
+    // registered registry, proving visibility.
+    let (code, text) = run(&home, &shim, &["add-registry", &app_reg]);
+    assert_eq!(code, 0, "{text}");
+    let (code, text) = run(&home, &shim, &["install", "app@1.0"]);
+    assert_eq!(code, 65, "{text}");
+    assert!(
+        text.contains("app 1.0 requires toolkit demotool (>= 1.3)"),
+        "{text}"
+    );
+    assert!(text.contains("no registered registry carries it"), "{text}");
+    assert!(
+        text.contains(&app_reg),
+        "the registered registry is listed — install saw it\n{text}"
+    );
+
+    // Register the carrier and retry in the SAME home, still no refresh:
+    // the walk resolves the edge and the closure lands.
+    let (code, text) = run(&home, &shim, &["add-registry", &tool_reg]);
+    assert_eq!(code, 0, "{text}");
+    let (code, text) = run(&home, &shim, &["install", "app@1.0"]);
+    assert_eq!(code, 0, "{text}");
+    // the retry is a cache hit for the app plus the closure walk — the
+    // failed first attempt left the app's verified record (resume
+    // semantics, library-pinned by install.rs's dep_walk_missing_dep
+    // test: "the app stays installed")
+    assert!(text.contains("app 1.0 is already installed"), "{text}");
+    assert!(home.join("payloads/app/1.0.tfs").is_file(), "{text}");
+    assert!(
+        home.join("payloads/demotool/1.4.tfs").is_file(),
+        "the dependency closure landed\n{text}"
+    );
+    assert!(home.join("payloads/demotool/1.4.manifest.yaml").is_file());
+    assert!(
+        !shim_path(&home, "demotool").exists(),
+        "an executable-less toolkit gets no shim"
+    );
 
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
# test(cli): pin add-registry → install registry visibility at argv level (#459)

**Diagnosis: not a product bug.** Reproducing the bench dogfood's exact
flow on current main (fresh `TEBAKO_HOME` → `tebako add-registry
tfs:github:tebako-packages/metanorma` → `tebako install metanorma@1.16.9`)
does produce exit 65 — but the full message is the **dependency-edge**
form, not a visibility failure:

```
tebako script failed: metanorma 1.16.9 requires toolkit inkscape (>= 1.3) but no registered registry carries it
  registered registries:
    - tfs:github:tebako-packages/metanorma
  register one with: tebako add-registry <ref> [65]
```

Install **saw** the freshly registered registry (it is listed), fetched
the payload, read its embedded manifest, and failed on its `requires:`
edges: metanorma 1.16.9's manifest declares `toolkit inkscape >= 1.3`
and `toolkit openjdk >= 21, < 26`, and only the metanorma registry was
registered. Registering `tfs:github:tebako-packages/inkscape` moves the
failure to openjdk; both registries exist under `tebako-packages/`.
`git log b57009a6..main` on `install.rs` / `config.rs` /
`registry.rs` / `regcache.rs` is empty — the dogfooded code is the
current code. The bench suite's `registries:` list (spec 27) must name
the dependency registries too; that fix belongs to #457's branch.

## What this PR changes

Tests only — no behavior change. The issue's acceptance, pinned at the
argv level in `crates/tebako-cli/tests/registry_cli.rs` (two separate
CLI processes, one `TEBAKO_HOME`, no refresh, network-free `file://`
fixtures with real zip images):

1. **Negative leg:** with only the app's registry registered, `install
   app@1.0` exits 65 naming the missing `toolkit demotool (>= 1.3)` and
   listing the registered registry — the visibility proof.
2. **Positive leg:** registering the carrier and retrying **in the same
   home** resolves the closure and installs the dependency — also
   pinning the resume semantics (the failed first attempt leaves the
   app's verified record; the retry is a cache hit plus the walk,
   matching install.rs's library-level
   `dep_walk_missing_dep_is_a_named_error_and_the_app_stays_installed`).

The library-level closure walk, cache-preference, newest-satisfying, and
language-edge cases were already covered in
`crates/tebako-cli/tests/install.rs`; the dep-free argv smoke was
already in this file. The gap was the requires-closure at the argv
level — the exact bench scenario.

## Verification

- `cargo test -p tebako-cli --test registry_cli` — 2/2 ok (the new test
  plus the existing smoke), debug profile.
- `cargo fmt -p tebako-cli` + `cargo clippy -p tebako-cli --tests` clean.
