### PR TITLE
The composition spectrum — carried/shared presets, the baked L2 lock, two-slot self-contained (tebako#458)

### DIFF
--- a/crates/tebako-bench/src/acquire.rs
+++ b/crates/tebako-bench/src/acquire.rs
@@ -929,12 +929,13 @@ pub fn assemble_fat_package(
         },
         entries: vec![tpkg::PackageEntry {
             name: entrypoint.name.clone(),
-            slot: 0,
+            slot: Some(0),
             entrypoint: entrypoint.path.clone(),
             runtime_ref: runtime_ref.clone(),
         }],
         jail: None,
         env: Default::default(),
+        lock: None,
         mounts: vec![tpkg::PackageMount {
             slot: 0,
             point: "/".to_string(),

--- a/crates/tebako-bootstrap/Cargo.toml
+++ b/crates/tebako-bootstrap/Cargo.toml
@@ -14,6 +14,10 @@ categories = ["filesystem", "no-std"]
 tpkg = { version = "0.2.1", path = "../tpkg" }
 tebako-signer = { version = "0.2.1", path = "../tebako-signer", optional = true }
 tebako-http = { version = "0.2.1", path = "../tebako-http" }
+# Shared-slice resolution + cache seeding (spec 23 §13, spec 05 §4):
+# default-features = false drops the git adapter (gix/reqwest) — the
+# bootstrap resolves `tfs:`/`https:`/`file://` lock sources only.
+tebako-resolve = { version = "0.2.1", path = "../tebako-resolve", default-features = false }
 tebako-term = { version = "0.2.1", path = "../tebako-term" }
 # OpenPGP trailer verification is OPTIONAL (feature `openpgp-verify`,
 # default OFF): the shipped bootstrap runs unverified-first — every

--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -1986,37 +1986,50 @@ pub fn verify_chain_with_home(
 // runtime resolution
 // ---------------------------------------------------------------------
 
-fn resolve_runtime(
-    runtime_ref: &str,
-    rr: &RuntimeRef,
-    self_path: &Path,
-    m: &tpkg::Manifest,
-) -> Result<(PathBuf, Option<PathBuf>), BootError> {
+/// The cache layout for one runtime entry (spec 05 §2, tebako#456): the
+/// exe spelling flows from the entry's cached release index when one
+/// exists — the identity-matched entry's `filename` — and falls back to
+/// the synthesized `<asset_base><exe_suffix>` otherwise (a fat/carried
+/// install never fetched an index).
+fn cache_layout(rr: &RuntimeRef) -> Result<CacheLayout, BootError> {
     let platform = platform_string();
     let id = ReleaseIdentity::of(rr, platform);
     let asset_base = format!("tebako-runtime-{}-{}-{platform}", rr.abi, rr.version);
     let entry = format!("{}-{}-{}-{platform}", rr.r#type, rr.version, rr.abi);
     let root = cache_root()?;
     let entry_dir = root.join("runtimes").join(&entry);
-    // spec 05 §2 (tebako#456): the cache entry's exe file keeps the index
-    // entry's `filename` spelling (windows runtimes publish SUFFIX-LESS).
-    // A cached entry carries the verified index the lean install left
-    // behind — flow it. No cached index (a fat-payload install) → the
-    // synthesized fallback spelling.
     let asset = std::fs::read_to_string(entry_dir.join("manifest.json"))
         .ok()
         .and_then(|text| id.entry(&text).map(|e| e.filename))
         .unwrap_or_else(|| format!("{asset_base}{}", exe_suffix()));
-    let layout = CacheLayout {
+    Ok(CacheLayout {
         exe_path: entry_dir.join(&asset),
         asset,
         root,
         entry_dir,
         asset_base,
         entry,
-    };
+    })
+}
 
+fn resolve_runtime(
+    runtime_ref: &str,
+    rr: &RuntimeRef,
+    self_path: &Path,
+    m: &tpkg::Manifest,
+    carried: Option<&tpkg::LockedRuntime>,
+) -> Result<(PathBuf, Option<String>), BootError> {
+    let layout = cache_layout(rr)?;
     let mut ux = BootUx::new();
+
+    // spec 19 §6.1 / spec 23 §13.2: a self-contained package carries the
+    // runtime pair as ordinary trailer slots — the exe (+ windows dll)
+    // stages into the runtime cache, the env image stays IN the package
+    // and reaches the driver as the `<package>:<slot>` form (spec 17
+    // §2.1). The lock's digest pins anchor every staged byte.
+    if let Some(lr) = carried {
+        return stage_carried_runtime(runtime_ref, rr, self_path, m, &layout, lr, &mut ux);
+    }
 
     // The interpreter: cache hit / fat payload slot / download+verify.
     let exe = if file_exists(&layout.exe_path) {
@@ -2058,7 +2071,9 @@ fn resolve_runtime(
     if runtime_ref_wants_image(runtime_ref) {
         resolve_dll(runtime_ref, rr, &layout, &mut ux)?;
     }
-    Ok((exe, image))
+    // The image value is a wire form, not necessarily a bare path: the
+    // carried branch spells it `<package>:<slot>` (spec 17 §2.1).
+    Ok((exe, image.map(|p| p.to_string_lossy().into_owned())))
 }
 
 fn download_executable(
@@ -2716,6 +2731,584 @@ fn resolve_dll(
 }
 
 // ---------------------------------------------------------------------
+// the composition spectrum (spec 23 §13, spec 19 §6.1, tebako#458):
+// carried two-slot runtime staging, shared-slice resolution, lazy seed
+// ---------------------------------------------------------------------
+
+/// The trailer slot `slot`, bounds-checked — a lock naming a slot the
+/// container does not carry is internally inconsistent (re-press).
+fn slot_at<'a>(
+    m: &'a tpkg::Manifest,
+    slot: u32,
+    self_path: &Path,
+) -> Result<&'a tpkg::Slot, BootError> {
+    m.slots.get(slot as usize).ok_or_else(|| {
+        BootError::new(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "the lock names slot {slot} but {} carries {} slot(s) — the package is internally inconsistent, re-press it",
+                self_path.display(),
+                m.slots.len()
+            ),
+        )
+    })
+}
+
+/// The lock's digest pin for this host (spec 23 §13.3): a per-triplet
+/// map that does not cover the host is a named coverage error, never a
+/// nearest-platform guess.
+fn pin_for_host<'a>(
+    pin: &'a tpkg::DigestPin,
+    what: &str,
+    self_path: &Path,
+) -> Result<&'a str, BootError> {
+    let host = tpkg::Platform::host();
+    pin.for_host(host).ok_or_else(|| {
+        BootError::new(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "the lock's {what} digest map does not cover this platform ({}) — {} was not pressed for it\n  the assertion narrows, never extends (spec 23 §13.3)",
+                host.release_asset_name(),
+                self_path.display()
+            ),
+        )
+    })
+}
+
+/// Stage one carried artifact's slot region into `dst`, verified against
+/// the lock's pin. Mirrors install_payload's extract→hash→compare; the
+/// caller owns tmp/lock cleanup on the error paths.
+fn stage_locked_slot(
+    self_path: &Path,
+    slot: &tpkg::Slot,
+    expected: &str,
+    dst: &Path,
+    what: &str,
+) -> Result<String, BootError> {
+    if let Err(rc) = extract_payload(self_path, slot.offset, slot.size, dst) {
+        return if rc == -2 {
+            fail(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "corrupt tebako manifest trailer in {} (the lock's {what} slot is outside file bounds) — re-press the package",
+                    self_path.display()
+                ),
+            )
+        } else {
+            io_fail(format!(
+                "cannot extract the {what} from {}",
+                self_path.display()
+            ))
+        };
+    }
+    let actual = sha256_file_hex(dst).map_err(|e| {
+        BootError::new(
+            EX_TEBAKO_IO,
+            format!("cannot hash extracted {what} ({}): {e}", dst.display()),
+        )
+    })?;
+    if actual != expected {
+        return fail(
+            EX_TEBAKO_SHA,
+            format!(
+                "SHA256 mismatch for the carried {what} of {} — refusing to install or execute\n  expected: {expected} (the press-time lock pin, spec 23 §13.4)\n  actual:   {actual}\n  the cache was not touched",
+                self_path.display()
+            ),
+        );
+    }
+    Ok(actual)
+}
+
+/// spec 19 §6.1: the carried two-slot runtime. The exe stages into the
+/// runtime cache exactly like a fat payload install (tmp + rename under
+/// the entry lock) — pinned to the lock's digest rather than a
+/// `;sha256=` ref segment — and the env image stays IN the package: the
+/// return's image value is the `<package>:<slot>` wire form the driver
+/// mounts as a slot region (spec 17 §2.1). The staged exe IS the cache
+/// entry: a later shared-runtime package resolving the same version
+/// finds it cached (the seed converges the presets onto one cache).
+fn stage_carried_runtime(
+    runtime_ref: &str,
+    rr: &RuntimeRef,
+    self_path: &Path,
+    m: &tpkg::Manifest,
+    layout: &CacheLayout,
+    lr: &tpkg::LockedRuntime,
+    ux: &mut BootUx,
+) -> Result<(PathBuf, Option<String>), BootError> {
+    // carry: true without the exe/image pair fails the lock's own
+    // validation at manifest parse; guard anyway — never an unwrap on
+    // this path (spec 14).
+    let (Some(exe_art), Some(image_art)) = (&lr.exe, &lr.image) else {
+        return fail(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "the lock of {} declares a carried runtime without its exe/image slots — re-press the package",
+                self_path.display()
+            ),
+        );
+    };
+
+    let exe = if file_exists(&layout.exe_path) {
+        ux.cached(rr);
+        layout.exe_path.clone()
+    } else {
+        let expected = pin_for_host(&exe_art.sha256, "runtime executable", self_path)?;
+        let slot = slot_at(m, exe_art.slot, self_path)?;
+        let Some(ins) = begin_entry_install(
+            &layout.root,
+            &layout.entry,
+            &layout.exe_path,
+            &layout.asset,
+            runtime_ref,
+        )?
+        else {
+            ux.cached(rr);
+            // A concurrent install won the race; the dll check below
+            // still runs (the winner may be a pre-dll-era lean install).
+            stage_carried_dll(self_path, m, layout, lr)?;
+            return Ok((
+                layout.exe_path.clone(),
+                Some(format!("{}:{}", self_path.display(), image_art.slot)),
+            ));
+        };
+        match stage_locked_slot(self_path, slot, expected, &ins.tmp_asset, "runtime executable") {
+            Ok(actual) => {
+                let origin = format!(
+                    "runtime_ref={runtime_ref}\ncarried={} slot {}\nsha256={actual}\n",
+                    self_path.display(),
+                    exe_art.slot
+                );
+                publish_entry(
+                    ins,
+                    &layout.entry_dir,
+                    &layout.exe_path,
+                    &layout.asset,
+                    &actual,
+                    &origin,
+                )?
+            }
+            Err(e) => {
+                cleanup_tmp_entry(&ins.tmp_dir, &layout.asset);
+                lock_release(ins.lock);
+                return Err(e);
+            }
+        }
+    };
+
+    // tebako-runtime-ruby#40: the windows dll-era facet rides a third
+    // slot; the PE loader resolves it next to the exe.
+    stage_carried_dll(self_path, m, layout, lr)?;
+
+    Ok((
+        exe,
+        Some(format!("{}:{}", self_path.display(), image_art.slot)),
+    ))
+}
+
+/// Stage the carried windows dll (tebako-runtime-ruby#40) next to the
+/// exe under its PE import name — single-file install into the
+/// (existing) entry dir, the same lock discipline as resolve_dll.
+/// A no-op when the lock declares no dll facet (every POSIX package).
+fn stage_carried_dll(
+    self_path: &Path,
+    m: &tpkg::Manifest,
+    layout: &CacheLayout,
+    lr: &tpkg::LockedRuntime,
+) -> Result<(), BootError> {
+    let Some(dll_art) = &lr.dll else {
+        return Ok(());
+    };
+    let Some(install_as) = dll_art.install_as.as_deref() else {
+        return fail(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "the lock of {} carries a dll slot without its install_as (the PE import name) — re-press with a current tebako",
+                self_path.display()
+            ),
+        );
+    };
+    let dll_path = layout.entry_dir.join(install_as);
+    let marker = layout.entry_dir.join(format!("{install_as}.sha256"));
+    if file_exists(&dll_path) && file_exists(&marker) {
+        return Ok(());
+    }
+    let expected = pin_for_host(&dll_art.sha256, "runtime dll", self_path)?;
+    let slot = slot_at(m, dll_art.slot, self_path)?;
+
+    let locks = layout.root.join("locks");
+    mkdir_p(&locks).map_err(|e| {
+        BootError::new(
+            EX_TEBAKO_IO,
+            format!(
+                "cannot create tebako cache directories under {}: {e}",
+                layout.root.display()
+            ),
+        )
+    })?;
+    let lock_path = locks.join(format!("{}.lock", layout.entry));
+    let lock = flock_acquire(&lock_path, LOCK_TIMEOUT_MS).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::TimedOut {
+            BootError::new(
+                EX_TEBAKO_UNAVAILABLE,
+                format!(
+                    "timed out after {}s waiting for another tebako bootstrap to finish installing \"{}\"\n  lock: {}\n  if no other tebako process is running, remove the stale lock file",
+                    LOCK_TIMEOUT_MS / 1000,
+                    layout.entry,
+                    lock_path.display()
+                ),
+            )
+        } else {
+            BootError::new(
+                EX_TEBAKO_IO,
+                format!("cannot acquire install lock {}: {e}", lock_path.display()),
+            )
+        }
+    })?;
+    if file_exists(&dll_path) && file_exists(&marker) {
+        lock_release(lock);
+        return Ok(());
+    }
+    let tmp_dir = layout
+        .root
+        .join("tmp")
+        .join(format!("{}.{}.dll", layout.entry, std::process::id()));
+    cleanup_tmp_entry(&tmp_dir, install_as);
+    let result = (|| -> Result<(), BootError> {
+        std::fs::create_dir(&tmp_dir).map_err(|e| {
+            BootError::new(
+                EX_TEBAKO_IO,
+                format!("cannot create {}: {e}", tmp_dir.display()),
+            )
+        })?;
+        let tmp_dll = tmp_dir.join(install_as);
+        let actual = stage_locked_slot(self_path, slot, expected, &tmp_dll, "runtime dll")?;
+        make_readonly(&tmp_dll);
+        os_rename(&tmp_dll, &dll_path).map_err(|e| {
+            BootError::new(
+                EX_TEBAKO_IO,
+                format!(
+                    "cannot install the runtime dll into the cache ({} -> {}): {e}",
+                    tmp_dll.display(),
+                    dll_path.display()
+                ),
+            )
+        })?;
+        let _ = write_small_file(&marker, &format!("{actual}  {install_as}\n"));
+        let _ = write_small_file(
+            &layout.entry_dir.join(format!("{install_as}.origin")),
+            &format!(
+                "carried={} slot {}\nsha256={actual}\n",
+                self_path.display(),
+                dll_art.slot
+            ),
+        );
+        Ok(())
+    })();
+    cleanup_tmp_entry(&tmp_dir, install_as);
+    lock_release(lock);
+    result
+}
+
+/// spec 23 §13.1: the shared slices resolve at first run into the
+/// machine payload cache BY THE LOCKED DIGEST (never fresh semver —
+/// spec 23 §4) and mount from the cache file. Returns `(slice name,
+/// cache path)` pairs in lock order; a coverage gap, an offline miss, or
+/// a digest mismatch is a named error (fail-closed, spec 23 §13.4).
+fn resolve_shared_slices(
+    lock: &tpkg::PackageLock,
+    self_path: &Path,
+) -> Result<Vec<(String, PathBuf)>, BootError> {
+    let mut out = Vec::new();
+    if lock.shared_slices().next().is_none() {
+        return Ok(out);
+    }
+    let cache = tebako_resolve::PayloadCache::with_root(cache_root()?);
+    for slice in lock.shared_slices() {
+        let pin = pin_for_host(
+            &slice.sha256,
+            &format!("shared slice \"{}\"", slice.name),
+            self_path,
+        )?;
+        let Some(source) = slice.source.as_deref() else {
+            return fail(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "shared slice \"{}\" of {} carries no source reference — re-press the package with a current tebako",
+                    slice.name,
+                    self_path.display()
+                ),
+            );
+        };
+        let reference = tebako_resolve::Reference::parse(source).map_err(|e| {
+            BootError::new(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "shared slice \"{}\" of {} carries an unparsable source reference \"{source}\" ({e}) — re-press the package",
+                    slice.name,
+                    self_path.display()
+                ),
+            )
+        })?;
+        let entry = tebako_resolve::resolve_locked_slice(
+            &cache,
+            &slice.name,
+            &slice.version,
+            pin,
+            &reference,
+        )
+        .map_err(|e| match e {
+            tebako_resolve::ResolveError::Sha256Mismatch {
+                expected, actual, ..
+            } => BootError::new(
+                EX_TEBAKO_SHA,
+                format!(
+                    "SHA256 mismatch for shared slice \"{}\" {} — refusing to install or execute\n  expected: {expected} (the press-time lock pin, spec 23 §13.4)\n  actual:   {actual}\n  the cache was not touched",
+                    slice.name, slice.version
+                ),
+            ),
+            other => BootError::new(
+                EX_TEBAKO_UNAVAILABLE,
+                format!(
+                    "cannot resolve shared slice \"{}\" {} of {}: {other}\n  the lock's fetch coordinates: {source}",
+                    slice.name,
+                    slice.version,
+                    self_path.display()
+                ),
+            ),
+        })?;
+        out.push((slice.name.clone(), entry.path));
+    }
+    Ok(out)
+}
+
+/// spec 05 §4's scoped lazy-seed exception (locked 2026-08-25,
+/// tebako#460): a package that CARRIES artifacts seeds the machine cache
+/// with them at run time, so later packages share them. Best-effort — a
+/// seed that cannot complete NEVER blocks or fails the run; the carried
+/// bytes keep serving from the package. tmp + rename under the entry
+/// lock; idempotent same-sha skip; never an overwrite; journaled
+/// (`event=lazy-seed`). `TEBAKO_OFFLINE=1` does not block seeding (no
+/// network is involved); `TPKG_FLAG_NO_INSTALL` packages never seed.
+///
+/// The exe (and the windows dll) need no seeding here — the run itself
+/// staged them into the runtime cache. What seeds: the env image (into
+/// the runtime cache entry) and every carried payload slice (into the
+/// payload cache).
+fn lazy_seed(
+    self_path: &Path,
+    m: &tpkg::Manifest,
+    lock: &tpkg::PackageLock,
+    runtime_ref: &str,
+    rr: &RuntimeRef,
+) {
+    if m.package_flags & tpkg::TPKG_FLAG_NO_INSTALL != 0 {
+        return;
+    }
+    let Ok(root) = cache_root() else {
+        return;
+    };
+    let host = tpkg::Platform::host();
+
+    // The carried env image → the runtime cache entry.
+    if let Some(image_art) = lock
+        .runtime
+        .as_ref()
+        .filter(|r| r.carry)
+        .and_then(|r| r.image.as_ref())
+    {
+        seed_carried_image(&root, self_path, m, image_art, runtime_ref, rr);
+    }
+
+    // Every carried payload slice → the payload cache.
+    let cache = tebako_resolve::PayloadCache::with_root(&root);
+    for slice in lock.slices.iter().filter(|s| s.carry) {
+        let seeded = (|| -> Result<&str, String> {
+            let slot_ix = slice
+                .slot
+                .ok_or_else(|| "a carried slice without its slot".to_string())?;
+            let pin = slice
+                .sha256
+                .for_host(host)
+                .ok_or_else(|| format!("no digest pin for {host:?}"))?;
+            let slot = m
+                .slots
+                .get(slot_ix as usize)
+                .ok_or_else(|| format!("slot {slot_ix} outside the container"))?;
+            let mut f = std::fs::File::open(self_path).map_err(|e| e.to_string())?;
+            f.seek(SeekFrom::Start(slot.offset)).map_err(|e| e.to_string())?;
+            let origin = format!("{} slot {slot_ix}", self_path.display());
+            cache
+                .seed(
+                    &slice.name,
+                    &slice.version,
+                    pin,
+                    &origin,
+                    std::io::Read::take(f, slot.size),
+                )
+                .map_err(|e| e.to_string())
+                .and_then(|outcome| match outcome {
+                    tebako_resolve::SeedOutcome::Seeded => Ok("seeded"),
+                    tebako_resolve::SeedOutcome::AlreadySame => Ok("already-cached"),
+                    tebako_resolve::SeedOutcome::Conflict { existing_sha256 } => Err(format!(
+                        "the cache holds {name}@{version} under a DIFFERENT digest ({existing_sha256}) — the cached bytes win, the package's copy was not installed",
+                        name = slice.name,
+                        version = slice.version
+                    )),
+                })
+        })();
+        match seeded {
+            Ok("seeded") => journal(
+                &root,
+                &format!(
+                    "event=lazy-seed artifact={}@{} origin={} slot={}",
+                    slice.name,
+                    slice.version,
+                    self_path.display(),
+                    slice.slot.unwrap_or(0)
+                ),
+            ),
+            Ok(_) => {}
+            Err(reason) => {
+                eprintln!(
+                    "tebako-bootstrap: WARNING: lazy seed of {}@{} from {} skipped: {reason}\n  the run is unaffected — the carried bytes serve from the package",
+                    slice.name,
+                    slice.version,
+                    self_path.display()
+                );
+                journal(
+                    &root,
+                    &format!(
+                        "event=lazy-seed artifact={}@{} outcome=skipped reason=\"{reason}\"",
+                        slice.name,
+                        slice.version
+                    ),
+                );
+            }
+        }
+    }
+}
+
+/// The env-image half of the runtime-pair seed (spec 05 §4, spec 19
+/// §6.1): extract the image slot into the runtime cache entry, verified
+/// against the lock pin BEFORE anything lands, tmp + rename under the
+/// entry lock. Same-sha entry skips; a different-sha entry is never
+/// overwritten (loud + journaled). Every failure journals and returns —
+/// the run mounts the package's own copy regardless.
+fn seed_carried_image(
+    root: &Path,
+    self_path: &Path,
+    m: &tpkg::Manifest,
+    image_art: &tpkg::LockedArtifact,
+    runtime_ref: &str,
+    rr: &RuntimeRef,
+) {
+    let skip = |reason: &str| {
+        journal(
+            root,
+            &format!(
+                "event=lazy-seed artifact=runtime-image outcome=skipped reason=\"{reason}\""
+            ),
+        );
+    };
+    let host = tpkg::Platform::host();
+    let Some(pin) = image_art.sha256.for_host(host) else {
+        return skip("no digest pin for this platform");
+    };
+    let Some(slot) = m.slots.get(image_art.slot as usize) else {
+        return skip("the image slot is outside the container");
+    };
+    let layout = match cache_layout(rr) {
+        Ok(l) => l,
+        Err(e) => return skip(&e.message),
+    };
+    // The entry's image spelling flows from its cached release index when
+    // one exists (spec 05 §2) — the same derivation resolve_image applies.
+    let id = ReleaseIdentity::of(rr, platform_string());
+    let cached_index = std::fs::read_to_string(layout.entry_dir.join("manifest.json")).ok();
+    let image_asset = cached_index
+        .as_deref()
+        .and_then(|text| id.entry(text))
+        .and_then(|e| manifest_entry_facet_filename(&e, "image"))
+        .unwrap_or_else(|| format!("{}.tfs", layout.asset_base));
+    let image_path = layout.entry_dir.join(&image_asset);
+    let marker = layout.entry_dir.join(format!("{image_asset}.sha256"));
+    let marker_sha = || {
+        std::fs::read_to_string(&marker)
+            .ok()
+            .and_then(|text| text.split_whitespace().next().map(str::to_string))
+    };
+    if file_exists(&image_path) && marker_sha().as_deref() == Some(pin) {
+        return; // idempotent same-sha skip
+    }
+    if file_exists(&image_path) && file_exists(&marker) {
+        let existing = marker_sha().unwrap_or_else(|| "unreadable".to_string());
+        eprintln!(
+            "tebako-bootstrap: WARNING: the runtime cache holds {image_asset} under a DIFFERENT digest ({existing}) than {}'s lock pin ({pin})\n  the cached image wins — the package's copy was not installed; the run is unaffected",
+            self_path.display()
+        );
+        return skip("a different-sha cache entry exists (never overwritten)");
+    }
+
+    let locks = root.join("locks");
+    if mkdir_p(&locks).is_err() || mkdir_p(&root.join("tmp")).is_err() {
+        return skip("cannot create the cache directories");
+    }
+    let lock_path = locks.join(format!("{}.lock", layout.entry));
+    let Ok(lock) = flock_acquire(&lock_path, LOCK_TIMEOUT_MS) else {
+        return skip("the entry lock is held by another bootstrap");
+    };
+    let result = (|| -> Result<(), String> {
+        if file_exists(&image_path) && file_exists(&marker) {
+            return Ok(()); // a concurrent seed won the race
+        }
+        mkdir_p(&layout.entry_dir).map_err(|e| e.to_string())?;
+        let tmp_dir = root
+            .join("tmp")
+            .join(format!("{}.{}.image-seed", layout.entry, std::process::id()));
+        cleanup_tmp_entry(&tmp_dir, &image_asset);
+        std::fs::create_dir(&tmp_dir).map_err(|e| e.to_string())?;
+        let inner = (|| -> Result<(), String> {
+            let tmp_image = tmp_dir.join(&image_asset);
+            let actual = stage_locked_slot(self_path, slot, pin, &tmp_image, "runtime image")
+                .map_err(|e| e.message)?;
+            make_readonly(&tmp_image);
+            os_rename(&tmp_image, &image_path).map_err(|e| e.to_string())?;
+            let _ = write_small_file(&marker, &format!("{actual}  {image_asset}\n"));
+            let _ = write_small_file(
+                &layout.entry_dir.join(format!("{image_asset}.origin")),
+                &format!(
+                    "runtime_ref={runtime_ref}\ncarried={} slot {}\nsha256={actual}\n",
+                    self_path.display(),
+                    image_art.slot
+                ),
+            );
+            Ok(())
+        })();
+        cleanup_tmp_entry(&tmp_dir, &image_asset);
+        inner
+    })();
+    lock_release(lock);
+    match result {
+        Ok(()) => journal(
+            root,
+            &format!(
+                "event=lazy-seed artifact={image_asset} origin={} slot={}",
+                self_path.display(),
+                image_art.slot
+            ),
+        ),
+        Err(reason) => {
+            eprintln!(
+                "tebako-bootstrap: WARNING: lazy seed of the runtime image from {} skipped: {reason}\n  the run is unaffected — the image serves from the package",
+                self_path.display()
+            );
+            skip(&reason);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
 // exec handoff (launcher ABI v1)
 // ---------------------------------------------------------------------
 
@@ -2729,32 +3322,110 @@ fn resolve_dll(
 /// construction), and slots no entry references (extra `--image` payloads)
 /// mount as always. Without a package manifest every non-runtime slot
 /// mounts and `--tebako-entry` is argv0 verbatim — the v1 behavior.
+///
+/// Locked packages (spec 23 §4/§13): `lock.slices` order IS the mount
+/// order — the app payload first, then its dependency closure — so a
+/// pointer entry's shared slice leads the image list (the entry resolves
+/// against the FIRST `--tebako-image` mount, spec 17 §1). A carried slice
+/// mounts its trailer slot; a shared slice mounts its cache file as
+/// `<path>:-:<mount>` (a bare image, slot `-` ≡ whole file); a slice
+/// without a declared mount is a cache prime and emits no triple. Slots
+/// the lock claims (the carried runtime pair) never mount; slots the
+/// lock does not describe (extra `--image` payloads) mount as always,
+/// after the locked slices.
 /// Public for the integration tests; the flow uses it once per run.
+#[allow(clippy::too_many_arguments)]
 pub fn handoff_argv(
     runtime: &Path,
     self_path: &Path,
     m: &tpkg::Manifest,
     selection: Option<&(tpkg::PackageManifest, tpkg::PackageEntry)>,
     argv: &[String],
+    lock: Option<&tpkg::PackageLock>,
+    shared: &[(String, PathBuf)],
 ) -> Vec<String> {
     let mut nargv: Vec<String> = vec![runtime.to_string_lossy().into_owned()];
-    for (s, slot) in m.slots.iter().enumerate() {
-        if slot.format_id == tpkg::TPKG_FORMAT_RUNTIME {
-            continue; // runtime payload: installed into the cache, never mounted
+    // Another suite member's slot (spec 03 §6) — skipped under both forms.
+    let suite_skip = |s: u32| -> bool {
+        match selection {
+            Some((pm, selected)) => {
+                selected.slot != Some(s) && pm.entries.iter().any(|e| e.slot == Some(s))
+            }
+            None => false,
         }
-        if let Some((pm, selected)) = selection {
-            if selected.slot != Some(s as u32)
-                && pm.entries.iter().any(|e| e.slot == Some(s as u32))
-            {
-                continue; // another suite member's image — not mounted
+    };
+    match lock {
+        None => {
+            for (s, slot) in m.slots.iter().enumerate() {
+                if slot.format_id == tpkg::TPKG_FORMAT_RUNTIME {
+                    continue; // runtime payload: installed into the cache, never mounted
+                }
+                if suite_skip(s as u32) {
+                    continue; // another suite member's image — not mounted
+                }
+                nargv.push("--tebako-image".to_string());
+                nargv.push(format!(
+                    "{}:{s}:{}",
+                    self_path.display(),
+                    slot.mount_point_str().unwrap_or_default()
+                ));
             }
         }
-        nargv.push("--tebako-image".to_string());
-        nargv.push(format!(
-            "{}:{s}:{}",
-            self_path.display(),
-            slot.mount_point_str().unwrap_or_default()
-        ));
+        Some(lock) => {
+            let claimed: std::collections::BTreeSet<u32> =
+                lock.claimed_slots().into_iter().collect();
+            let mut emitted: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
+            for slice in &lock.slices {
+                match slice.slot {
+                    Some(s) => {
+                        if suite_skip(s) {
+                            continue; // another suite member's carried image
+                        }
+                        let Some(slot) = m.slots.get(s as usize) else {
+                            continue; // the selection gate already bounds-checks
+                        };
+                        nargv.push("--tebako-image".to_string());
+                        nargv.push(format!(
+                            "{}:{s}:{}",
+                            self_path.display(),
+                            slot.mount_point_str().unwrap_or_default()
+                        ));
+                        emitted.insert(s);
+                    }
+                    None => {
+                        // A shared slice with no declared mount is a cache
+                        // prime — no triple (spec 23 §13.1).
+                        let Some(mount) = slice.mount.as_deref() else {
+                            continue;
+                        };
+                        let Some((_, path)) = shared.iter().find(|(n, _)| n == &slice.name)
+                        else {
+                            continue; // resolution failed closed before this point
+                        };
+                        nargv.push("--tebako-image".to_string());
+                        nargv.push(format!("{}:-:{mount}", path.display()));
+                    }
+                }
+            }
+            // Slots the lock does not describe (extra `--image` payloads)
+            // mount as always, after the locked slices.
+            for (s, slot) in m.slots.iter().enumerate() {
+                let s = s as u32;
+                if slot.format_id == tpkg::TPKG_FORMAT_RUNTIME
+                    || claimed.contains(&s)
+                    || emitted.contains(&s)
+                    || suite_skip(s)
+                {
+                    continue;
+                }
+                nargv.push("--tebako-image".to_string());
+                nargv.push(format!(
+                    "{}:{s}:{}",
+                    self_path.display(),
+                    slot.mount_point_str().unwrap_or_default()
+                ));
+            }
+        }
     }
     nargv.push("--tebako-entry".to_string());
     nargv.push(match selection {
@@ -2770,24 +3441,29 @@ pub fn handoff_argv(
 
 /// Unix: execv(3) replaces the bootstrap — never returns on success.
 #[cfg(unix)]
+#[allow(clippy::too_many_arguments)]
 fn exec_runtime(
     runtime: &Path,
-    image: Option<&Path>,
+    image: Option<&str>,
     self_path: &Path,
     m: &tpkg::Manifest,
     selection: Option<&(tpkg::PackageManifest, tpkg::PackageEntry)>,
     argv: &[String],
     jail: Option<&JailEnv>,
+    lock: Option<&tpkg::PackageLock>,
+    shared: &[(String, PathBuf)],
 ) -> BootError {
     use std::os::unix::process::CommandExt;
 
-    let nargv = handoff_argv(runtime, self_path, m, selection, argv);
+    let nargv = handoff_argv(runtime, self_path, m, selection, argv, lock, shared);
     let mut cmd = std::process::Command::new(runtime);
     cmd.args(&nargv[1..]);
     if let Some(image) = image {
         // item 30b: the runtime image rides the environment; image-era
         // drivers mount it instead of an embedded image, v1 drivers
-        // ignore it. The handoff options themselves are unchanged.
+        // ignore it. The handoff options themselves are unchanged. The
+        // value is a wire form: a bare path, or `<package>:<slot>` for a
+        // carried env image (spec 17 §2.1, spec 19 §6.1).
         cmd.env("TEBAKO_RUNTIME_IMAGE", image);
     }
     if let Some(jail) = jail {
@@ -2813,16 +3489,19 @@ fn exec_runtime(
 /// the spawn/wait failure maps onto the same EX_TEBAKO_IO message body
 /// as the unix exec failure.
 #[cfg(windows)]
+#[allow(clippy::too_many_arguments)]
 fn exec_runtime(
     runtime: &Path,
-    image: Option<&Path>,
+    image: Option<&str>,
     self_path: &Path,
     m: &tpkg::Manifest,
     selection: Option<&(tpkg::PackageManifest, tpkg::PackageEntry)>,
     argv: &[String],
     jail: Option<&JailEnv>,
+    lock: Option<&tpkg::PackageLock>,
+    shared: &[(String, PathBuf)],
 ) -> BootError {
-    let nargv = handoff_argv(runtime, self_path, m, selection, argv);
+    let nargv = handoff_argv(runtime, self_path, m, selection, argv, lock, shared);
     let err = platform::spawn_handoff(runtime, &nargv[1..], image, jail);
     BootError::new(
         EX_TEBAKO_IO,
@@ -2940,7 +3619,26 @@ pub fn run(argv: &[String]) -> Result<std::convert::Infallible, BootError> {
         prepare_jail(&m, user.as_ref(), argv, &home)?
     };
 
-    let (runtime, image) = resolve_runtime(&runtime_ref, &rr, &self_path, &m)?;
+    // The composition spectrum (spec 23 §13, tebako#458): the L2 lock
+    // rides the package manifest. A carried runtime (`lock.runtime.carry`)
+    // stages its exe from its trailer slot and hands the env image to the
+    // driver as `<package>:<slot>` — keyed on the lock, never on the
+    // (deprecated) LEAN flag; the legacy format-4 slot scan below keeps
+    // serving pre-#458 fat packages.
+    let pm_lock = selection.as_ref().and_then(|(pm, _)| pm.lock.as_ref());
+    let carried = pm_lock
+        .and_then(|l| l.runtime.as_ref())
+        .filter(|r| r.carry);
+    let (runtime, image) = resolve_runtime(&runtime_ref, &rr, &self_path, &m, carried)?;
+    let shared = match pm_lock {
+        Some(lock) => resolve_shared_slices(lock, &self_path)?,
+        None => Vec::new(),
+    };
+    // spec 05 §4's scoped exception: carried artifacts seed the machine
+    // cache — best-effort, journaled, never blocking the run.
+    if let Some(lock) = pm_lock {
+        lazy_seed(&self_path, &m, lock, &runtime_ref, &rr);
+    }
     Err(exec_runtime(
         &runtime,
         image.as_deref(),
@@ -2949,6 +3647,8 @@ pub fn run(argv: &[String]) -> Result<std::convert::Infallible, BootError> {
         selection.as_ref(),
         argv,
         jail.as_ref(),
+        pm_lock,
+        &shared,
     ))
 }
 

--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -301,7 +301,9 @@ pub fn select_entry<'a>(pm: &'a tpkg::PackageManifest, argv0: &str) -> &'a tpkg:
 /// package carries no type-2 block (v1 behavior, byte-identical), else
 /// the parsed manifest and the entry `argv0` selects. A corrupt block is
 /// a named error; an entry naming a slot the container does not carry is
-/// a named error (the package is internally inconsistent).
+/// a named error (the package is internally inconsistent). A slot-less
+/// entry (`slot: None`) is the pointer form — backed by a shared lock
+/// slice of the same name, guaranteed by the manifest's own validation.
 pub fn package_selection(
     m: &tpkg::Manifest,
     argv0: &str,
@@ -309,16 +311,18 @@ pub fn package_selection(
     match m.package_manifest() {
         Ok(Some(pm)) => {
             let entry = select_entry(&pm, argv0).clone();
-            if entry.slot as usize >= m.slots.len() {
-                return fail(
-                    EX_TEBAKO_MANIFEST,
-                    format!(
-                        "package manifest entry \"{}\" names slot {} but the package carries {} slot(s) — the package is internally inconsistent, re-stitch it",
-                        entry.name,
-                        entry.slot,
-                        m.slots.len()
-                    ),
-                );
+            if let Some(slot) = entry.slot {
+                if slot as usize >= m.slots.len() {
+                    return fail(
+                        EX_TEBAKO_MANIFEST,
+                        format!(
+                            "package manifest entry \"{}\" names slot {} but the package carries {} slot(s) — the package is internally inconsistent, re-stitch it",
+                            entry.name,
+                            slot,
+                            m.slots.len()
+                        ),
+                    );
+                }
             }
             Ok(Some((pm, entry.clone())))
         }
@@ -2739,7 +2743,9 @@ pub fn handoff_argv(
             continue; // runtime payload: installed into the cache, never mounted
         }
         if let Some((pm, selected)) = selection {
-            if s != selected.slot as usize && pm.entries.iter().any(|e| e.slot as usize == s) {
+            if selected.slot != Some(s as u32)
+                && pm.entries.iter().any(|e| e.slot == Some(s as u32))
+            {
                 continue; // another suite member's image — not mounted
             }
         }

--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -2872,7 +2872,13 @@ fn stage_carried_runtime(
                 Some(format!("{}:{}", self_path.display(), image_art.slot)),
             ));
         };
-        match stage_locked_slot(self_path, slot, expected, &ins.tmp_asset, "runtime executable") {
+        match stage_locked_slot(
+            self_path,
+            slot,
+            expected,
+            &ins.tmp_asset,
+            "runtime executable",
+        ) {
             Ok(actual) => {
                 let origin = format!(
                     "runtime_ref={runtime_ref}\ncarried={} slot {}\nsha256={actual}\n",
@@ -2969,10 +2975,11 @@ fn stage_carried_dll(
         lock_release(lock);
         return Ok(());
     }
-    let tmp_dir = layout
-        .root
-        .join("tmp")
-        .join(format!("{}.{}.dll", layout.entry, std::process::id()));
+    let tmp_dir =
+        layout
+            .root
+            .join("tmp")
+            .join(format!("{}.{}.dll", layout.entry, std::process::id()));
     cleanup_tmp_entry(&tmp_dir, install_as);
     let result = (|| -> Result<(), BootError> {
         std::fs::create_dir(&tmp_dir).map_err(|e| {
@@ -3136,7 +3143,8 @@ fn lazy_seed(
                 .get(slot_ix as usize)
                 .ok_or_else(|| format!("slot {slot_ix} outside the container"))?;
             let mut f = std::fs::File::open(self_path).map_err(|e| e.to_string())?;
-            f.seek(SeekFrom::Start(slot.offset)).map_err(|e| e.to_string())?;
+            f.seek(SeekFrom::Start(slot.offset))
+                .map_err(|e| e.to_string())?;
             let origin = format!("{} slot {slot_ix}", self_path.display());
             cache
                 .seed(
@@ -3180,8 +3188,7 @@ fn lazy_seed(
                     &root,
                     &format!(
                         "event=lazy-seed artifact={}@{} outcome=skipped reason=\"{reason}\"",
-                        slice.name,
-                        slice.version
+                        slice.name, slice.version
                     ),
                 );
             }
@@ -3206,9 +3213,7 @@ fn seed_carried_image(
     let skip = |reason: &str| {
         journal(
             root,
-            &format!(
-                "event=lazy-seed artifact=runtime-image outcome=skipped reason=\"{reason}\""
-            ),
+            &format!("event=lazy-seed artifact=runtime-image outcome=skipped reason=\"{reason}\""),
         );
     };
     let host = tpkg::Platform::host();
@@ -3263,9 +3268,11 @@ fn seed_carried_image(
             return Ok(()); // a concurrent seed won the race
         }
         mkdir_p(&layout.entry_dir).map_err(|e| e.to_string())?;
-        let tmp_dir = root
-            .join("tmp")
-            .join(format!("{}.{}.image-seed", layout.entry, std::process::id()));
+        let tmp_dir = root.join("tmp").join(format!(
+            "{}.{}.image-seed",
+            layout.entry,
+            std::process::id()
+        ));
         cleanup_tmp_entry(&tmp_dir, &image_asset);
         std::fs::create_dir(&tmp_dir).map_err(|e| e.to_string())?;
         let inner = (|| -> Result<(), String> {
@@ -3398,8 +3405,7 @@ pub fn handoff_argv(
                         let Some(mount) = slice.mount.as_deref() else {
                             continue;
                         };
-                        let Some((_, path)) = shared.iter().find(|(n, _)| n == &slice.name)
-                        else {
+                        let Some((_, path)) = shared.iter().find(|(n, _)| n == &slice.name) else {
                             continue; // resolution failed closed before this point
                         };
                         nargv.push("--tebako-image".to_string());
@@ -3626,9 +3632,7 @@ pub fn run(argv: &[String]) -> Result<std::convert::Infallible, BootError> {
     // (deprecated) LEAN flag; the legacy format-4 slot scan below keeps
     // serving pre-#458 fat packages.
     let pm_lock = selection.as_ref().and_then(|(pm, _)| pm.lock.as_ref());
-    let carried = pm_lock
-        .and_then(|l| l.runtime.as_ref())
-        .filter(|r| r.carry);
+    let carried = pm_lock.and_then(|l| l.runtime.as_ref()).filter(|r| r.carry);
     let (runtime, image) = resolve_runtime(&runtime_ref, &rr, &self_path, &m, carried)?;
     let shared = match pm_lock {
         Some(lock) => resolve_shared_slices(lock, &self_path)?,

--- a/crates/tebako-bootstrap/src/platform.rs
+++ b/crates/tebako-bootstrap/src/platform.rs
@@ -320,7 +320,7 @@ pub fn lock_release(lock: EntryLock) {
 pub fn spawn_handoff(
     runtime: &Path,
     args: &[String],
-    image: Option<&Path>,
+    image: Option<&str>,
     jail: Option<&crate::JailEnv>,
 ) -> io::Error {
     install_ctrl_swallow();
@@ -329,7 +329,9 @@ pub fn spawn_handoff(
     if let Some(image) = image {
         // item 30b: the runtime image rides the environment; image-era
         // drivers mount it instead of an embedded image, v1 drivers
-        // ignore it. The handoff options themselves are unchanged.
+        // ignore it. The handoff options themselves are unchanged. The
+        // value is a wire form: a bare path, or `<package>:<slot>` for a
+        // carried env image (spec 17 §2.1, spec 19 §6.1).
         cmd.env("TEBAKO_RUNTIME_IMAGE", image);
     }
     if let Some(jail) = jail {

--- a/crates/tebako-bootstrap/tests/compose.rs
+++ b/crates/tebako-bootstrap/tests/compose.rs
@@ -77,7 +77,8 @@ fn stitch_composed(
     let mut outf = std::fs::File::create(&out).unwrap();
     {
         use std::io::Write as _;
-        outf.write_all(&std::fs::read(&h.bootstrap).unwrap()).unwrap();
+        outf.write_all(&std::fs::read(&h.bootstrap).unwrap())
+            .unwrap();
         for (p, _, _) in parts {
             outf.write_all(&std::fs::read(p).unwrap()).unwrap();
         }
@@ -165,7 +166,12 @@ fn the_carried_package_boots_offline_and_seeds_the_cache() {
     let (pkg, env_image, app) = self_contained_pkg(&h, "mnconvert-sc", 0);
     let home = h.home("home");
 
-    let (rc, out, _err) = h.run(&pkg, &home, &[("TEBAKO_OFFLINE", "1")], &["mnconvert", "doc.xml"]);
+    let (rc, out, _err) = h.run(
+        &pkg,
+        &home,
+        &[("TEBAKO_OFFLINE", "1")],
+        &["mnconvert", "doc.xml"],
+    );
     assert_eq!(rc, 0, "stdout:\n{out}");
     assert!(out.contains("FAKE-RUNTIME"), "stdout:\n{out}");
     // The bootstrap canonicalizes its own path (run()'s current_exe).
@@ -191,7 +197,10 @@ fn the_carried_package_boots_offline_and_seeds_the_cache() {
     assert!(h.cache_image(&home).is_file());
     let marker = std::fs::read_to_string(format!("{}.sha256", h.cache_image(&home).display()))
         .expect("the seeded image carries its trust anchor");
-    assert!(marker.starts_with(&sha256_of(&env_image)), "marker: {marker}");
+    assert!(
+        marker.starts_with(&sha256_of(&env_image)),
+        "marker: {marker}"
+    );
     let seeded = cached_slice(&home, "mnconvert", APP_VER);
     assert!(seeded.is_file());
     let anchor =
@@ -202,7 +211,10 @@ fn the_carried_package_boots_offline_and_seeds_the_cache() {
         journal.contains("event=lazy-seed artifact=mnconvert@1.2.3"),
         "journal:\n{journal}"
     );
-    assert!(journal.contains("event=lazy-seed artifact="), "journal:\n{journal}");
+    assert!(
+        journal.contains("event=lazy-seed artifact="),
+        "journal:\n{journal}"
+    );
 }
 
 /// spec 23 §13.1: a shared slice resolves at first run BY THE LOCKED
@@ -240,7 +252,7 @@ fn the_shared_slice_resolves_mid_run_by_its_locked_digest() {
                 slot: None,
                 mount: Some("/__tfs__/mnt/mn2pdf".to_string()),
                 sha256: pin(&shared_file),
-                source: Some(format!("file://{}", shared_file.display())),
+                source: Some(tebako_http::file_url(&shared_file)),
             },
         ],
     };
@@ -401,7 +413,7 @@ fn a_shared_slice_mismatching_its_lock_pin_fails_closed_with_70() {
                 slot: None,
                 mount: Some("/__tfs__/mnt/mn2pdf".to_string()),
                 sha256: pin(&app), // wrong on purpose
-                source: Some(format!("file://{}", shared_file.display())),
+                source: Some(tebako_http::file_url(&shared_file)),
             },
         ],
     };
@@ -479,7 +491,10 @@ fn a_lock_without_host_coverage_is_a_named_65() {
 
     let (rc, out, err) = h.run(&pkg, &home, &[], &["mnconvert"]);
     assert_eq!(rc, 65, "stdout:\n{out}\nstderr:\n{err}");
-    assert!(err.contains("does not cover this platform"), "stderr:\n{err}");
+    assert!(
+        err.contains("does not cover this platform"),
+        "stderr:\n{err}"
+    );
     assert!(
         err.contains(tpkg::Platform::host().release_asset_name()),
         "stderr:\n{err}"
@@ -517,8 +532,10 @@ fn the_pointer_entrys_shared_slice_leads_the_image_list() {
         tpkg::TPKG_FORMAT_DWARFS,
         "/__tfs__",
     ));
-    m.slots.push(tpkg::Slot::new(100, 50, tpkg::TPKG_FORMAT_AUTO, ""));
-    m.slots.push(tpkg::Slot::new(150, 60, tpkg::TPKG_FORMAT_DWARFS, ""));
+    m.slots
+        .push(tpkg::Slot::new(100, 50, tpkg::TPKG_FORMAT_AUTO, ""));
+    m.slots
+        .push(tpkg::Slot::new(150, 60, tpkg::TPKG_FORMAT_DWARFS, ""));
     let runtime_ref = "ruby@3.3.7;tebako=9.9.9;image";
     let sha = |c: char| c.to_string().repeat(64);
     let lock = tpkg::PackageLock {

--- a/crates/tebako-bootstrap/tests/compose.rs
+++ b/crates/tebako-bootstrap/tests/compose.rs
@@ -1,0 +1,645 @@
+//! The composition spectrum e2e (spec 23 §13, spec 19 §6.1, tebako#458):
+//! the bootstrap runs the L2 lock — a self-contained package stages its
+//! carried runtime exe from its trailer slot, hands the env image to the
+//! driver as `<package>:<slot>`, resolves shared slices by their locked
+//! digest, and lazily seeds the machine cache (spec 05 §4). The fake
+//! runtime echoes TEBAKO_RUNTIME_IMAGE and its argv, so the wire forms
+//! are asserted byte-exact.
+
+// The harness is shared with selftest/progress/chain/jail; this suite
+// uses a subset of its API — silence per-binary unused-function warnings.
+#[allow(dead_code)]
+mod harness;
+
+use std::path::{Path, PathBuf};
+
+use harness::{rust_bootstrap, sha256_of, Harness};
+
+const APP_VER: &str = "1.2.3";
+const SHARED_VER: &str = "2.0.0";
+
+fn pin(path: &Path) -> tpkg::DigestPin {
+    tpkg::DigestPin::One(sha256_of(path))
+}
+
+/// The package manifest of a composed package: one `mnconvert` entry on
+/// slot 0 plus the lock under test.
+fn composed_pm(runtime_ref: &str, lock: tpkg::PackageLock) -> tpkg::PackageManifest {
+    tpkg::PackageManifest {
+        schema_version: tpkg::PACKAGE_SCHEMA_VERSION,
+        package: tpkg::PackageIdentity {
+            name: "mnconvert".to_string(),
+            version: APP_VER.to_string(),
+            producer: tpkg::Producer {
+                tool: "tebako-cli".to_string(),
+                tool_version: "0.16.0".to_string(),
+            },
+            created: "2026-08-25T00:00:00Z".to_string(),
+        },
+        entries: vec![tpkg::PackageEntry {
+            name: "mnconvert".to_string(),
+            slot: Some(0),
+            entrypoint: "mnconvert".to_string(),
+            runtime_ref: runtime_ref.to_string(),
+        }],
+        jail: None,
+        env: Default::default(),
+        lock: Some(lock),
+        mounts: Vec::new(),
+    }
+}
+
+/// The harness stitch, generalized: explicit parts + a type-2 package
+/// manifest block + explicit package flags.
+fn stitch_composed(
+    h: &Harness,
+    name: &str,
+    parts: &[(PathBuf, u32, &str)],
+    runtime_ref: &str,
+    pm: &tpkg::PackageManifest,
+    package_flags: u32,
+) -> PathBuf {
+    let out = h.tmp.0.join(name);
+    let mut m = tpkg::Manifest {
+        package_flags,
+        launcher_abi: 0,
+        ..Default::default()
+    };
+    m.set_runtime_ref(runtime_ref.as_bytes());
+    let mut pos = std::fs::metadata(&h.bootstrap).unwrap().len();
+    for (path, format_id, mount) in parts {
+        let size = std::fs::metadata(path).unwrap().len();
+        let slot = tpkg::Slot::new(pos, size, *format_id, mount);
+        m.slots.push(slot);
+        pos += size;
+    }
+    m.set_package_manifest(pm).unwrap();
+    let mut outf = std::fs::File::create(&out).unwrap();
+    {
+        use std::io::Write as _;
+        outf.write_all(&std::fs::read(&h.bootstrap).unwrap()).unwrap();
+        for (p, _, _) in parts {
+            outf.write_all(&std::fs::read(p).unwrap()).unwrap();
+        }
+    }
+    tpkg::write_to(&mut outf, &m).unwrap();
+    drop(outf);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&out, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    out
+}
+
+/// A self-contained package (spec 23 §13.2): app slice on slot 0, the
+/// carried runtime pair on slots 1 (exe) and 2 (env image) — exe bytes
+/// are the fake-runtime stub, so a successful boot prints its markers.
+/// Returns (package path, env-image bytes path, app image path).
+fn self_contained_pkg(h: &Harness, name: &str, package_flags: u32) -> (PathBuf, PathBuf, PathBuf) {
+    let app = h.fake_image();
+    let env_image = h.tmp.0.join(format!("{name}-env.tfs"));
+    std::fs::write(&env_image, b"FAKE RUNTIME ENV IMAGE").unwrap();
+    let runtime_ref = format!("{};image", h.runtime_ref);
+    let lock = tpkg::PackageLock {
+        runtime: Some(tpkg::LockedRuntime {
+            version: harness::RUBY_VER.to_string(),
+            carry: true,
+            exe: Some(tpkg::LockedArtifact {
+                slot: 1,
+                sha256: pin(&h.fake_runtime),
+                install_as: None,
+            }),
+            image: Some(tpkg::LockedArtifact {
+                slot: 2,
+                sha256: pin(&env_image),
+                install_as: None,
+            }),
+            dll: None,
+        }),
+        slices: vec![tpkg::LockedSlice {
+            name: "mnconvert".to_string(),
+            version: APP_VER.to_string(),
+            carry: true,
+            slot: Some(0),
+            mount: Some("/__tfs__".to_string()),
+            sha256: pin(&app),
+            source: None,
+        }],
+    };
+    let pm = composed_pm(&runtime_ref, lock);
+    let pkg = stitch_composed(
+        h,
+        name,
+        &[
+            (app.clone(), tpkg::TPKG_FORMAT_DWARFS, "/__tfs__"),
+            (h.fake_runtime.clone(), tpkg::TPKG_FORMAT_AUTO, ""),
+            (env_image.clone(), tpkg::TPKG_FORMAT_DWARFS, ""),
+        ],
+        &runtime_ref,
+        &pm,
+        package_flags,
+    );
+    (pkg, env_image, app)
+}
+
+fn journal_of(home: &Path) -> String {
+    std::fs::read_to_string(home.join("journal.log")).unwrap_or_default()
+}
+
+/// The payload cache entry a seed would have written.
+fn cached_slice(home: &Path, name: &str, version: &str) -> PathBuf {
+    home.join("payloads")
+        .join(name)
+        .join(format!("{version}.tfs"))
+}
+
+/// spec 19 §6.1 / spec 23 §13.2: a self-contained package boots with an
+/// EMPTY cache and NO network — the carried exe stages into the runtime
+/// cache, the env image rides to the driver as `<package>:2`, the app
+/// slice mounts from slot 0, and both carried artifacts seed the cache
+/// (spec 05 §4), journaled.
+#[test]
+fn the_carried_package_boots_offline_and_seeds_the_cache() {
+    let h = Harness::new(rust_bootstrap());
+    let (pkg, env_image, app) = self_contained_pkg(&h, "mnconvert-sc", 0);
+    let home = h.home("home");
+
+    let (rc, out, _err) = h.run(&pkg, &home, &[("TEBAKO_OFFLINE", "1")], &["mnconvert", "doc.xml"]);
+    assert_eq!(rc, 0, "stdout:\n{out}");
+    assert!(out.contains("FAKE-RUNTIME"), "stdout:\n{out}");
+    // The bootstrap canonicalizes its own path (run()'s current_exe).
+    let canon = pkg.canonicalize().unwrap();
+    // The env image slot form (spec 17 §2.1) — the driver is handed the
+    // package's own path plus the slot number, never an extracted copy.
+    assert!(
+        out.contains(&format!("TEBAKO_RUNTIME_IMAGE={}:2", canon.display())),
+        "stdout:\n{out}"
+    );
+    assert!(
+        out.contains(&format!("argv[1]={}:0:/__tfs__", canon.display())),
+        "stdout:\n{out}"
+    );
+    // argv[3] is the entrypoint; the user's argv (mnconvert doc.xml) follows.
+    assert!(out.contains("argv[4]=mnconvert"), "stdout:\n{out}");
+    assert!(out.contains("argv[5]=doc.xml"), "stdout:\n{out}");
+
+    // The staged exe IS the cache entry (spec 19 §6.1).
+    assert!(h.cache_exe(&home).is_file());
+    // The lazy seed: the env image in the runtime cache entry, the
+    // carried app slice in the payload cache — both journaled.
+    assert!(h.cache_image(&home).is_file());
+    let marker = std::fs::read_to_string(format!("{}.sha256", h.cache_image(&home).display()))
+        .expect("the seeded image carries its trust anchor");
+    assert!(marker.starts_with(&sha256_of(&env_image)), "marker: {marker}");
+    let seeded = cached_slice(&home, "mnconvert", APP_VER);
+    assert!(seeded.is_file());
+    let anchor =
+        std::fs::read_to_string(format!("{}.sha256", seeded.display())).expect("slice anchor");
+    assert!(anchor.starts_with(&sha256_of(&app)), "anchor: {anchor}");
+    let journal = journal_of(&home);
+    assert!(
+        journal.contains("event=lazy-seed artifact=mnconvert@1.2.3"),
+        "journal:\n{journal}"
+    );
+    assert!(journal.contains("event=lazy-seed artifact="), "journal:\n{journal}");
+}
+
+/// spec 23 §13.1: a shared slice resolves at first run BY THE LOCKED
+/// DIGEST into the payload cache and mounts from the cache file as
+/// `<path>:-:<mount>`; a warm cache then serves offline.
+#[test]
+fn the_shared_slice_resolves_mid_run_by_its_locked_digest() {
+    let h = Harness::new(rust_bootstrap());
+    let app = h.fake_image();
+    let shared_file = h.tmp.0.join("mn2pdf-2.0.0.tfs");
+    std::fs::write(&shared_file, b"FAKE MN2PDF SLIDE IMAGE").unwrap();
+    let runtime_ref = format!("{};image", h.runtime_ref);
+    let lock = tpkg::PackageLock {
+        runtime: Some(tpkg::LockedRuntime {
+            version: harness::RUBY_VER.to_string(),
+            carry: false,
+            exe: None,
+            image: None,
+            dll: None,
+        }),
+        slices: vec![
+            tpkg::LockedSlice {
+                name: "mnconvert".to_string(),
+                version: APP_VER.to_string(),
+                carry: true,
+                slot: Some(0),
+                mount: Some("/__tfs__".to_string()),
+                sha256: pin(&app),
+                source: None,
+            },
+            tpkg::LockedSlice {
+                name: "mn2pdf".to_string(),
+                version: SHARED_VER.to_string(),
+                carry: false,
+                slot: None,
+                mount: Some("/__tfs__/mnt/mn2pdf".to_string()),
+                sha256: pin(&shared_file),
+                source: Some(format!("file://{}", shared_file.display())),
+            },
+        ],
+    };
+    let pm = composed_pm(&runtime_ref, lock);
+    let pkg = stitch_composed(
+        &h,
+        "mnconvert-lean",
+        &[(app, tpkg::TPKG_FORMAT_DWARFS, "/__tfs__")],
+        &runtime_ref,
+        &pm,
+        0,
+    );
+    let home = h.home("home");
+
+    let (rc, out, err) = h.run(&pkg, &home, &[], &["mnconvert", "in.xml"]);
+    assert_eq!(rc, 0, "stdout:\n{out}\nstderr:\n{err}");
+    // The runtime pair lean-resolved from the mirror into the cache.
+    assert!(
+        out.contains(&format!(
+            "TEBAKO_RUNTIME_IMAGE={}",
+            h.cache_image(&home).display()
+        )),
+        "stdout:\n{out}"
+    );
+    // Mount order is the lock's slice order: the carried app slice, then
+    // the shared slice's cache file as a bare image (slot `-`). The
+    // package path rides canonicalized (run()'s current_exe).
+    let canon = pkg.canonicalize().unwrap();
+    let cached = cached_slice(&home, "mn2pdf", SHARED_VER);
+    assert!(
+        out.contains(&format!("argv[1]={}:0:/__tfs__", canon.display())),
+        "stdout:\n{out}"
+    );
+    assert!(
+        out.contains(&format!(
+            "argv[3]={}:-:/__tfs__/mnt/mn2pdf",
+            cached.display()
+        )),
+        "stdout:\n{out}"
+    );
+    assert!(cached.is_file());
+
+    // Second run, cold network: the cache serves both the runtime pair
+    // and the shared slice.
+    let (rc, out, err) = h.run(&pkg, &home, &[("TEBAKO_OFFLINE", "1")], &["mnconvert"]);
+    assert_eq!(rc, 0, "stdout:\n{out}\nstderr:\n{err}");
+    assert!(out.contains("FAKE-RUNTIME"), "stdout:\n{out}");
+}
+
+/// spec 19 §6.1's convergence: the staged exe + the seeded env image ARE
+/// the cache entry — a later shared-runtime package on the same machine
+/// boots offline from what the self-contained run left behind.
+#[test]
+fn the_seeded_runtime_pair_serves_a_shared_runtime_package_offline() {
+    let h = Harness::new(rust_bootstrap());
+    let (pkg, _, _) = self_contained_pkg(&h, "mnconvert-sc", 0);
+    let home = h.home("home");
+    let (rc, out, _err) = h.run(&pkg, &home, &[], &[]);
+    assert_eq!(rc, 0, "stdout:\n{out}");
+
+    // A plain lean package (no lock, no type-2 block) on the same home,
+    // fully offline: the seeded cache must serve it without the mirror.
+    let lean = h.lean_pkg_image("mnconvert-lean");
+    let (rc, out, err) = h.run(&lean, &home, &[("TEBAKO_OFFLINE", "1")], &["mnconvert"]);
+    assert_eq!(rc, 0, "stdout:\n{out}\nstderr:\n{err}");
+    assert!(
+        out.contains(&format!(
+            "TEBAKO_RUNTIME_IMAGE={}",
+            h.cache_image(&home).display()
+        )),
+        "stdout:\n{out}"
+    );
+}
+
+/// spec 23 §13.4: run-time resolution verifies against the lock,
+/// fail-closed — carried bytes that no longer match the press-time pin
+/// are a named exit 70, and the cache is not touched.
+#[test]
+fn a_tampered_carried_exe_fails_closed_with_70() {
+    let h = Harness::new(rust_bootstrap());
+    // A package pressed with a pin that matches OTHER bytes (the app
+    // image): the exe slot's content no longer matches the lock.
+    let app = h.fake_image();
+    let env_image = h.tmp.0.join("tampered-env.tfs");
+    std::fs::write(&env_image, b"FAKE RUNTIME ENV IMAGE").unwrap();
+    let runtime_ref = format!("{};image", h.runtime_ref);
+    let lock = tpkg::PackageLock {
+        runtime: Some(tpkg::LockedRuntime {
+            version: harness::RUBY_VER.to_string(),
+            carry: true,
+            exe: Some(tpkg::LockedArtifact {
+                slot: 1,
+                sha256: pin(&app), // wrong on purpose: the exe slot's bytes differ
+                install_as: None,
+            }),
+            image: Some(tpkg::LockedArtifact {
+                slot: 2,
+                sha256: pin(&env_image),
+                install_as: None,
+            }),
+            dll: None,
+        }),
+        slices: vec![],
+    };
+    let pm = composed_pm(&runtime_ref, lock);
+    let pkg = stitch_composed(
+        &h,
+        "mnconvert-tampered",
+        &[
+            (app, tpkg::TPKG_FORMAT_DWARFS, "/__tfs__"),
+            (h.fake_runtime.clone(), tpkg::TPKG_FORMAT_AUTO, ""),
+            (env_image, tpkg::TPKG_FORMAT_DWARFS, ""),
+        ],
+        &runtime_ref,
+        &pm,
+        0,
+    );
+    let home = h.home("home");
+
+    let (rc, out, err) = h.run(&pkg, &home, &[], &["mnconvert"]);
+    assert_eq!(rc, 70, "stdout:\n{out}\nstderr:\n{err}");
+    assert!(err.contains("SHA256 mismatch"), "stderr:\n{err}");
+    assert!(err.contains("lock pin"), "stderr:\n{err}");
+    assert!(!h.cache_exe(&home).exists(), "the cache was not touched");
+}
+
+/// The same fail-closed rule on the shared path: registry bytes that do
+/// not match the lock pin are a named exit 70 (never a silent re-fetch).
+#[test]
+fn a_shared_slice_mismatching_its_lock_pin_fails_closed_with_70() {
+    let h = Harness::new(rust_bootstrap());
+    let app = h.fake_image();
+    let shared_file = h.tmp.0.join("mn2pdf-evil.tfs");
+    std::fs::write(&shared_file, b"NOT THE PRESSED BYTES").unwrap();
+    let runtime_ref = format!("{};image", h.runtime_ref);
+    let lock = tpkg::PackageLock {
+        runtime: Some(tpkg::LockedRuntime {
+            version: harness::RUBY_VER.to_string(),
+            carry: false,
+            exe: None,
+            image: None,
+            dll: None,
+        }),
+        slices: vec![
+            tpkg::LockedSlice {
+                name: "mnconvert".to_string(),
+                version: APP_VER.to_string(),
+                carry: true,
+                slot: Some(0),
+                mount: Some("/__tfs__".to_string()),
+                sha256: pin(&app),
+                source: None,
+            },
+            tpkg::LockedSlice {
+                name: "mn2pdf".to_string(),
+                version: SHARED_VER.to_string(),
+                carry: false,
+                slot: None,
+                mount: Some("/__tfs__/mnt/mn2pdf".to_string()),
+                sha256: pin(&app), // wrong on purpose
+                source: Some(format!("file://{}", shared_file.display())),
+            },
+        ],
+    };
+    let pm = composed_pm(&runtime_ref, lock);
+    let pkg = stitch_composed(
+        &h,
+        "mnconvert-evil",
+        &[(app, tpkg::TPKG_FORMAT_DWARFS, "/__tfs__")],
+        &runtime_ref,
+        &pm,
+        0,
+    );
+    let home = h.home("home");
+
+    let (rc, out, err) = h.run(&pkg, &home, &[], &["mnconvert"]);
+    assert_eq!(rc, 70, "stdout:\n{out}\nstderr:\n{err}");
+    assert!(err.contains("SHA256 mismatch"), "stderr:\n{err}");
+    assert!(!cached_slice(&home, "mn2pdf", SHARED_VER).exists());
+}
+
+/// spec 23 §13.3: a per-triplet digest map that does not cover the host
+/// is a named coverage error (exit 65), never a nearest-platform guess.
+#[test]
+fn a_lock_without_host_coverage_is_a_named_65() {
+    let h = Harness::new(rust_bootstrap());
+    let app = h.fake_image();
+    let other = tpkg::Platform::ALL
+        .iter()
+        .copied()
+        .find(|p| *p != tpkg::Platform::host())
+        .unwrap();
+    let runtime_ref = format!("{};image", h.runtime_ref);
+    let lock = tpkg::PackageLock {
+        runtime: Some(tpkg::LockedRuntime {
+            version: harness::RUBY_VER.to_string(),
+            carry: false,
+            exe: None,
+            image: None,
+            dll: None,
+        }),
+        slices: vec![
+            tpkg::LockedSlice {
+                name: "mnconvert".to_string(),
+                version: APP_VER.to_string(),
+                carry: true,
+                slot: Some(0),
+                mount: Some("/__tfs__".to_string()),
+                sha256: pin(&app),
+                source: None,
+            },
+            tpkg::LockedSlice {
+                name: "mn2pdf".to_string(),
+                version: SHARED_VER.to_string(),
+                carry: false,
+                slot: None,
+                mount: Some("/__tfs__/mnt/mn2pdf".to_string()),
+                sha256: tpkg::DigestPin::PerTriplet(std::collections::BTreeMap::from([(
+                    other.release_asset_name().to_string(),
+                    sha256_of(&app),
+                )])),
+                source: Some("file:///nonexistent.tfs".to_string()),
+            },
+        ],
+    };
+    let pm = composed_pm(&runtime_ref, lock);
+    let pkg = stitch_composed(
+        &h,
+        "mnconvert-uncovered",
+        &[(app, tpkg::TPKG_FORMAT_DWARFS, "/__tfs__")],
+        &runtime_ref,
+        &pm,
+        0,
+    );
+    let home = h.home("home");
+
+    let (rc, out, err) = h.run(&pkg, &home, &[], &["mnconvert"]);
+    assert_eq!(rc, 65, "stdout:\n{out}\nstderr:\n{err}");
+    assert!(err.contains("does not cover this platform"), "stderr:\n{err}");
+    assert!(
+        err.contains(tpkg::Platform::host().release_asset_name()),
+        "stderr:\n{err}"
+    );
+}
+
+/// spec 05 §4: TPKG_FLAG_NO_INSTALL packages never seed — the run works
+/// standalone and leaves the payload store untouched.
+#[test]
+fn a_no_install_package_runs_but_never_seeds() {
+    let h = Harness::new(rust_bootstrap());
+    let (pkg, _, _) = self_contained_pkg(&h, "mnconvert-frozen", tpkg::TPKG_FLAG_NO_INSTALL);
+    let home = h.home("home");
+
+    let (rc, out, err) = h.run(&pkg, &home, &[], &["mnconvert"]);
+    assert_eq!(rc, 0, "stdout:\n{out}\nstderr:\n{err}");
+    assert!(out.contains("FAKE-RUNTIME"), "stdout:\n{out}");
+    // The run's own exe staging is not a seed; the payload store and the
+    // env-image cache copy are.
+    assert!(!cached_slice(&home, "mnconvert", APP_VER).exists());
+    assert!(!h.cache_image(&home).exists());
+    assert!(!journal_of(&home).contains("event=lazy-seed"));
+}
+
+/// The pointer-entry mount rule (spec 23 §4): the shared app slice's
+/// triple leads the image list — the entrypoint resolves against the
+/// FIRST `--tebako-image` mount (spec 17 §1). Asserted at the argv level
+/// (the driver never runs here).
+#[test]
+fn the_pointer_entrys_shared_slice_leads_the_image_list() {
+    let mut m = tpkg::Manifest::default();
+    m.slots.push(tpkg::Slot::new(
+        0,
+        100,
+        tpkg::TPKG_FORMAT_DWARFS,
+        "/__tfs__",
+    ));
+    m.slots.push(tpkg::Slot::new(100, 50, tpkg::TPKG_FORMAT_AUTO, ""));
+    m.slots.push(tpkg::Slot::new(150, 60, tpkg::TPKG_FORMAT_DWARFS, ""));
+    let runtime_ref = "ruby@3.3.7;tebako=9.9.9;image";
+    let sha = |c: char| c.to_string().repeat(64);
+    let lock = tpkg::PackageLock {
+        runtime: Some(tpkg::LockedRuntime {
+            version: "3.3.7".to_string(),
+            carry: true,
+            exe: Some(tpkg::LockedArtifact {
+                slot: 1,
+                sha256: tpkg::DigestPin::One(sha('c')),
+                install_as: None,
+            }),
+            image: Some(tpkg::LockedArtifact {
+                slot: 2,
+                sha256: tpkg::DigestPin::One(sha('d')),
+                install_as: None,
+            }),
+            dll: None,
+        }),
+        slices: vec![
+            tpkg::LockedSlice {
+                name: "mnconvert".to_string(),
+                version: APP_VER.to_string(),
+                carry: true,
+                slot: Some(0),
+                mount: Some("/__tfs__".to_string()),
+                sha256: tpkg::DigestPin::One(sha('a')),
+                source: None,
+            },
+            tpkg::LockedSlice {
+                name: "mn2pdf".to_string(),
+                version: SHARED_VER.to_string(),
+                carry: false,
+                slot: None,
+                mount: Some("/__tfs__/mnt/mn2pdf".to_string()),
+                sha256: tpkg::DigestPin::One(sha('b')),
+                source: Some("tfs:github:tebako-packages/mn2pdf-feedstock:2.0.0".to_string()),
+            },
+        ],
+    };
+    let pm = tpkg::PackageManifest {
+        schema_version: tpkg::PACKAGE_SCHEMA_VERSION,
+        package: tpkg::PackageIdentity {
+            name: "suite".to_string(),
+            version: "1.0.0".to_string(),
+            producer: tpkg::Producer {
+                tool: "tebako-cli".to_string(),
+                tool_version: "0.16.0".to_string(),
+            },
+            created: "2026-08-25T00:00:00Z".to_string(),
+        },
+        entries: vec![
+            tpkg::PackageEntry {
+                name: "mnconvert".to_string(),
+                slot: Some(0),
+                entrypoint: "mnconvert".to_string(),
+                runtime_ref: runtime_ref.to_string(),
+            },
+            tpkg::PackageEntry {
+                name: "mn2pdf".to_string(),
+                slot: None, // the pointer form — backed by the shared slice
+                entrypoint: "bin/mn2pdf".to_string(),
+                runtime_ref: runtime_ref.to_string(),
+            },
+        ],
+        jail: None,
+        env: Default::default(),
+        lock: Some(lock),
+        mounts: Vec::new(),
+    };
+    m.set_package_manifest(&pm).unwrap();
+
+    let runtime = Path::new("/rt/ruby");
+    let self_path = Path::new("/pkg/suite");
+    let cache_path = PathBuf::from("/home/.tebako/payloads/mn2pdf/2.0.0.tfs");
+    let shared = vec![("mn2pdf".to_string(), cache_path.clone())];
+
+    // The pointer entry: the shared slice's triple leads; the carried
+    // slot-0 image (another entry's) does not mount.
+    let selection = tebako_bootstrap::package_selection(&m, "mn2pdf").unwrap();
+    let argv = tebako_bootstrap::handoff_argv(
+        runtime,
+        self_path,
+        &m,
+        selection.as_ref(),
+        &["mn2pdf".to_string()],
+        pm.lock.as_ref(),
+        &shared,
+    );
+    assert_eq!(
+        argv,
+        vec![
+            "/rt/ruby".to_string(),
+            "--tebako-image".to_string(),
+            format!("{}:-:/__tfs__/mnt/mn2pdf", cache_path.display()),
+            "--tebako-entry".to_string(),
+            "bin/mn2pdf".to_string(),
+        ]
+    );
+
+    // The primary entry: carried slot 0 first, the shared slice second;
+    // the claimed runtime slots (1, 2) never mount.
+    let selection = tebako_bootstrap::package_selection(&m, "mnconvert").unwrap();
+    let argv = tebako_bootstrap::handoff_argv(
+        runtime,
+        self_path,
+        &m,
+        selection.as_ref(),
+        &["mnconvert".to_string()],
+        pm.lock.as_ref(),
+        &shared,
+    );
+    assert_eq!(
+        argv,
+        vec![
+            "/rt/ruby".to_string(),
+            "--tebako-image".to_string(),
+            "/pkg/suite:0:/__tfs__".to_string(),
+            "--tebako-image".to_string(),
+            format!("{}:-:/__tfs__/mnt/mn2pdf", cache_path.display()),
+            "--tebako-entry".to_string(),
+            "mnconvert".to_string(),
+        ]
+    );
+}

--- a/crates/tebako-bootstrap/tests/ext_blocks.rs
+++ b/crates/tebako-bootstrap/tests/ext_blocks.rs
@@ -32,7 +32,7 @@ fn package_manifest(entries: &[(&str, u32, &str, &str)]) -> tpkg::PackageManifes
             .map(
                 |&(name, slot, entrypoint, runtime_ref)| tpkg::PackageEntry {
                     name: name.to_string(),
-                    slot,
+                    slot: Some(slot),
                     entrypoint: entrypoint.to_string(),
                     runtime_ref: runtime_ref.to_string(),
                 },
@@ -40,6 +40,7 @@ fn package_manifest(entries: &[(&str, u32, &str, &str)]) -> tpkg::PackageManifes
             .collect(),
         jail: None,
         env: Default::default(),
+        lock: None,
         mounts: Vec::new(),
     }
 }

--- a/crates/tebako-bootstrap/tests/ext_blocks.rs
+++ b/crates/tebako-bootstrap/tests/ext_blocks.rs
@@ -222,6 +222,8 @@ fn handoff_mounts_only_the_selected_entrys_slot() {
         &m.with_package_manifest(&pm),
         selection.as_ref(),
         &["mn2pdf".to_string(), "in.xml".to_string()],
+        None,
+        &[],
     );
     assert_eq!(
         argv,
@@ -244,6 +246,8 @@ fn handoff_mounts_only_the_selected_entrys_slot() {
         &m.with_package_manifest(&pm),
         selection.as_ref(),
         &["metanorma".to_string()],
+        None,
+        &[],
     );
     assert_eq!(
         argv,
@@ -266,6 +270,8 @@ fn handoff_without_a_package_manifest_is_byte_identical_to_v1() {
         &m,
         None,
         &["./app".to_string(), "go".to_string()],
+        None,
+        &[],
     );
     assert_eq!(
         argv,

--- a/crates/tebako-bootstrap/tests/jail.rs
+++ b/crates/tebako-bootstrap/tests/jail.rs
@@ -39,12 +39,13 @@ fn package_manifest(runtime_ref: &str, jail: tpkg::HostJail) -> tpkg::PackageMan
         },
         entries: vec![tpkg::PackageEntry {
             name: "jailtest".to_string(),
-            slot: 0,
+            slot: Some(0),
             entrypoint: "jailtest".to_string(),
             runtime_ref: runtime_ref.to_string(),
         }],
         jail: Some(jail),
         env: Default::default(),
+        lock: None,
         mounts: Vec::new(),
     }
 }

--- a/crates/tebako-cli/README.md
+++ b/crates/tebako-cli/README.md
@@ -6,9 +6,12 @@ design): a port of the reference Ruby gem's lean/fat press
 
 ```console
 $ tebako press -r <root> -e <entry> [-o <output>] [-p <prefix>]
-               [-c <cwd>] [-R <ruby>] [-m lean|fat] [-l error|warn|debug|trace]
+               [-c <cwd>] [-R <ruby>] [-m self-contained|shared-runtime]
+               [-l error|warn|debug|trace]
                [--image <path>:<mount>]... [--bootstrap <path>]
                [--tebako-version <v>] [--prefer-local] [--jail <spec>]
+               [--compose <tebako.yaml>] [--carry all|none|<name,...>]
+               [--share <name,...>]
 $ tebako run <pkg> [--jail <spec>] [--mount <host:mount:ro|rw>]... [--no-host]
                [--] [<args>...]
 $ tebako cache list
@@ -52,14 +55,21 @@ audit journal (`$TEBAKO_HOME/journal.log`, spec 08 §2).
 4. **strip** build artefacts, align the arch layout to the runtime, write
    the entry dispatcher at `/local/stub.rb`;
 5. **image** the app (in-process dwarfs-t Writer → `fs.tfs`) and
-   **stitch** the three-part package:
-   bootstrap + image slot(s) + tpkg trailer (LEAN flag, launcher ABI 1,
-   runtime_ref `ruby@<rv>;tebako=<v>`; `fat` mode adds the runtime as a
-   FORMAT_RUNTIME payload slot and appends `;sha256=<hex>`).
+   **stitch** the package:
+   bootstrap + image slot(s) + tpkg trailer (launcher ABI 1, runtime_ref
+   `ruby@<rv>;tebako=<v>[;image]`) + the L2 manifest's composition lock
+   (spec 23 §4 — EVERY press locks the resolved runtime and slice
+   digests; `--compose <tebako.yaml>` adds the composition's payload
+   slices as carried slots or locked shared references, spec 23 §13).
+   `--mode=self-contained` (the `fat` successor) carries the runtime as
+   TWO ordinary slots — the interpreter exe + the env image, plus the
+   windows dll facet when the release declares one (spec 19 §6.1) —
+   pinned by the lock, never the retired `;sha256=` runtime_ref form.
 
 At first run the packaged binary's bootstrap resolves the runtime into
-the shared cache (fat: installs the payload instead) and hands over via
-the launcher ABI.
+the shared cache (self-contained: stages the carried pair into the same
+cache, verified against the lock's digest pins) and hands over via the
+launcher ABI.
 
 ## Scenarios
 

--- a/crates/tebako-cli/src/check.rs
+++ b/crates/tebako-cli/src/check.rs
@@ -1528,7 +1528,7 @@ fn plan_exec(
             // through the owning slice's own manifest (the name's one
             // authority), then compare paths.
             let package_entry = entries.iter().find(|e| {
-                Some(e.slot) == owner.slot
+                e.slot == owner.slot
                     && owner
                         .dispatchables
                         .iter()
@@ -1540,7 +1540,13 @@ fn plan_exec(
                     owner.slot.unwrap_or(0),
                     entries
                         .iter()
-                        .map(|e| format!("{}→slot {}:{}", e.name, e.slot, e.entrypoint))
+                        .map(|e| {
+                            let slot = match e.slot {
+                                Some(s) => s.to_string(),
+                                None => "shared".to_string(),
+                            };
+                            format!("{}→slot {}:{}", e.name, slot, e.entrypoint)
+                        })
                         .collect::<Vec<_>>()
                         .join(", ")
                 )));

--- a/crates/tebako-cli/src/check.rs
+++ b/crates/tebako-cli/src/check.rs
@@ -629,6 +629,10 @@ fn load_image(path: &Path, parsed: &CheckArgs) -> Result<CheckTarget, TebakoErro
 /// runtime slot is never mounted, spec 17 §1 — its checks belong to the
 /// factory/gate, not the package surface). A multi-slice package groups
 /// the report by slice; a single-slice package keeps the bare form.
+/// The two-slot era (spec 19 §6.1 / spec 23 §13): the lock's runtime
+/// artifacts (exe / env image / windows dll) are skipped by slot number
+/// — the exe and dll are not images at all, and the env image's checks
+/// belong to the factory like the format-4 slot's always did.
 fn load_package(path: &Path) -> Result<CheckTarget, TebakoError> {
     let mut f = std::fs::File::open(path)
         .map_err(|e| plain_error(format!("cannot open the package {}: {e}", path.display())))?;
@@ -646,10 +650,25 @@ fn load_package(path: &Path) -> Result<CheckTarget, TebakoError> {
         ))
     })?;
 
+    // The lock-claimed runtime artifact slots (the two-slot carried
+    // runtime) — never payload surfaces.
+    let runtime_slots: BTreeSet<u32> = pm
+        .as_ref()
+        .and_then(|pm| pm.lock.as_ref())
+        .and_then(|lock| lock.runtime.as_ref())
+        .map(|runtime| {
+            [&runtime.exe, &runtime.image, &runtime.dll]
+                .into_iter()
+                .flatten()
+                .map(|a| a.slot)
+                .collect()
+        })
+        .unwrap_or_default();
+
     let mut owners = Vec::new();
     let mut caps = BTreeSet::new();
     for (index, slot) in m.slots.iter().enumerate() {
-        if slot.format_id == tpkg::TPKG_FORMAT_RUNTIME {
+        if slot.format_id == tpkg::TPKG_FORMAT_RUNTIME || runtime_slots.contains(&(index as u32)) {
             continue;
         }
         let image = ImageRef::Region(path.to_path_buf(), slot.offset, slot.size);

--- a/crates/tebako-cli/src/compose.rs
+++ b/crates/tebako-cli/src/compose.rs
@@ -1,0 +1,451 @@
+//! `tebako press --compose <tebako.yaml>` (spec 23 §3 D2 / §13) — the
+//! composition document's press path.
+//!
+//! tpkg owns the document MODEL (`tpkg::parse_compose`); this module owns
+//! the press-side pipeline: the `--carry`/`--share` overrides (D5 beats
+//! the document, spec 23 §13.2), the runtime-row checks, and the FULL
+//! closure resolution — every slice resolved, fetched, verified and
+//! pinned at build time, so the §4 lock bakes exactly what press tested
+//! (run-time resolution then follows the locked digest, never fresh
+//! semver).
+//!
+//! Press is NOT install: the bytes land in the payload cache (the same
+//! trust-anchored store), but no mirrors, shims, or materialized trees
+//! are written — those are the install verb's surface (spec 07 §2).
+
+use std::collections::{BTreeMap, VecDeque};
+use std::path::{Path, PathBuf};
+
+use tebako_resolve::registry::RegistryPlatforms;
+use tebako_resolve::{Fetcher, PayloadCache, ResolveError, Transport};
+use tebako_shim::versions;
+use tpkg::{ComposeDoc, ComposePreset, Constraint, Platform, Platforms};
+
+use crate::error::TebakoError;
+use crate::image_manifest;
+use crate::install;
+
+// The spec 06 §4 named set (the codes install.rs already owns; compose
+// errors are manifest/resolution failures of the same family).
+const EX_TEBAKO_MANIFEST: i32 = 65;
+
+fn err(message: impl Into<String>) -> TebakoError {
+    TebakoError::new(message, EX_TEBAKO_MANIFEST)
+}
+
+/// One resolved composition slice: the concrete version, the carry
+/// verdict, the digest pin (spec 23 §13.3 — the single `universal`
+/// digest or the host triplet's row of the per-triplet map), the cache
+/// path of the verified bytes (carried slices stitch from here), and
+/// the canonical fetch coordinates (the lock's `source:`).
+#[derive(Debug)]
+pub struct ComposeSlice {
+    pub name: String,
+    pub version: String,
+    pub carry: bool,
+    /// The declared mount point; `None` = a cache prime (no consumer
+    /// edge declared one — spec 23 §3's D2 rows carry no mount key).
+    pub mount: Option<String>,
+    pub pin: tpkg::DigestPin,
+    pub cache_path: PathBuf,
+    pub source: String,
+}
+
+/// Read + parse + validate the composition document (tpkg owns the
+/// model; the Phase-R jail keys are refused there by name).
+pub fn load(path: &Path) -> Result<(ComposeDoc, Vec<String>), TebakoError> {
+    let text = std::fs::read_to_string(path).map_err(|e| {
+        err(format!(
+            "cannot read the compose document {}: {e}",
+            path.display()
+        ))
+    })?;
+    tpkg::parse_compose(&text).map_err(|e| err(format!("{}: {e}", path.display())))
+}
+
+/// The compose document's runtime row against the press's ruby: ruby is
+/// the only engine today, and the requirement must COVER the resolved
+/// interpreter version (press always resolves by constraint, spec 23
+/// §4 — a disagreement is named, never a silently different runtime).
+pub fn check_runtime_row(doc: &ComposeDoc, ruby_ver: &str) -> Result<(), TebakoError> {
+    if doc.runtime.name != "ruby" {
+        return Err(err(format!(
+            "the compose runtime is '{}' — ruby is the only runtime engine today",
+            doc.runtime.name
+        )));
+    }
+    let requirement = doc
+        .runtime
+        .requirement
+        .as_ref()
+        .expect("parse_compose refuses a runtime row without a requirement");
+    if !versions::from_validated(requirement).matches(ruby_ver) {
+        return Err(err(format!(
+            "the compose runtime requirement '{}' does not cover the pressed ruby {ruby_ver} — pass -R/--Ruby (or a Gemfile constraint) that agrees with the document",
+            requirement.as_str()
+        )));
+    }
+    Ok(())
+}
+
+/// The entrypoint selector: with a local root (-r/-e) the package's
+/// entry is the app's own, so the document may only name the package
+/// itself. Selecting a slice-provided command is the pointer-package
+/// form — supported by the bootstrap/driver, but its press is the N7
+/// milestone.
+pub fn check_entrypoint(doc: &ComposeDoc, package_stem: &str) -> Result<(), TebakoError> {
+    if let Some(entrypoint) = &doc.entrypoint {
+        if entrypoint != package_stem {
+            return Err(err(format!(
+                "compose entrypoint '{entrypoint}' selects a slice-provided command — pointer-package presses (the entry rides a compose slice, not the local root) are the N7 milestone; with -r/-e the package entry is the app's own ('{package_stem}')"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// The D5 overrides (spec 23 §13.2): `--carry=all|none|<name,…>` and
+/// `--share=<name,…>` rewrite the document's per-slice `carry:` verdicts
+/// (explicit invocation beats authored defaults). Names resolve against
+/// the runtime row plus the slice rows; an unknown name, a
+/// carry/share conflict, or `--share` naming the local app are named
+/// errors — never a silent no-op.
+pub fn apply_overrides(
+    doc: &mut ComposeDoc,
+    carry: Option<&str>,
+    share: Option<&str>,
+    app_name: &str,
+) -> Result<(), TebakoError> {
+    fn declared_names(doc: &ComposeDoc) -> String {
+        let mut names: Vec<&str> = vec![doc.runtime.name.as_str()];
+        names.extend(doc.slices.iter().map(|s| s.name.as_str()));
+        names.join(", ")
+    }
+    fn set(
+        doc: &mut ComposeDoc,
+        name: &str,
+        value: bool,
+        app_name: &str,
+    ) -> Result<(), TebakoError> {
+        if doc.runtime.name == name {
+            doc.runtime.carry = Some(value);
+            return Ok(());
+        }
+        if let Some(slice) = doc.slices.iter_mut().find(|s| s.name == name) {
+            slice.carry = Some(value);
+            return Ok(());
+        }
+        if name == app_name && !value {
+            return Err(err(format!(
+                "--share names the app payload '{name}' — the app is pressed from the local root and always rides in the package; to share it, publish it as a payload and compose it by name (pointer packages are the N7 milestone)"
+            )));
+        }
+        Err(err(format!(
+            "--{} names '{name}' which the composition does not declare (declared: {})",
+            if value { "carry" } else { "share" },
+            declared_names(doc)
+        )))
+    }
+    let list = |flag: Option<&str>| -> Vec<String> {
+        flag.map(|f| {
+            f.split(',')
+                .map(|n| n.trim().to_string())
+                .filter(|n| !n.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+    };
+    let carry_names = list(carry);
+    let share_names = list(share);
+    if let Some(name) = carry_names.iter().find(|n| share_names.contains(n)) {
+        return Err(err(format!(
+            "--carry and --share both name '{name}' — a slice is either carried or shared, never both"
+        )));
+    }
+    match carry {
+        Some(flag) if flag.trim() == "all" || flag.trim() == "none" => {
+            let value = flag.trim() == "all";
+            doc.runtime.carry = Some(value);
+            for slice in doc.slices.iter_mut() {
+                slice.carry = Some(value);
+            }
+        }
+        _ => {
+            for name in &carry_names {
+                set(doc, name, true, app_name)?;
+            }
+        }
+    }
+    for name in &share_names {
+        set(doc, name, false, app_name)?;
+    }
+    Ok(())
+}
+
+/// Resolve the document's full closure (spec 23 §4/§6): every slice row
+/// plus the transitive `requires:` walk of the embedded manifests, each
+/// fetched, verified, and pinned. Top-level rows resolve in document
+/// order; a re-encountered name must AGREE with the locked version
+/// (one version per package) and an edge-declared `mount:` upgrades a
+/// cache-prime row to a mounted one (conflicting mounts are named).
+/// Deps discovered in the walk are carried unless the document lists
+/// them (their row's verdict stands — doc rows resolve first).
+///
+/// `pub` for the integration tests (the `install_with` precedent); the
+/// transport injection keeps the suite on `file://` mirrors.
+pub fn resolve_closure<T: Transport>(
+    home: &Path,
+    fetcher: &Fetcher<T>,
+    doc: &ComposeDoc,
+    preset: ComposePreset,
+    host: Platform,
+) -> Result<Vec<ComposeSlice>, TebakoError> {
+    struct Pending {
+        name: String,
+        requirement: Option<Constraint>,
+        carry: bool,
+        mount: Option<String>,
+        platforms: Option<Platforms>,
+        consumer: Option<String>,
+    }
+    impl Pending {
+        fn from_doc(doc: &ComposeDoc, preset: ComposePreset) -> VecDeque<Pending> {
+            doc.slices
+                .iter()
+                .map(|s| Pending {
+                    name: s.name.clone(),
+                    requirement: s.requirement.clone(),
+                    carry: s.carry.unwrap_or_else(|| preset.default_carry(false)),
+                    mount: None,
+                    platforms: s.platforms.clone(),
+                    consumer: None,
+                })
+                .collect()
+        }
+    }
+
+    let mut work: VecDeque<Pending> = Pending::from_doc(doc, preset);
+    let mut resolved: Vec<ComposeSlice> = Vec::new();
+    let cache = PayloadCache::with_root(home);
+
+    while let Some(pending) = work.pop_front() {
+        if let Some(existing) = resolved.iter_mut().find(|s| s.name == pending.name) {
+            if let Some(requirement) = &pending.requirement {
+                if !versions::from_validated(requirement).matches(&existing.version) {
+                    return Err(err(format!(
+                        "slice '{}' is required at '{}' (by {}) but the composition already locked {} — one version per package",
+                        pending.name,
+                        requirement.as_str(),
+                        pending.consumer.as_deref().unwrap_or("the document"),
+                        existing.version
+                    )));
+                }
+            }
+            match (&existing.mount, &pending.mount) {
+                (None, Some(mount)) => existing.mount = Some(mount.clone()),
+                (Some(a), Some(b)) if a != b => {
+                    return Err(err(format!(
+                        "slice '{}' is required mounted at both '{a}' and '{b}' — one mount point per slice",
+                        pending.name
+                    )));
+                }
+                _ => {}
+            }
+            continue;
+        }
+
+        let mut found = install::find_in_registries(home, fetcher, &pending.name)?;
+        let (reg_ref, payload) = match found.len() {
+            0 => {
+                return Err(err(format!(
+                    "compose slice '{}'{} is not carried by any registered registry — register one with: tebako add-registry <ref>",
+                    pending.name,
+                    pending
+                        .consumer
+                        .map(|c| format!(" (required by {c})"))
+                        .unwrap_or_default()
+                )));
+            }
+            1 => found.pop().expect("len == 1 checked"),
+            n => {
+                return Err(err(format!(
+                    "compose slice '{}' is listed by {n} registered registries (AmbiguousRegistries):\n{}\n  narrow it with an explicit registry set",
+                    pending.name,
+                    found
+                        .iter()
+                        .map(|(r, _)| format!("    - {r}"))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                )));
+            }
+        };
+        match payload.kind {
+            tpkg::PayloadKind::Runtime | tpkg::PayloadKind::Language => {
+                return Err(err(format!(
+                    "compose slice '{}' is a runtime payload — the composition's runtime: row owns the engine (spec 23 §3)",
+                    pending.name
+                )));
+            }
+            _ => {}
+        }
+
+        let version = match &pending.requirement {
+            Some(requirement) => {
+                let eval = versions::from_validated(requirement);
+                payload
+                    .versions
+                    .iter()
+                    .map(|v| v.version.as_str())
+                    .filter(|v| eval.matches(v))
+                    .max_by(|a, b| versions::compare(a, b))
+                    .map(str::to_string)
+                    .ok_or_else(|| {
+                        err(format!(
+                            "no published version of '{}' satisfies '{}' (available: {})",
+                            pending.name,
+                            requirement.as_str(),
+                            payload
+                                .versions
+                                .iter()
+                                .map(|v| v.version.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        ))
+                    })?
+            }
+            None => payload
+                .default_version()
+                .map(|v| v.version.clone())
+                .ok_or_else(|| {
+                    err(format!(
+                        "registry {reg_ref} pins no default for '{}' — name a requirement in the compose document",
+                        pending.name
+                    ))
+                })?,
+        };
+        let entry = payload.version(&version).expect("selected above");
+
+        // The §13.3 coverage assertion, checked against the registry's
+        // mirrored coverage rows (fail-closed, never a silent fallback).
+        let declared = match &entry.platforms {
+            RegistryPlatforms::Universal => Platforms::Universal,
+            RegistryPlatforms::PerTriplet(map) => {
+                Platforms::Triplets(map.keys().copied().collect())
+            }
+        };
+        tpkg::check_platforms_assertion(
+            &pending.name,
+            &declared,
+            pending.platforms.as_ref(),
+            host,
+        )
+        .map_err(|e| err(e.to_string()))?;
+
+        let plan = install::plan_from_registry_entry(&reg_ref, &payload, Some(&version), Some(host))?;
+
+        // Fetch → verify → cache: a hit stands on its trust anchor
+        // (spec 05 §4); a miss fetches and verifies BEFORE anything
+        // enters the cache. No mirrors/shims — press is not install.
+        let cached = match cache.get(&plan.name, &plan.version).map_err(install::map_resolve)? {
+            Some(cached) => cached,
+            None => {
+                if tebako_resolve::cache::offline() {
+                    return Err(install::map_resolve(ResolveError::Offline {
+                        what: format!("payload {}@{}", plan.name, plan.version),
+                    }));
+                }
+                let fetched = fetcher.fetch(&plan.reference).map_err(install::map_resolve)?;
+                let (cached, _status) = cache
+                    .install(
+                        &plan.name,
+                        &plan.version,
+                        plan.expected_sha256.as_deref(),
+                        || Ok(fetched),
+                    )
+                    .map_err(install::map_resolve)?;
+                cached
+            }
+        };
+
+        // The lock's pin (spec 23 §13.3): the single universal digest,
+        // or the host triplet's row — press verifies the host's bytes;
+        // other triplets are never asserted.
+        let pin = match &entry.platforms {
+            RegistryPlatforms::Universal => tpkg::DigestPin::One(cached.sha256.clone()),
+            RegistryPlatforms::PerTriplet(_) => tpkg::DigestPin::PerTriplet(BTreeMap::from([(
+                host.release_asset_name().to_string(),
+                cached.sha256.clone(),
+            )])),
+        };
+
+        // The embedded manifest (tier 1, authoritative) cross-checks the
+        // registry's identity and drives the transitive walk; an image
+        // without one contributes no edges.
+        let mut deps = Vec::new();
+        if let Some(text) = image_manifest::read_embedded_manifest(&cached.path)? {
+            let manifest = tpkg::PayloadManifest::from_yaml(&text).map_err(|e| {
+                err(format!(
+                    "the embedded manifest of {} does not parse: {e}",
+                    cached.path.display()
+                ))
+            })?;
+            if manifest.identity.name != plan.name || manifest.identity.version != plan.version {
+                return Err(err(format!(
+                    "the embedded manifest declares {} {} but the composition resolved {} {} — the registry entry is inconsistent with the payload it names",
+                    manifest.identity.name, manifest.identity.version, plan.name, plan.version
+                )));
+            }
+            for requirement in &manifest.requires {
+                let (name, constraint, mount) = match requirement {
+                    // The runtime axis: the composition's runtime: row
+                    // owns it — never walked here.
+                    tpkg::Requirement::Language { .. } => continue,
+                    tpkg::Requirement::Toolkit {
+                        name,
+                        constraint,
+                        mount,
+                        ..
+                    } => (name, constraint, mount),
+                    tpkg::Requirement::Data {
+                        name,
+                        constraint,
+                        mount,
+                    } => (name, constraint, mount),
+                };
+                let authored = doc.slices.iter().find(|s| &s.name == name);
+                deps.push(Pending {
+                    name: name.clone(),
+                    requirement: Some(constraint.clone()),
+                    carry: match authored {
+                        Some(row) => row.carry.unwrap_or_else(|| preset.default_carry(false)),
+                        // Discovered deps ride in the package unless the
+                        // document says otherwise (spec 23 §13.2).
+                        None => true,
+                    },
+                    mount: mount.clone(),
+                    platforms: authored.and_then(|row| row.platforms.clone()),
+                    consumer: Some(plan.name.clone()),
+                });
+            }
+        }
+
+        resolved.push(ComposeSlice {
+            name: plan.name,
+            version: plan.version,
+            carry: pending.carry,
+            mount: pending.mount,
+            pin,
+            cache_path: cached.path,
+            source: plan.reference.to_string(),
+        });
+        work.extend(deps);
+    }
+    Ok(resolved)
+}
+
+/// The tebako home the compose closure resolves against — tebako-shim
+/// owns the rule ($TEBAKO_HOME > platform default).
+pub(crate) fn tebako_home() -> Result<PathBuf, TebakoError> {
+    let env: BTreeMap<String, String> = std::env::vars().collect();
+    tebako_shim::tebako_home(&env).map_err(install::map_shim)
+}

--- a/crates/tebako-cli/src/compose.rs
+++ b/crates/tebako-cli/src/compose.rs
@@ -333,20 +333,19 @@ pub fn resolve_closure<T: Transport>(
                 Platforms::Triplets(map.keys().copied().collect())
             }
         };
-        tpkg::check_platforms_assertion(
-            &pending.name,
-            &declared,
-            pending.platforms.as_ref(),
-            host,
-        )
-        .map_err(|e| err(e.to_string()))?;
+        tpkg::check_platforms_assertion(&pending.name, &declared, pending.platforms.as_ref(), host)
+            .map_err(|e| err(e.to_string()))?;
 
-        let plan = install::plan_from_registry_entry(&reg_ref, &payload, Some(&version), Some(host))?;
+        let plan =
+            install::plan_from_registry_entry(&reg_ref, &payload, Some(&version), Some(host))?;
 
         // Fetch → verify → cache: a hit stands on its trust anchor
         // (spec 05 §4); a miss fetches and verifies BEFORE anything
         // enters the cache. No mirrors/shims — press is not install.
-        let cached = match cache.get(&plan.name, &plan.version).map_err(install::map_resolve)? {
+        let cached = match cache
+            .get(&plan.name, &plan.version)
+            .map_err(install::map_resolve)?
+        {
             Some(cached) => cached,
             None => {
                 if tebako_resolve::cache::offline() {
@@ -354,7 +353,9 @@ pub fn resolve_closure<T: Transport>(
                         what: format!("payload {}@{}", plan.name, plan.version),
                     }));
                 }
-                let fetched = fetcher.fetch(&plan.reference).map_err(install::map_resolve)?;
+                let fetched = fetcher
+                    .fetch(&plan.reference)
+                    .map_err(install::map_resolve)?;
                 let (cached, _status) = cache
                     .install(
                         &plan.name,

--- a/crates/tebako-cli/src/deploy.rs
+++ b/crates/tebako-cli/src/deploy.rs
@@ -205,12 +205,13 @@ impl RuntimeDeployer {
                 },
                 entries: vec![tpkg::PackageEntry {
                     name: "tebako-deploy-driver".to_string(),
-                    slot: 0,
+                    slot: Some(0),
                     entrypoint: "/local/stub.rb".to_string(),
                     runtime_ref,
                 }],
                 jail: None,
                 env: Default::default(),
+                lock: None,
                 mounts: vec![tpkg::PackageMount {
                     slot: 0,
                     point: declared.to_string(),

--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -58,7 +58,7 @@ fn err(code: i32, message: impl Into<String>) -> TebakoError {
     TebakoError::new(message, code)
 }
 
-fn map_resolve(e: ResolveError) -> TebakoError {
+pub(crate) fn map_resolve(e: ResolveError) -> TebakoError {
     let code = match &e {
         ResolveError::Reference(_) | ResolveError::GitPathRequired { .. } => EX_USAGE,
         ResolveError::Sha256Mismatch { .. } => EX_TEBAKO_SHA,
@@ -75,7 +75,7 @@ fn map_resolve(e: ResolveError) -> TebakoError {
     TebakoError::new(e.to_string(), code)
 }
 
-fn map_shim(e: ShimError) -> TebakoError {
+pub(crate) fn map_shim(e: ShimError) -> TebakoError {
     TebakoError::new(e.message, i32::from(e.code))
 }
 
@@ -199,21 +199,24 @@ pub struct InstallOutcome {
 }
 
 /// Everything needed to place one payload — the two install forms
-/// converge on this.
-struct InstallPlan {
-    name: String,
-    version: String,
+/// converge on this. `pub(crate)` for the compose press path (spec 23
+/// §13): it resolves through the same registry selection, then stops
+/// before the install verbs (mirror/shims/materialize are install's,
+/// never press's).
+pub(crate) struct InstallPlan {
+    pub(crate) name: String,
+    pub(crate) version: String,
     /// The payload kind (the registry declares it; the ref form assumes
     /// app — its mirror falls back to the entrypoint convention).
-    kind: tpkg::PayloadKind,
-    reference: Reference,
+    pub(crate) kind: tpkg::PayloadKind,
+    pub(crate) reference: Reference,
     /// The registry per-triplet sha256 anchor (the cache's expected
     /// digest; the reference's own pin is verified at the fetch boundary).
-    expected_sha256: Option<String>,
+    pub(crate) expected_sha256: Option<String>,
     signature: Option<SignaturePin>,
     /// Registry-declared entrypoint names (the ref form has none and
     /// falls back to the payload name).
-    entrypoints: Vec<String>,
+    pub(crate) entrypoints: Vec<String>,
     /// engine + constraint + the optional abi line (native-extension
     /// payloads, spec 05 §5)
     runtime_requirement: Option<(String, String, Option<String>)>,
@@ -245,10 +248,10 @@ pub fn install_with<T: Transport>(
 ) -> Result<InstallOutcome, TebakoError> {
     if looks_like_reference(target) {
         let plan = plan_from_reference(target)?;
-        finish_install(home, fetcher, plan, shim_binary)
+        finish_install(home, fetcher, plan, shim_binary, &mut Vec::new())
     } else {
         let plan = plan_from_nickname(home, fetcher, target, host)?;
-        finish_install(home, fetcher, plan, shim_binary)
+        finish_install(home, fetcher, plan, shim_binary, &mut Vec::new())
     }
 }
 
@@ -326,6 +329,29 @@ pub fn install_local(
         ));
     }
     let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    // The two-slot era (spec 19 §6.1 / spec 23 §13): the lock's runtime
+    // artifacts (exe / env image / windows dll) are not payload slices —
+    // they seed the runtime cache on first run, never the payload store.
+    let pm = m.package_manifest().map_err(|e| {
+        err(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "invalid package manifest (extension block type 2) in {}: {e}",
+                path.display()
+            ),
+        )
+    })?;
+    let runtime_slots: BTreeSet<usize> = pm
+        .and_then(|pm| pm.lock)
+        .and_then(|lock| lock.runtime)
+        .map(|runtime| {
+            [&runtime.exe, &runtime.image, &runtime.dll]
+                .into_iter()
+                .flatten()
+                .map(|a| a.slot as usize)
+                .collect()
+        })
+        .unwrap_or_default();
     let cache = PayloadCache::with_root(home);
     let mut outcome = LocalInstallOutcome {
         installed: Vec::new(),
@@ -345,6 +371,13 @@ pub fn install_local(
             if slot.format_id == tpkg::TPKG_FORMAT_RUNTIME {
                 outcome.notes.push(
                     "the runtime slot is not store-installed; it resolves into the runtime cache on first run (unchanged)"
+                        .to_string(),
+                );
+                continue;
+            }
+            if runtime_slots.contains(&i) {
+                outcome.notes.push(
+                    "the carried runtime artifacts seed the runtime cache on first run (spec 05 §4) — not store-installed"
                         .to_string(),
                 );
                 continue;
@@ -688,7 +721,7 @@ fn plan_from_nickname<T: Transport>(
 /// Every registered registry carrying `name`, as (registry ref, payload)
 /// pairs — the one search both the nickname form and dependency edges
 /// run (spec 04 §2: the registered set is the whole namespace).
-fn find_in_registries<T: Transport>(
+pub(crate) fn find_in_registries<T: Transport>(
     home: &Path,
     fetcher: &Fetcher<T>,
     name: &str,
@@ -796,7 +829,7 @@ fn plan_from_dependency_edge<T: Transport>(
     }
 }
 
-fn plan_from_registry_entry(
+pub(crate) fn plan_from_registry_entry(
     reg_ref: &str,
     payload: &RegistryPayload,
     version_req: Option<&str>,
@@ -884,7 +917,7 @@ fn plan_from_registry_entry(
 
 /// The host platform as a tpkg [`Platform`] (spec 03 §3: ONE type owns
 /// the mapping — the CLI's host form is the release-asset name).
-fn host_platform() -> Result<Platform, TebakoError> {
+pub(crate) fn host_platform() -> Result<Platform, TebakoError> {
     let host = crate::options::host_platform()?;
     Platform::from_release_asset_name(&host).ok_or_else(|| {
         err(
@@ -896,11 +929,17 @@ fn host_platform() -> Result<Platform, TebakoError> {
 
 // ---- the shared tail: fetch → verify → cache → mirror → shims → deps --------
 
+/// `chain` is the dependency path from the top-level install down to
+/// this plan (spec 18 §5.6 S32): the closure walk pushes each payload's
+/// name before walking its edges and pops after — a `requires:` edge
+/// naming a payload already on the path is a dependency CYCLE, a named
+/// error instead of the cache check's silent short-circuit.
 fn finish_install<T: Transport>(
     home: &Path,
     fetcher: &Fetcher<T>,
     plan: InstallPlan,
     shim_binary: Option<&Path>,
+    chain: &mut Vec<String>,
 ) -> Result<InstallOutcome, TebakoError> {
     let cache = PayloadCache::with_root(home);
     let mut notes = Vec::new();
@@ -972,9 +1011,12 @@ fn finish_install<T: Transport>(
     // The dependency closure (spec 03 §2.3): the mirror's toolkit/data
     // edges resolve to cached-or-registry installs, recursively. Every
     // payload is cached BEFORE its own edges walk, so a re-encountered
-    // name short-circuits on the cache check — no cycle guard, and the
-    // finite registry set bounds the recursion.
-    install_dependency_closure(home, fetcher, &mirror, shim_binary)?;
+    // name short-circuits on the cache check — the chain guard (S32)
+    // turns a true cycle into the named error first.
+    chain.push(plan.name.clone());
+    let closure = install_dependency_closure(home, fetcher, &mirror, shim_binary, chain);
+    chain.pop();
+    closure?;
 
     Ok(InstallOutcome {
         name: plan.name,
@@ -995,12 +1037,15 @@ fn finish_install<T: Transport>(
 /// failing that, the newest registry version satisfying the edge's
 /// constraint, installed through the same fetch → verify → cache → walk
 /// tail. `kind: language` edges are the runtime axis — the dispatcher
-/// resolves them at run time, never here.
+/// resolves them at run time, never here. An edge naming a payload
+/// already on `chain` is a requires CYCLE (spec 18 §5.6 S32) — a named
+/// error, never the cache check's silent short-circuit.
 fn install_dependency_closure<T: Transport>(
     home: &Path,
     fetcher: &Fetcher<T>,
     mirror: &Manifest,
     shim_binary: Option<&Path>,
+    chain: &mut Vec<String>,
 ) -> Result<(), TebakoError> {
     for req in mirror.requires() {
         let (kind, name, constraint) = match req {
@@ -1012,13 +1057,28 @@ fn install_dependency_closure<T: Transport>(
                 name, constraint, ..
             } => ("data", name, constraint),
         };
+        if chain.iter().any(|n| n == name) {
+            let start = chain
+                .iter()
+                .position(|n| n == name)
+                .expect("membership checked");
+            let mut cycle: Vec<String> = chain[start..].to_vec();
+            cycle.push(name.clone());
+            return Err(err(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "dependency cycle: {} (spec 18 §5.6 S32) — break the cycle in the payloads' requires: declarations",
+                    cycle.join(" → ")
+                ),
+            ));
+        }
         let eval = versions::from_validated(constraint);
         let installed = tebako_shim::resolve::installed_versions(home, name).map_err(map_shim)?;
         if installed.iter().any(|v| eval.matches(v)) {
             continue;
         }
         let plan = plan_from_dependency_edge(home, fetcher, mirror, kind, name, constraint)?;
-        finish_install(home, fetcher, plan, shim_binary)?;
+        finish_install(home, fetcher, plan, shim_binary, chain)?;
     }
     Ok(())
 }

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -279,10 +279,16 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
         };
         compose::check_runtime_row(&doc, &ruby_ver)?;
         compose::check_entrypoint(&doc, &stem)?;
-        compose::apply_overrides(&mut doc, opts.carry.as_deref(), opts.share.as_deref(), &stem)?;
+        compose::apply_overrides(
+            &mut doc,
+            opts.carry.as_deref(),
+            opts.share.as_deref(),
+            &stem,
+        )?;
         let home = compose::tebako_home()?;
         let host = install::host_platform()?;
-        compose_slices = compose::resolve_closure(&home, &tebako_resolve::Fetcher::new(), &doc, preset, host)?;
+        compose_slices =
+            compose::resolve_closure(&home, &tebako_resolve::Fetcher::new(), &doc, preset, host)?;
         runtime_carried = doc
             .runtime
             .carry
@@ -329,11 +335,7 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
         let exe_sha = resolve::sha256_file_hex(&runtime_path)
             .ok_or_else(|| plain_error(format!("cannot hash {}", runtime_path.display())))?;
         let exe_slot = images.len() as u32;
-        images.push((
-            runtime_path.clone(),
-            String::new(),
-            tpkg::TPKG_FORMAT_AUTO,
-        ));
+        images.push((runtime_path.clone(), String::new(), tpkg::TPKG_FORMAT_AUTO));
         let image_path = runtime_path
             .parent()
             .map(|dir| dir.join(&image_ref.filename))
@@ -1214,7 +1216,8 @@ mod tests {
     fn stitch_clears_the_lean_flag_only_when_self_contained() {
         // spec 23 §13.2: a self-contained press resolves nothing at run
         // time — TPKG_FLAG_LEAN stays CLEAR; every other press sets it.
-        let dir = std::env::temp_dir().join(format!("tebako-cli-stitch-lean-{}", std::process::id()));
+        let dir =
+            std::env::temp_dir().join(format!("tebako-cli-stitch-lean-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let base = dir.join("bootstrap");

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -533,12 +533,13 @@ fn press_package_manifest(
         },
         entries: vec![tpkg::PackageEntry {
             name: stem.clone(),
-            slot: 0,
+            slot: Some(0),
             entrypoint: "/local/stub.rb".to_string(),
             runtime_ref: runtime_ref.to_string(),
         }],
         jail,
         env: Default::default(),
+        lock: None,
         mounts: vec![tpkg::PackageMount {
             slot: 0,
             point: mount_point.to_string(),
@@ -870,7 +871,7 @@ mod tests {
         assert_eq!(m.package.name, "hello");
         assert_eq!(m.package.producer.tool, "tebako-cli");
         assert_eq!(m.entries.len(), 1);
-        assert_eq!(m.entries[0].slot, 0);
+        assert_eq!(m.entries[0].slot, Some(0));
         // The entry is the in-image dispatcher, mount-relative (the
         // driver joins mount+entry — spec 17 §1).
         assert_eq!(m.entries[0].entrypoint, "/local/stub.rb");

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -2,7 +2,8 @@
 //! the reference gem's lean press (tebako-chainwt lib/tebako):
 //!
 //!   tebako press -r <root> -e <entry> [-o <output>] [-p <prefix>]
-//!                [--cwd <dir>] [-R <ruby>] [-m lean|fat]
+//!                [--cwd <dir>] [-R <ruby>] [-m self-contained|shared-runtime]
+//!                [--compose <tebako.yaml>] [--carry ...] [--share ...]
 //!                [--image <path>:<mount>]... [--bootstrap <path>]
 //!                [--tebako-version <v>]
 //!   tebako press --suite <suite.yaml>   (one package, N commands —
@@ -62,6 +63,7 @@
 //! - .tebako.yml is not read.
 
 pub mod check;
+pub mod compose;
 pub mod contract;
 pub mod deploy;
 pub mod error;
@@ -141,6 +143,12 @@ const WARN2: &str = "
 pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     // --suite: one package, N entries (spec 03 §6 — src/suite.rs).
     if let Some(suite_path) = &opts.suite {
+        if opts.compose.is_some() || opts.carry.is_some() || opts.share.is_some() {
+            return Err(packaging_error(
+                130,
+                Some("--compose/--carry/--share do not apply to a suite press (the suite's entries carry their own refs, spec 03 §6)"),
+            ));
+        }
         let yaml = fs::read_to_string(suite_path).map_err(|e| {
             plain_error(format!(
                 "cannot read the suite file {}: {e}",
@@ -159,7 +167,7 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     }
     if opts.mode == PressMode::Classic {
         return Err(plain_error(
-            "the 'classic' press mode is a later tebako-rs milestone (use --mode=lean or --mode=fat)",
+            "the 'classic' press mode is a later tebako-rs milestone (use --mode=shared-runtime or --mode=self-contained)",
         ));
     }
 
@@ -184,6 +192,30 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
         None => None,
     };
 
+    // spec 23 §3/§13: the composition document parses before any heavy
+    // work (a bad document must not cost a runtime download); the
+    // closure resolves below, once the ruby version is known. The D5
+    // overrides (--carry/--share) refine a composition — they require
+    // --compose.
+    let compose_doc = match &opts.compose {
+        Some(path) => {
+            let (doc, warnings) = compose::load(path)?;
+            for warning in &warnings {
+                eprintln!("tebako: WARNING: {warning}");
+            }
+            Some(doc)
+        }
+        None => {
+            if opts.carry.is_some() || opts.share.is_some() {
+                return Err(packaging_error(
+                    130,
+                    Some("--carry/--share refine a composition (spec 23 §13) and require --compose <tebako.yaml>"),
+                ));
+            }
+            None
+        }
+    };
+
     // Cli#bootstrap: the cache version guard runs before the press
     // (skipped in devmode, like the gem).
     if !opts.devmode {
@@ -204,6 +236,12 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     check_warnings(opts);
     println!("{}", opts.press_announce(&ruby_ver));
 
+    let package = format!("{}{}", opts.package(), scenario.exe_suffix);
+    let stem = Path::new(&package)
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| package.clone());
+
     let platform = host_platform()?;
     // The bootstrap is resolved BEFORE the runtime download: the local
     // sources first, else the spec 19 §4 store flow (the CLI's own
@@ -214,28 +252,164 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     let runtime_resolver = Resolver::new();
     let resolved = runtime_resolver.resolve_runtime(&ruby_ver, &platform, &opts.tebako_version)?;
     let runtime_path = resolved.executable.clone();
+    // The windows dll-era facet (tebako-runtime-ruby#40), when the
+    // resolved release carries one — a carried runtime's third slot.
+    let resolved_dll = runtime_resolver.resolved_dll(&ruby_ver, &platform, &opts.tebako_version);
 
     let app_image = packager::build_app_image(opts, &mut scenario, &resolved, &ruby_ver)?;
 
+    // The composition (spec 23 §13): the document's preset governs the
+    // carry defaults; an explicit --mode OVERRIDES it (the invocation
+    // beats authored defaults); --carry/--share rewrite the per-slice
+    // verdicts. The FULL closure resolves at press time — the lock bakes
+    // exactly what press tested (spec 23 §4).
+    let mut compose_slices: Vec<compose::ComposeSlice> = Vec::new();
+    let mut runtime_carried = opts.mode == PressMode::Fat;
+    if let Some(doc) = &compose_doc {
+        let mut doc = doc.clone();
+        let preset = if opts.mode_explicit {
+            match opts.mode {
+                PressMode::Fat => tpkg::ComposePreset::SelfContained,
+                // Classic/Runtime are gated above; Lean is the shared
+                // preset.
+                _ => tpkg::ComposePreset::SharedRuntime,
+            }
+        } else {
+            doc.preset
+        };
+        compose::check_runtime_row(&doc, &ruby_ver)?;
+        compose::check_entrypoint(&doc, &stem)?;
+        compose::apply_overrides(&mut doc, opts.carry.as_deref(), opts.share.as_deref(), &stem)?;
+        let home = compose::tebako_home()?;
+        let host = install::host_platform()?;
+        compose_slices = compose::resolve_closure(&home, &tebako_resolve::Fetcher::new(), &doc, preset, host)?;
+        runtime_carried = doc
+            .runtime
+            .carry
+            .unwrap_or_else(|| preset.default_carry(true));
+    }
+
     let mut images: Vec<(PathBuf, String, u32)> = vec![(
-        app_image,
+        app_image.clone(),
         declared_mount(&scenario.fs_mount_point).to_string(),
         opts.format.tpkg_format_id(),
     )];
     for (path, mount) in opts.images()? {
         images.push((PathBuf::from(path), mount, tpkg::TPKG_FORMAT_DWARFS));
     }
-    let payload_sha256 = if opts.mode == PressMode::Fat {
-        let sha = resolve::sha256_file_hex(&runtime_path)
+    // Carried compose slices ride as ordinary slots (spec 23 §13.1) with
+    // the AUTO format hint — press did not author the bytes, detection
+    // stays authoritative (the §4 orthogonality law). The mount is the
+    // requiring edge's, else "" (a cache prime).
+    let mut carried_slots: Vec<(String, u32)> = Vec::new();
+    for s in &compose_slices {
+        if s.carry {
+            carried_slots.push((s.name.clone(), images.len() as u32));
+            images.push((
+                s.cache_path.clone(),
+                s.mount.clone().unwrap_or_default(),
+                tpkg::TPKG_FORMAT_AUTO,
+            ));
+        }
+    }
+
+    // The lock's runtime row (spec 23 §4/§13): EVERY press locks the
+    // runtime it resolved. Carried = the two-slot self-contained shape
+    // (spec 19 §6.1: exe + env image, + the windows dll facet when the
+    // release declares one) with the press-time digest pins; shared =
+    // the version alone, resolved at run time through the ordinary
+    // spec 05 §5 chain.
+    let lock_runtime = if runtime_carried {
+        let Some(image_ref) = &resolved.image else {
+            return Err(packaging_error(
+                130,
+                Some("self-contained press requires an image-era runtime (the resolved runtime carries no env image)"),
+            ));
+        };
+        let exe_sha = resolve::sha256_file_hex(&runtime_path)
             .ok_or_else(|| plain_error(format!("cannot hash {}", runtime_path.display())))?;
+        let exe_slot = images.len() as u32;
         images.push((
             runtime_path.clone(),
             String::new(),
-            tpkg::TPKG_FORMAT_RUNTIME,
+            tpkg::TPKG_FORMAT_AUTO,
         ));
-        Some(sha)
+        let image_path = runtime_path
+            .parent()
+            .map(|dir| dir.join(&image_ref.filename))
+            .unwrap_or_else(|| PathBuf::from(&image_ref.filename));
+        let image_slot = images.len() as u32;
+        images.push((image_path, String::new(), tpkg::TPKG_FORMAT_DWARFS));
+        let dll = match &resolved_dll {
+            Some(d) => {
+                let slot = images.len() as u32;
+                images.push((d.path.clone(), String::new(), tpkg::TPKG_FORMAT_AUTO));
+                Some(tpkg::LockedArtifact {
+                    slot,
+                    sha256: tpkg::DigestPin::One(d.sha256.clone()),
+                    install_as: Some(d.install_as.clone()),
+                })
+            }
+            None => None,
+        };
+        tpkg::LockedRuntime {
+            version: ruby_ver.clone(),
+            carry: true,
+            exe: Some(tpkg::LockedArtifact {
+                slot: exe_slot,
+                sha256: tpkg::DigestPin::One(exe_sha),
+                install_as: None,
+            }),
+            image: Some(tpkg::LockedArtifact {
+                slot: image_slot,
+                sha256: tpkg::DigestPin::One(image_ref.sha256.clone()),
+                install_as: None,
+            }),
+            dll,
+        }
     } else {
-        None
+        tpkg::LockedRuntime {
+            version: ruby_ver.clone(),
+            carry: false,
+            exe: None,
+            image: None,
+            dll: None,
+        }
+    };
+
+    // The lock's slice rows, in mount order: the app payload first
+    // (always carried — slot 0), then the resolved composition closure.
+    let app_sha = resolve::sha256_file_hex(&app_image)
+        .ok_or_else(|| plain_error(format!("cannot hash {}", app_image.display())))?;
+    let mut lock_slices = vec![tpkg::LockedSlice {
+        name: stem.clone(),
+        version: "0.0.0".to_string(),
+        carry: true,
+        slot: Some(0),
+        mount: Some(declared_mount(&scenario.fs_mount_point).to_string()),
+        sha256: tpkg::DigestPin::One(app_sha),
+        source: None,
+    }];
+    for s in &compose_slices {
+        let slot = carried_slots
+            .iter()
+            .find(|(name, _)| name == &s.name)
+            .map(|(_, slot)| *slot);
+        lock_slices.push(tpkg::LockedSlice {
+            name: s.name.clone(),
+            version: s.version.clone(),
+            carry: s.carry,
+            slot,
+            mount: s.mount.clone(),
+            sha256: s.pin.clone(),
+            // Carried: provenance; shared: the fetch coordinates the
+            // bootstrap resolves from (spec 23 §13.4).
+            source: Some(s.source.clone()),
+        });
+    }
+    let lock = tpkg::PackageLock {
+        runtime: Some(lock_runtime),
+        slices: lock_slices,
     };
 
     let mut runtime_ref = format!("ruby@{ruby_ver};tebako={}", opts.tebako_version);
@@ -244,11 +418,7 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
         // the .tfs alongside the interpreter at first run.
         runtime_ref.push_str(";image");
     }
-    if let Some(sha) = &payload_sha256 {
-        runtime_ref.push_str(&format!(";sha256={sha}"));
-    }
 
-    let package = format!("{}{}", opts.package(), scenario.exe_suffix);
     // The L2 package manifest rides EVERY runnable press (spec 03 §6):
     // entries[0] names the in-image dispatcher entry (mount-relative —
     // the driver joins mount+entry, spec 17 §1) and the mounts block
@@ -256,12 +426,14 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     // root (the image-era mount model — the env image owns the root,
     // the app image merges over it). A --jail press composes the policy
     // into the SAME block (spec 08 §4 — one manifest, never two paths).
+    // The lock (spec 23 §4) rides the same manifest.
     let package_manifest = press_package_manifest(
         &package,
         &runtime_ref,
         &opts.tebako_version,
         declared_mount(&scenario.fs_mount_point),
         jail,
+        Some(lock),
     );
     stitch(
         &bootstrap_path,
@@ -269,6 +441,7 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
         &package,
         &runtime_ref,
         Some(&package_manifest),
+        !runtime_carried,
         opts.no_install,
     )?;
     println!("Created tebako package at \"{package}\"");
@@ -364,13 +537,17 @@ pub(crate) fn press_bootstrap_with(
 /// refs, spec 02 §5b / spec 03 §6). `package_manifest`, when present, is
 /// embedded as extension block type 2 (every runnable press writes one —
 /// the union mount model, spec 03 §6); `None` keeps the package
-/// block-less (the v1 shape — bare payload stitching, tests).
+/// block-less (the v1 shape — bare payload stitching, tests). `lean` is
+/// the TPKG_FLAG_LEAN verdict: CLEAR only for a self-contained press
+/// (the runtime rides as the two carried slots, spec 19 §6.1 / spec 23
+/// §13.2) — every other package resolves the runtime at run time.
 pub(crate) fn stitch(
     bootstrap_path: &Path,
     images: &[(PathBuf, String, u32)],
     package: &str,
     runtime_ref: &str,
     package_manifest: Option<&tpkg::PackageManifest>,
+    lean: bool,
     no_install: bool,
 ) -> Result<(), TebakoError> {
     if images.is_empty() {
@@ -459,12 +636,14 @@ pub(crate) fn stitch(
         .collect();
     let pkg_options = tebako_pkg::PackageOptions {
         runtime_ref: runtime_ref.to_string(),
-        // TPKG_FLAG_LEAN always; TPKG_FLAG_NO_INSTALL when the press
-        // froze the package (--no-install, TODO.v2-1/12).
-        package_flags: if no_install {
-            tpkg::TPKG_FLAG_LEAN | tpkg::TPKG_FLAG_NO_INSTALL
-        } else {
-            tpkg::TPKG_FLAG_LEAN
+        // TPKG_FLAG_LEAN unless the press is self-contained;
+        // TPKG_FLAG_NO_INSTALL when the press froze the package
+        // (--no-install, TODO.v2-1/12).
+        package_flags: match (lean, no_install) {
+            (true, true) => tpkg::TPKG_FLAG_LEAN | tpkg::TPKG_FLAG_NO_INSTALL,
+            (true, false) => tpkg::TPKG_FLAG_LEAN,
+            (false, true) => tpkg::TPKG_FLAG_NO_INSTALL,
+            (false, false) => 0,
         },
         launcher_abi: LAUNCHER_ABI,
         // The L2 package manifest rides along when the caller declares
@@ -508,13 +687,15 @@ pub(crate) fn declared_mount(mount_point: &str) -> &str {
 /// declared form: `/__tfs__` on POSIX, `/t` on windows — so the two stay
 /// consistent by construction). A --jail press composes the policy into
 /// the same block — the package's host-access REQUEST the bootstrap
-/// tightens at handoff (spec 08 §2).
+/// tightens at handoff (spec 08 §2). `lock` is the press-time
+/// composition lock (spec 23 §4/§13) — baked by every runnable press.
 fn press_package_manifest(
     package: &str,
     runtime_ref: &str,
     tebako_version: &str,
     mount_point: &str,
     jail: Option<tpkg::HostJail>,
+    lock: Option<tpkg::PackageLock>,
 ) -> tpkg::PackageManifest {
     let stem = Path::new(package)
         .file_stem()
@@ -539,7 +720,7 @@ fn press_package_manifest(
         }],
         jail,
         env: Default::default(),
-        lock: None,
+        lock,
         mounts: vec![tpkg::PackageMount {
             slot: 0,
             point: mount_point.to_string(),
@@ -864,6 +1045,7 @@ mod tests {
             "0.15.9",
             "/__tfs__",
             Some(jail),
+            None,
         );
         // Valid per the tpkg discipline (schema version, N>=1 entries, the
         // jail block's own validation, the mounts block's rules).
@@ -899,6 +1081,7 @@ mod tests {
             "0.15.9",
             "/__tfs__",
             None,
+            None,
         );
         m.validate().unwrap();
         assert!(m.jail.is_none());
@@ -929,6 +1112,7 @@ mod tests {
             "ruby@3.3.7;tebako=9.9.9",
             None,
             true,
+            true,
         )
         .unwrap();
         let mut f = std::fs::File::open(&frozen).unwrap();
@@ -943,12 +1127,133 @@ mod tests {
             plain.to_str().unwrap(),
             "ruby@3.3.7;tebako=9.9.9",
             None,
+            true,
             false,
         )
         .unwrap();
         let mut f = std::fs::File::open(&plain).unwrap();
         let m = tpkg::read_from(&mut f).unwrap();
         assert_eq!(m.package_flags & tpkg::TPKG_FLAG_NO_INSTALL, 0);
+    }
+
+    #[test]
+    fn press_package_manifest_bakes_the_lock() {
+        // spec 23 §4/§13: the lock rides the type-2 manifest — the
+        // carried runtime pair's slots + pins and the app slice row.
+        let hex = |c: char| c.to_string().repeat(64);
+        let lock = tpkg::PackageLock {
+            runtime: Some(tpkg::LockedRuntime {
+                version: "3.3.7".to_string(),
+                carry: true,
+                exe: Some(tpkg::LockedArtifact {
+                    slot: 1,
+                    sha256: tpkg::DigestPin::One(hex('a')),
+                    install_as: None,
+                }),
+                image: Some(tpkg::LockedArtifact {
+                    slot: 2,
+                    sha256: tpkg::DigestPin::One(hex('b')),
+                    install_as: None,
+                }),
+                dll: None,
+            }),
+            slices: vec![
+                tpkg::LockedSlice {
+                    name: "hello".to_string(),
+                    version: "0.0.0".to_string(),
+                    carry: true,
+                    slot: Some(0),
+                    mount: Some("/__tfs__".to_string()),
+                    sha256: tpkg::DigestPin::One(hex('c')),
+                    source: None,
+                },
+                tpkg::LockedSlice {
+                    name: "templates".to_string(),
+                    version: "3.2".to_string(),
+                    carry: false,
+                    slot: None,
+                    mount: None,
+                    sha256: tpkg::DigestPin::One(hex('d')),
+                    source: Some("tfs:github:acme/templates:3.2".to_string()),
+                },
+            ],
+        };
+        let m = press_package_manifest(
+            "/tmp/out/hello",
+            "ruby@3.3.7;tebako=0.15.9;image",
+            "0.15.9",
+            "/__tfs__",
+            None,
+            Some(lock.clone()),
+        );
+        m.validate().unwrap();
+        assert_eq!(m.lock.as_ref(), Some(&lock));
+        // the claimed slots: the carried runtime pair + the app slice
+        let mut claimed = lock.claimed_slots();
+        claimed.sort_unstable();
+        assert_eq!(claimed, vec![0, 1, 2]);
+        // the YAML round trip preserves the lock (the bootstrap reads it)
+        let back = tpkg::PackageManifest::from_yaml(&m.to_yaml().unwrap()).unwrap();
+        assert_eq!(back, m);
+        assert_eq!(
+            back.lock
+                .as_ref()
+                .unwrap()
+                .runtime
+                .as_ref()
+                .unwrap()
+                .image
+                .as_ref()
+                .unwrap()
+                .slot,
+            2
+        );
+    }
+
+    #[test]
+    fn stitch_clears_the_lean_flag_only_when_self_contained() {
+        // spec 23 §13.2: a self-contained press resolves nothing at run
+        // time — TPKG_FLAG_LEAN stays CLEAR; every other press sets it.
+        let dir = std::env::temp_dir().join(format!("tebako-cli-stitch-lean-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let base = dir.join("bootstrap");
+        std::fs::write(&base, b"BASE").unwrap();
+        let img = dir.join("img.tfs");
+        std::fs::write(&img, b"IMG").unwrap();
+
+        let contained = dir.join("contained");
+        stitch(
+            &base,
+            &[(img.clone(), "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+            contained.to_str().unwrap(),
+            "ruby@3.3.7;tebako=9.9.9",
+            None,
+            false,
+            false,
+        )
+        .unwrap();
+        let mut f = std::fs::File::open(&contained).unwrap();
+        let m = tpkg::read_from(&mut f).unwrap();
+        assert_eq!(m.package_flags & tpkg::TPKG_FLAG_LEAN, 0);
+        assert_eq!(m.package_flags & tpkg::TPKG_FLAG_NO_INSTALL, 0);
+
+        let shared = dir.join("shared");
+        stitch(
+            &base,
+            &[(img, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+            shared.to_str().unwrap(),
+            "ruby@3.3.7;tebako=9.9.9",
+            None,
+            true,
+            false,
+        )
+        .unwrap();
+        let mut f = std::fs::File::open(&shared).unwrap();
+        let m = tpkg::read_from(&mut f).unwrap();
+        assert!(m.package_flags & tpkg::TPKG_FLAG_LEAN != 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     fn press_opts(bootstrap: Option<PathBuf>) -> PressOptions {
@@ -972,6 +1277,10 @@ mod tests {
             jail: None,
             no_install: false,
             format: options::PressImageFormat::Dwarfs,
+            compose: None,
+            carry: None,
+            share: None,
+            mode_explicit: false,
         }
     }
 

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -10,10 +10,12 @@ use tebako_cli::{cache_list, cache_list_json, cache_prune, press, VERSION_BANNER
 
 const USAGE: &str = "Usage:
   tebako press -r <root> -e <entry> [-o <output>] [-p <prefix>] [-c <cwd>]
-               [-R <ruby>] [-m lean|fat] [-l error|warn|debug|trace]
+               [-R <ruby>] [-m self-contained|shared-runtime] [-l error|warn|debug|trace]
                [--image <path>:<mount>]... [--bootstrap <path>]
                [--tebako-version <v>] [--prefer-local] [--jail <spec>]
-               [--format dwarfs|limnifs]
+               [--format dwarfs|limnifs] [--compose <tebako.yaml>]
+               [--carry all|none|<name,...>] [--share <name,...>]
+               (lean/fat stay accepted as deprecated aliases, spec 23 §13.2)
   tebako press --suite <suite.yaml> [-o <output>] [-p <prefix>] [-R <ruby>]
                one package, N commands (spec 03 §6: per-entry slots + type-2 manifest)
   tebako run <pkg> [--jail <spec>] [--mount <host:mount:ro|rw>]... [--no-host]
@@ -680,6 +682,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
     let mut cwd: Option<String> = None;
     let mut ruby: Option<String> = None;
     let mut mode = PressMode::Lean;
+    let mut mode_explicit = false;
     let mut log_level = "error".to_string();
     let mut image_specs: Vec<String> = Vec::new();
     let mut bootstrap: Option<PathBuf> = None;
@@ -690,6 +693,9 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
     let mut jail: Option<String> = None;
     let mut no_install = false;
     let mut format = tebako_cli::options::PressImageFormat::Limnifs;
+    let mut compose: Option<PathBuf> = None;
+    let mut carry: Option<String> = None;
+    let mut share: Option<String> = None;
 
     let mut i = 0;
     while i < args.len() {
@@ -716,7 +722,12 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
             "-R" | "--Ruby" => ruby = Some(take_value(&mut i)?),
             "-m" | "--mode" => {
                 let v = take_value(&mut i)?;
-                mode = PressMode::parse(&v).map_err(CliExit::Usage)?;
+                let (m, warning) = PressMode::parse_named(&v).map_err(CliExit::Usage)?;
+                if let Some(w) = warning {
+                    eprintln!("tebako: WARNING: {w}");
+                }
+                mode = m;
+                mode_explicit = true;
             }
             "-l" | "--log-level" => log_level = take_value(&mut i)?,
             "--image" => image_specs.push(take_value(&mut i)?),
@@ -732,6 +743,9 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
                     tebako_cli::options::PressImageFormat::parse(&v).map_err(CliExit::Usage)?;
             }
             "-D" | "--devmode" => devmode = true,
+            "--compose" => compose = Some(PathBuf::from(take_value(&mut i)?)),
+            "--carry" => carry = Some(take_value(&mut i)?),
+            "--share" => share = Some(take_value(&mut i)?),
             "-t" | "--tebafile" => {
                 let _ = take_value(&mut i)?;
                 return Err(CliExit::Usage(
@@ -797,5 +811,9 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
         jail,
         no_install,
         format,
+        compose,
+        carry,
+        share,
+        mode_explicit,
     })
 }

--- a/crates/tebako-cli/src/options.rs
+++ b/crates/tebako-cli/src/options.rs
@@ -388,4 +388,3 @@ mod tests {
         assert!(err.contains("lean/fat"), "{err}");
     }
 }
-

--- a/crates/tebako-cli/src/options.rs
+++ b/crates/tebako-cli/src/options.rs
@@ -16,13 +16,35 @@ pub enum PressMode {
 
 impl PressMode {
     pub fn parse(s: &str) -> Result<PressMode, String> {
+        Self::parse_named(s).map(|(mode, _)| mode)
+    }
+
+    /// The spec 23 §13.2 vocabulary: `self-contained`/`shared-runtime`
+    /// are the locked preset names; `lean`/`fat` stay accepted as
+    /// deprecated aliases and return a named warning for the caller to
+    /// print (never silent). `classic`/`runtime` are unchanged.
+    pub fn parse_named(s: &str) -> Result<(PressMode, Option<String>), String> {
         match s {
-            "lean" => Ok(PressMode::Lean),
-            "fat" => Ok(PressMode::Fat),
-            "classic" => Ok(PressMode::Classic),
-            "runtime" => Ok(PressMode::Runtime),
+            "shared-runtime" => Ok((PressMode::Lean, None)),
+            "self-contained" => Ok((PressMode::Fat, None)),
+            "lean" => Ok((
+                PressMode::Lean,
+                Some(
+                    "`--mode lean` is deprecated: the preset is now named `shared-runtime` (spec 23 §13.2)"
+                        .to_string(),
+                ),
+            )),
+            "fat" => Ok((
+                PressMode::Fat,
+                Some(
+                    "`--mode fat` is deprecated: the preset is now named `self-contained` — the runtime travels as two carried slots (spec 23 §13.2)"
+                        .to_string(),
+                ),
+            )),
+            "classic" => Ok((PressMode::Classic, None)),
+            "runtime" => Ok((PressMode::Runtime, None)),
             _ => Err(format!(
-                "invalid mode '{s}' (lean/fat/classic/runtime expected)"
+                "invalid mode '{s}' (self-contained/shared-runtime/classic/runtime expected; lean/fat accepted as deprecated aliases)"
             )),
         }
     }
@@ -123,6 +145,19 @@ pub struct PressOptions {
     /// --format <dwarfs|limnifs> (spec 20 §6): the application image
     /// format. Limnifs by default; `dwarfs` stays an explicit opt-in.
     pub format: PressImageFormat,
+    /// --compose <tebako.yaml> (spec 23 §3 D2): the composition document
+    /// naming the payload slices pressed around the local app.
+    pub compose: Option<PathBuf>,
+    /// --carry <all|none|name,…> (spec 23 §13.2): per-slice carry
+    /// override; requires --compose.
+    pub carry: Option<String>,
+    /// --share <name,…> (spec 23 §13.2): per-slice share override;
+    /// requires --compose.
+    pub share: Option<String>,
+    /// True when -m/--mode was passed explicitly (spec 23 §13.2: an
+    /// explicit --mode OVERRIDES the compose document's preset — the
+    /// invocation beats authored defaults; a defaulted mode never does).
+    pub mode_explicit: bool,
 }
 
 impl PressOptions {
@@ -305,3 +340,52 @@ fn join_path(base: &str, rel: &str) -> String {
 pub fn host_platform() -> Result<String, TebakoError> {
     Ok(tpkg::Platform::host().release_asset_name().to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_named_speaks_the_locked_vocabulary() {
+        assert_eq!(
+            PressMode::parse_named("self-contained").unwrap(),
+            (PressMode::Fat, None)
+        );
+        assert_eq!(
+            PressMode::parse_named("shared-runtime").unwrap(),
+            (PressMode::Lean, None)
+        );
+        assert_eq!(
+            PressMode::parse_named("classic").unwrap(),
+            (PressMode::Classic, None)
+        );
+        assert_eq!(
+            PressMode::parse_named("runtime").unwrap(),
+            (PressMode::Runtime, None)
+        );
+    }
+
+    #[test]
+    fn parse_named_aliases_warn_never_silent() {
+        let (mode, warning) = PressMode::parse_named("lean").unwrap();
+        assert_eq!(mode, PressMode::Lean);
+        let warning = warning.expect("the alias warns");
+        assert!(warning.contains("deprecated"), "{warning}");
+        assert!(warning.contains("shared-runtime"), "{warning}");
+
+        let (mode, warning) = PressMode::parse_named("fat").unwrap();
+        assert_eq!(mode, PressMode::Fat);
+        let warning = warning.expect("the alias warns");
+        assert!(warning.contains("deprecated"), "{warning}");
+        assert!(warning.contains("self-contained"), "{warning}");
+
+        // the quiet parse (non-CLI callers) keeps the alias mapping
+        assert_eq!(PressMode::parse("fat").unwrap(), PressMode::Fat);
+        assert_eq!(PressMode::parse("shared-runtime").unwrap(), PressMode::Lean);
+
+        let err = PressMode::parse_named("chunky").unwrap_err();
+        assert!(err.contains("self-contained/shared-runtime"), "{err}");
+        assert!(err.contains("lean/fat"), "{err}");
+    }
+}
+

--- a/crates/tebako-cli/src/packager.rs
+++ b/crates/tebako-cli/src/packager.rs
@@ -766,6 +766,10 @@ mod tests {
             jail: None,
             no_install: false,
             format: crate::options::PressImageFormat::Dwarfs,
+            compose: None,
+            carry: None,
+            share: None,
+            mode_explicit: false,
         }
     }
 

--- a/crates/tebako-cli/src/resolve.rs
+++ b/crates/tebako-cli/src/resolve.rs
@@ -115,6 +115,17 @@ pub struct Resolved {
     pub image: Option<ImageRef>,
 }
 
+/// The resolved windows dll facet of a runtime entry
+/// (tebako-runtime-ruby#40): the installed path, its PE name
+/// (`install_as`), and the verified sha256 — the pin a press lock
+/// carries.
+#[derive(Debug, Clone)]
+pub struct ResolvedDll {
+    pub path: PathBuf,
+    pub install_as: String,
+    pub sha256: String,
+}
+
 #[derive(Debug)]
 pub struct Resolver {
     pub cache_root: PathBuf,
@@ -222,6 +233,40 @@ impl Resolver {
         Ok(Resolved {
             executable,
             image: image_marker(),
+        })
+    }
+
+    /// The dll facet of an ALREADY-RESOLVED runtime entry (windows,
+    /// tebako-runtime-ruby#40), for press's lock: the installed path
+    /// (under the PE name), the `install_as`, and the pin — the entry
+    /// marker's first token (the verified sha of the installed file),
+    /// else the index facet's sha256. `None` for every POSIX entry, for
+    /// entries without the facet, and for a facet that never
+    /// materialized (a sums-derived ref carries no PE name).
+    pub fn resolved_dll(
+        &self,
+        ruby_version: &str,
+        platform: &str,
+        tebako_version: &str,
+    ) -> Option<ResolvedDll> {
+        let dir = self.entry_dir(ruby_version, platform, tebako_version);
+        let dll = self
+            .cached_index_entry(&dir, ruby_version, platform, tebako_version)?
+            .dll?;
+        let install_as = dll.install_as?;
+        let path = dir.join(&install_as);
+        if !path.is_file() {
+            return None;
+        }
+        let sha256 = fs::read_to_string(dir.join(format!("{install_as}.sha256")))
+            .ok()
+            .and_then(|body| body.split_whitespace().next().map(str::to_string))
+            .filter(|s| !s.is_empty())
+            .unwrap_or(dll.sha256);
+        Some(ResolvedDll {
+            path,
+            install_as,
+            sha256,
         })
     }
 

--- a/crates/tebako-cli/src/suite.rs
+++ b/crates/tebako-cli/src/suite.rs
@@ -397,6 +397,9 @@ pub fn press_suite(
         &package,
         &runtime_refs[0],
         Some(&package_manifest),
+        // Suites never carry the runtime (press_suite refuses the
+        // self-contained mode) — the LEAN flag stands.
+        true,
         opts.no_install,
     )?;
     println!("Created tebako suite package at \"{package}\"");

--- a/crates/tebako-cli/src/suite.rs
+++ b/crates/tebako-cli/src/suite.rs
@@ -277,13 +277,14 @@ pub fn suite_package_manifest(
             .enumerate()
             .map(|(i, e)| tpkg::PackageEntry {
                 name: e.name.clone(),
-                slot: i as u32,
+                slot: Some(i as u32),
                 entrypoint: e.name.clone(),
                 runtime_ref: runtime_refs[i].clone(),
             })
             .collect(),
         jail: None,
         env: BTreeMap::new(),
+        lock: None,
         // Suite members keep exclusive mounts for now: their shared
         // point collides with the env image's runtime root exactly like
         // the plain press's app slot did — the union rows for suites

--- a/crates/tebako-cli/tests/check.rs
+++ b/crates/tebako-cli/tests/check.rs
@@ -567,7 +567,7 @@ fn package_with_checks(dir: &Path) -> PathBuf {
         },
         entries: vec![tpkg::PackageEntry {
             name: "acme".to_string(),
-            slot: 0,
+            slot: Some(0),
             // The entry table names the PROVIDES entrypoint BY NAME; the
             // engine resolves it to the in-image path through the slot
             // manifest.
@@ -576,6 +576,7 @@ fn package_with_checks(dir: &Path) -> PathBuf {
         }],
         jail: None,
         env: Default::default(),
+        lock: None,
         mounts: Vec::new(),
     })
     .unwrap();

--- a/crates/tebako-cli/tests/cli_e2e.rs
+++ b/crates/tebako-cli/tests/cli_e2e.rs
@@ -89,7 +89,7 @@ fn run(cmd: &mut Command) -> (i32, String) {
     text.push_str(&String::from_utf8_lossy(&out.stderr));
     (
         out.status.code().unwrap_or(-1),
-        strip_progress(&strip_legacy_warning(&text)),
+        strip_progress(&strip_legacy_warning(&strip_lazy_seed_warning(&text))),
     )
 }
 
@@ -131,6 +131,32 @@ fn strip_legacy_warning(text: &str) -> String {
         if line.starts_with("tebako-bootstrap: WARNING: ")
             && line.contains("unsigned v1 (legacy) tpkg trailer")
         {
+            skip_next = true;
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+/// Spec 23 §13's lazy seed: when the cache already holds a
+/// same-name@version payload under a DIFFERENT digest than the package's
+/// carried copy (digest drift — this harness's press phase primes the
+/// cache, the package then carries its own build), the bootstrap prints a
+/// loud skip warning on stderr BY DESIGN (two lines; the run serves the
+/// carried bytes, unaffected). Strip it for output comparison — the
+/// warning's emission and text are pinned by tebako-bootstrap's compose
+/// tests (src/lib.rs's two seed sites).
+fn strip_lazy_seed_warning(text: &str) -> String {
+    let mut out = String::new();
+    let mut skip_next = false;
+    for line in text.lines() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if line.starts_with("tebako-bootstrap: WARNING: lazy seed of ") {
             skip_next = true;
             continue;
         }

--- a/crates/tebako-cli/tests/compose_press.rs
+++ b/crates/tebako-cli/tests/compose_press.rs
@@ -1,0 +1,601 @@
+//! Compose press tests (spec 23 §3/§13 — the composition spectrum): the
+//! document load + D5 overrides + runtime/entrypoint gates as pure units,
+//! and the full closure resolution over `file://` registries (temp
+//! TEBAKO_HOMEs, no network, no env mutation).
+
+use std::fs;
+use std::io::Write as _;
+use std::path::PathBuf;
+
+use tebako_cli::compose;
+use tebako_resolve::{sha256_hex, Fetcher};
+use tpkg::{ComposePreset, Platform};
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("tebako-cli-compose-{tag}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A temp TEBAKO_HOME plus a mirror dir holding payload/registry files.
+struct Fixture {
+    dir: PathBuf,
+    home: PathBuf,
+    mirror: PathBuf,
+}
+
+impl Fixture {
+    fn new(tag: &str) -> Fixture {
+        let dir = scratch(tag);
+        let home = dir.join("home");
+        let mirror = dir.join("mirror");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&mirror).unwrap();
+        Fixture { dir, home, mirror }
+    }
+
+    fn payload(&self, file: &str, bytes: &[u8]) -> String {
+        fs::write(self.mirror.join(file), bytes).unwrap();
+        tebako_http::file_url(&self.mirror.join(file))
+    }
+
+    fn registry(&self, file: &str, yaml: &str) -> String {
+        fs::write(self.mirror.join(file), yaml).unwrap();
+        tebako_http::file_url(&self.mirror.join(file))
+    }
+
+    /// Register a registry file in the home's config (the add-registry
+    /// effect, without the verb's summary obligations).
+    fn register(&self, reg_ref: &str) {
+        tebako_cli::install::add_registry(&self.home, reg_ref).unwrap();
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn sha(byte: u8) -> String {
+    String::from(char::from(byte)).repeat(64)
+}
+
+fn zip_image_with_manifest(manifest_yaml: &str) -> Vec<u8> {
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let options = zip::write::SimpleFileOptions::default();
+    writer
+        .start_file("__tpkg__/manifest.yaml", options)
+        .unwrap();
+    writer.write_all(manifest_yaml.as_bytes()).unwrap();
+    writer.start_file("app/bin/app", options).unwrap();
+    writer.write_all(b"#!/bin/sh\n").unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+/// An app-kind embedded manifest; `requires` is the pre-indented edge
+/// block ("" for none).
+fn manifest_yaml(kind: &str, name: &str, version: &str, requires: &str) -> String {
+    let provides = match kind {
+        "app" => format!(
+            "provides:\n  entrypoints:\n    - name: {name}\n      path: /app/bin/{name}\n      runtime_requirement: {{engine: ruby, constraint: \">= 3.3, < 5.0\"}}\n  platforms: universal\n  capabilities: {{exec: true, read: true}}\n"
+        ),
+        "toolkit" => "provides:\n  platforms: universal\n  capabilities: {exec: false, read: true}\n"
+            .to_string(),
+        _ => "provides:\n  mount_semantics: {suggested: \"/\"}\n  capabilities: {exec: false, read: true}\n"
+            .to_string(),
+    };
+    let requires = if requires.is_empty() {
+        String::new()
+    } else {
+        format!("requires:\n{requires}")
+    };
+    format!(
+        "identity:\n  schema_version: 1\n  kind: {kind}\n  name: {name}\n  version: {version}\n  producer: {{tool: tebako, tool_version: 0.15.9}}\n  created: \"2026-07-26T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{}\"\n    blob_sha256: \"{}\"\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\n{provides}{requires}",
+        sha(b'a'),
+        sha(b'b')
+    )
+}
+
+fn image(kind: &str, name: &str, version: &str, requires: &str) -> Vec<u8> {
+    zip_image_with_manifest(&manifest_yaml(kind, name, version, requires))
+}
+
+/// A registry carrying one payload at the given versions; every ref must
+/// already be written to the mirror.
+fn registry_yaml(name: &str, kind: &str, versions: &[(&str, &str)], default: Option<&str>) -> String {
+    let mut yaml = format!(
+        "schema_version: 1\npayloads:\n  - name: {name}\n    kind: {kind}\n    versions:\n"
+    );
+    for (version, payload_ref) in versions {
+        yaml.push_str(&format!(
+            "      - version: {version}\n        platforms: universal\n        release: {{ref: {payload_ref}}}\n"
+        ));
+        // The registry model refuses an app that declares no entrypoints
+        // (the install.rs helper's shape).
+        if kind == "app" {
+            yaml.push_str(&format!(
+                "        runtime_requirement: {{engine: ruby, constraint: \">= 3.3, < 5.0\"}}\n        entrypoints: [{name}]\n"
+            ));
+        }
+    }
+    if let Some(d) = default {
+        yaml.push_str(&format!("    default: {d}\n"));
+    }
+    yaml
+}
+
+fn doc(yaml_tail: &str) -> String {
+    format!("version: 1\nruntime: {{ref: \"ruby@~> 3.3\"}}\n{yaml_tail}")
+}
+
+fn parse(yaml: &str) -> tpkg::ComposeDoc {
+    let (doc, warnings) = tpkg::parse_compose(yaml).expect("the document parses");
+    assert!(warnings.is_empty(), "no aliases in these fixtures: {warnings:?}");
+    doc
+}
+
+fn non_host_asset_name() -> String {
+    Platform::ALL
+        .iter()
+        .find(|p| **p != Platform::host())
+        .expect("the axis has more than one triplet")
+        .release_asset_name()
+        .to_string()
+}
+
+// ---------------------------------------------------------------------
+// load / the pure gates
+// ---------------------------------------------------------------------
+
+#[test]
+fn load_parses_the_document_and_surfaces_alias_warnings() {
+    let fx = Fixture::new("load");
+    let path = fx.dir.join("tebako.yaml");
+    fs::write(&path, doc("preset: fat\n")).unwrap();
+    let (parsed, warnings) = compose::load(&path).unwrap();
+    assert_eq!(parsed.preset, ComposePreset::SelfContained);
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("'fat' preset is deprecated"), "{warnings:?}");
+
+    let err = compose::load(&fx.dir.join("missing.yaml")).unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("cannot read the compose document"), "{err}");
+
+    fs::write(&path, doc("policy: deny\n")).unwrap();
+    let err = compose::load(&path).unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("Phase-R"), "{err}");
+}
+
+#[test]
+fn check_runtime_row_gates_the_engine_and_the_version() {
+    let ok = parse(&doc(""));
+    compose::check_runtime_row(&ok, "3.3.7").unwrap();
+
+    let mismatch = parse("version: 1\nruntime: {name: ruby, requirement: \"~> 3.4\"}\n");
+    let err = compose::check_runtime_row(&mismatch, "3.3.7").unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("does not cover the pressed ruby 3.3.7"), "{err}");
+
+    let python = parse("version: 1\nruntime: {ref: \"python@>= 3\"}\n");
+    let err = compose::check_runtime_row(&python, "3.3.7").unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("ruby is the only runtime engine today"), "{err}");
+}
+
+#[test]
+fn check_entrypoint_gates_the_pointer_form() {
+    let parsed = parse(&doc("entrypoint: mnconvert\n"));
+    let err = compose::check_entrypoint(&parsed, "hello").unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("pointer-package"), "{err}");
+    assert!(err.message.contains("N7"), "{err}");
+    compose::check_entrypoint(&parsed, "mnconvert").unwrap();
+    compose::check_entrypoint(&parse(&doc("")), "anything").unwrap();
+}
+
+#[test]
+fn apply_overrides_rewrite_the_carry_verdicts() {
+    let base = || {
+        parse(&doc(
+            "slices:\n  - {name: metanorma, requirement: \">= 2.0\"}\n  - {name: templates, requirement: \"3\", carry: true}\n",
+        ))
+    };
+
+    // --carry=all: the runtime and every slice ride in the package
+    let mut d = base();
+    compose::apply_overrides(&mut d, Some("all"), None, "hello").unwrap();
+    assert_eq!(d.runtime.carry, Some(true));
+    assert!(d.slices.iter().all(|s| s.carry == Some(true)));
+
+    // --carry=none: everything shares
+    let mut d = base();
+    compose::apply_overrides(&mut d, Some("none"), None, "hello").unwrap();
+    assert_eq!(d.runtime.carry, Some(false));
+    assert!(d.slices.iter().all(|s| s.carry == Some(false)));
+
+    // named overrides, both directions
+    let mut d = base();
+    compose::apply_overrides(&mut d, Some("ruby"), Some("templates"), "hello").unwrap();
+    assert_eq!(d.runtime.carry, Some(true));
+    assert_eq!(d.slices[1].carry, Some(false));
+    assert_eq!(d.slices[0].carry, None);
+
+    // an unknown name is a named error listing the declared set
+    let mut d = base();
+    let err = compose::apply_overrides(&mut d, Some("wat"), None, "hello").unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("--carry names 'wat'"), "{err}");
+    assert!(err.message.contains("ruby, metanorma, templates"), "{err}");
+
+    // --share naming the local app is the pointer form — named, N7
+    let mut d = base();
+    let err = compose::apply_overrides(&mut d, None, Some("hello"), "hello").unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("publish it as a payload"), "{err}");
+
+    // one slice in both flags is a conflict
+    let mut d = base();
+    let err =
+        compose::apply_overrides(&mut d, Some("metanorma"), Some("metanorma"), "hello").unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("either carried or shared"), "{err}");
+}
+
+// ---------------------------------------------------------------------
+// resolve_closure over file:// registries
+// ---------------------------------------------------------------------
+
+#[test]
+fn resolve_closure_resolves_pins_and_caches_the_document_order() {
+    let fx = Fixture::new("closure");
+    let mn_image = image("app", "metanorma", "2.1.4", "");
+    let mn_old = image("app", "metanorma", "2.0.0", "");
+    let tpl_image = image("data", "templates", "3.2", "");
+    let mn_ref = fx.payload("metanorma-2.1.4.tfs", &mn_image);
+    let mn_old_ref = fx.payload("metanorma-2.0.0.tfs", &mn_old);
+    let tpl_ref = fx.payload("templates-3.2.tfs", &tpl_image);
+    fx.register(&fx.registry(
+        "metanorma-registry.yaml",
+        &registry_yaml(
+            "metanorma",
+            "app",
+            &[("2.0.0", &mn_old_ref), ("2.1.4", &mn_ref)],
+            None,
+        ),
+    ));
+    fx.register(&fx.registry(
+        "templates-registry.yaml",
+        &registry_yaml("templates", "data", &[("3.2", &tpl_ref)], Some("3.2")),
+    ));
+
+    let doc = parse(&doc(
+        "slices:\n  - {name: metanorma, requirement: \">= 2.0\"}\n  - {name: templates}\n",
+    ));
+    let slices = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &doc,
+        ComposePreset::SharedRuntime,
+        Platform::host(),
+    )
+    .unwrap();
+
+    // document order; the newest satisfying version; shared-runtime
+    // CARRIES the payload slices (only the runtime shares by default)
+    assert_eq!(slices.len(), 2);
+    assert_eq!(slices[0].name, "metanorma");
+    assert_eq!(slices[0].version, "2.1.4");
+    assert!(slices[0].carry);
+    assert_eq!(slices[0].mount, None);
+    assert_eq!(
+        slices[0].pin,
+        tpkg::DigestPin::One(sha256_hex(&mn_image)),
+        "the pin is the verified universal digest"
+    );
+    assert_eq!(slices[1].name, "templates");
+    assert_eq!(slices[1].version, "3.2");
+    assert_eq!(slices[1].pin, tpkg::DigestPin::One(sha256_hex(&tpl_image)));
+    for s in &slices {
+        assert!(s.cache_path.is_file(), "{} cached", s.cache_path.display());
+        assert!(s.source.starts_with("file://"), "{}", s.source);
+        assert_eq!(
+            fx.home
+                .join("payloads")
+                .join(&s.name)
+                .join(format!("{}.tfs", s.version)),
+            s.cache_path
+        );
+    }
+
+    // a second resolution is a cache hit — same pins, no refetch
+    let again = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &doc,
+        ComposePreset::SharedRuntime,
+        Platform::host(),
+    )
+    .unwrap();
+    assert_eq!(again[0].pin, slices[0].pin);
+}
+
+#[test]
+fn resolve_closure_walks_the_requires_edges_and_the_doc_verdict_stands() {
+    let fx = Fixture::new("deps");
+    let a_image = image(
+        "app",
+        "appa",
+        "1.0",
+        "  - kind: toolkit\n    name: toolb\n    constraint: \">= 1.0\"\n    mount: /opt/toolb\n",
+    );
+    let b_image = image("toolkit", "toolb", "1.4", "");
+    let a_ref = fx.payload("appa-1.0.tfs", &a_image);
+    let b_ref = fx.payload("toolb-1.4.tfs", &b_image);
+    fx.register(&fx.registry(
+        "appa-registry.yaml",
+        &registry_yaml("appa", "app", &[("1.0", &a_ref)], Some("1.0")),
+    ));
+    fx.register(&fx.registry(
+        "toolb-registry.yaml",
+        &registry_yaml("toolb", "toolkit", &[("1.4", &b_ref)], Some("1.4")),
+    ));
+
+    // toolb NOT in the document: the discovered dep is carried, and the
+    // requiring edge's mount flows into the lock row.
+    let parsed = parse(&doc("slices:\n  - {name: appa, requirement: \"1.0\"}\n"));
+    let slices = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &parsed,
+        ComposePreset::SharedRuntime,
+        Platform::host(),
+    )
+    .unwrap();
+    assert_eq!(slices.len(), 2);
+    assert_eq!(slices[1].name, "toolb");
+    assert!(slices[1].carry, "a discovered dep rides in the package");
+    assert_eq!(slices[1].mount.as_deref(), Some("/opt/toolb"));
+
+    // toolb IN the document (shared): the doc verdict stands and the
+    // dep edge upgrades the cache prime to a mounted share.
+    let parsed = parse(&doc(
+        "slices:\n  - {name: appa, requirement: \"1.0\"}\n  - {name: toolb, carry: false}\n",
+    ));
+    let slices = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &parsed,
+        ComposePreset::SharedRuntime,
+        Platform::host(),
+    )
+    .unwrap();
+    assert_eq!(slices.len(), 2);
+    assert_eq!(slices[1].name, "toolb");
+    assert!(!slices[1].carry, "the document's verdict stands");
+    assert_eq!(
+        slices[1].mount.as_deref(),
+        Some("/opt/toolb"),
+        "the requiring edge's mount upgrades the cache prime"
+    );
+}
+
+#[test]
+fn resolve_closure_re_encounter_must_agree_on_the_version() {
+    let fx = Fixture::new("reencounter");
+    let a_image = image(
+        "app",
+        "appa",
+        "1.0",
+        "  - kind: toolkit\n    name: toolb\n    constraint: \">= 2.0\"\n",
+    );
+    let b_old = image("toolkit", "toolb", "1.4", "");
+    let b_new = image("toolkit", "toolb", "2.1", "");
+    let a_ref = fx.payload("appa-1.0.tfs", &a_image);
+    let b_old_ref = fx.payload("toolb-1.4.tfs", &b_old);
+    let b_new_ref = fx.payload("toolb-2.1.tfs", &b_new);
+    fx.register(&fx.registry(
+        "appa-registry.yaml",
+        &registry_yaml("appa", "app", &[("1.0", &a_ref)], Some("1.0")),
+    ));
+    fx.register(&fx.registry(
+        "toolb-registry.yaml",
+        &registry_yaml(
+            "toolb",
+            "toolkit",
+            &[("1.4", &b_old_ref), ("2.1", &b_new_ref)],
+            None,
+        ),
+    ));
+
+    // The document locks toolb < 2; appa's edge wants >= 2.0 — named.
+    let doc = parse(&doc(
+        "slices:\n  - {name: appa, requirement: \"1.0\"}\n  - {name: toolb, requirement: \"< 2\"}\n",
+    ));
+    let err = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &doc,
+        ComposePreset::SharedRuntime,
+        Platform::host(),
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("one version per package"), "{err}");
+    assert!(err.message.contains("'>= 2.0'"), "{err}");
+    assert!(err.message.contains("locked 1.4"), "{err}");
+}
+
+#[test]
+fn resolve_closure_mount_conflicts_are_named() {
+    let fx = Fixture::new("mountconflict");
+    let a_image = image(
+        "app",
+        "appa",
+        "1.0",
+        "  - kind: toolkit\n    name: toolb\n    constraint: \">= 1.0\"\n    mount: /x\n",
+    );
+    let c_image = image(
+        "app",
+        "appc",
+        "1.0",
+        "  - kind: toolkit\n    name: toolb\n    constraint: \">= 1.0\"\n    mount: /y\n",
+    );
+    let b_image = image("toolkit", "toolb", "1.4", "");
+    let a_ref = fx.payload("appa-1.0.tfs", &a_image);
+    let c_ref = fx.payload("appc-1.0.tfs", &c_image);
+    let b_ref = fx.payload("toolb-1.4.tfs", &b_image);
+    let both = format!(
+        "schema_version: 1\npayloads:\n  - name: appa\n    kind: app\n    versions:\n      - version: 1.0\n        platforms: universal\n        release: {{ref: {a_ref}}}\n        runtime_requirement: {{engine: ruby, constraint: \">= 3.3, < 5.0\"}}\n        entrypoints: [appa]\n  - name: appc\n    kind: app\n    versions:\n      - version: 1.0\n        platforms: universal\n        release: {{ref: {c_ref}}}\n        runtime_requirement: {{engine: ruby, constraint: \">= 3.3, < 5.0\"}}\n        entrypoints: [appc]\n  - name: toolb\n    kind: toolkit\n    versions:\n      - version: 1.4\n        platforms: universal\n        release: {{ref: {b_ref}}}\n"
+    );
+    fx.register(&fx.registry("all-registry.yaml", &both));
+
+    let doc = parse(&doc(
+        "slices:\n  - {name: appa, requirement: \"1.0\"}\n  - {name: appc, requirement: \"1.0\"}\n",
+    ));
+    let err = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &doc,
+        ComposePreset::SharedRuntime,
+        Platform::host(),
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("mounted at both '/x' and '/y'"), "{err}");
+}
+
+#[test]
+fn resolve_closure_the_platforms_assertion_is_fail_closed() {
+    let fx = Fixture::new("platforms");
+    let tpl_image = image("data", "templates", "3.2", "");
+    let tpl_ref = fx.payload("templates-3.2.tfs", &tpl_image);
+    fx.register(&fx.registry(
+        "templates-registry.yaml",
+        &registry_yaml("templates", "data", &[("3.2", &tpl_ref)], Some("3.2")),
+    ));
+
+    // The assertion names a triplet that is not the host: even over a
+    // universal payload the host check is fail-closed (spec 23 §13.3).
+    let doc = parse(&doc(&format!(
+        "slices:\n  - {{name: templates, platforms: [{}]}}\n",
+        non_host_asset_name()
+    )));
+    let err = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &doc,
+        ComposePreset::SharedRuntime,
+        Platform::host(),
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("does not cover the host triplet"), "{err}");
+    assert!(err.message.contains("templates"), "{err}");
+}
+
+#[test]
+fn resolve_closure_a_pin_mismatch_fails_closed_70() {
+    let fx = Fixture::new("pinmismatch");
+    let tpl_image = image("data", "templates", "3.2", "");
+    let tpl_ref = fx.payload("templates-3.2.tfs", &tpl_image);
+    fx.register(&fx.registry(
+        "templates-registry.yaml",
+        &registry_yaml(
+            "templates",
+            "data",
+            &[("3.2", &format!("\"{tpl_ref}?sha256={}\"", sha(b'0')))],
+            Some("3.2"),
+        ),
+    ));
+    let doc = parse(&doc("slices:\n  - {name: templates}\n"));
+    let err = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &doc,
+        ComposePreset::SharedRuntime,
+        Platform::host(),
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 70, "{err:?}");
+    // nothing entered the cache
+    assert!(!fx.home.join("payloads").join("templates").exists());
+}
+
+#[test]
+fn resolve_closure_refuses_a_runtime_kind_slice() {
+    let fx = Fixture::new("runtimekind");
+    let rt_ref = fx.payload("ruby-ish.tfs", b"not-an-image");
+    fx.register(&fx.registry(
+        "runtime-registry.yaml",
+        &registry_yaml("ruby-ish", "runtime", &[("1.0", &rt_ref)], Some("1.0")),
+    ));
+    let doc = parse(&doc("slices:\n  - {name: ruby-ish}\n"));
+    let err = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &doc,
+        ComposePreset::SharedRuntime,
+        Platform::host(),
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("runtime: row owns the engine"), "{err}");
+}
+
+#[test]
+fn resolve_closure_requires_a_registered_registry() {
+    let fx = Fixture::new("noregistry");
+    let doc = parse(&doc("slices:\n  - {name: ghost}\n"));
+    let err = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &doc,
+        ComposePreset::SharedRuntime,
+        Platform::host(),
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("not carried by any registered registry"), "{err}");
+    assert!(err.message.contains("tebako add-registry"), "{err}");
+}
+
+#[test]
+fn resolve_closure_self_contained_carries_everything() {
+    let fx = Fixture::new("selfcontained");
+    let mn_image = image("app", "metanorma", "2.1.4", "");
+    let mn_ref = fx.payload("metanorma-2.1.4.tfs", &mn_image);
+    fx.register(&fx.registry(
+        "metanorma-registry.yaml",
+        &registry_yaml("metanorma", "app", &[("2.1.4", &mn_ref)], Some("2.1.4")),
+    ));
+    // the preset carries every slice; the authored `carry: false`
+    // overrides it (spec 23 §13.2)
+    let doc = parse(
+        "version: 1\npreset: self-contained\nruntime: {ref: \"ruby@~> 3.3\"}\nslices:\n  - {name: metanorma}\n",
+    );
+    let slices = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &doc,
+        ComposePreset::SelfContained,
+        Platform::host(),
+    )
+    .unwrap();
+    assert!(slices[0].carry);
+
+    let doc = parse(
+        "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nslices:\n  - {name: metanorma, carry: false}\n",
+    );
+    let slices = compose::resolve_closure(
+        &fx.home,
+        &Fetcher::new(),
+        &doc,
+        ComposePreset::SelfContained,
+        Platform::host(),
+    )
+    .unwrap();
+    assert!(!slices[0].carry, "the authored verdict beats the preset");
+}

--- a/crates/tebako-cli/tests/compose_press.rs
+++ b/crates/tebako-cli/tests/compose_press.rs
@@ -104,7 +104,12 @@ fn image(kind: &str, name: &str, version: &str, requires: &str) -> Vec<u8> {
 
 /// A registry carrying one payload at the given versions; every ref must
 /// already be written to the mirror.
-fn registry_yaml(name: &str, kind: &str, versions: &[(&str, &str)], default: Option<&str>) -> String {
+fn registry_yaml(
+    name: &str,
+    kind: &str,
+    versions: &[(&str, &str)],
+    default: Option<&str>,
+) -> String {
     let mut yaml = format!(
         "schema_version: 1\npayloads:\n  - name: {name}\n    kind: {kind}\n    versions:\n"
     );
@@ -132,7 +137,10 @@ fn doc(yaml_tail: &str) -> String {
 
 fn parse(yaml: &str) -> tpkg::ComposeDoc {
     let (doc, warnings) = tpkg::parse_compose(yaml).expect("the document parses");
-    assert!(warnings.is_empty(), "no aliases in these fixtures: {warnings:?}");
+    assert!(
+        warnings.is_empty(),
+        "no aliases in these fixtures: {warnings:?}"
+    );
     doc
 }
 
@@ -157,11 +165,17 @@ fn load_parses_the_document_and_surfaces_alias_warnings() {
     let (parsed, warnings) = compose::load(&path).unwrap();
     assert_eq!(parsed.preset, ComposePreset::SelfContained);
     assert_eq!(warnings.len(), 1);
-    assert!(warnings[0].contains("'fat' preset is deprecated"), "{warnings:?}");
+    assert!(
+        warnings[0].contains("'fat' preset is deprecated"),
+        "{warnings:?}"
+    );
 
     let err = compose::load(&fx.dir.join("missing.yaml")).unwrap_err();
     assert_eq!(err.code, 65, "{err:?}");
-    assert!(err.message.contains("cannot read the compose document"), "{err}");
+    assert!(
+        err.message.contains("cannot read the compose document"),
+        "{err}"
+    );
 
     fs::write(&path, doc("policy: deny\n")).unwrap();
     let err = compose::load(&path).unwrap_err();
@@ -177,12 +191,20 @@ fn check_runtime_row_gates_the_engine_and_the_version() {
     let mismatch = parse("version: 1\nruntime: {name: ruby, requirement: \"~> 3.4\"}\n");
     let err = compose::check_runtime_row(&mismatch, "3.3.7").unwrap_err();
     assert_eq!(err.code, 65, "{err:?}");
-    assert!(err.message.contains("does not cover the pressed ruby 3.3.7"), "{err}");
+    assert!(
+        err.message
+            .contains("does not cover the pressed ruby 3.3.7"),
+        "{err}"
+    );
 
     let python = parse("version: 1\nruntime: {ref: \"python@>= 3\"}\n");
     let err = compose::check_runtime_row(&python, "3.3.7").unwrap_err();
     assert_eq!(err.code, 65, "{err:?}");
-    assert!(err.message.contains("ruby is the only runtime engine today"), "{err}");
+    assert!(
+        err.message
+            .contains("ruby is the only runtime engine today"),
+        "{err}"
+    );
 }
 
 #[test]
@@ -238,8 +260,8 @@ fn apply_overrides_rewrite_the_carry_verdicts() {
 
     // one slice in both flags is a conflict
     let mut d = base();
-    let err =
-        compose::apply_overrides(&mut d, Some("metanorma"), Some("metanorma"), "hello").unwrap_err();
+    let err = compose::apply_overrides(&mut d, Some("metanorma"), Some("metanorma"), "hello")
+        .unwrap_err();
     assert_eq!(err.code, 65, "{err:?}");
     assert!(err.message.contains("either carried or shared"), "{err}");
 }
@@ -464,7 +486,10 @@ fn resolve_closure_mount_conflicts_are_named() {
     )
     .unwrap_err();
     assert_eq!(err.code, 65, "{err:?}");
-    assert!(err.message.contains("mounted at both '/x' and '/y'"), "{err}");
+    assert!(
+        err.message.contains("mounted at both '/x' and '/y'"),
+        "{err}"
+    );
 }
 
 #[test]
@@ -492,7 +517,10 @@ fn resolve_closure_the_platforms_assertion_is_fail_closed() {
     )
     .unwrap_err();
     assert_eq!(err.code, 65, "{err:?}");
-    assert!(err.message.contains("does not cover the host triplet"), "{err}");
+    assert!(
+        err.message.contains("does not cover the host triplet"),
+        "{err}"
+    );
     assert!(err.message.contains("templates"), "{err}");
 }
 
@@ -542,7 +570,10 @@ fn resolve_closure_refuses_a_runtime_kind_slice() {
     )
     .unwrap_err();
     assert_eq!(err.code, 65, "{err:?}");
-    assert!(err.message.contains("runtime: row owns the engine"), "{err}");
+    assert!(
+        err.message.contains("runtime: row owns the engine"),
+        "{err}"
+    );
 }
 
 #[test]
@@ -558,7 +589,11 @@ fn resolve_closure_requires_a_registered_registry() {
     )
     .unwrap_err();
     assert_eq!(err.code, 65, "{err:?}");
-    assert!(err.message.contains("not carried by any registered registry"), "{err}");
+    assert!(
+        err.message
+            .contains("not carried by any registered registry"),
+        "{err}"
+    );
     assert!(err.message.contains("tebako add-registry"), "{err}");
 }
 

--- a/crates/tebako-cli/tests/install.rs
+++ b/crates/tebako-cli/tests/install.rs
@@ -1013,6 +1013,42 @@ fn install_walks_the_requires_closure_and_installs_the_deps() {
 }
 
 #[test]
+fn dep_walk_requires_cycle_is_a_named_error() {
+    // spec 18 §5.6 S32: A requires B and B requires A — the named cycle
+    // error at install, never the cache check's silent short-circuit.
+    let fx = Fixture::new("depcycle");
+    let appa_image = app_image_with_requires(
+        "appa",
+        "1.0",
+        "  - kind: toolkit\n    name: appb\n    constraint: \">= 1.0\"\n    mount: /opt/appb\n",
+    );
+    let appb_image = app_image_with_requires(
+        "appb",
+        "1.0",
+        "  - kind: toolkit\n    name: appa\n    constraint: \">= 1.0\"\n    mount: /opt/appa\n",
+    );
+    let appa_ref = fx.payload("appa-1.0.tfs", &appa_image);
+    let appb_ref = fx.payload("appb-1.0.tfs", &appb_image);
+    let appa_reg = fx.registry(
+        "appa-registry.yaml",
+        &registry_yaml("appa", "1.0", &appa_ref, Some("1.0")),
+    );
+    let appb_reg = fx.registry(
+        "appb-registry.yaml",
+        &registry_yaml("appb", "1.0", &appb_ref, Some("1.0")),
+    );
+    install::add_registry(&fx.home, &appa_reg).unwrap();
+    install::add_registry(&fx.home, &appb_reg).unwrap();
+
+    let err = install::install(&fx.home, "appa", None, Some(&fx.shim_binary)).unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(
+        err.message.contains("dependency cycle: appa → appb → appa"),
+        "{err}"
+    );
+}
+
+#[test]
 fn dep_walk_prefers_a_cached_satisfying_version_over_a_newer_registry_one() {
     let fx = Fixture::new("depcached");
     let i143 = fx.payload("inkscape-1.4.3.tfs", &toolkit_image("inkscape", "1.4.3"));

--- a/crates/tebako-cli/tests/run.rs
+++ b/crates/tebako-cli/tests/run.rs
@@ -46,12 +46,13 @@ fn package_manifest(jail: tpkg::HostJail) -> tpkg::PackageManifest {
         },
         entries: vec![tpkg::PackageEntry {
             name: "probe".to_string(),
-            slot: 0,
+            slot: Some(0),
             entrypoint: "probe".to_string(),
             runtime_ref: "ruby@9.9.9;tebako=9.9.9".to_string(),
         }],
         jail: Some(jail),
         env: Default::default(),
+        lock: None,
         mounts: Vec::new(),
     }
 }

--- a/crates/tebako-cli/tests/suite.rs
+++ b/crates/tebako-cli/tests/suite.rs
@@ -125,11 +125,11 @@ fn package_manifest_carries_per_entry_refs_and_slots() {
     assert_eq!(pm.package.version, "1.2.3");
     assert_eq!(pm.entries.len(), 2);
     assert_eq!(pm.entries[0].name, "metanorma");
-    assert_eq!(pm.entries[0].slot, 0);
+    assert_eq!(pm.entries[0].slot, Some(0));
     assert_eq!(pm.entries[0].entrypoint, "metanorma");
     assert_eq!(pm.entries[0].runtime_ref, refs[0]);
     assert_eq!(pm.entries[1].name, "mn2pdf");
-    assert_eq!(pm.entries[1].slot, 1);
+    assert_eq!(pm.entries[1].slot, Some(1));
     assert_eq!(pm.entries[1].runtime_ref, refs[1]);
     // the block validates + round-trips (set_package_manifest re-validates)
     let yaml = pm.to_yaml().unwrap();

--- a/crates/tebako-cli/tests/suite.rs
+++ b/crates/tebako-cli/tests/suite.rs
@@ -33,6 +33,10 @@ fn opts() -> PressOptions {
         jail: None,
         no_install: false,
         format: tebako_cli::options::PressImageFormat::Dwarfs,
+        compose: None,
+        carry: None,
+        share: None,
+        mode_explicit: false,
     }
 }
 

--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -517,12 +517,31 @@ fn mount_at_point(
     }
 }
 
+/// The `TEBAKO_RUNTIME_IMAGE` value split: `<path>[:<slot>]` — the tail
+/// after the LAST ':' counts as the slot only when it parses as u32 (a
+/// windows drive colon never does; `<file>:0` on a bare image ≡ whole —
+/// the spec 17 grammar's bare rule). The pure half of the slot form
+/// (spec 23 §13.1), unit-tested without a mount.
+fn env_image_ref(image: &str) -> (&str, Option<u32>) {
+    match image.rfind(':') {
+        Some(i) if i > 0 => match image[i + 1..].parse::<u32>() {
+            Ok(n) => (&image[..i], Some(n)),
+            Err(_) => (image, None),
+        },
+        _ => (image, None),
+    }
+}
+
 /// The env image (`TEBAKO_RUNTIME_IMAGE`): a bare `.tfs`, mounted whole
-/// at the runtime root. Records `runtime_root` in `mounted`. A boot
-/// without it is a legal shape (bare interpreter) but in managed mode a
-/// missing handoff otherwise surfaces much later as load errors with no
-/// obvious cause (incident 13 round 5) — so the absence is named on
-/// stderr (stdout is the payload's, never the log's).
+/// at the runtime root — OR the slot form `<package-path>:<slot>` (spec 23
+/// §13.1: the two-slot carried pair, where the env image rides INSIDE the
+/// stitched package). The tail splits at the LAST ':' and only counts as
+/// a slot when it parses as u32 (a windows drive colon never does).
+/// Records `runtime_root` in `mounted`. A boot without it is a legal
+/// shape (bare interpreter) but in managed mode a missing handoff
+/// otherwise surfaces much later as load errors with no obvious cause
+/// (incident 13 round 5) — so the absence is named on stderr (stdout is
+/// the payload's, never the log's).
 fn mount_env_image(
     env: &dyn Env,
     runtime_root: &str,
@@ -536,15 +555,36 @@ fn mount_env_image(
         );
         return Ok(());
     };
+    let (path, slot) = env_image_ref(&image);
     let desc = format!("env image '{image}'");
-    mount_exclusive(
-        build_error(
-            tfs::mount::build_from_file(&image, runtime_root),
-            &format!("failed to mount the runtime filesystem image from '{image}'"),
-        )?,
-        &format!("failed to mount the runtime filesystem image from '{image}'"),
-        &desc,
-    )?;
+    let what = format!("failed to mount the runtime filesystem image from '{image}'");
+    let mount = match slot {
+        None => build_error(tfs::mount::build_from_file(&image, runtime_root), &what)?,
+        Some(n) => {
+            let resolved = resolve_image(Path::new(path), SlotRef::Slot(n), path, runtime_root)?;
+            match resolved.region {
+                // A bare image spelled '<file>:0' — slot 0 ≡ the whole
+                // bare file (the spec 17 grammar's bare rule).
+                ResolvedRegion::Whole => {
+                    build_error(tfs::mount::build_from_file(path, runtime_root), &what)?
+                }
+                ResolvedRegion::Region(offset, size) => {
+                    let mut mount = build_error(
+                        tfs::mount::build_from_file_at(path, offset, size, runtime_root),
+                        &what,
+                    )?;
+                    // A slot-mounted package region carries its slot
+                    // identity so a spawned child's TEBAKO_TFS_MOUNTS
+                    // re-mounts this region — never the whole package
+                    // (spec 17 §2.1's emit rule; the env image obeys it
+                    // exactly like a payload slot).
+                    mount.slot = Some(n);
+                    mount
+                }
+            }
+        }
+    };
+    mount_exclusive(mount, &what, &desc)?;
     mounted.push(MountedMember {
         point: runtime_root.to_string(),
         desc,
@@ -1093,6 +1133,35 @@ mod tests {
         assert_eq!(vfs_drive("//share/x"), None);
         assert_eq!(vfs_drive("1:/x"), None);
         assert_eq!(vfs_drive(""), None);
+    }
+
+    #[test]
+    fn env_image_ref_splits_only_a_u32_tail() {
+        // the plain bare form
+        assert_eq!(env_image_ref("/cache/env.tfs"), ("/cache/env.tfs", None));
+        // the slot form (spec 23 §13.1)
+        assert_eq!(env_image_ref("/pkg/app.tpkg:2"), ("/pkg/app.tpkg", Some(2)));
+        assert_eq!(env_image_ref("/pkg/app.tpkg:0"), ("/pkg/app.tpkg", Some(0)));
+        // a windows drive colon never parses as a slot
+        assert_eq!(
+            env_image_ref("C:/cache/env.tfs"),
+            ("C:/cache/env.tfs", None)
+        );
+        assert_eq!(
+            env_image_ref("C:\\cache\\env.tfs"),
+            ("C:\\cache\\env.tfs", None)
+        );
+        // …but a windows package path with a slot tail splits
+        assert_eq!(
+            env_image_ref("C:/pkg/app.tpkg:2"),
+            ("C:/pkg/app.tpkg", Some(2))
+        );
+        // an empty path before the colon is no slot form
+        assert_eq!(env_image_ref(":2"), (":2", None));
+        // a trailing colon is no slot form
+        assert_eq!(env_image_ref("/pkg/x:"), ("/pkg/x:", None));
+        // a colon inside the name stays part of the path
+        assert_eq!(env_image_ref("/p:with/img.tfs"), ("/p:with/img.tfs", None));
     }
 
     #[test]

--- a/crates/tebako-driver/src/lib.rs
+++ b/crates/tebako-driver/src/lib.rs
@@ -8,8 +8,10 @@
 //!           --tebako-entry <argv0> <user args...>
 //! ```
 //!
-//! - the **env image** (`TEBAKO_RUNTIME_IMAGE`, a bare `.tfs`) mounts whole
-//!   at the runtime root the interpreter was compiled against;
+//! - the **env image** (`TEBAKO_RUNTIME_IMAGE`) mounts whole at the
+//!   runtime root the interpreter was compiled against — a bare `.tfs`,
+//!   or the slot form `<package-path>:<slot>` (spec 23 §13.1: the carried
+//!   pair's env image riding INSIDE the stitched package);
 //! - each **payload triple** mounts its image: a bare file whole (slot `0`
 //!   ≡ `-`), or a package file's trailer-described slot region;
 //! - `TEBAKO_JAIL` is parsed and installed (after the mounts — the mount

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -298,7 +298,11 @@ fn the_slot_form_refuses_a_runtime_slot_by_name() {
     env.set("TEBAKO_RUNTIME_IMAGE", format!("{}:0", image.display()));
     let err = boot(&argv(&["ruby", "--version"]), "/__tfs__", &env).unwrap_err();
     assert_eq!(err.code, 65, "{}", err.message);
-    assert!(err.message.contains("runtime payload slot"), "{}", err.message);
+    assert!(
+        err.message.contains("runtime payload slot"),
+        "{}",
+        err.message
+    );
 }
 
 #[test]

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -219,6 +219,101 @@ fn a_boot_without_the_env_image_is_legal_and_mounts_nothing() {
 }
 
 // ---------------------------------------------------------------------
+// the env-image slot form (spec 23 §13.1 — the two-slot carried pair)
+// ---------------------------------------------------------------------
+
+/// The carried pair's wire shape: dummy bootstrap bytes at slot 0, the
+/// env image at slot 1 (both format AUTO — the orthogonality law), then
+/// the trailer.
+fn write_two_slot_package(dir: &Path) -> PathBuf {
+    let env_image = write_env_image(dir);
+    let env_bytes = std::fs::read(&env_image).unwrap();
+    let exe = b"dummy bootstrap bytes (not an executable)";
+    let p = dir.join("app.tpkg");
+    let mut m = tpkg::Manifest {
+        package_flags: 0,
+        launcher_abi: 1,
+        ..Default::default()
+    };
+    m.slots.push(tpkg::Slot::new(
+        0,
+        exe.len() as u64,
+        tpkg::TPKG_FORMAT_AUTO,
+        "",
+    ));
+    m.slots.push(tpkg::Slot::new(
+        exe.len() as u64,
+        env_bytes.len() as u64,
+        tpkg::TPKG_FORMAT_AUTO,
+        "",
+    ));
+    m.validate().unwrap();
+    let mut f = std::fs::File::create(&p).unwrap();
+    f.write_all(exe).unwrap();
+    f.write_all(&env_bytes).unwrap();
+    tpkg::write_to(&mut f, &m).unwrap();
+    p
+}
+
+#[test]
+fn the_env_image_slot_form_mounts_the_package_region() {
+    let g = guard("env-slot");
+    let pkg = write_two_slot_package(g.path());
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", format!("{}:1", pkg.display()));
+
+    let out = boot(&argv(&["ruby", "--version"]), "/__tfs__", &env).unwrap();
+    assert_eq!(out.argv, argv(&["ruby", "--version"]));
+    let bytes = read_file("/__tfs__/lib/ruby/rubygems.rb");
+    assert_eq!(bytes, b"# rubygems core\n");
+    // The slot identity rides the mount: a spawned child's
+    // TEBAKO_TFS_MOUNTS re-mounts this REGION, never the whole package
+    // (spec 17 §2.1's emit rule).
+    let mounts = context().read().unwrap().mounts_env().unwrap();
+    let mounts = mounts.to_string_lossy().into_owned();
+    assert!(
+        mounts.contains(&format!("{}:1:/__tfs__", pkg.display())),
+        "{mounts}"
+    );
+}
+
+#[test]
+fn the_slot_form_names_an_out_of_range_slot() {
+    let g = guard("env-slot-range");
+    let pkg = write_two_slot_package(g.path());
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", format!("{}:5", pkg.display()));
+    let err = boot(&argv(&["ruby", "--version"]), "/__tfs__", &env).unwrap_err();
+    assert_eq!(err.code, 65, "{}", err.message);
+    assert!(err.message.contains("out of range"), "{}", err.message);
+    assert!(!context().read().unwrap().is_mounted());
+}
+
+#[test]
+fn the_slot_form_refuses_a_runtime_slot_by_name() {
+    let g = guard("env-slot-runtime");
+    let image = write_env_image(g.path());
+    package_in_place(&image, tpkg::TPKG_FORMAT_RUNTIME);
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", format!("{}:0", image.display()));
+    let err = boot(&argv(&["ruby", "--version"]), "/__tfs__", &env).unwrap_err();
+    assert_eq!(err.code, 65, "{}", err.message);
+    assert!(err.message.contains("runtime payload slot"), "{}", err.message);
+}
+
+#[test]
+fn a_bare_image_spelled_with_slot_zero_mounts_whole() {
+    let g = guard("env-slot-zero");
+    let image = write_env_image(g.path());
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", format!("{}:0", image.display()));
+    let out = boot(&argv(&["ruby", "--version"]), "/__tfs__", &env).unwrap();
+    assert_eq!(out.argv, argv(&["ruby", "--version"]));
+    let bytes = read_file("/__tfs__/lib/ruby/rubygems.rb");
+    assert_eq!(bytes, b"# rubygems core\n");
+}
+
+// ---------------------------------------------------------------------
 // the trace channel (spec 25 §2, phase T1)
 // ---------------------------------------------------------------------
 

--- a/crates/tebako-pkg/src/lib.rs
+++ b/crates/tebako-pkg/src/lib.rs
@@ -333,16 +333,20 @@ fn assemble(
         }
     }
     // The L2 package manifest (ext block type 2, spec 03 §6) references
-    // slots by index — every entry must point at a real slot.
+    // slots by index — every entry must point at a real slot. A slot-less
+    // entry is the pointer form (spec 23 §4): it is backed by a shared
+    // lock slice of the same name, not by a container slot.
     if let Some(pm) = &options.package_manifest {
         for (i, entry) in pm.entries.iter().enumerate() {
-            if entry.slot as usize >= slots.len() {
-                return Err(format!(
-                    "package manifest entry {i} ({}) references slot {} but the package has {} slot(s)",
-                    entry.name,
-                    entry.slot,
-                    slots.len()
-                ));
+            if let Some(slot) = entry.slot {
+                if slot as usize >= slots.len() {
+                    return Err(format!(
+                        "package manifest entry {i} ({}) references slot {} but the package has {} slot(s)",
+                        entry.name,
+                        slot,
+                        slots.len()
+                    ));
+                }
             }
         }
     }
@@ -1194,9 +1198,13 @@ fn package_manifest_section(m: &Manifest) -> String {
             ));
             out.push_str(&format!("  entries: {}\n", pm.entries.len()));
             for (i, e) in pm.entries.iter().enumerate() {
+                let slot = match e.slot {
+                    Some(s) => format!("slot {s}"),
+                    None => "shared slice (pointer entry)".to_string(),
+                };
                 out.push_str(&format!(
-                    "    [{i}] {} -> slot {}, entrypoint {}, runtime {}\n",
-                    e.name, e.slot, e.entrypoint, e.runtime_ref
+                    "    [{i}] {} -> {slot}, entrypoint {}, runtime {}\n",
+                    e.name, e.entrypoint, e.runtime_ref
                 ));
             }
             if !pm.env.is_empty() {

--- a/crates/tebako-resolve/Cargo.toml
+++ b/crates/tebako-resolve/Cargo.toml
@@ -10,6 +10,15 @@ homepage.workspace = true
 keywords = ["tebako", "resolve", "reference", "cache", "registry"]
 categories = ["data-structures", "filesystem", "parser-implementations"]
 
+[features]
+default = ["git"]
+# `tfs+git:` payload references via gitoxide (spec 04 §3) — the ONLY
+# consumer of gix/reqwest (and of this crate's own rustls provider
+# selection; tebako-http always brings its own). tebako-bootstrap links
+# this crate with default-features = false: the loader never fetches git
+# references, and keeping the git stack out holds its 3 MiB size gate.
+git = ["dep:gix", "dep:reqwest", "dep:rustls"]
+
 [dependencies]
 tebako-http = { version = "0.2.1", path = "../tebako-http" }
 # Release-API JSON responses are parsed with the workspace's own minimal
@@ -34,21 +43,22 @@ libc = "0.2"
 # EXCEPT windows-gnu — ring 0.17 has no windows-gnu support (its C fails
 # to compile under mingw), so the gnu target rides aws-lc-rs instead (a
 # vendored crate exactly like ring; no native-tls, no schannel, no
-# behavior change).
-gix = { version = "0.86", default-features = false, features = [
+# behavior change). All three are the `git` feature's — off for the
+# bootstrap's link.
+gix = { version = "0.86", default-features = false, optional = true, features = [
     "sha1",
     "blocking-network-client",
     "blocking-http-transport-reqwest",
     "revision",
     "tree-editor",
 ] }
-reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider"] }
+reqwest = { version = "0.13", default-features = false, optional = true, features = ["rustls-no-provider"] }
 
 [target.'cfg(not(all(windows, target_env = "gnu")))'.dependencies]
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+rustls = { version = "0.23", default-features = false, optional = true, features = ["ring", "std", "tls12", "logging"] }
 
 [target.'cfg(all(windows, target_env = "gnu"))'.dependencies]
-rustls = { version = "0.23", default-features = false, features = [
+rustls = { version = "0.23", default-features = false, optional = true, features = [
     "aws_lc_rs",
     "std",
     "tls12",

--- a/crates/tebako-resolve/src/cache.rs
+++ b/crates/tebako-resolve/src/cache.rs
@@ -19,6 +19,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use sha2::Digest as _;
+
 use crate::error::ResolveError;
 use crate::fetch::FetchedPayload;
 
@@ -57,6 +59,21 @@ pub fn offline() -> bool {
 pub enum InstallStatus {
     Hit,
     Installed,
+}
+
+/// The outcome of [`PayloadCache::seed`] (the lazy-seed verb, spec 23
+/// §13.4): never an overwrite, always loud on divergence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SeedOutcome {
+    /// The bytes verified against the pin and were placed (markers too).
+    Seeded,
+    /// The entry already existed with the SAME trust anchor — nothing to
+    /// do (idempotent re-seed).
+    AlreadySame,
+    /// The entry already exists with a DIFFERENT trust anchor — reported,
+    /// never overwritten (the cache holds registry bytes; the existing
+    /// anchor stays authoritative).
+    Conflict { existing_sha256: String },
 }
 
 /// A cached payload entry (artifact + trust anchor).
@@ -261,33 +278,137 @@ impl PayloadCache {
         })
     }
 
-    /// tmp + rename (a partial install is invisible), then the markers —
-    /// the same order as tebako-cli's `place`.
-    fn place(&self, file: &Path, fetched: &FetchedPayload) -> Result<(), ResolveError> {
+    /// The lazy-seed verb (spec 23 §13.4): place payload bytes the caller
+    /// already holds (a carried slice read out of the running package)
+    /// into the cache — sha256-verified against `expected_sha256` BEFORE
+    /// anything lands, tmp+rename under the per-entry lock. NO offline
+    /// gate: seeding moves local bytes, never the network. Never an
+    /// overwrite: an existing entry with the same anchor is
+    /// [`SeedOutcome::AlreadySame`] (idempotent), a different anchor is
+    /// [`SeedOutcome::Conflict`] — the cached bytes win and the caller
+    /// journals the divergence.
+    pub fn seed(
+        &self,
+        name: &str,
+        version: &str,
+        expected_sha256: &str,
+        origin: &str,
+        mut reader: impl std::io::Read,
+    ) -> Result<SeedOutcome, ResolveError> {
+        let file = self.entry_file(name, version)?;
+        let expected = expected_sha256.to_ascii_lowercase();
+        if expected.len() != 64 || !expected.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err(ResolveError::InvalidCacheKey {
+                key: format!("{name}@{version}"),
+                reason: "the seed pin must be 64 hex".to_string(),
+            });
+        }
+        if let Some(entry) = self.get(name, version)? {
+            return Ok(if entry.sha256 == expected {
+                SeedOutcome::AlreadySame
+            } else {
+                SeedOutcome::Conflict {
+                    existing_sha256: entry.sha256,
+                }
+            });
+        }
+        // The same defense-in-depth store gate as install (spec 18 C13).
+        crate::store::check_once(&self.root).map_err(|e| ResolveError::CacheIo {
+            op: "checking the store layout of",
+            path: self.root.clone(),
+            reason: e.to_string(),
+        })?;
+        let lock_path = self.lock_file(name, version);
+        let origin = origin.to_string();
+        self.with_entry_lock(&lock_path, || {
+            if let Some(entry) = self.get(name, version)? {
+                return Ok(if entry.sha256 == expected {
+                    SeedOutcome::AlreadySame
+                } else {
+                    SeedOutcome::Conflict {
+                        existing_sha256: entry.sha256,
+                    }
+                });
+            }
+            let (tmp, file_name) = self.tmp_path(&file)?;
+            let result = (|| {
+                let mut hasher = sha2::Sha256::new();
+                {
+                    let mut out =
+                        fs::File::create(&tmp).map_err(|e| cache_io("writing", &tmp, e))?;
+                    let mut buf = [0u8; 65536];
+                    loop {
+                        let n = std::io::Read::read(&mut reader, &mut buf)
+                            .map_err(|e| cache_io("streaming the seed bytes into", &tmp, e))?;
+                        if n == 0 {
+                            break;
+                        }
+                        sha2::Digest::update(&mut hasher, &buf[..n]);
+                        std::io::Write::write_all(&mut out, &buf[..n])
+                            .map_err(|e| cache_io("writing", &tmp, e))?;
+                    }
+                }
+                let actual = crate::fetch::hex_digest(&sha2::Digest::finalize(hasher));
+                if actual != expected {
+                    return Err(ResolveError::Sha256Mismatch {
+                        origin: origin.clone(),
+                        expected,
+                        actual,
+                    });
+                }
+                self.finish_place(&tmp, &file, &file_name, &expected, &origin)
+            })();
+            if result.is_err() {
+                let _ = fs::remove_file(&tmp);
+            }
+            result.map(|_| SeedOutcome::Seeded)
+        })
+    }
+
+    /// tmp path + the entry's file name (the place/seed prelude).
+    fn tmp_path(&self, file: &Path) -> Result<(PathBuf, String), ResolveError> {
         let tmp_dir = self.root.join(TMP_DIR);
         fs::create_dir_all(&tmp_dir).map_err(|e| cache_io("creating", &tmp_dir, e))?;
         let file_name = file
             .file_name()
             .map(|n| n.to_string_lossy().into_owned())
             .unwrap_or_else(|| "payload".to_string());
-        let tmp = tmp_dir.join(format!("{file_name}.{}.part", std::process::id()));
+        Ok((
+            tmp_dir.join(format!("{file_name}.{}.part", std::process::id())),
+            file_name,
+        ))
+    }
+
+    /// tmp + rename (a partial install is invisible), then the markers —
+    /// the same order as tebako-cli's `place`.
+    fn place(&self, file: &Path, fetched: &FetchedPayload) -> Result<(), ResolveError> {
+        let (tmp, file_name) = self.tmp_path(file)?;
         let result = (|| {
             fs::write(&tmp, &fetched.bytes).map_err(|e| cache_io("writing", &tmp, e))?;
-            make_readonly(&tmp).map_err(|e| cache_io("chmod", &tmp, e))?;
-            fs::rename(&tmp, file).map_err(|e| cache_io("installing", file, e))?;
-            fs::write(
-                sha_marker(file),
-                format!("{}  {file_name}\n", fetched.sha256),
-            )
-            .map_err(|e| cache_io("marking", &sha_marker(file), e))?;
-            fs::write(origin_marker(file), format!("{}\n", fetched.origin))
-                .map_err(|e| cache_io("marking", &origin_marker(file), e))?;
-            Ok(())
+            self.finish_place(&tmp, file, &file_name, &fetched.sha256, &fetched.origin)
         })();
         if result.is_err() {
             let _ = fs::remove_file(&tmp);
         }
         result
+    }
+
+    /// Readonly → rename → markers: the shared tail of place/seed.
+    fn finish_place(
+        &self,
+        tmp: &Path,
+        file: &Path,
+        file_name: &str,
+        sha256: &str,
+        origin: &str,
+    ) -> Result<(), ResolveError> {
+        make_readonly(tmp).map_err(|e| cache_io("chmod", tmp, e))?;
+        fs::rename(tmp, file).map_err(|e| cache_io("installing", file, e))?;
+        fs::write(sha_marker(file), format!("{sha256}  {file_name}\n"))
+            .map_err(|e| cache_io("marking", &sha_marker(file), e))?;
+        fs::write(origin_marker(file), format!("{origin}\n"))
+            .map_err(|e| cache_io("marking", &origin_marker(file), e))?;
+        Ok(())
     }
 
     /// The per-entry flock (spec 05 §4): LOCK_EX|LOCK_NB retried for
@@ -448,9 +569,10 @@ mod tests {
     use super::*;
 
     /// Every test in this module touches the machine-cache env knobs
-    /// (TEBAKO_OFFLINE is read on each install), so they serialize on one
-    /// mutex — the default parallel test runner would otherwise race them.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    /// (TEBAKO_OFFLINE is read on each install), so they serialize on the
+    /// crate-wide test-env mutex — the default parallel test runner would
+    /// otherwise race them.
+    use crate::TEST_ENV_LOCK as ENV_LOCK;
 
     fn scratch() -> PathBuf {
         let dir = std::env::temp_dir().join(format!("tebako-resolve-cache-{}", std::process::id()));
@@ -628,6 +750,93 @@ mod tests {
         assert!(matches!(err, ResolveError::LockTimeout { .. }));
         let msg = err.to_string();
         assert!(msg.contains("lockfile") && msg.contains("remove it if the holder crashed"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn seed_places_verified_bytes_and_reseeds_idempotently() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let root = scratch();
+        let cache = PayloadCache::with_root(&root);
+        let pin = crate::fetch::sha256_hex(b"carried-slice");
+        let origin = "seeded-from:/tmp/pkg.tpkg#slot2";
+        let outcome = cache
+            .seed("tool", "1.0", &pin, origin, b"carried-slice".as_slice())
+            .unwrap();
+        assert_eq!(outcome, SeedOutcome::Seeded);
+        // the seeded entry is a full cache citizen: 0444 + both markers
+        let entry = cache.get("tool", "1.0").unwrap().unwrap();
+        assert_eq!(entry.sha256, pin);
+        assert_eq!(entry.origin.as_deref(), Some(origin));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&entry.path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o444);
+        }
+        // re-seed with the same pin: idempotent
+        let outcome = cache
+            .seed("tool", "1.0", &pin, origin, b"carried-slice".as_slice())
+            .unwrap();
+        assert_eq!(outcome, SeedOutcome::AlreadySame);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn seed_conflict_never_overwrites() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let root = scratch();
+        let cache = PayloadCache::with_root(&root);
+        cache
+            .install("tool", "1.0", None, || Ok(fetched(b"registry-bytes")))
+            .unwrap();
+        let other = crate::fetch::sha256_hex(b"carried-slice");
+        let outcome = cache
+            .seed("tool", "1.0", &other, "seeded", b"carried-slice".as_slice())
+            .unwrap();
+        let SeedOutcome::Conflict { existing_sha256 } = outcome else {
+            panic!("expected Conflict, got {outcome:?}")
+        };
+        assert_eq!(existing_sha256, crate::fetch::sha256_hex(b"registry-bytes"));
+        // the cached bytes are the registry's, untouched
+        assert_eq!(
+            fs::read(root.join("payloads/tool/1.0.tfs")).unwrap(),
+            b"registry-bytes"
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn seed_verifies_before_place_and_caches_nothing_on_mismatch() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let root = scratch();
+        let cache = PayloadCache::with_root(&root);
+        let err = cache
+            .seed("tool", "1.0", &"f".repeat(64), "seeded", b"carried-slice".as_slice())
+            .unwrap_err();
+        assert!(matches!(err, ResolveError::Sha256Mismatch { .. }));
+        assert!(!root.join("payloads/tool/1.0.tfs").exists());
+        assert!(!root.join("payloads/tool/1.0.tfs.sha256").exists());
+        // tmp is cleaned up too
+        assert_eq!(
+            fs::read_dir(root.join("tmp")).map(|d| d.count()).unwrap_or(0),
+            0
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn seed_has_no_offline_gate() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let root = scratch();
+        let cache = PayloadCache::with_root(&root);
+        std::env::set_var("TEBAKO_OFFLINE", "1");
+        let pin = crate::fetch::sha256_hex(b"carried-slice");
+        let outcome = cache
+            .seed("tool", "1.0", &pin, "seeded", b"carried-slice".as_slice())
+            .unwrap();
+        std::env::remove_var("TEBAKO_OFFLINE");
+        assert_eq!(outcome, SeedOutcome::Seeded);
         let _ = fs::remove_dir_all(&root);
     }
 }

--- a/crates/tebako-resolve/src/cache.rs
+++ b/crates/tebako-resolve/src/cache.rs
@@ -812,14 +812,22 @@ mod tests {
         let root = scratch();
         let cache = PayloadCache::with_root(&root);
         let err = cache
-            .seed("tool", "1.0", &"f".repeat(64), "seeded", b"carried-slice".as_slice())
+            .seed(
+                "tool",
+                "1.0",
+                &"f".repeat(64),
+                "seeded",
+                b"carried-slice".as_slice(),
+            )
             .unwrap_err();
         assert!(matches!(err, ResolveError::Sha256Mismatch { .. }));
         assert!(!root.join("payloads/tool/1.0.tfs").exists());
         assert!(!root.join("payloads/tool/1.0.tfs.sha256").exists());
         // tmp is cleaned up too
         assert_eq!(
-            fs::read_dir(root.join("tmp")).map(|d| d.count()).unwrap_or(0),
+            fs::read_dir(root.join("tmp"))
+                .map(|d| d.count())
+                .unwrap_or(0),
             0
         );
         let _ = fs::remove_dir_all(&root);

--- a/crates/tebako-resolve/src/contract.rs
+++ b/crates/tebako-resolve/src/contract.rs
@@ -16,17 +16,18 @@
 //!   a reason to invent a value.
 //!
 //! The fail-closed gate ([`gate`]) returns the declared set on success;
-//! the refusal classes are [`ContractError`]'s. The size-capped
-//! tebako-bootstrap cannot link this crate (gix/reqwest would blow its
-//! 3 MiB gate), so it mirrors these semantics with its own string-scan
-//! reader — [`SPOKEN_ERA`]/[`SPOKEN_CONTRACT`] are the canonical values,
-//! and both sides pin the mirror with refusal-message tests.
+//! the refusal classes are [`ContractError]'s. tebako-bootstrap links this
+//! crate with default-features = false (the gix/reqwest git stack stays
+//! outside its 3 MiB gate) for the payload-cache layer, but keeps reading
+//! the release card with its own string-scan reader — [`SPOKEN_ERA`]/
+//! [`SPOKEN_CONTRACT`] are the canonical values, and both sides pin the
+//! mirror with refusal-message tests.
 
 use std::fmt;
 
 /// The contract era this tebako speaks (spec 18: era 1 is the undeclared
-/// pre-era). Mirrored by tebako-bootstrap (which cannot link this crate
-/// — see the module docs); keep the values identical.
+/// pre-era). Mirrored by tebako-bootstrap's own release-card reader (see
+/// the module docs); keep the values identical.
 pub const SPOKEN_ERA: u32 = 2;
 
 /// The bootstrap↔runtime handoff contract this loader speaks (spec 17's
@@ -35,9 +36,8 @@ pub const SPOKEN_ERA: u32 = 2;
 /// the roadmap-45 interim numbering is superseded and the factory
 /// declares 2 from v0.16.0). A different declared contract is another
 /// generation — refused either direction, both numbers named. Canonical
-/// value — tebako-bootstrap's `SUPPORTED_CONTRACT` mirrors it (the
-/// size-capped bootstrap cannot link this crate; pinned identical by
-/// both sides' refusal-message tests).
+/// value — tebako-bootstrap's `SUPPORTED_CONTRACT` mirrors it (pinned
+/// identical by both sides' refusal-message tests).
 pub const SPOKEN_CONTRACT: u32 = 2;
 
 /// The contract fields of one release-manifest entry, in refusal-message

--- a/crates/tebako-resolve/src/fetch.rs
+++ b/crates/tebako-resolve/src/fetch.rs
@@ -10,6 +10,7 @@ use tebako_http::FetchError;
 
 use crate::adapters::adapter_for;
 use crate::error::ResolveError;
+#[cfg(feature = "git")]
 use crate::git;
 use crate::reference::{Reference, Service};
 use crate::transport::{HttpTransport, Transport};
@@ -29,9 +30,13 @@ pub struct FetchedPayload {
 pub fn sha256_hex(bytes: &[u8]) -> String {
     let mut hasher = sha2::Sha256::new();
     hasher.update(bytes);
-    let digest = hasher.finalize();
+    hex_digest(&hasher.finalize())
+}
+
+/// Lowercase hex of a digest (the seed path streams its hash).
+pub(crate) fn hex_digest(digest: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = String::with_capacity(64);
+    let mut out = String::with_capacity(digest.len() * 2);
     for b in digest {
         out.push(HEX[(b >> 4) as usize] as char);
         out.push(HEX[(b & 0xf) as usize] as char);
@@ -89,8 +94,19 @@ impl<T: Transport> Fetcher<T> {
                 let Some(path) = path else {
                     return Err(ResolveError::GitPathRequired { url: url.clone() });
                 };
-                let bytes = git::fetch_blob(url, git_ref.as_deref(), path)?;
-                (bytes, reference.to_string())
+                #[cfg(feature = "git")]
+                {
+                    let bytes = git::fetch_blob(url, git_ref.as_deref(), path)?;
+                    (bytes, reference.to_string())
+                }
+                #[cfg(not(feature = "git"))]
+                {
+                    let _ = (git_ref, path);
+                    return Err(ResolveError::Git {
+                        url: url.clone(),
+                        reason: "this build was compiled without the 'git' feature — tfs+git: references are unsupported".to_string(),
+                    });
+                }
             }
         };
         let sha256 = sha256_hex(&bytes);

--- a/crates/tebako-resolve/src/lib.rs
+++ b/crates/tebako-resolve/src/lib.rs
@@ -8,10 +8,13 @@
 //!   never host-triplet guessing).
 //! - [`Fetcher`] — reference → bytes over an injected [`Transport`]
 //!   (tebako-http in production, mocks and `file://` mirrors in tests);
-//!   `tfs+git:` via gitoxide, never the git CLI.
+//!   `tfs+git:` via gitoxide, never the git CLI (the default `git`
+//!   feature — off in the size-capped bootstrap's link).
 //! - [`PayloadCache`] — the shared `~/.tebako/payloads` store (spec 05
 //!   §3–4): per-entry flock, tmp+rename atomic installs, `.sha256` trust
-//!   anchor + `.origin` marker, `TEBAKO_OFFLINE` hard errors.
+//!   anchor + `.origin` marker, `TEBAKO_OFFLINE` hard errors — plus the
+//!   spec 23 §13.4 lazy-[`seed`](cache::PayloadCache::seed) verb and the
+//!   lock-pinned [`resolve_locked_slice`].
 //! - [`Registry`] / [`RegistryRef`] — the developer-hosted
 //!   `tpkg-registry.yaml` model and its resolution (spec 04 §2): exactly
 //!   one location per form, declarative host-triplet selection.
@@ -25,13 +28,14 @@ pub mod cache;
 pub mod contract;
 pub mod error;
 pub mod fetch;
+#[cfg(feature = "git")]
 pub mod git;
 pub mod reference;
 pub mod registry;
 pub mod store;
 pub mod transport;
 
-pub use cache::{default_cache_root, CacheEntry, InstallStatus, PayloadCache};
+pub use cache::{default_cache_root, CacheEntry, InstallStatus, PayloadCache, SeedOutcome};
 pub use contract::{ContractError, ContractSet};
 pub use error::{ReferenceError, RegistryError, ResolveError};
 pub use fetch::{sha256_hex, FetchedPayload, Fetcher};
@@ -81,4 +85,163 @@ pub fn fetch_and_cache(
 ) -> Result<(CacheEntry, InstallStatus), ResolveError> {
     let fetcher = Fetcher::new();
     cache.install(name, version, expected_sha256, || fetcher.fetch(reference))
+}
+
+/// Resolve a lock-pinned shared slice (spec 23 §4/§13 — the composition
+/// spectrum): a cache hit requires the trust anchor to EQUAL the lock's
+/// pin — a different anchor is the spec 18 S63 digest mismatch,
+/// fail-closed, never a silent re-resolve by semver. A miss fetches the
+/// lock's `source` reference with the pin as the trust anchor
+/// (`TEBAKO_OFFLINE=1` → the named offline error; a pin mismatch at the
+/// fetch boundary deletes the download and caches nothing).
+pub fn resolve_locked_slice(
+    cache: &PayloadCache,
+    name: &str,
+    version: &str,
+    pin: &str,
+    source: &Reference,
+) -> Result<CacheEntry, ResolveError> {
+    let pin = pin.to_ascii_lowercase();
+    let check = |entry: CacheEntry| -> Result<CacheEntry, ResolveError> {
+        if entry.sha256 == pin {
+            Ok(entry)
+        } else {
+            Err(ResolveError::Sha256Mismatch {
+                origin: entry
+                    .origin
+                    .clone()
+                    .unwrap_or_else(|| format!("cached payload {}@{}", entry.name, entry.version)),
+                expected: pin.clone(),
+                actual: entry.sha256.clone(),
+            })
+        }
+    };
+    if let Some(entry) = cache.get(name, version)? {
+        return check(entry);
+    }
+    // The entry may land between the miss check and the install lock (a
+    // concurrent process) — install returns it as a hit UNVERIFIED
+    // against the pin, so the anchor check applies to its outcome too.
+    let (entry, _) = fetch_and_cache(cache, source, name, version, Some(&pin))?;
+    check(entry)
+}
+
+/// Every env-mutating test in this crate (TEBAKO_OFFLINE & friends)
+/// serializes on this one mutex — the test modules share one process.
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("tebako-resolve-locked-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    fn file_reference(path: &std::path::Path) -> Reference {
+        Reference::File {
+            path: path.to_string_lossy().into_owned(),
+            sha256: None,
+        }
+    }
+
+    #[test]
+    fn locked_slice_hit_requires_the_anchor_to_equal_the_pin() {
+        let root = scratch();
+        let cache = PayloadCache::with_root(&root);
+        let pin = sha256_hex(b"payload");
+        cache
+            .install("tool", "1.0", None, || {
+                Ok(FetchedPayload {
+                    bytes: b"payload".to_vec(),
+                    origin: "https://cdn.example.com/tool.tfs".to_string(),
+                    sha256: pin.clone(),
+                })
+            })
+            .unwrap();
+        // The source does not exist — a fetch would fail; a hit never fetches.
+        let missing = file_reference(&root.join("definitely-not-there.tfs"));
+        let entry = resolve_locked_slice(&cache, "tool", "1.0", &pin, &missing).unwrap();
+        assert_eq!(entry.sha256, pin);
+
+        let err =
+            resolve_locked_slice(&cache, "tool", "1.0", &"f".repeat(64), &missing).unwrap_err();
+        let ResolveError::Sha256Mismatch {
+            expected, actual, ..
+        } = &err
+        else {
+            panic!("expected Sha256Mismatch, got {err:?}")
+        };
+        assert_eq!(expected, &"f".repeat(64));
+        assert_eq!(actual, &pin);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn locked_slice_miss_fetches_with_the_pin_as_anchor() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        std::env::remove_var("TEBAKO_OFFLINE");
+        let root = scratch();
+        let mirror = root.join("mirror");
+        std::fs::create_dir_all(&mirror).unwrap();
+        let file = mirror.join("tool-1.0.tfs");
+        std::fs::write(&file, b"payload").unwrap();
+        let cache = PayloadCache::with_root(&root);
+        let pin = sha256_hex(b"payload");
+        let entry =
+            resolve_locked_slice(&cache, "tool", "1.0", &pin, &file_reference(&file)).unwrap();
+        assert_eq!(entry.sha256, pin);
+        assert_eq!(std::fs::read(&entry.path).unwrap(), b"payload");
+        // The second resolution is a cache hit — the mirror can go away.
+        std::fs::remove_file(&file).unwrap();
+        let entry =
+            resolve_locked_slice(&cache, "tool", "1.0", &pin, &file_reference(&file)).unwrap();
+        assert_eq!(entry.sha256, pin);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn locked_slice_offline_miss_is_the_named_offline_error() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let root = scratch();
+        let cache = PayloadCache::with_root(&root);
+        std::env::set_var("TEBAKO_OFFLINE", "1");
+        let err = resolve_locked_slice(
+            &cache,
+            "tool",
+            "1.0",
+            &"a".repeat(64),
+            &file_reference(&root.join("x.tfs")),
+        )
+        .unwrap_err();
+        std::env::remove_var("TEBAKO_OFFLINE");
+        assert!(matches!(err, ResolveError::Offline { .. }));
+        assert!(err.to_string().contains("tool@1.0"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn locked_slice_pin_mismatch_at_the_boundary_caches_nothing() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        std::env::remove_var("TEBAKO_OFFLINE");
+        let root = scratch();
+        std::fs::create_dir_all(&root).unwrap();
+        let file = root.join("tool-1.0.tfs");
+        std::fs::write(&file, b"payload").unwrap();
+        let cache = PayloadCache::with_root(&root);
+        let err = resolve_locked_slice(
+            &cache,
+            "tool",
+            "1.0",
+            &"f".repeat(64),
+            &file_reference(&file),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ResolveError::Sha256Mismatch { .. }));
+        assert!(!root.join("payloads/tool/1.0.tfs").exists());
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }

--- a/crates/tebako-resolve/src/lib.rs
+++ b/crates/tebako-resolve/src/lib.rs
@@ -136,7 +136,15 @@ mod tests {
     use super::*;
 
     fn scratch() -> std::path::PathBuf {
-        let dir = std::env::temp_dir().join(format!("tebako-resolve-locked-{}", std::process::id()));
+        // Unique per test, not just per process: the tests run threaded,
+        // and a shared pid-only dir means one test's remove_dir_all wipes
+        // a sibling's mirror mid-fetch (the ubuntu CI NotFound flake).
+        static N: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "tebako-resolve-locked-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        ));
         let _ = std::fs::remove_dir_all(&dir);
         dir
     }
@@ -182,7 +190,7 @@ mod tests {
 
     #[test]
     fn locked_slice_miss_fetches_with_the_pin_as_anchor() {
-        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let _guard = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("TEBAKO_OFFLINE");
         let root = scratch();
         let mirror = root.join("mirror");
@@ -205,7 +213,7 @@ mod tests {
 
     #[test]
     fn locked_slice_offline_miss_is_the_named_offline_error() {
-        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let _guard = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let root = scratch();
         let cache = PayloadCache::with_root(&root);
         std::env::set_var("TEBAKO_OFFLINE", "1");
@@ -225,7 +233,7 @@ mod tests {
 
     #[test]
     fn locked_slice_pin_mismatch_at_the_boundary_caches_nothing() {
-        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let _guard = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("TEBAKO_OFFLINE");
         let root = scratch();
         std::fs::create_dir_all(&root).unwrap();

--- a/crates/tebako-resolve/src/store.rs
+++ b/crates/tebako-resolve/src/store.rs
@@ -9,10 +9,12 @@
 //! - a brand-new store is born at the current version (nothing to say).
 //!
 //! One owner, every consumer flows: tebako-shim and tebako-cli call
-//! [`check_once`] at their store entry points (the size-capped
-//! tebako-bootstrap cannot link this crate and mirrors the semantics —
+//! [`check_once`] at their store entry points; tebako-bootstrap links
+//! this crate with default-features = false, so its payload install/seed
+//! paths flow [`check_once`] through [`crate::cache::PayloadCache`] while
+//! its older runtime-cache paths keep their mirrored check.
 //! [`STORE_LAYOUT_VERSION`] is the canonical value, pinned identical by
-//! both sides' tests).
+//! both sides' tests.
 
 use std::fmt;
 use std::path::{Path, PathBuf};

--- a/crates/tpkg/src/compose.rs
+++ b/crates/tpkg/src/compose.rs
@@ -227,17 +227,15 @@ fn resolve_slice_ref(raw: &RawSlice, what: &str) -> Result<ComposeSliceRef, Comp
         .requirement
         .as_deref()
         .map(|r| {
-            Constraint::new(r).map_err(|e| {
-                invalid(format!("{what}: unparseable requirement '{r}': {e}"))
-            })
+            Constraint::new(r)
+                .map_err(|e| invalid(format!("{what}: unparseable requirement '{r}': {e}")))
         })
         .transpose()?;
     let (name, requirement) = match (shorthand, expanded_name, expanded_req) {
         (Some((ref_name, ref_req)), Some(name), req) => {
             // Both spellings present: they must AGREE — a conflict is a
             // named error (spec 23 §3); agreement = the expanded form.
-            let conflict = ref_name != name
-                || req.as_ref().is_some_and(|r| *r != ref_req);
+            let conflict = ref_name != name || req.as_ref().is_some_and(|r| *r != ref_req);
             if conflict {
                 return Err(invalid(format!(
                     "{what}: ref '{ref_name}@{}' conflicts with the expanded name/requirement — one semantics, two spellings, never two meanings",
@@ -296,7 +294,9 @@ impl ComposeDoc {
     /// The carry verdict of one slice: authored `carry:` wins, else the
     /// preset's default (spec 23 §13.2).
     pub fn carry_of(&self, slice: &ComposeSliceRef, is_runtime: bool) -> bool {
-        slice.carry.unwrap_or_else(|| self.preset.default_carry(is_runtime))
+        slice
+            .carry
+            .unwrap_or_else(|| self.preset.default_carry(is_runtime))
     }
 }
 
@@ -528,11 +528,13 @@ entrypoint: mnconvert
         assert!(bad("runtime: {ref: \"ruby@~> 3.3\"}\n")); // no version
         assert!(bad("version: 2\nruntime: {ref: \"ruby@~> 3.3\"}\n"));
         assert!(bad("version: 1\n")); // no runtime
-        assert!(bad("version: 1\npreset: chunky\nruntime: {ref: \"ruby@~> 3.3\"}\n"));
+        assert!(bad(
+            "version: 1\npreset: chunky\nruntime: {ref: \"ruby@~> 3.3\"}\n"
+        ));
         assert!(bad("version: 1\nruntime: {name: ruby}\n")); // no requirement
         assert!(bad("version: 1\nruntime: {ref: \"ruby\"}\n")); // shorthand without constraint
         assert!(bad("version: 1\nruntime: {ref: \"@~> 3.3\"}\n")); // empty name
-        // a ref/expanded conflict
+                                                                   // a ref/expanded conflict
         assert!(bad(
             "version: 1\nruntime: {name: ruby, requirement: \"~> 3.3\", ref: \"ruby@>= 3.4\"}\n"
         ));
@@ -541,9 +543,15 @@ entrypoint: mnconvert
             "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nslices:\n  - {name: a, requirement: \"1\"}\n  - {ref: \"a@2\"}\n"
         ));
         // the Phase-R keys refuse by name
-        assert!(bad("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\npolicy: deny\n"));
-        assert!(bad("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nmounts: []\n"));
-        assert!(bad("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nneeds: {}\n"));
+        assert!(bad(
+            "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\npolicy: deny\n"
+        ));
+        assert!(bad(
+            "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nmounts: []\n"
+        ));
+        assert!(bad(
+            "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nneeds: {}\n"
+        ));
         // unknown platforms spellings
         assert!(bad(
             "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nslices:\n  - {name: a, platforms: [plan9]}\n"
@@ -613,7 +621,10 @@ entrypoint: mnconvert
             check_platforms_assertion("my-slice", &declared, None, Platform::X86_64WindowsUcrt)
                 .unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("my-slice") && msg.contains("x86_64-windows-ucrt"), "{msg}");
+        assert!(
+            msg.contains("my-slice") && msg.contains("x86_64-windows-ucrt"),
+            "{msg}"
+        );
         // universal declares everything
         check_platforms_assertion(
             "s",

--- a/crates/tpkg/src/compose.rs
+++ b/crates/tpkg/src/compose.rs
@@ -1,0 +1,626 @@
+//! The D2 composition document (spec 23 §3/§13) — the press-time subset.
+//!
+//! `tebako press --compose <tebako.yaml>` reads this document: one runtime
+//! requirement plus N payload slice references, the per-slice `carry`
+//! verdicts (the composition spectrum, spec 23 §13), and the `platforms:`
+//! coverage assertions (§13.3). Press resolves the full closure at build
+//! time and bakes the lock into the L2 package manifest (§4).
+//!
+//! Out of this layer (Phase-R, spec 23's status line): the jail/policy
+//! keys (`policy:`, `mounts:`, `needs:`). They are REFUSED by name here —
+//! a compose document that looks jail-declaring but is pressed without
+//! its policy would be a silent security downgrade (fail-closed, spec 00
+//! §9). Truly unknown keys stay tolerated (forward compatibility).
+//!
+//! ```yaml
+//! version: 1
+//! preset: shared-runtime        # self-contained | shared-runtime
+//!                               # (lean/fat: deprecated aliases, a named
+//!                               # warning each — never silent)
+//! runtime:                      # … or the shorthand: ref: "ruby@~> 3.3"
+//!   name: ruby
+//!   requirement: "~> 3.3"
+//!   carry: false                # true = the two-slot carried pair (spec 19 §6.1)
+//!   platforms: [macos-arm64]    # OPTIONAL coverage assertion (release-asset names)
+//! slices:
+//!   - name: metanorma           # … or ref: "metanorma@>= 2.1"
+//!     requirement: ">= 2.1"
+//!     carry: true
+//!   - ref: "openjdk@21"
+//!     platforms: universal      # assertion: fails the press when not universal
+//! entrypoint: mnconvert         # the pointer-package form's entry selector
+//! ```
+
+use serde::Deserialize;
+use std::fmt;
+
+use crate::manifest::{Constraint, Platform, Platforms};
+
+/// The only `version` this implementation reads.
+pub const COMPOSE_SCHEMA_VERSION: u32 = 1;
+
+/// The compose document keys that are declared in spec 23 §3 but belong to
+/// the Phase-R jail/dispatch wiring — refused by name, never silently
+/// dropped.
+const PHASE_R_KEYS: [&str; 3] = ["policy", "mounts", "needs"];
+
+/// Compose document errors.
+#[derive(Debug)]
+pub enum ComposeError {
+    /// YAML structural failure (the document does not match the model).
+    Yaml(serde_yml::Error),
+    /// Semantic validation failure (the reason travels).
+    Invalid(String),
+}
+
+impl fmt::Display for ComposeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ComposeError::Yaml(e) => write!(f, "compose document yaml error: {e}"),
+            ComposeError::Invalid(reason) => write!(f, "invalid compose document: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for ComposeError {}
+
+impl From<serde_yml::Error> for ComposeError {
+    fn from(e: serde_yml::Error) -> ComposeError {
+        ComposeError::Yaml(e)
+    }
+}
+
+fn invalid(reason: impl Into<String>) -> ComposeError {
+    ComposeError::Invalid(reason.into())
+}
+
+/// The package preset (spec 23 §13.2). The deprecated aliases parse with a
+/// named warning each — never silently (invariant 9).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComposePreset {
+    /// Carries the full closure: runtime exe + env image + every payload
+    /// slice. Zero network, empty cache, one file. (The "fat" successor.)
+    SelfContained,
+    /// Carries the app payload(s), shares the runtime and any slice marked
+    /// shared. The DEFAULT. (The "lean" successor.)
+    SharedRuntime,
+}
+
+impl ComposePreset {
+    /// Parse a preset spelling; the deprecated aliases map onto their
+    /// successors and return the named warning the caller surfaces.
+    pub fn parse(spelling: &str) -> Result<(ComposePreset, Option<String>), ComposeError> {
+        match spelling {
+            "self-contained" => Ok((ComposePreset::SelfContained, None)),
+            "shared-runtime" => Ok((ComposePreset::SharedRuntime, None)),
+            "fat" => Ok((
+                ComposePreset::SelfContained,
+                Some(
+                    "the 'fat' preset is deprecated — spell it 'self-contained' (spec 23 §13.2)"
+                        .to_string(),
+                ),
+            )),
+            "lean" => Ok((
+                ComposePreset::SharedRuntime,
+                Some(
+                    "the 'lean' preset is deprecated — spell it 'shared-runtime' (spec 23 §13.2)"
+                        .to_string(),
+                ),
+            )),
+            _ => Err(invalid(format!(
+                "unknown preset '{spelling}' (self-contained | shared-runtime expected; lean/fat are deprecated aliases)"
+            ))),
+        }
+    }
+
+    /// The spelling this preset serializes as (the canonical, never the
+    /// deprecated alias).
+    pub fn name(self) -> &'static str {
+        match self {
+            ComposePreset::SelfContained => "self-contained",
+            ComposePreset::SharedRuntime => "shared-runtime",
+        }
+    }
+
+    /// The preset's default carry verdict (spec 23 §13.2): self-contained
+    /// carries everything; shared-runtime shares the runtime and carries
+    /// the payload slices. A slice's authored `carry:` overrides this.
+    pub fn default_carry(self, is_runtime: bool) -> bool {
+        match self {
+            ComposePreset::SelfContained => true,
+            ComposePreset::SharedRuntime => !is_runtime,
+        }
+    }
+}
+
+/// One slice reference of the document (the runtime or a payload slice):
+/// `name:` + `requirement:`, or the `ref: "name@constraint"` shorthand —
+/// one semantics, two spellings (a conflict is a named validation error).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposeSliceRef {
+    pub name: String,
+    pub requirement: Option<Constraint>,
+    /// The authored carry verdict; `None` = the preset decides.
+    pub carry: Option<bool>,
+    /// The coverage assertion (spec 23 §13.3); `None` = the payload's own
+    /// declaration rules.
+    pub platforms: Option<Platforms>,
+}
+
+#[derive(Clone, Deserialize)]
+struct RawSlice {
+    name: Option<String>,
+    #[serde(rename = "ref")]
+    ref_: Option<String>,
+    requirement: Option<String>,
+    carry: Option<bool>,
+    platforms: Option<RawPlatforms>,
+}
+
+/// The assertion's YAML shape: `universal` or a list of release-asset
+/// platform names (the spec 23 §3 example's spelling).
+#[derive(Clone, Deserialize)]
+#[serde(untagged)]
+enum RawPlatforms {
+    Universal(String),
+    List(Vec<String>),
+}
+
+impl RawPlatforms {
+    fn to_platforms(&self, what: &str) -> Result<Platforms, ComposeError> {
+        match self {
+            RawPlatforms::Universal(s) if s == "universal" => Ok(Platforms::Universal),
+            RawPlatforms::Universal(s) => Err(invalid(format!(
+                "{what}: platforms must be 'universal' or a list of platform names, got '{s}'"
+            ))),
+            RawPlatforms::List(names) => {
+                let mut out = Vec::new();
+                for name in names {
+                    let Some(p) = Platform::from_release_asset_name(name) else {
+                        return Err(invalid(format!(
+                            "{what}: unknown platform '{name}' (release-asset names: macos-arm64, linux-gnu-x86_64, …)"
+                        )));
+                    };
+                    out.push(p);
+                }
+                if out.is_empty() {
+                    return Err(invalid(format!(
+                        "{what}: an empty platforms list asserts nothing (spell 'universal')"
+                    )));
+                }
+                Ok(Platforms::Triplets(out))
+            }
+        }
+    }
+}
+
+/// The shorthand: `name@constraint` — the name is everything before the
+/// FIRST '@', the constraint the rest (the requirement grammar).
+fn parse_ref_shorthand(ref_: &str, what: &str) -> Result<(String, Constraint), ComposeError> {
+    let Some(at) = ref_.find('@') else {
+        return Err(invalid(format!(
+            "{what}: ref '{ref_}' is not 'name@constraint' (the shorthand needs both)"
+        )));
+    };
+    let (name, constraint) = (&ref_[..at], &ref_[at + 1..]);
+    if name.is_empty() || constraint.is_empty() {
+        return Err(invalid(format!(
+            "{what}: ref '{ref_}' is not 'name@constraint' (empty name or constraint)"
+        )));
+    }
+    let constraint = Constraint::new(constraint).map_err(|e| {
+        invalid(format!(
+            "{what}: ref '{ref_}' carries an unparseable constraint: {e}"
+        ))
+    })?;
+    Ok((name.to_string(), constraint))
+}
+
+fn resolve_slice_ref(raw: &RawSlice, what: &str) -> Result<ComposeSliceRef, ComposeError> {
+    let shorthand = raw
+        .ref_
+        .as_deref()
+        .map(|r| parse_ref_shorthand(r, what))
+        .transpose()?;
+    let expanded_name = raw.name.clone().filter(|n| !n.trim().is_empty());
+    let expanded_req = raw
+        .requirement
+        .as_deref()
+        .map(|r| {
+            Constraint::new(r).map_err(|e| {
+                invalid(format!("{what}: unparseable requirement '{r}': {e}"))
+            })
+        })
+        .transpose()?;
+    let (name, requirement) = match (shorthand, expanded_name, expanded_req) {
+        (Some((ref_name, ref_req)), Some(name), req) => {
+            // Both spellings present: they must AGREE — a conflict is a
+            // named error (spec 23 §3); agreement = the expanded form.
+            let conflict = ref_name != name
+                || req.as_ref().is_some_and(|r| *r != ref_req);
+            if conflict {
+                return Err(invalid(format!(
+                    "{what}: ref '{ref_name}@{}' conflicts with the expanded name/requirement — one semantics, two spellings, never two meanings",
+                    ref_req.as_str()
+                )));
+            }
+            (name, Some(req.unwrap_or(ref_req)))
+        }
+        (Some((ref_name, ref_req)), None, None) => (ref_name, Some(ref_req)),
+        (Some((ref_name, ref_req)), None, Some(_)) => {
+            // A requirement alongside the shorthand is a conflict waiting
+            // to happen — the shorthand already carries one.
+            return Err(invalid(format!(
+                "{what}: ref '{ref_name}@{}' and a separate requirement: key — use one spelling",
+                ref_req.as_str()
+            )));
+        }
+        (None, Some(name), req) => (name, req),
+        (None, None, _) => {
+            return Err(invalid(format!(
+                "{what}: a slice needs a name (or the ref: 'name@constraint' shorthand)"
+            )));
+        }
+    };
+    let platforms = raw
+        .platforms
+        .as_ref()
+        .map(|p| p.to_platforms(what))
+        .transpose()?;
+    Ok(ComposeSliceRef {
+        name,
+        requirement,
+        carry: raw.carry,
+        platforms,
+    })
+}
+
+/// The parsed + validated composition document, plus the deprecation
+/// warnings the caller surfaces (the aliases' named warnings ride
+/// out-of-band — they are not errors).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposeDoc {
+    pub preset: ComposePreset,
+    /// The runtime slice reference. The name is the engine (`ruby`); the
+    /// requirement the version constraint.
+    pub runtime: ComposeSliceRef,
+    /// The payload slices, in document order.
+    pub slices: Vec<ComposeSliceRef>,
+    /// The pointer-package form's entry selector (a PROVIDES entrypoint
+    /// name of one of the slices). Absent when the press packages a local
+    /// root (the app's own entry governs).
+    pub entrypoint: Option<String>,
+}
+
+impl ComposeDoc {
+    /// The carry verdict of one slice: authored `carry:` wins, else the
+    /// preset's default (spec 23 §13.2).
+    pub fn carry_of(&self, slice: &ComposeSliceRef, is_runtime: bool) -> bool {
+        slice.carry.unwrap_or_else(|| self.preset.default_carry(is_runtime))
+    }
+}
+
+#[derive(Deserialize)]
+struct RawDoc {
+    version: Option<u32>,
+    preset: Option<String>,
+    runtime: Option<RawSlice>,
+    #[serde(default)]
+    slices: Vec<RawSlice>,
+    entrypoint: Option<String>,
+    // Phase-R keys — present ⇒ the named refusal, never a silent drop.
+    policy: Option<serde_yml::Value>,
+    mounts: Option<serde_yml::Value>,
+    needs: Option<serde_yml::Value>,
+}
+
+/// Parse and validate a composition document. Returns the document and
+/// the deprecation warnings to surface (preset aliases).
+pub fn parse_compose(yaml: &str) -> Result<(ComposeDoc, Vec<String>), ComposeError> {
+    let raw: RawDoc = serde_yml::from_str(yaml)?;
+    for key in PHASE_R_KEYS {
+        let present = match key {
+            "policy" => raw.policy.is_some(),
+            "mounts" => raw.mounts.is_some(),
+            _ => raw.needs.is_some(),
+        };
+        if present {
+            return Err(invalid(format!(
+                "the '{key}:' key is the Phase-R jail wiring (spec 23 §5–§8) — not pressable today; press --jail owns a package's policy request"
+            )));
+        }
+    }
+    if raw.version != Some(COMPOSE_SCHEMA_VERSION) {
+        return Err(invalid(format!(
+            "version: {} is required (the compose document's schema version)",
+            COMPOSE_SCHEMA_VERSION
+        )));
+    }
+    let mut warnings = Vec::new();
+    let (preset, warning) = match raw.preset.as_deref() {
+        Some(spelling) => ComposePreset::parse(spelling)?,
+        None => (ComposePreset::SharedRuntime, None),
+    };
+    if let Some(warning) = warning {
+        warnings.push(warning);
+    }
+    let runtime = raw
+        .runtime
+        .as_ref()
+        .map(|r| resolve_slice_ref(r, "runtime"))
+        .transpose()?
+        .ok_or_else(|| invalid("runtime: is required (the composition's engine slice)"))?;
+    if runtime.requirement.is_none() {
+        return Err(invalid(
+            "runtime: needs a requirement (a version constraint — press always resolves by constraint)",
+        ));
+    }
+    let mut slices = Vec::new();
+    for (i, raw_slice) in raw.slices.iter().enumerate() {
+        slices.push(resolve_slice_ref(raw_slice, &format!("slices[{}]", i + 1))?);
+    }
+    let mut names: Vec<&str> = slices.iter().map(|s| s.name.as_str()).collect();
+    names.sort_unstable();
+    if names.windows(2).any(|w| w[0] == w[1]) {
+        return Err(invalid("duplicate slice name (one row per slice)"));
+    }
+    let entrypoint = raw.entrypoint.filter(|e| !e.trim().is_empty());
+    Ok((
+        ComposeDoc {
+            preset,
+            runtime,
+            slices,
+            entrypoint,
+        },
+        warnings,
+    ))
+}
+
+/// The spec 23 §13.3 coverage check (fail-closed, press-side): the
+/// document's per-slice `platforms:` assertion must be COVERED by the
+/// payload's declared coverage (the assertion narrows, never extends), and
+/// the host triplet must be covered by the (possibly narrowed) effective
+/// coverage. The named error names the slice, the triplet, and the
+/// declared coverage.
+pub fn check_platforms_assertion(
+    slice: &str,
+    declared: &Platforms,
+    assertion: Option<&Platforms>,
+    host: Platform,
+) -> Result<(), ComposeError> {
+    let declared_list = |declared: &Platforms| match declared {
+        Platforms::Universal => "universal".to_string(),
+        Platforms::Triplets(ts) => ts
+            .iter()
+            .map(|p| p.as_triplet())
+            .collect::<Vec<_>>()
+            .join(", "),
+    };
+    match assertion {
+        Some(Platforms::Universal) => {
+            // A universal assertion over a triplet-listed payload EXTENDS
+            // the declared coverage — refused by name.
+            if let Platforms::Triplets(_) = declared {
+                return Err(invalid(format!(
+                    "slice '{slice}': the assertion is universal but the payload declares coverage {} — the assertion narrows, never extends (spec 23 §13.3)",
+                    declared_list(declared),
+                )));
+            }
+            Ok(())
+        }
+        Some(Platforms::Triplets(ts)) => {
+            let uncovered = ts.iter().find(|p| !declared.covers(**p));
+            if let Some(p) = uncovered {
+                return Err(invalid(format!(
+                    "slice '{slice}': the platforms assertion names {} but the payload declares coverage {} — the assertion narrows, never extends (spec 23 §13.3)",
+                    p.as_triplet(),
+                    declared_list(declared),
+                )));
+            }
+            if !ts.contains(&host) {
+                return Err(invalid(format!(
+                    "slice '{slice}': the platforms assertion does not cover the host triplet {} (assertion: {}; declared coverage: {})",
+                    host.as_triplet(),
+                    ts.iter()
+                        .map(|p| p.as_triplet())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    declared_list(declared),
+                )));
+            }
+            Ok(())
+        }
+        None => {
+            if !declared.covers(host) {
+                return Err(invalid(format!(
+                    "slice '{slice}': the payload's declared coverage ({}) does not cover the host triplet {} (spec 23 §13.3)",
+                    declared_list(declared),
+                    host.as_triplet(),
+                )));
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(yaml: &str) -> Result<(ComposeDoc, Vec<String>), ComposeError> {
+        parse_compose(yaml)
+    }
+
+    #[test]
+    fn the_spec_23_example_parses() {
+        let yaml = "\
+version: 1
+preset: shared-runtime
+runtime:
+  name: ruby
+  requirement: \"~> 3.3\"
+  carry: false
+  platforms: [macos-arm64, linux-gnu-x86_64]
+slices:
+  - name: metanorma
+    requirement: \">= 2.1\"
+    carry: true
+  - name: openjdk
+    requirement: \"21\"
+    carry: true
+  - ref: \"ourorg-templates@3\"
+    carry: false
+    platforms: universal
+entrypoint: mnconvert
+";
+        let (doc, warnings) = parse(yaml).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(doc.preset, ComposePreset::SharedRuntime);
+        assert_eq!(doc.runtime.name, "ruby");
+        assert_eq!(doc.runtime.requirement.unwrap().as_str(), "~> 3.3");
+        assert_eq!(doc.runtime.carry, Some(false));
+        assert_eq!(
+            doc.runtime.platforms,
+            Some(Platforms::Triplets(vec![
+                Platform::Aarch64Macos,
+                Platform::X86_64LinuxGnu
+            ]))
+        );
+        assert_eq!(doc.slices.len(), 3);
+        assert_eq!(doc.slices[2].name, "ourorg-templates");
+        assert_eq!(doc.slices[2].requirement.as_ref().unwrap().as_str(), "3");
+        assert_eq!(doc.slices[2].carry, Some(false));
+        assert_eq!(doc.slices[2].platforms, Some(Platforms::Universal));
+        assert_eq!(doc.entrypoint.as_deref(), Some("mnconvert"));
+    }
+
+    #[test]
+    fn the_default_preset_is_shared_runtime() {
+        let yaml = "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\n";
+        let (doc, warnings) = parse(yaml).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(doc.preset, ComposePreset::SharedRuntime);
+        assert_eq!(doc.runtime.name, "ruby");
+        assert!(!doc.carry_of(&doc.runtime, true));
+    }
+
+    #[test]
+    fn lean_and_fat_are_named_warnings_never_silent() {
+        let (doc, warnings) =
+            parse("version: 1\npreset: lean\nruntime: {ref: \"ruby@~> 3.3\"}\n").unwrap();
+        assert_eq!(doc.preset, ComposePreset::SharedRuntime);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("'lean' preset is deprecated"));
+        assert!(warnings[0].contains("shared-runtime"));
+
+        let (doc, warnings) =
+            parse("version: 1\npreset: fat\nruntime: {ref: \"ruby@~> 3.3\"}\n").unwrap();
+        assert_eq!(doc.preset, ComposePreset::SelfContained);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("'fat' preset is deprecated"));
+        assert!(warnings[0].contains("self-contained"));
+        assert!(doc.carry_of(&doc.runtime, true));
+    }
+
+    #[test]
+    fn validation_is_fail_closed() {
+        let bad = |yaml: &str| parse(yaml).is_err();
+        assert!(bad("runtime: {ref: \"ruby@~> 3.3\"}\n")); // no version
+        assert!(bad("version: 2\nruntime: {ref: \"ruby@~> 3.3\"}\n"));
+        assert!(bad("version: 1\n")); // no runtime
+        assert!(bad("version: 1\npreset: chunky\nruntime: {ref: \"ruby@~> 3.3\"}\n"));
+        assert!(bad("version: 1\nruntime: {name: ruby}\n")); // no requirement
+        assert!(bad("version: 1\nruntime: {ref: \"ruby\"}\n")); // shorthand without constraint
+        assert!(bad("version: 1\nruntime: {ref: \"@~> 3.3\"}\n")); // empty name
+        // a ref/expanded conflict
+        assert!(bad(
+            "version: 1\nruntime: {name: ruby, requirement: \"~> 3.3\", ref: \"ruby@>= 3.4\"}\n"
+        ));
+        // a duplicate slice name
+        assert!(bad(
+            "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nslices:\n  - {name: a, requirement: \"1\"}\n  - {ref: \"a@2\"}\n"
+        ));
+        // the Phase-R keys refuse by name
+        assert!(bad("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\npolicy: deny\n"));
+        assert!(bad("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nmounts: []\n"));
+        assert!(bad("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nneeds: {}\n"));
+        // unknown platforms spellings
+        assert!(bad(
+            "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nslices:\n  - {name: a, platforms: [plan9]}\n"
+        ));
+        // unknown keys stay tolerated (forward compatibility)
+        let (doc, _) =
+            parse("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nfuture: {anything: goes}\n")
+                .unwrap();
+        assert!(doc.slices.is_empty());
+    }
+
+    #[test]
+    fn agreeing_spellings_are_not_a_conflict() {
+        let (doc, _) = parse(
+            "version: 1\nruntime: {name: ruby, requirement: \"~> 3.3\", ref: \"ruby@~> 3.3\"}\n",
+        )
+        .unwrap();
+        assert_eq!(doc.runtime.name, "ruby");
+        assert_eq!(doc.runtime.requirement.unwrap().as_str(), "~> 3.3");
+    }
+
+    #[test]
+    fn the_platforms_assertion_narrows_never_extends() {
+        let declared = Platforms::Triplets(vec![Platform::Aarch64Macos, Platform::X86_64LinuxGnu]);
+        // covered assertion
+        check_platforms_assertion(
+            "s",
+            &declared,
+            Some(&Platforms::Triplets(vec![Platform::Aarch64Macos])),
+            Platform::Aarch64Macos,
+        )
+        .unwrap();
+        // extending assertion
+        let err = check_platforms_assertion(
+            "my-slice",
+            &declared,
+            Some(&Platforms::Triplets(vec![Platform::X86_64WindowsUcrt])),
+            Platform::Aarch64Macos,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("my-slice"), "{msg}");
+        assert!(msg.contains("x86_64-windows-ucrt"), "{msg}");
+        assert!(msg.contains("narrows, never extends"), "{msg}");
+        // a universal assertion over a triplet-listed payload extends — refused
+        let err = check_platforms_assertion(
+            "my-slice",
+            &declared,
+            Some(&Platforms::Universal),
+            Platform::Aarch64Macos,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("assertion is universal"), "{msg}");
+        assert!(msg.contains("narrows, never extends"), "{msg}");
+        // assertion not covering the host
+        let err = check_platforms_assertion(
+            "my-slice",
+            &declared,
+            Some(&Platforms::Triplets(vec![Platform::X86_64LinuxGnu])),
+            Platform::Aarch64Macos,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("does not cover the host triplet"));
+        // no assertion: the declaration rules — an uncovered host is named
+        let err =
+            check_platforms_assertion("my-slice", &declared, None, Platform::X86_64WindowsUcrt)
+                .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("my-slice") && msg.contains("x86_64-windows-ucrt"), "{msg}");
+        // universal declares everything
+        check_platforms_assertion(
+            "s",
+            &Platforms::Universal,
+            Some(&Platforms::Triplets(vec![Platform::X86_64WindowsUcrt])),
+            Platform::X86_64WindowsUcrt,
+        )
+        .unwrap();
+    }
+}

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -142,6 +142,7 @@
 
 pub mod atoms;
 mod codec;
+pub mod compose;
 mod contract;
 mod crc32;
 mod envelope;
@@ -159,6 +160,10 @@ mod region;
 pub use codec::{
     encode_ext_blocks, encode_trailer, parse_ext_blocks, parse_trailer, trailer_len,
     v2_signed_region,
+};
+pub use compose::{
+    check_platforms_assertion, parse_compose, ComposeDoc, ComposeError, ComposePreset,
+    ComposeSliceRef, COMPOSE_SCHEMA_VERSION,
 };
 pub use contract::{ContractError, PackageContract};
 pub use crc32::{crc32, Crc32};
@@ -183,8 +188,9 @@ pub use merkle::{
 };
 pub use model::{Manifest, Slot, V2Extension};
 pub use package::{
-    MountMode, PackageEntry, PackageIdentity, PackageManifest, PackageManifestError, PackageMount,
-    Precedence, PACKAGE_SCHEMA_VERSION,
+    DigestPin, LockedArtifact, LockedRuntime, LockedSlice, MountMode, PackageEntry,
+    PackageIdentity, PackageLock, PackageManifest, PackageManifestError, PackageMount, Precedence,
+    PACKAGE_SCHEMA_VERSION,
 };
 pub use region::{resolve_slot_region, SlotRegion, SlotRegionError};
 

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -241,6 +241,17 @@ impl Platforms {
         }
         Ok(())
     }
+
+    /// True when this coverage declaration covers `platform` (universal
+    /// covers everything). The compose document's `platforms:` coverage
+    /// assertion (spec 23 §13.3) and the lock's per-host digest-pin lookup
+    /// both phrase their checks in terms of this.
+    pub fn covers(&self, platform: Platform) -> bool {
+        match self {
+            Platforms::Universal => true,
+            Platforms::Triplets(ts) => ts.contains(&platform),
+        }
+    }
 }
 
 /// Shared triplet-list checks (app `platforms`, toolkit-dep `triplets`).

--- a/crates/tpkg/src/package.rs
+++ b/crates/tpkg/src/package.rs
@@ -1118,7 +1118,10 @@ mod tests {
     #[test]
     fn digest_pin_host_lookup() {
         let one = DigestPin::One(sha('a'));
-        assert_eq!(one.for_host(crate::Platform::Aarch64Macos), Some(sha('a').as_str()));
+        assert_eq!(
+            one.for_host(crate::Platform::Aarch64Macos),
+            Some(sha('a').as_str())
+        );
         let map = DigestPin::PerTriplet(BTreeMap::from([("macos-arm64".to_string(), sha('b'))]));
         assert_eq!(
             map.for_host(crate::Platform::Aarch64Macos),

--- a/crates/tpkg/src/package.rs
+++ b/crates/tpkg/src/package.rs
@@ -102,12 +102,21 @@ pub struct PackageIdentity {
 /// for simple apps, N entries for suites). `slot` names the payload image,
 /// `entrypoint` the PROVIDES entrypoint inside it, and `runtime_ref` the
 /// per-entry runtime reference (no 128-byte cap — suites/multi-runtime).
+///
+/// `slot` is `None` for a pointer-package entry (spec 23 §13): the entry's
+/// slice is SHARED — resolved at run time from the machine cache by the
+/// [`PackageLock`] under the entry's own name (entry name == lock slice
+/// name). Every package pressed before the composition spectrum has
+/// `Some(slot)`; the key stays absent in the YAML exactly when `None`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PackageEntry {
     /// The command name (the shim registers under this).
     pub name: String,
-    /// Which payload slot carries the entrypoint's image.
-    pub slot: u32,
+    /// Which payload slot carries the entrypoint's image; `None` = the
+    /// entry's slice is shared (a lock slice named `name` must exist and
+    /// be `carry: false`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slot: Option<u32>,
     /// Which PROVIDES entrypoint inside that image.
     pub entrypoint: String,
     /// Per-entry runtime reference (`type@version;tebako=<abi>[;params]`).
@@ -200,6 +209,284 @@ pub struct PackageMount {
     pub precedence: Option<Precedence>,
 }
 
+// ---------------------------------------------------------------------
+// The press-time lock (spec 23 §4/§13 — the composition spectrum)
+// ---------------------------------------------------------------------
+
+/// A slice's digest pin (spec 23 §13.3): the single digest — the carried
+/// form (the bytes are fixed at stitch) or a `universal`-coverage slice —
+/// OR the per-target-triplet digest map. The map keys are release-asset
+/// platform names (`macos-arm64`, … — the registry row spelling, spec 04).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DigestPin {
+    /// One digest regardless of triplet.
+    One(String),
+    /// Per-triplet digests; the run-time lookup keys on the host triplet.
+    PerTriplet(BTreeMap<String, String>),
+}
+
+impl Serialize for DigestPin {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            DigestPin::One(digest) => serializer.serialize_str(digest),
+            DigestPin::PerTriplet(map) => map.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for DigestPin {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            One(String),
+            Map(BTreeMap<String, String>),
+        }
+        match Repr::deserialize(deserializer)? {
+            Repr::One(digest) => Ok(DigestPin::One(digest)),
+            Repr::Map(map) => Ok(DigestPin::PerTriplet(map)),
+        }
+    }
+}
+
+fn check_sha256_hex(digest: &str, what: &'static str) -> Result<(), PackageManifestError> {
+    if digest.len() == 64
+        && digest
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        Ok(())
+    } else {
+        Err(PackageManifestError::Invalid(what))
+    }
+}
+
+impl DigestPin {
+    /// The digest locked for `host` (release-asset-name keyed map lookup);
+    /// `None` when the map does not cover the host (a coverage gap the
+    /// caller turns into the spec 23 §13.3 named error).
+    pub fn for_host(&self, host: crate::Platform) -> Option<&str> {
+        match self {
+            DigestPin::One(digest) => Some(digest),
+            DigestPin::PerTriplet(map) => map.get(host.release_asset_name()).map(String::as_str),
+        }
+    }
+
+    fn validate(&self, what: &'static str) -> Result<(), PackageManifestError> {
+        match self {
+            DigestPin::One(digest) => check_sha256_hex(digest, what),
+            DigestPin::PerTriplet(map) => {
+                if map.is_empty() {
+                    return Err(PackageManifestError::Invalid(what));
+                }
+                for (triplet, digest) in map {
+                    if crate::Platform::from_release_asset_name(triplet).is_none() {
+                        return Err(PackageManifestError::Invalid(
+                            "lock digest map key is not a known platform release-asset name",
+                        ));
+                    }
+                    check_sha256_hex(digest, what)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// One carried artifact of the runtime pair (spec 19 §6.1): the slot the
+/// bytes ride in plus the press-time digest pin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockedArtifact {
+    /// The trailer slot carrying the bytes.
+    pub slot: u32,
+    pub sha256: DigestPin,
+}
+
+/// The locked runtime (spec 23 §4): the concrete version, the carry
+/// verdict, and — when carried (the self-contained preset, spec 19 §6.1) —
+/// the exe / env-image / (windows) dll slots with their digest pins. A
+/// shared runtime (`carry: false`) records only the version: run-time
+/// resolution and verification then ride the ordinary spec 05 §5 chain
+/// (runtime_ref → cache/index anchors), never the lock.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockedRuntime {
+    /// The concrete runtime version the press resolved.
+    pub version: String,
+    pub carry: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exe: Option<LockedArtifact>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<LockedArtifact>,
+    /// The windows dll-era facet (tebako-runtime-ruby#40): carried as a
+    /// third slot when the resolved release declares it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dll: Option<LockedArtifact>,
+}
+
+/// One locked payload slice (spec 23 §4/§13): the concrete version, the
+/// carry verdict, the digest pin, the declared mount when a consumer edge
+/// declares one (spec 03 §2.3's mount rule), and — for a shared slice —
+/// the fetch coordinates (a spec 04 reference) the press resolved from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockedSlice {
+    pub name: String,
+    pub version: String,
+    pub carry: bool,
+    /// The trailer slot (carried slices only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slot: Option<u32>,
+    /// The declared mount point; absent = the slice is carried/shared as
+    /// a cache prime with no mount (no consumer edge declared one).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mount: Option<String>,
+    pub sha256: DigestPin,
+    /// The fetch coordinates (shared slices only — required there; on a
+    /// carried slice it is provenance, never a fallback fetch path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+/// The `lock:` block of the L2 package manifest (spec 23 §4/§13): what
+/// press resolved is what runs — the full composition closure locked per
+/// slice. Run-time resolution follows the lock by locked digest, never
+/// fresh semver (fail-closed on mismatch — spec 18 S63).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PackageLock {
+    /// The locked runtime pair; absent on packages pressed before the
+    /// composition spectrum (and on suites, whose per-entry refs ride
+    /// `entries[].runtime_ref` unchanged).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<LockedRuntime>,
+    /// Every resolved payload slice, in mount order: the app payload
+    /// first, then its dependency closure.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub slices: Vec<LockedSlice>,
+}
+
+impl PackageLock {
+    /// The slice named `name`, when the lock carries one.
+    pub fn slice(&self, name: &str) -> Option<&LockedSlice> {
+        self.slices.iter().find(|s| s.name == name)
+    }
+
+    /// The trailer slots the lock claims (the carried runtime pair plus
+    /// every carried slice) — the set the bootstrap must never hand to
+    /// the driver as payload mounts.
+    pub fn claimed_slots(&self) -> Vec<u32> {
+        let mut out = Vec::new();
+        if let Some(runtime) = &self.runtime {
+            for artifact in [&runtime.exe, &runtime.image, &runtime.dll]
+                .into_iter()
+                .flatten()
+            {
+                out.push(artifact.slot);
+            }
+        }
+        for slice in &self.slices {
+            if let Some(slot) = slice.slot {
+                out.push(slot);
+            }
+        }
+        out
+    }
+
+    /// The shared slices (carry: false) in declaration order.
+    pub fn shared_slices(&self) -> impl Iterator<Item = &LockedSlice> {
+        self.slices.iter().filter(|s| !s.carry)
+    }
+
+    fn validate(&self) -> Result<(), PackageManifestError> {
+        if let Some(runtime) = &self.runtime {
+            check_non_empty(&runtime.version, "lock.runtime.version must not be empty")?;
+            match runtime.carry {
+                true => {
+                    if runtime.exe.is_none() || runtime.image.is_none() {
+                        return Err(PackageManifestError::Invalid(
+                            "lock.runtime with carry: true requires the exe and image slots (the two-slot carried pair, spec 19 §6.1)",
+                        ));
+                    }
+                }
+                false => {
+                    if runtime.exe.is_some() || runtime.image.is_some() || runtime.dll.is_some() {
+                        return Err(PackageManifestError::Invalid(
+                            "lock.runtime with carry: false declares no slots — a shared runtime resolves through the ordinary spec 05 §5 chain",
+                        ));
+                    }
+                }
+            }
+            for artifact in [&runtime.exe, &runtime.image, &runtime.dll]
+                .into_iter()
+                .flatten()
+            {
+                if artifact.slot >= TPKG_MAX_SLOTS {
+                    return Err(PackageManifestError::Invalid(
+                        "lock.runtime slot is outside the container's slot capacity (0..TPKG_MAX_SLOTS-1)",
+                    ));
+                }
+                artifact
+                    .sha256
+                    .validate("lock.runtime sha256 pins must be 64 lowercase hex")?;
+            }
+        }
+        let mut names: Vec<&str> = Vec::new();
+        for slice in &self.slices {
+            check_non_empty(&slice.name, "lock.slices[].name must not be empty")?;
+            check_non_empty(&slice.version, "lock.slices[].version must not be empty")?;
+            names.push(slice.name.as_str());
+            slice
+                .sha256
+                .validate("lock.slices[].sha256 pins must be 64 lowercase hex")?;
+            match (slice.carry, slice.slot) {
+                (true, Some(slot)) => {
+                    if slot >= TPKG_MAX_SLOTS {
+                        return Err(PackageManifestError::Invalid(
+                            "lock.slices[].slot is outside the container's slot capacity (0..TPKG_MAX_SLOTS-1)",
+                        ));
+                    }
+                }
+                (true, None) => {
+                    return Err(PackageManifestError::Invalid(
+                        "lock.slices[] with carry: true requires its trailer slot",
+                    ));
+                }
+                (false, Some(_)) => {
+                    return Err(PackageManifestError::Invalid(
+                        "lock.slices[] with carry: false declares no slot — a shared slice rides the machine cache",
+                    ));
+                }
+                (false, None) => {
+                    if slice.source.as_deref().map_or(true, |s| s.is_empty()) {
+                        return Err(PackageManifestError::Invalid(
+                            "lock.slices[] with carry: false requires its fetch coordinates (source:)",
+                        ));
+                    }
+                }
+            }
+            if let Some(mount) = &slice.mount {
+                if mount.is_empty() || !mount.starts_with('/') {
+                    return Err(PackageManifestError::Invalid(
+                        "lock.slices[].mount must be a declared (POSIX-absolute) mount point",
+                    ));
+                }
+            }
+        }
+        names.sort_unstable();
+        if names.windows(2).any(|w| w[0] == w[1]) {
+            return Err(PackageManifestError::Invalid(
+                "duplicate lock.slices[].name (one lock row per slice)",
+            ));
+        }
+        let mut slots = self.claimed_slots();
+        slots.sort_unstable();
+        if slots.windows(2).any(|w| w[0] == w[1]) {
+            return Err(PackageManifestError::Invalid(
+                "two locked artifacts claim the same trailer slot",
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// The L2 package manifest (spec 03 §6).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PackageManifest {
@@ -223,6 +510,10 @@ pub struct PackageManifest {
     /// exclusive.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mounts: Vec<PackageMount>,
+    /// The press-time composition lock (spec 23 §4/§13). Absent on
+    /// pre-spectrum packages — they resolve exactly as before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lock: Option<PackageLock>,
 }
 
 impl PackageManifest {
@@ -273,10 +564,28 @@ impl PackageManifest {
                 &entry.runtime_ref,
                 "entries[].runtime_ref must not be empty",
             )?;
-            if entry.slot >= TPKG_MAX_SLOTS {
-                return Err(PackageManifestError::Invalid(
-                    "entries[].slot is outside the container's slot capacity (0..TPKG_MAX_SLOTS-1)",
-                ));
+            match entry.slot {
+                Some(slot) if slot >= TPKG_MAX_SLOTS => {
+                    return Err(PackageManifestError::Invalid(
+                        "entries[].slot is outside the container's slot capacity (0..TPKG_MAX_SLOTS-1)",
+                    ));
+                }
+                // A slot-less entry is the pointer-package form (spec 23
+                // §13): the lock must carry the entry's slice as shared,
+                // under the entry's own name.
+                None => {
+                    let backed = self
+                        .lock
+                        .as_ref()
+                        .and_then(|lock| lock.slice(&entry.name))
+                        .is_some_and(|slice| !slice.carry);
+                    if !backed {
+                        return Err(PackageManifestError::Invalid(
+                            "entries[].slot is absent (a shared entry slice) but no lock slice with the entry's name and carry: false backs it",
+                        ));
+                    }
+                }
+                _ => {}
             }
         }
         let mut names: Vec<&str> = self.entries.iter().map(|e| e.name.as_str()).collect();
@@ -344,6 +653,26 @@ impl PackageManifest {
                 ));
             }
         }
+        if let Some(lock) = &self.lock {
+            lock.validate()?;
+            // Entry ↔ slice consistency: an entry whose name a lock slice
+            // carries must agree on the physical placement — carried slice
+            // slot == entry slot, shared slice ⇔ slot-less entry.
+            for entry in &self.entries {
+                let Some(slice) = lock.slice(&entry.name) else {
+                    continue;
+                };
+                match (slice.carry, slice.slot, entry.slot) {
+                    (true, Some(slice_slot), Some(entry_slot)) if slice_slot == entry_slot => {}
+                    (false, None, None) => {}
+                    _ => {
+                        return Err(PackageManifestError::Invalid(
+                            "entries[] and the lock disagree on the slice's placement (carry verdict / slot)",
+                        ));
+                    }
+                }
+            }
+        }
         if let Some(jail) = &self.jail {
             jail.validate().map_err(PackageManifestError::Jail)?;
         }
@@ -369,13 +698,14 @@ mod tests {
             },
             entries: vec![PackageEntry {
                 name: "metanorma".to_string(),
-                slot: 0,
+                slot: Some(0),
                 entrypoint: "metanorma".to_string(),
                 runtime_ref: "ruby@3.4.2;tebako=0.15.9".to_string(),
             }],
             jail: None,
             env: BTreeMap::new(),
             mounts: Vec::new(),
+            lock: None,
         }
     }
 
@@ -409,7 +739,11 @@ mod tests {
         assert!(bad(&m));
 
         let mut m = minimal();
-        m.entries[0].slot = TPKG_MAX_SLOTS;
+        m.entries[0].slot = Some(TPKG_MAX_SLOTS);
+        assert!(bad(&m));
+
+        let mut m = minimal();
+        m.entries[0].slot = None; // a shared entry slice with no lock backing
         assert!(bad(&m));
 
         let mut m = minimal();
@@ -422,7 +756,7 @@ mod tests {
 
         let mut m = minimal();
         m.entries.push(m.entries[0].clone()); // duplicate name
-        m.entries[1].slot = 1;
+        m.entries[1].slot = Some(1);
         assert!(bad(&m));
 
         let mut m = minimal();
@@ -586,5 +920,191 @@ mod tests {
         assert!(bad(
             "  - {slot: 0, point: /x, mode: union, precedence: first}\n"
         ));
+    }
+
+    // ---------------------------------------------------------------
+    // The press-time lock (spec 23 §4/§13)
+    // ---------------------------------------------------------------
+
+    fn sha(byte: char) -> String {
+        byte.to_string().repeat(64)
+    }
+
+    fn carried_slice() -> LockedSlice {
+        LockedSlice {
+            name: "metanorma".to_string(),
+            version: "2.1.4".to_string(),
+            carry: true,
+            slot: Some(0),
+            mount: Some("/__tfs__".to_string()),
+            sha256: DigestPin::One(sha('a')),
+            source: Some(
+                "tfs:github:tebako-packages/metanorma-feedstock:2.1.4#metanorma-2.1.4.tfs"
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn shared_slice() -> LockedSlice {
+        LockedSlice {
+            name: "openjdk".to_string(),
+            version: "21.0.5".to_string(),
+            carry: false,
+            slot: None,
+            mount: Some("/opt/openjdk".to_string()),
+            sha256: DigestPin::PerTriplet(BTreeMap::from([(
+                "macos-arm64".to_string(),
+                sha('b'),
+            )])),
+            source: Some(
+                "tfs:github:tebako-packages/openjdk-feedstock:21.0.5#openjdk-21.0.5-macos-arm64.tfs"
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn carried_lock() -> PackageLock {
+        PackageLock {
+            runtime: Some(LockedRuntime {
+                version: "3.3.7".to_string(),
+                carry: true,
+                exe: Some(LockedArtifact {
+                    slot: 1,
+                    sha256: DigestPin::PerTriplet(BTreeMap::from([(
+                        "macos-arm64".to_string(),
+                        sha('c'),
+                    )])),
+                }),
+                image: Some(LockedArtifact {
+                    slot: 2,
+                    sha256: DigestPin::PerTriplet(BTreeMap::from([(
+                        "macos-arm64".to_string(),
+                        sha('d'),
+                    )])),
+                }),
+                dll: None,
+            }),
+            slices: vec![carried_slice(), shared_slice()],
+        }
+    }
+
+    #[test]
+    fn lock_round_trips_and_stays_absent_when_none() {
+        // absent lock: the v1 shape, byte-stable
+        let m = minimal();
+        let text = m.to_yaml().unwrap();
+        assert!(!text.contains("lock"), "{text}");
+
+        let mut m = minimal();
+        m.lock = Some(carried_lock());
+        let text = m.to_yaml().unwrap();
+        let back = PackageManifest::from_yaml(&text).unwrap();
+        assert_eq!(back, m);
+    }
+
+    #[test]
+    fn lock_validation_is_fail_closed() {
+        let bad = |lock: PackageLock| {
+            let mut m = minimal();
+            m.lock = Some(lock);
+            m.validate().is_err()
+        };
+
+        // carried runtime without the pair slots
+        let mut lock = carried_lock();
+        lock.runtime.as_mut().unwrap().image = None;
+        assert!(bad(lock));
+
+        // shared runtime carrying slots
+        let mut lock = carried_lock();
+        let rt = lock.runtime.as_mut().unwrap();
+        rt.carry = false;
+        assert!(bad(lock));
+
+        // carried slice without a slot
+        let mut lock = carried_lock();
+        lock.slices[0].slot = None;
+        assert!(bad(lock));
+
+        // shared slice with a slot
+        let mut lock = carried_lock();
+        lock.slices[1].slot = Some(3);
+        assert!(bad(lock));
+
+        // shared slice without fetch coordinates
+        let mut lock = carried_lock();
+        lock.slices[1].source = None;
+        assert!(bad(lock));
+
+        // duplicate slice names
+        let mut lock = carried_lock();
+        lock.slices.push(lock.slices[1].clone());
+        assert!(bad(lock));
+
+        // two artifacts claiming one slot (the app slice and the exe)
+        let mut lock = carried_lock();
+        lock.runtime.as_mut().unwrap().exe.as_mut().unwrap().slot = 0;
+        assert!(bad(lock));
+
+        // slot outside the container's capacity
+        let mut lock = carried_lock();
+        lock.runtime.as_mut().unwrap().image.as_mut().unwrap().slot = TPKG_MAX_SLOTS;
+        assert!(bad(lock));
+
+        // a malformed digest
+        let mut lock = carried_lock();
+        lock.slices[0].sha256 = DigestPin::One("not-hex".to_string());
+        assert!(bad(lock));
+
+        // an unknown triplet key in the digest map
+        let mut lock = carried_lock();
+        lock.slices[1].sha256 =
+            DigestPin::PerTriplet(BTreeMap::from([("plan9-mips".to_string(), sha('b'))]));
+        assert!(bad(lock));
+
+        // a relative mount point
+        let mut lock = carried_lock();
+        lock.slices[0].mount = Some("relative".to_string());
+        assert!(bad(lock));
+    }
+
+    #[test]
+    fn lock_entry_slice_agreement_is_checked() {
+        // entry slot and the carried slice's slot must agree
+        let mut m = minimal();
+        m.lock = Some(carried_lock());
+        m.entries[0].slot = Some(3);
+        assert!(m.validate().is_err());
+
+        // a slot-less entry backed by a shared lock slice of the same name
+        let mut m = minimal();
+        m.entries[0].name = "openjdk".to_string();
+        m.entries[0].slot = None;
+        m.lock = Some(PackageLock {
+            runtime: None,
+            slices: vec![shared_slice()],
+        });
+        m.validate().unwrap();
+
+        // ... but a CARRIED slice of the entry's name refuses the slot-less entry
+        let mut m = minimal();
+        m.entries[0].slot = None;
+        m.lock = Some(PackageLock {
+            runtime: None,
+            slices: vec![carried_slice()],
+        });
+        assert!(m.validate().is_err());
+    }
+
+    #[test]
+    fn digest_pin_host_lookup() {
+        let one = DigestPin::One(sha('a'));
+        assert_eq!(one.for_host(crate::Platform::Aarch64Macos), Some(sha('a').as_str()));
+        let map = DigestPin::PerTriplet(BTreeMap::from([("macos-arm64".to_string(), sha('b'))]));
+        assert_eq!(
+            map.for_host(crate::Platform::Aarch64Macos),
+            Some(sha('b').as_str())
+        );
+        assert_eq!(map.for_host(crate::Platform::X86_64LinuxGnu), None);
     }
 }

--- a/crates/tpkg/src/package.rs
+++ b/crates/tpkg/src/package.rs
@@ -300,6 +300,13 @@ pub struct LockedArtifact {
     /// The trailer slot carrying the bytes.
     pub slot: u32,
     pub sha256: DigestPin,
+    /// The PE install name (the windows dll-era facet only,
+    /// tebako-runtime-ruby#40): the DLL is staged next to the exe under
+    /// THIS name — the name the exe's imports reference — never the
+    /// release-asset spelling. Flowed from the release manifest's
+    /// `dll.install_as` at press; absent on every other artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_as: Option<String>,
 }
 
 /// The locked runtime (spec 23 §4): the concrete version, the carry
@@ -426,6 +433,16 @@ impl PackageLock {
                 artifact
                     .sha256
                     .validate("lock.runtime sha256 pins must be 64 lowercase hex")?;
+                if let Some(install_as) = &artifact.install_as {
+                    if install_as.is_empty()
+                        || install_as.contains('/')
+                        || install_as.contains('\\')
+                    {
+                        return Err(PackageManifestError::Invalid(
+                            "lock.runtime install_as must be a bare file name (the PE import name)",
+                        ));
+                    }
+                }
             }
         }
         let mut names: Vec<&str> = Vec::new();
@@ -974,6 +991,7 @@ mod tests {
                         "macos-arm64".to_string(),
                         sha('c'),
                     )])),
+                    install_as: None,
                 }),
                 image: Some(LockedArtifact {
                     slot: 2,
@@ -981,6 +999,7 @@ mod tests {
                         "macos-arm64".to_string(),
                         sha('d'),
                     )])),
+                    install_as: None,
                 }),
                 dll: None,
             }),

--- a/crates/tpkg/tests/compose.rs
+++ b/crates/tpkg/tests/compose.rs
@@ -1,0 +1,110 @@
+//! Golden-fixture tests for the D2 composition document (spec 23 §3/§13):
+//! the spec's example parses through the crate AND validates against the
+//! versioned JSON Schema `schema/tebako-compose-v1.schema.json` (the schema
+//! and the serde model are kept MECE with each other by this cross-check —
+//! same discipline as the payload and package manifests).
+
+use tpkg::*;
+
+fn schema_path() -> String {
+    format!(
+        "{}/../../schema/tebako-compose-v1.schema.json",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+/// The spec 23 §3 example (the shared-runtime preset with one carried and
+/// one shared slice, a universal platforms assertion, and the pointer
+/// form's entry selector).
+const SPEC_EXAMPLE: &str = "\
+version: 1
+preset: shared-runtime
+runtime:
+  name: ruby
+  requirement: \"~> 3.3\"
+  carry: false
+  platforms: [macos-arm64, linux-gnu-x86_64]
+slices:
+  - name: metanorma
+    requirement: \">= 2.1\"
+    carry: true
+  - ref: \"ourorg-templates@3\"
+    carry: false
+    platforms: universal
+entrypoint: mnconvert
+";
+
+/// YAML value -> JSON value (for the jsonschema cross-check).
+fn yaml_to_json(v: &serde_yml::Value) -> serde_json::Value {
+    match v {
+        serde_yml::Value::Null => serde_json::Value::Null,
+        serde_yml::Value::Bool(b) => serde_json::Value::Bool(*b),
+        serde_yml::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_json::Value::from(i)
+            } else if let Some(u) = n.as_u64() {
+                serde_json::Value::from(u)
+            } else {
+                serde_json::Value::from(n.as_f64().unwrap())
+            }
+        }
+        serde_yml::Value::String(s) => serde_json::Value::String(s.clone()),
+        serde_yml::Value::Sequence(seq) => {
+            serde_json::Value::Array(seq.iter().map(yaml_to_json).collect())
+        }
+        serde_yml::Value::Mapping(map) => {
+            let mut out = serde_json::Map::new();
+            for (k, v) in map {
+                let serde_yml::Value::String(key) = k else {
+                    panic!("non-string mapping key {k:?}");
+                };
+                out.insert(key.clone(), yaml_to_json(v));
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_yml::Value::Tagged(tagged) => yaml_to_json(&tagged.value),
+    }
+}
+
+#[test]
+fn spec_example_validates_against_the_json_schema() {
+    let schema: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(schema_path()).expect("read schema"))
+            .expect("schema json");
+    let validator = jsonschema::validator_for(&schema).expect("the schema itself compiles");
+    let value: serde_yml::Value = serde_yml::from_str(SPEC_EXAMPLE).expect("yaml parses");
+    validator
+        .validate(&yaml_to_json(&value))
+        .unwrap_or_else(|e| panic!("the spec 23 example against the JSON schema: {e}"));
+}
+
+#[test]
+fn the_schema_refuses_the_phase_r_keys_too() {
+    let schema: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(schema_path()).expect("read schema"))
+            .expect("schema json");
+    let validator = jsonschema::validator_for(&schema).expect("the schema itself compiles");
+    for key in ["policy", "mounts", "needs"] {
+        let doc = format!("version: 1\nruntime: {{ref: \"ruby@~> 3.3\"}}\n{key}: null\n");
+        let value: serde_yml::Value = serde_yml::from_str(&doc).expect("yaml parses");
+        assert!(
+            validator.validate(&yaml_to_json(&value)).is_err(),
+            "the schema must refuse the Phase-R key {key:?}"
+        );
+    }
+}
+
+#[test]
+fn schema_and_crate_agree_on_the_example() {
+    let (doc, warnings) = parse_compose(SPEC_EXAMPLE).expect("the crate parses the example");
+    assert!(warnings.is_empty());
+    assert_eq!(doc.preset, ComposePreset::SharedRuntime);
+    assert_eq!(
+        doc.runtime.platforms,
+        Some(Platforms::Triplets(vec![
+            Platform::Aarch64Macos,
+            Platform::X86_64LinuxGnu
+        ]))
+    );
+    assert_eq!(doc.slices[1].platforms, Some(Platforms::Universal));
+}

--- a/crates/tpkg/tests/fixtures/manifests/package-lock.yaml
+++ b/crates/tpkg/tests/fixtures/manifests/package-lock.yaml
@@ -1,0 +1,43 @@
+# The spec 23 §4/§13 lock shape (the composition spectrum): a
+# self-contained package — the carried app slice (slot 0), the two-slot
+# carried runtime pair (slots 1+2, spec 19 §6.1), a shared toolkit slice
+# resolved at run time by locked digest, and a pointer entry (slot-less)
+# backed by that shared slice under its own name.
+schema_version: 1
+package:
+  name: mnconvert
+  version: 2.1.0
+  producer: { tool: tebako-cli, tool_version: 0.17.0 }
+  created: 2026-08-25T00:00:00Z
+entries:
+  - name: mnconvert
+    slot: 0
+    entrypoint: mnconvert
+    runtime_ref: ruby@3.4.5;tebako=0.17.0;image
+  - name: mn2pdf
+    entrypoint: mn2pdf
+    runtime_ref: ruby@3.4.5;tebako=0.17.0;image
+mounts:
+  - { slot: 0, point: /__tfs__, mode: union, precedence: after-env }
+lock:
+  runtime:
+    version: 3.4.5
+    carry: true
+    exe: { slot: 1, sha256: "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a" }
+    image: { slot: 2, sha256: "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b" }
+  slices:
+    - name: mnconvert
+      version: 2.1.0
+      carry: true
+      slot: 0
+      mount: /__tfs__
+      sha256: "1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c"
+      source: https://github.com/tebako-packages/metanorma-feedstock/releases/download/mnconvert-v2.1.0/mnconvert-2.1.0-universal.tfs
+    - name: mn2pdf
+      version: 1.9.2
+      carry: false
+      mount: /__tfs__/mnt/mn2pdf
+      sha256:
+        macos-arm64: "2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d"
+        linux-gnu-x86_64: "3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e"
+      source: gh:tebako-packages/mn2pdf-feedstock@mn2pdf-v1.9.2

--- a/crates/tpkg/tests/package.rs
+++ b/crates/tpkg/tests/package.rs
@@ -144,7 +144,10 @@ fn lock_fixture_parses_validates_and_round_trips() {
         Some("2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d")
     );
     assert_eq!(
-        lock.slices[0].sha256.for_host(Platform::X86_64WindowsUcrt).map(str::len),
+        lock.slices[0]
+            .sha256
+            .for_host(Platform::X86_64WindowsUcrt)
+            .map(str::len),
         Some(64)
     );
     assert_eq!(lock.claimed_slots(), vec![1, 2, 0]);

--- a/crates/tpkg/tests/package.rs
+++ b/crates/tpkg/tests/package.rs
@@ -93,11 +93,11 @@ fn fixture_shape_is_the_spec_example() {
     assert_eq!(m.package.producer.tool, "tebako-cli");
     assert_eq!(m.entries.len(), 2);
     assert_eq!(m.entries[0].name, "metanorma");
-    assert_eq!(m.entries[0].slot, 0);
+    assert_eq!(m.entries[0].slot, Some(0));
     assert_eq!(m.entries[0].entrypoint, "metanorma");
     assert_eq!(m.entries[0].runtime_ref, "ruby@3.4.2;tebako=0.15.9");
     assert_eq!(m.entries[1].name, "mn2pdf");
-    assert_eq!(m.entries[1].slot, 1);
+    assert_eq!(m.entries[1].slot, Some(1));
     assert_eq!(m.entries[1].runtime_ref, "ruby@3.3.7;tebako=0.15.9");
     assert!(m.jail.is_some());
     assert_eq!(
@@ -116,4 +116,50 @@ fn per_entry_runtime_refs_exceed_the_trailer_field_limit() {
     m.entries[0].runtime_ref = long_ref.clone();
     let back = PackageManifest::from_yaml(&m.to_yaml().unwrap()).unwrap();
     assert_eq!(back.entries[0].runtime_ref, long_ref);
+}
+
+#[test]
+fn lock_fixture_parses_validates_and_round_trips() {
+    let text = read(&fixture_path("package-lock"));
+    let m = PackageManifest::from_yaml(&text).unwrap_or_else(|e| panic!("fixture: {e}"));
+    assert_eq!(m.entries[0].slot, Some(0));
+    assert_eq!(m.entries[1].slot, None); // the pointer entry
+    let lock = m.lock.as_ref().expect("the lock block");
+    let runtime = lock.runtime.as_ref().expect("the locked runtime");
+    assert!(runtime.carry);
+    assert_eq!(runtime.exe.as_ref().unwrap().slot, 1);
+    assert_eq!(runtime.image.as_ref().unwrap().slot, 2);
+    assert!(runtime.dll.is_none());
+    assert_eq!(lock.slices.len(), 2);
+    // Mount order: the app payload first, then the closure.
+    assert!(lock.slices[0].carry);
+    assert_eq!(lock.slices[0].slot, Some(0));
+    assert!(!lock.slices[1].carry);
+    assert_eq!(lock.slices[1].slot, None);
+    assert!(lock.slices[1].source.is_some());
+    // The per-triplet pin answers by host; the single pin regardless.
+    let host = Platform::Aarch64Macos;
+    assert_eq!(
+        lock.slices[1].sha256.for_host(host),
+        Some("2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d")
+    );
+    assert_eq!(
+        lock.slices[0].sha256.for_host(Platform::X86_64WindowsUcrt).map(str::len),
+        Some(64)
+    );
+    assert_eq!(lock.claimed_slots(), vec![1, 2, 0]);
+    let back = PackageManifest::from_yaml(&m.to_yaml().unwrap()).unwrap();
+    assert_eq!(back, m);
+}
+
+#[test]
+fn lock_fixture_validates_against_the_json_schema() {
+    let schema: serde_json::Value =
+        serde_json::from_str(&read(&schema_path())).expect("schema json");
+    let validator = jsonschema::validator_for(&schema).expect("the schema itself compiles");
+    let value: serde_yml::Value =
+        serde_yml::from_str(&read(&fixture_path("package-lock"))).expect("yaml parses");
+    validator
+        .validate(&yaml_to_json(&value))
+        .unwrap_or_else(|e| panic!("lock fixture against the JSON schema: {e}"));
 }

--- a/docs/spec/02-tpkg-wire-format.md
+++ b/docs/spec/02-tpkg-wire-format.md
@@ -31,6 +31,15 @@ container itself stays byte-identical either way.
 
 `TPKG_MAGIC_PREFIX_LEN` = 4 (`"TEBA"`) discriminates absent vs corrupt.
 
+Bit0's *name* is the only deprecated thing about it (locked 2026-08-25,
+tebako#460): read **LEAN = 1** as "the package does not carry its
+runtime pair" and LEAN = 0 as "the runtime pair is carried as ordinary
+slots" — the *shared-runtime* and *self-contained* presets of spec 23
+§13.2 (whose `lean`/`fat` aliases exist only so older documents stay
+readable). The BIT itself stays load-bearing exactly as spec 18 S4
+requires: flags are never skipped, and an unknown set bit is a named
+refusal.
+
 ## 3. Slot record — 280 bytes
 
 | offset | size | field |
@@ -60,9 +69,13 @@ everything except the signature and its length field.
 ## 5. The installability flag (bit2 `NO_INSTALL`; TODO.v2-1/12)
 
 A run is a run — a plain execution never writes payload slices into the
-local store. Installation is the EXPLICIT verb (`tebako install <path>`;
-the bootstrap's `--tebako-install` refuses or guides, spec 06 §4 exit
-76). `NO_INSTALL` marks a publisher-frozen package: it RUNS standalone
+local store, with exactly one scoped exception: the lazy seed of spec 05
+§4 (a self-contained package MAY seed the cache with the artifacts it
+carries — best-effort, never blocking the run). `NO_INSTALL` packages
+never seed. Installation is otherwise the EXPLICIT verb
+(`tebako install <path>`; the bootstrap's `--tebako-install` refuses or
+guides, spec 06 §4 exit 76). `NO_INSTALL` marks a publisher-frozen
+package: it RUNS standalone
 but every install attempt is refused with a named error. Absence means
 installable-on-request, including packages pressed before the verb
 existed — pass-through like every flag.
@@ -75,7 +88,10 @@ Whether a slot is a runtime, and which payload carries the entrypoint, are
 the format axis. The v1 `format_id = 4 (TPKG_FORMAT_RUNTIME)` marks the fat
 runtime slot so v1 loaders skip handing it over as a mount; it is a role
 riding in the format field, kept only for backward compatibility. The
-cleanup path: slot role moves to slot flags / package manifest, and
+two-slot era makes the wart obsolete in practice: a self-contained
+package carries its runtime as ordinary exe + env-image slots
+(spec 19 §6.1), and presses never emit format 4 anymore. The cleanup
+path: slot role moves to slot flags / package manifest, and
 `format_id` returns to pure image-format semantics. New semantics must
 never again be smuggled into the format axis.
 

--- a/docs/spec/04-references-and-registry.md
+++ b/docs/spec/04-references-and-registry.md
@@ -102,6 +102,13 @@ payloads:
 - **Host-triplet selection happens HERE, declaratively**: the dispatcher
   reads `platforms[host_triplet].artifact` (or `universal`), fetches THAT
   artifact from the named release. Never adapter-side guessing.
+- **Concrete rows only (locked 2026-08-25, tebako#460).** A version
+  carries a `universal:` row OR per-triplet rows — never patterns
+  (`linux-*-*` is rejected at validation), never both. Identical bytes
+  under multiple rows dedup naturally (content-addressed cache). A
+  composition's `platforms:` assertion (spec 23 §13.3) CONSTRAINS the
+  mirrored coverage — checked fail-closed against it — and NEVER
+  extends it.
 - `tebako add-registry <ref>` registers one; shipped config has ZERO
   registries (explicit only — spec 16).
 - Install = resolve the registry → select the host entry → download →

--- a/docs/spec/05-resolution-and-cache.md
+++ b/docs/spec/05-resolution-and-cache.md
@@ -92,6 +92,25 @@ installs, pre-identity manifests).
   content is never overwritten (loud warning + journal). Shims link only
   via the explicit `--shims` (spec 07). `TPKG_FLAG_NO_INSTALL` packages
   refuse (spec 02 §5).
+- **Lazy seeding (the scoped exception, locked 2026-08-25, tebako#460):**
+  a package that CARRIES artifacts (the self-contained preset — spec 23
+  §13) MAY seed the machine cache with them at run time: the runtime
+  pair (exe + env image) and each carried payload slice, so later
+  packages share them. The exception is exactly this wide and no wider:
+  - best-effort — a seed that cannot complete NEVER blocks or fails the
+    run; the carried artifacts keep serving from the package;
+  - tmp + rename under the entry lock — a partial seed is invisible and
+    the next run re-seeds;
+  - idempotent — a same-sha entry skips;
+  - trust anchors exactly as `tebako install`: trailer slot digests for
+    signed (v2) packages, the computed digest for unsigned ones — the
+    run's own enforcement strength, never upgraded;
+  - journaled (`event=lazy-seed`), and shown by `tebako cache list`
+    with the seeding package as origin;
+  - `TEBAKO_OFFLINE=1` does not block seeding (no network is involved);
+  - `TPKG_FLAG_NO_INSTALL` packages never seed (spec 02 §5).
+  The shared-runtime preset needs no exception: its artifacts arrive
+  through the ordinary resolve-download-verify-install path.
 
 ## 5. Resolution chains
 
@@ -100,11 +119,20 @@ installs, pre-identity manifests).
 download) → else download the newest compatible from the runtime releases
 → verify → cache. Swapping runtimes never touches the payload.
 
-**Runtime for a lean package (first run):** trailer runtime_ref → cache
-hit → use; miss → download from the index (manifest.json primary,
-SHA256SUMS fallback) → sha256-verify → flock'd atomic install. Fat: the
-runtime payload slot is extracted from the package itself and verified
-against `;sha256=`.
+**Runtime for a shared-runtime package (first run):** trailer
+runtime_ref → cache hit → use; miss → download from the index
+(manifest.json primary, SHA256SUMS fallback) → sha256-verify → flock'd
+atomic install. (Preset names per spec 23 §13.2: *shared-runtime* is
+the default preset and the successor of the deprecated name *lean*;
+*self-contained* succeeds *fat*.) Self-contained: the runtime pair is
+carried as two package slots — the interpreter exe and the env image
+(spec 19 §6.1): the exe stages into the runtime cache, the env image
+mounts from the package file through the ordinary
+`<self>:<slot>:<mount>` grammar, both verified against the trailer slot
+digests, and both seed the cache per §4's lazy-seed rule. (Pre-#458
+packages carry the runtime as one legacy `format_id = 4` slot, extracted
+and verified against `;sha256=` — readers keep serving that form;
+presses never emit it.)
 
 **Compatibility model:** pure-language payloads take a range (`>= 3.3,
 < 5.0`) — any newer runtime works; native-extension payloads lock to the

--- a/docs/spec/17-runtime-driver-contract.md
+++ b/docs/spec/17-runtime-driver-contract.md
@@ -70,6 +70,17 @@ exact contract (roadmap 22's "add a language" playbook).
   refuse a union package loudly (EEXIST), never silently. Payloads
   handed over without a package manifest (shim dispatch, bare images)
   are always exclusive.
+- **Carried and shared payloads are indistinguishable on this wire**
+  (spec 23 §13, additive 2026-08-25): a SHARED slice the loader resolved
+  into the machine cache is handed over as an ordinary
+  `<image-path>:-:<mount>` triple — a bare cache file, mounted whole; a
+  CARRIED slice is the `<self>:<slot>:<mount>` form. Mount order,
+  longest-prefix dispatch, union/exclusive modes, and
+  unmount-all-on-failure apply identically — the driver neither knows
+  nor cares where the bytes physically live. Resolution is loader-side
+  (spec 05 §5): an unresolvable shared slice is the loader's named error
+  BEFORE the handoff, never a driver case; and resolution follows the
+  press-time lock (spec 23 §4) by locked digest, never fresh semver.
 - `--tebako-entry` separates loader args from user args; `argv0` is the
   entrypoint inside the mounted tree, resolved against the FIRST
   `--tebako-image` mount (the app payload) — or against the runtime root

--- a/docs/spec/18-contract-set.md
+++ b/docs/spec/18-contract-set.md
@@ -372,6 +372,14 @@ behavior. (S-numbers are the e2e/test ids to implement.)
   resolution filters, then named error if nothing remains.
 - **S37** data payload version requiring newer registry schema → C8's
   refusal.
+- **S62** shared slice unresolvable at run time (uncached + offline, or
+  no compatible artifact) → the loader's named resolution error BEFORE
+  the handoff; the boot never starts (carried slices have no such case).
+- **S63** locked-digest mismatch on a shared slice (registry bytes ≠ the
+  press-time lock) → fail-closed trust refusal (exit 70 class): the lock
+  is the pin, never fresh semver (spec 23 §4/§13).
+- **S64** crash mid-lazy-seed → tmp+rename keeps the partial seed
+  invisible; the run is unaffected; the next run re-seeds (spec 05 §4).
 
 ### 5.7 Press × inputs
 - **S38** `TEBAKO_BOOTSTRAP` override with an era-1 bootstrap binary →
@@ -478,7 +486,8 @@ tebako publish
 | 75 | runtime contract mismatch / pre-era runtime | loader, pre-download |
 | 77 | package/payload contract-era mismatch (either direction) | any trailer/manifest reader |
 | 78 | env image layout mismatch | driver |
-| 79 | reserved: ABI mismatch (C11 provides_abi, C20 FFI) | binder |
+| 79 | payload check FAIL aggregate (`EX_TEBAKO_CHECK`, spec 26 §2) | tebako check |
+| — | ABI mismatch (C11 provides_abi, C20 FFI): named refusal, both versions printed; exit code unallocated — pinned at implementation | binder |
 | 73 | jail malformed | driver |
 | 132 | pre-era/corrupt source tarball | runtime factory |
 

--- a/docs/spec/19-bootstrap-distribution.md
+++ b/docs/spec/19-bootstrap-distribution.md
@@ -187,18 +187,34 @@ change. When a new bootstrap ships, old packages keep their old
 bootstrap — that is by design (a package is a reproducible artifact, not
 a living install).
 
-If you want the new bootstrap on an existing package, there are two
-honest paths:
+If you want the new bootstrap on an existing package there is one honest
+path: **re-press** from the payload. The payload images are the durable
+part; stitching is cheap. The `tebako-pkg set-runtime` in-place region
+swap is retired: with the runtime carried as ordinary package slots
+(§6.1) a region swap would have to re-layout the whole file — which is
+re-pressing by another name. The decision stays explicit, and
+`tebako inspect <package>` always tells you which bootstrap era and
+version a package carries.
 
-- **Re-press** from the payload (the recommended path — the payload
-  images are the durable part; stitching is cheap).
-- **`tebako-pkg set-runtime`**, which swaps only the bootstrap region of
-  the package in place. The swap **verifies the contract card first**: a
-  new bootstrap that would refuse the package (era mismatch) is rejected
-  at swap time, not at the user's run time.
+### 6.1 The carried runtime: two ordinary slots (tebako#458)
 
-Either way, the decision is explicit, and `tebako inspect <package>`
-always tells you which bootstrap era and version a package carries.
+A self-contained package (spec 23 §13.2) carries the runtime as TWO
+ordinary trailer slots: the interpreter exe and the env image — never
+the legacy single `format_id = 4` runtime slot (spec 02 §6). At first
+run the bootstrap:
+
+1. stages the exe slot into the runtime cache — tmp + rename under the
+   entry lock, verified against the trailer slot digest (signed v2) or
+   the computed digest (unsigned), exactly the lazy-seed rule of
+   spec 05 §4;
+2. hands the env-image slot to the driver through the ordinary
+   `<self>:<slot>:<mount>` grammar (spec 17 §1) — embedding changes byte
+   placement, never semantics.
+
+The staged exe IS the cache entry: a later shared-runtime package
+resolving the same runtime version finds it already cached — the seed
+converges the two presets onto one cache. The legacy single-slot form
+keeps READING as before; presses never emit it.
 
 ## 7. The contract card inside every bootstrap
 

--- a/docs/spec/23-declarative-composition.md
+++ b/docs/spec/23-declarative-composition.md
@@ -7,6 +7,10 @@ layer (`TEBAKO_JAIL=record`, `tfs needs --from-journal`, `tfs exec
 --compose` — tfs crate + tfs-cli); the D1–D5 manifest/shim/press wiring
 is Phase-R. Dogfooded 2026-08-14: a JVM boot recorded, drafted, and
 replayed under deny with zero hand edits and zero unexpected denials.
+**Amended 2026-08-25 (owner-locked, tebako#460): §13 — the composition
+spectrum: per-slice `carry`, the `self-contained`/`shared-runtime`
+presets, and the `platforms:` coverage assertion. PLANNED; lands with
+the implementation PR (spec 14 order).**
 
 A tebako run is a composition of one runtime (exe + env image) and N
 payload slices, executed under one host-access policy. This spec makes
@@ -111,14 +115,26 @@ the cwd (evolving `.tebako-tools.yaml`; version pins ride here as
 
 ```yaml
 version: 1
+preset: shared-runtime        # self-contained | shared-runtime (§13);
+                              # DEFAULT shared-runtime; presets set carry
+                              # defaults, per-slice carry: overrides them
 runtime:                      # the runtime slice reference + requirement
-  name: ruby
+  name: ruby                  # … or the shorthand: ref: "ruby@~> 3.3"
   requirement: "~> 3.3"
+  carry: false                # §13 — share the runtime (machine cache);
+                              # true = the two-slot carried shape (spec 19)
+  platforms: [macos-arm64, linux-gnu-x86_64]   # OPTIONAL coverage
+                              # ASSERTION (§13.3): narrows, never extends
 slices:                       # executable + data payload slices
-  - name: metanorma
+  - name: metanorma           # … or ref: "metanorma@>= 2.1"
     requirement: ">= 2.1"
+    carry: true               # §13 — bytes ride in the package
   - name: openjdk
     requirement: "21"
+    carry: true
+  - ref: "ourorg-templates@3"
+    carry: false              # resolved per machine/org at first run
+    platforms: universal      # assertion: fail at press if not universal
 entrypoint: mnconvert         # which declared entrypoint runs
 policy: deny                  # deny (DEFAULT here) | open — see §5
 mounts:                       # operator bind-mounts (docker -v)
@@ -130,11 +146,25 @@ needs:                        # composition-level additions, D1 grammar
     - { path: "$HOME/.fontist", access: rw, why: "fontist cache" }
 ```
 
+`ref:` is the shorthand spelling of `name:` + `requirement:` —
+`name@constraint` where the constraint is the requirement grammar; one
+semantics, two spellings (the expanded form wins when both are present —
+a conflict is a named validation error). `carry:` and `platforms:` are
+the §13 axes; both are OPTIONAL, both default to the payload's own
+declaration and the preset.
+
 D5 (CLI) is this document written inline: `tebako run` accepts
 `--image/--slice name@req`, `--runtime`, `--entrypoint`, `--mount
 host:mount:ro|rw` (repeatable), `--policy open|deny`, `--need
 path:ro` (repeatable). Every flag maps 1:1 onto a D2 key; `-f` and
 flags compose, flags win (documented precedence, spec 07 amendment).
+Press gains the §13 surface: `--mode=self-contained|shared-runtime`
+(the preset; `lean|fat` accepted as deprecated aliases with a named
+warning, never silent), `--carry=all|none|<name,…>` and
+`--share=<name,…>` (per-slice overrides of the authored `carry:` —
+explicit invocation beats authored defaults, spec 07's precedence).
+`--carry=none` (even the app payload shared) is the extreme pointer
+package — legal, documented as requiring a registry at first run.
 
 ## 4. D3 — the press-baked union
 
@@ -146,6 +176,15 @@ run time, composes it with the operator env (spec 08 §4), runs the
 needs-check, and hands off. Lean packages additionally union the
 fetched runtime's release-manifest needs at resolve time — the same
 grammar, the same code path.
+
+**The lock (§13).** Press ALWAYS resolves the full composition closure
+at build time — the runtime ref plus every payload ref, transitively —
+and locks, per slice, into the L2 manifest: the concrete version, the
+`carry` verdict, and the digest pin — the single `universal` digest OR
+the per-target-triplet digest map (§13.3). What press tested is what
+runs, always: a shared slice resolves at run time BY THE LOCKED DIGEST,
+never by fresh semver (fail-closed on mismatch). Carry changes where
+the bytes come from, never WHAT runs.
 
 ## 5. The default policy — jail-safe by default
 
@@ -285,10 +324,10 @@ therefore swappable at run time:
   hit wins: `--compose <path>` (argv before `--`), then
   `TEBAKO_COMPOSE=<path>`, then a sidecar `<package>.tebako.yaml` next
   to the package file. The override REPLACES the baked
-  policy/mounts/needs/entrypoint (and, for lean packages, the slice
-  requirements); a fat package's slice SET is physical (trailer slots)
-  — an override naming a slice the trailer does not carry is a named
-  error, never a silent skip.
+  policy/mounts/needs/entrypoint and the requirements of SHARED slices;
+  the CARRIED slice set is physical (trailer slots) — an override naming
+  a carried slice the trailer does not carry is a named error, never a
+  silent skip (§13).
 - **Validation**: the override is the same D2 document with the same
   versioned schema; the bootstrap parses it (fail-closed, sysexits
   `EX_CONFIG`), resolves, needs-checks (§6.4), and only then execs.
@@ -375,3 +414,107 @@ and becomes relevant only when java is a package's ENTRY language.
 - The grammar is YAML with versioned JSON Schemas (invariant 6); the
   env serialization stays the spec 08 form (authored only — §6 step 5),
   extended by exactly one token: `record` as a policy default (§8).
+
+## 13. The composition spectrum — carried and shared (owner-locked 2026-08-25, tebako#460)
+
+**Status: PLANNED** — lands with the implementation PR (spec 14 order).
+Fat and lean are the same architecture: ONE composition pipeline whose
+only dial is which resolved slices are physically embedded as trailer
+slots. "Fat" meant *fully resolved with no hanging dependencies*;
+"lean" was a range. The locked words make the dial obvious.
+
+### 13.1 The two per-slice words
+
+Every resolved slice (the runtime pair or a payload) is either:
+
+- **carried** — its bytes ride inside the package (a trailer slot), or
+- **shared** — resolved at first run into the machine cache
+  (`~/.tebako`), verified against the press-time locked digest (§4's
+  lock), and shared with every other package that carries or needs the
+  same slice.
+
+Carried slices seed the same cache lazily (the scoped spec 05 §4
+exception: best-effort, tmp+rename, journaled, idempotent same-sha
+skip, never blocks or fails the run), so both paths converge — a
+self-contained download is a cache prime with a runnable side effect.
+The runtime pair seeds the runtime cache the same way (spec 19's
+two-slot shape).
+
+### 13.2 The two package presets
+
+- **self-contained** — carries its full closure: runtime exe + env
+  image + every payload slice. Zero network, empty cache, one file.
+  (Replaces "fat".)
+- **shared-runtime** — carries the app payload(s), shares the runtime
+  and any slices marked shared. (Today's packed-mn "lean"; the DEFAULT
+  preset.)
+
+`lean`/`fat` remain accepted as deprecated aliases (a named warning,
+never silent) mapping to `shared-runtime`/`self-contained`. A preset
+sets the DEFAULT carry verdict for every slice; a slice's authored
+`carry:` overrides it; D5's `--carry`/`--share` override the document.
+
+### 13.3 The `platforms:` coverage assertion
+
+The truth lives in exactly two places, and the composition is not one
+of them:
+
+- **The payload declares** its own coverage (spec 03 §3, already
+  locked): `platforms: universal` OR an explicit triplet list.
+  "Universal" = pure-language/data bytes, one artifact for every
+  triplet. Partial independence (arch-free, libc-free) is expressed by
+  ENUMERATION — list every triplet the bytes serve; honest and dumb.
+- **The registry mirrors** concrete rows only (spec 04): a `universal:`
+  row OR per-triplet rows — never patterns, never both. Wildcard
+  pattern rows (`linux-*-*`) are REJECTED; expansion belongs to
+  authored manifests at publish time.
+
+The composition's per-slice `platforms:` key is an ASSERTION, checked
+fail-closed against the payload's declared/mirrored coverage:
+
+- Omitted = the payload's declaration rules (the common case: runtimes
+  and native payloads are triplet-bound by nature).
+- Present = press/dispatch verifies the assertion is COVERED by the
+  declaration. A lack of coverage — for the assertion or for the host
+  triplet — is a named error naming the slice, the triplet, and the
+  declared coverage. Never a silent nearest-platform fallback
+  (spec 00 §9). The assertion narrows; it NEVER extends.
+
+The lock (§4) records the outcome: per slice, the single `universal`
+digest or the per-target-triplet digest map. Run-time resolution is
+then: host triplet → locked digest → carried-slot verify /
+shared fetch+verify. Carry/shared stays orthogonal: a slice of any
+coverage class may be carried or shared.
+
+**The honesty proof.** A `universal` claim with native bytes inside is
+a lie that only fails on someone's machine — unless checked. The
+spec-26 payload-check framework is the proof: feedstock CI runs a
+universal slice's in-image acceptance check on EVERY target triplet;
+native bytes in a "universal" image fail there, before publication.
+
+### 13.4 Rules that make this safe
+
+- The L2 lock records the digest of every slice, carried or shared —
+  run-time resolution verifies against it, fail-closed. Carry/shared
+  never changes WHAT runs, only where the bytes come from.
+- Jail defaults are unaffected by carry/shared: mount points and
+  permissions are declared identically either way (§2/§5).
+- Trust is uniform across both paths: the same sha256 anchors, the same
+  unsigned-is-loud + journal rules, the same `TEBAKO_REQUIRE_SIGNED=1`
+  fail-closed; verification at fetch/install — never per run.
+- Transitive payload DEPENDS (payloads needing payloads) resolve
+  through the same registry path with cycle detection (spec 18 §5.6);
+  mount-point arbitration and jail-by-default are this spec's §5–§7
+  unchanged.
+
+### 13.5 SSOT and error additions
+
+| Value | Owner |
+|---|---|
+| `carry` / preset / `platforms:` assertion grammar | THIS section (D2 §3 mirrors it) |
+| The lock's digest-map shape | the L2 package-manifest schema (spec 02 §5b type-2 block; `schema/tebako-compose-v1.schema.json` stays the D2 document's) |
+| Coverage declaration | spec 03 §3 (unchanged — the assertion references it) |
+| Registry row shape (concrete only) | spec 04 (amended: one sentence) |
+| Lazy-seed mechanics | spec 05 §4 (amended: the scoped exception) |
+| Two-slot carried runtime | spec 19 (amended) + tebako#458 |
+| Lean/fat alias warning | the named-warning vocabulary (invariant 9); exit codes unchanged — carry choices never gate a run |

--- a/docs/spec/schemas/payload-manifest.yaml
+++ b/docs/spec/schemas/payload-manifest.yaml
@@ -216,7 +216,8 @@ grammar:
           notes: >-
             The spec-18 C11 contract field (feature/toolkit payloads): a C
             ABI name + version at an in-image path. Consumers bind only on
-            match, both versions printed on mismatch (exit 79 reserved).
+            match, both versions printed on mismatch (named refusal; exit
+            code unallocated, spec 18 §7 — 79 is spec 26's CHECK).
           entry:
             name: {type: string, required: true}
             version: {type: string, required: true}
@@ -319,7 +320,7 @@ refusals:
   - case: entrypoint's runtime_requirement unsatisfiable at dispatch (S26/C10)
     behavior: named error naming the entrypoint and the requirement — never a segfault
   - case: provides_abi mismatch at bind (C11)
-    behavior: named refusal, both versions printed (exit 79 reserved)
+    behavior: named refusal, both versions printed (exit code unallocated — spec 18 §7; 79 is spec 26's CHECK)
   - case: a materialize entry absent from the image, or not a regular file (schema_minor 1)
     behavior: the manifest lies — boot fails with a named error (exit 65), never a skipped entry
   - case: a materialized copy failing digest verification at boot (schema_minor 1)
@@ -336,7 +337,7 @@ refusals:
     behavior: named validation error at parse (exit 65) — exec-only keys on a structural check are a grammar violation
   - case: a slice manifest declaring fixtures_inline/fixtures_host, or a composition check declaring fixtures (schema_minor 3)
     behavior: named validation error at parse (exit 65) — the fixture families are MECE per context (spec 26 §2.1); a composition check is validated by the engine at document load, a slice check at press/`tfs validate`
-  - case: a duplicate check name within one checks: block (schema_minor 3)
+  - case: "a duplicate check name within one checks: block (schema_minor 3)"
     behavior: named structural error at parse — an authoring ambiguity, never a silent winner (the map's own deserializer refuses)
   - case: a malformed checks block otherwise (bad name grammar, relative entry, absolute expect.files, '..' components, non-positive timeout, a when value outside windows/macos/linux) (schema_minor 3)
     behavior: named validation error at press/`tfs validate` (exit 65), never discovered at run time (spec 26 §7)

--- a/schema/tebako-compose-v1.schema.json
+++ b/schema/tebako-compose-v1.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tebako.org/schemas/tebako-compose-v1.schema.json",
+  "title": "tebako composition document v1",
+  "description": "The D2 composition document (spec 23 §3/§13) — the press-time subset read by `tebako press --compose`: one runtime requirement plus N payload slice references, the per-slice carry verdicts (the composition spectrum), and the platforms: coverage assertions (§13.3). This schema is the STRUCTURAL contract; the tpkg crate's parse_compose() is the semantic gate (the constraint grammar, the ref:/expanded agreement rule, slice-name uniqueness, the host-triplet coverage checks). The Phase-R jail keys (policy:, mounts:, needs:) are REFUSED structurally — fail-closed: a compose document that looks jail-declaring but is pressed without its policy would be a silent security downgrade. Truly unknown keys stay tolerated (forward compatibility).",
+  "type": "object",
+  "required": ["version", "runtime"],
+  "not": {
+    "anyOf": [
+      { "required": ["policy"] },
+      { "required": ["mounts"] },
+      { "required": ["needs"] }
+    ]
+  },
+  "properties": {
+    "version": { "const": 1 },
+    "preset": {
+      "enum": ["self-contained", "shared-runtime", "lean", "fat"],
+      "description": "The package preset (spec 23 §13.2); default shared-runtime. lean/fat are the deprecated aliases — they parse with a named warning each, never silently (invariant 9)."
+    },
+    "runtime": { "$ref": "#/$defs/sliceRef" },
+    "slices": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/sliceRef" },
+      "description": "The payload slices, in document order (= mount order in the baked lock: the app payload first, then its dependency closure)."
+    },
+    "entrypoint": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The pointer-package form's entry selector — a PROVIDES entrypoint name of one of the slices. Absent when the press packages a local root (the app's own entry governs)."
+    }
+  },
+  "$defs": {
+    "sliceRef": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The `name@constraint` shorthand (the name is everything before the FIRST '@') — one semantics, two spellings; a conflict with the expanded name:/requirement: keys is a named validation error (semantic)."
+        },
+        "requirement": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The version constraint (the spec 03 §4 grammar — only non-emptiness is structural here). Required on the runtime; optional on payload slices."
+        },
+        "carry": {
+          "type": "boolean",
+          "description": "The authored carry verdict; absent = the preset decides (self-contained carries everything; shared-runtime shares the runtime and carries the payload slices)."
+        },
+        "platforms": {
+          "description": "The coverage assertion (spec 23 §13.3): narrows, never extends the payload's declared coverage (the narrowing and host-coverage checks are semantic — press-side, fail-closed).",
+          "anyOf": [
+            { "const": "universal" },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/releaseAssetName" }
+            }
+          ]
+        }
+      }
+    },
+    "releaseAssetName": {
+      "type": "string",
+      "enum": ["macos-arm64", "macos-x86_64", "linux-gnu-x86_64", "linux-gnu-arm64", "linux-musl-x86_64", "linux-musl-arm64", "windows-ucrt64", "windows-ucrt-arm64"],
+      "description": "The registry-row platform spelling (spec 04) — the triplet ↔ release-asset-name mapping's single owner is the tpkg crate's Platform."
+    }
+  }
+}

--- a/schema/tpkg-package-manifest-v1.schema.json
+++ b/schema/tpkg-package-manifest-v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tebako.org/schemas/tpkg-package-manifest-v1.schema.json",
   "title": "tpkg package manifest v1",
-  "description": "The L2 package manifest (spec 03 §6), carried as tpkg extension block type 2 (spec 02 §5b) — YAML in the container, OUTSIDE every payload image, readable without backend knowledge. It owns composition (identity, entrypoint/suite entries, package-level jail + env, per-entry runtime refs); payload manifests stay inside images and own self-description. This schema is the STRUCTURAL contract; the tpkg crate's PackageManifest::validate() is the semantic gate (unique entry names, slot-capacity bound, non-empty fields, the spec 08 jail block's own validation). Unknown keys are tolerated at every level for forward compatibility.",
+  "description": "The L2 package manifest (spec 03 §6), carried as tpkg extension block type 2 (spec 02 §5b) — YAML in the container, OUTSIDE every payload image, readable without backend knowledge. It owns composition (identity, entrypoint/suite entries, package-level jail + env, per-entry runtime refs); payload manifests stay inside images and own self-description. The optional `lock` block (spec 23 §4/§13 — the composition spectrum) is the press-time closure lock: the concrete runtime pair plus every resolved payload slice with carry verdicts, digest pins, and (shared slices) fetch coordinates; run-time resolution follows the lock by locked digest, never fresh semver. This schema is the STRUCTURAL contract; the tpkg crate's PackageManifest::validate() is the semantic gate (unique entry names, slot-capacity bound, non-empty fields, the carry⇔slot agreements, the spec 08 jail block's own validation). Unknown keys are tolerated at every level for forward compatibility.",
   "type": "object",
   "required": ["schema_version", "package", "entries"],
   "properties": {
@@ -21,6 +21,9 @@
       "type": "object",
       "additionalProperties": { "type": "string" },
       "description": "Package-level environment (composition rules: spec 07)."
+    },
+    "lock": {
+      "$ref": "#/$defs/packageLock"
     }
   },
   "$defs": {
@@ -77,7 +80,7 @@
     },
     "packageEntry": {
       "type": "object",
-      "required": ["name", "slot", "entrypoint", "runtime_ref"],
+      "required": ["name", "entrypoint", "runtime_ref"],
       "properties": {
         "name": {
           "type": "string",
@@ -88,7 +91,7 @@
           "type": "integer",
           "minimum": 0,
           "maximum": 7,
-          "description": "Which payload slot carries the entrypoint's image (0..TPKG_MAX_SLOTS-1; the bound against the concrete package's slot count happens at embed time)."
+          "description": "Which payload slot carries the entrypoint's image (0..TPKG_MAX_SLOTS-1; the bound against the concrete package's slot count happens at embed time). ABSENT for a pointer-package entry (spec 23 §13): the entry's slice is then SHARED — backed by a lock.slices[] row of the same name with carry: false (the agreement is semantic, the crate's validate())."
         },
         "entrypoint": {
           "type": "string",
@@ -101,6 +104,95 @@
           "description": "Per-entry runtime reference (type@version;tebako=<abi>[;params]) — kills the trailer's 128-byte single-field limit for suites and multi-runtime packages."
         }
       }
+    },
+    "sha256hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "releaseAssetName": {
+      "type": "string",
+      "enum": ["macos-arm64", "macos-x86_64", "linux-gnu-x86_64", "linux-gnu-arm64", "linux-musl-x86_64", "linux-musl-arm64", "windows-ucrt64", "windows-ucrt-arm64"],
+      "description": "The registry-row platform spelling (spec 04) — the triplet ↔ release-asset-name mapping's single owner is the tpkg crate's Platform."
+    },
+    "digestPin": {
+      "description": "A slice's digest pin (spec 23 §13.3): EITHER the single digest (the carried form — the bytes are fixed at stitch — or a universal-coverage slice) OR the per-triplet digest map keyed by release-asset names (the run-time lookup keys on the host triplet; a coverage gap is the consumer's named error).",
+      "anyOf": [
+        { "$ref": "#/$defs/sha256hex" },
+        {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": { "$ref": "#/$defs/releaseAssetName" },
+          "additionalProperties": { "$ref": "#/$defs/sha256hex" }
+        }
+      ]
+    },
+    "lockedArtifact": {
+      "type": "object",
+      "required": ["slot", "sha256"],
+      "properties": {
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 7,
+          "description": "The trailer slot carrying the bytes (0..TPKG_MAX_SLOTS-1)."
+        },
+        "sha256": { "$ref": "#/$defs/digestPin" }
+      },
+      "description": "One carried artifact of the runtime pair (spec 19 §6.1): the slot the bytes ride in plus the press-time digest pin."
+    },
+    "lockedRuntime": {
+      "type": "object",
+      "required": ["version", "carry"],
+      "properties": {
+        "version": { "type": "string", "minLength": 1 },
+        "carry": { "type": "boolean" },
+        "exe": { "$ref": "#/$defs/lockedArtifact" },
+        "image": { "$ref": "#/$defs/lockedArtifact" },
+        "dll": {
+          "$ref": "#/$defs/lockedArtifact",
+          "description": "The windows dll-era facet (tebako-runtime-ruby#40): carried as a third slot when the resolved release declares it."
+        }
+      },
+      "description": "The locked runtime (spec 23 §4). carry: true requires the exe and image slots (the two-slot carried pair, spec 19 §6.1); carry: false declares NO slots — a shared runtime resolves and verifies through the ordinary spec 05 §5 chain, never the lock. The carry⇔slots agreement is semantic (the crate's validate())."
+    },
+    "lockedSlice": {
+      "type": "object",
+      "required": ["name", "version", "carry", "sha256"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "carry": { "type": "boolean" },
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 7,
+          "description": "The trailer slot (carried slices only — the carry⇔slot agreement is semantic: carry: true requires it, carry: false forbids it)."
+        },
+        "mount": {
+          "type": "string",
+          "pattern": "^/",
+          "description": "The declared mount point, sourced only from a consumer edge's mount: (spec 03 §2.3 — the provider never dictates); absent = the slice is a cache prime with no mount."
+        },
+        "sha256": { "$ref": "#/$defs/digestPin" },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The fetch coordinates (a spec 04 reference) the press resolved from — required on a shared slice; on a carried slice it is provenance, never a fallback fetch path."
+        }
+      },
+      "description": "One locked payload slice (spec 23 §4/§13)."
+    },
+    "packageLock": {
+      "type": "object",
+      "properties": {
+        "runtime": { "$ref": "#/$defs/lockedRuntime" },
+        "slices": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/lockedSlice" },
+          "description": "Every resolved payload slice, in mount order: the app payload first, then its dependency closure. Slice-name uniqueness and the no-two-artifacts-per-slot rule are semantic (the crate's validate())."
+        }
+      },
+      "description": "The press-time lock (spec 23 §4/§13): what press resolved is what runs — the full composition closure locked per slice."
     }
   }
 }

--- a/schema/tpkg-package-manifest-v1.schema.json
+++ b/schema/tpkg-package-manifest-v1.schema.json
@@ -136,7 +136,13 @@
           "maximum": 7,
           "description": "The trailer slot carrying the bytes (0..TPKG_MAX_SLOTS-1)."
         },
-        "sha256": { "$ref": "#/$defs/digestPin" }
+        "sha256": { "$ref": "#/$defs/digestPin" },
+        "install_as": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[^/\\\\]+$",
+          "description": "The PE install name (the windows dll-era facet only, tebako-runtime-ruby#40): a bare file name, flowed from the release manifest's dll.install_as at press."
+        }
       },
       "description": "One carried artifact of the runtime pair (spec 19 §6.1): the slot the bytes ride in plus the press-time digest pin."
     },


### PR DESCRIPTION
## The composition spectrum — carried/shared presets, the L2 lock, lazy seed (tebako#458, spec tebako#460)

Stacked draft implementing the composition spectrum end to end across the
product repo. **Draft — do not merge** (owner gate: the whole chain green
before anything touches main).

### What each layer does

- **spec** (`97917e5d`, tebako#460): carried/shared presets, the lock
  digest map, lazy seed.
- **tpkg** (`3670760f`, `517bc0ef`): the L2 composition lock model +
  the D2 compose document model + the platforms assertion + JSON
  schemas; `LockedArtifact.install_as` (the carried dll's PE name).
- **tebako-resolve** (`92aeeeca`): the `git` feature gate (default on;
  bootstrap links `default-features = false` so gix/reqwest stay out of
  the loader), the cache seed, `resolve_locked_slice` (digest-pinned
  fetch of a lock row).
- **tebako-driver** (`b30bf472`): the env-image slot form —
  `TEBAKO_RUNTIME_IMAGE=<package>:<slot>` mounts the slot region.
- **tebako-bootstrap** (`fcfd7407`, `eb31601c`): two-slot staging of a
  carried runtime (exe slot → runtime cache under the lock digest, dll
  facet under `install_as`, env image handed to the driver as
  `<package>:<slot>`); shared slices resolved at first run into the
  payload cache by the locked digest; the spec 05 §4 lazy seed;
  the 8-proof golden suite (`tests/compose.rs`).
- **tebako-cli** (this branch's head): the press pipeline —
  `--compose/--carry/--share`, the closure resolver over the payloads'
  `requires:` edges, the lock baked into every package manifest, the
  two-slot self-contained stitch (runtime exe + env image as ordinary
  slots, LEAN cleared), the S32 install-time cycle guard.

### Compatibility notes reviewers should see

- **Old bootstraps cannot run two-slot self-contained packages
  offline**: a pre-#458 bootstrap only understands the legacy format-4
  runtime slot; a package stitched by this press carries the runtime as
  two ordinary slots + lock rows. New bootstrap reads old packages
  (the format-4 scan is untouched); the reverse is not guaranteed.
- **Fat output shape changed**: `runtime_ref` keeps `;image` but drops
  `;sha256=` entirely — the lock's digest map is the pin. Anything
  parsing `;sha256=` off authored refs (the suite path does, and keeps
  rejecting it there) is unaffected; external parsers would need to
  follow.
- **spec 19 §6.1 wording**: "TWO ordinary slots" arguably needs a
  sentence for the windows dll-era facet (a third slot under
  `install_as`). The spec files were NOT amended in this stack —
  flagging for the spec owner's call.

### Gate evidence

- Per-crate suites green at each commit: tpkg 206, tebako-resolve 77,
  tebako-driver 150, tebako-bootstrap 89 (incl. the golden suite).
- tebako-cli suite: see the head commit's CI run / local tail below.
- Bootstrap size gate: local release build 1,504,880 bytes vs the
  3,145,728 budget (macOS arm64); the git stack is feature-gated out of
  the bootstrap's link, so the gate holds with ~52% headroom.
- Full workspace `cargo test` (debug): see below / CI.

All local runs are debug-profile except the size-gate release build of
`tebako-bootstrap` alone.
