### PR TITLE
release: v0.2.6 — version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "crates/tebako-bench", "tests/contract"]
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"


### PR DESCRIPTION
# release: v0.2.6 — version bump

Workspace `version` 0.2.5 → 0.2.6 (root `Cargo.toml`, one line — same
shape as the v0.2.5 bump). Carries the serial-fix chain:

- #461 — bootstrap asset-name SSOT (#456)
- #462 — `TEBAKO_TFS_MOUNTS` slot form: package slots survive the spawn
  hand-off (#455)
- #463 — limnifs floor raised to 0.2.62
- #465 — the Release pipeline fires on the `v*` tag push itself (the
  v0.2.5 bare-tag lesson): prepare creates the Release, per-ref
  concurrency, no `release: published` double-fire
- #466 — the #459 regression pin: add-registry → install registry
  visibility at the argv level

Tagging `v0.2.6` on this merge commit is the end-to-end proof of #465:
the tag push fires the pipeline, prepare creates the Release, every leg
uploads against it, and finalize's completeness gate (44 assets) must
pass.
