### PR TITLE
Quiet the per-run noise: TEBAKO_NO_PROGRESS gates progress lines; the v1-legacy warning fires once per package (#400)

### DIFF
--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -57,6 +57,7 @@
 //! stderr — `resolving` → `downloading` + live bar → `verifying sha256` →
 //! `installing (locked)` → `installed … and shared by every tebako app on
 //! this machine`; a cache hit is one quiet `runtime <ref> (cached)` line.
+//! `TEBAKO_NO_PROGRESS=1` silences these lines entirely (tebako#400).
 //! stdout is the payload's and is never touched.
 
 pub mod artifact_info;
@@ -71,6 +72,7 @@ use platform::{
     make_readonly, mkdir_p, os_rename, platform_string, remove_file, write_small_file, EntryLock,
 };
 use sha::sha256_file_hex;
+use sha2::Digest;
 
 /// The launcher ABI this bootstrap speaks.
 pub const LAUNCHER_ABI: u32 = 1;
@@ -1703,8 +1705,12 @@ fn sha256_hex(bytes: &[u8]) -> String {
 ///   (`EX_TEBAKO_SHA` on mismatch, streaming one pass at install; a
 ///   trusted-cache marker avoids re-hashing unchanged packages).
 /// - v1 (legacy unsigned) trailer: accepted with a loud stderr warning
-///   and an audit-journal record — unless TEBAKO_REQUIRE_SIGNED=1, which
-///   turns it into a hard `EX_TEBAKO_SIGNATURE` failure.
+///   on first acceptance per machine (tebako#400; marker under
+///   `~/.tebako/warned-legacy/`, keyed on path|size|mtime) and an
+///   audit-journal record on every acceptance — unless
+///   TEBAKO_REQUIRE_SIGNED=1, which turns it into a hard
+///   `EX_TEBAKO_SIGNATURE` failure. The durable remedy is
+///   `tebako press --sign`: v2-signed trailers never warn.
 pub fn verify_chain(self_path: &Path, m: &tpkg::Manifest) -> Result<(), BootError> {
     let home = cache_root()?;
     verify_chain_with_home(self_path, m, &home)
@@ -1815,6 +1821,42 @@ fn verify_v2_signature(
     Ok(())
 }
 
+/// The v1-legacy warning cadence (tebako#400): loud on the FIRST
+/// acceptance of a given package per machine, silent afterwards — the
+/// audit journal still records every acceptance. Returns true exactly
+/// once per marker key. Best effort: when the marker cannot be written
+/// the warning simply re-prints next run — bookkeeping never breaks a
+/// boot.
+#[doc(hidden)]
+pub fn legacy_warn_due(home: &Path, self_path: &Path) -> bool {
+    let marker = legacy_warn_marker(home, self_path);
+    if marker.exists() {
+        return false;
+    }
+    if let Some(parent) = marker.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&marker, b"");
+    true
+}
+
+/// `~/.tebako/warned-legacy/<sha256(path|size|mtime)>` — the key rides
+/// path + size + mtime so a re-pressed or replaced binary warns again.
+fn legacy_warn_marker(home: &Path, self_path: &Path) -> PathBuf {
+    let mut h = sha2::Sha256::new();
+    h.update(self_path.as_os_str().as_encoded_bytes());
+    if let Ok(md) = std::fs::metadata(self_path) {
+        h.update(md.len().to_be_bytes());
+        if let Ok(mtime) = md.modified() {
+            if let Ok(d) = mtime.duration_since(std::time::UNIX_EPOCH) {
+                h.update(d.as_secs().to_be_bytes());
+                h.update(d.subsec_nanos().to_be_bytes());
+            }
+        }
+    }
+    home.join("warned-legacy").join(sha::hex(&h.finalize()))
+}
+
 /// The home-parameterized core of [`verify_chain`] (tests inject a temp
 /// home; production resolves it through `cache_root()`).
 pub fn verify_chain_with_home(
@@ -1833,10 +1875,12 @@ pub fn verify_chain_with_home(
                 ),
             );
         }
-        eprintln!(
-            "tebako-bootstrap: WARNING: {} carries an unsigned v1 (legacy) tpkg trailer\n  — accepted for compatibility; re-bundle the package for integrity protection",
-            self_path.display()
-        );
+        if legacy_warn_due(home, self_path) {
+            eprintln!(
+                "tebako-bootstrap: WARNING: {} carries an unsigned v1 (legacy) tpkg trailer\n  — accepted for compatibility; re-bundle the package for integrity protection",
+                self_path.display()
+            );
+        }
         journal(
             home,
             &format!("event=legacy-v1-accepted package={}", self_path.display()),

--- a/crates/tebako-bootstrap/src/sha.rs
+++ b/crates/tebako-bootstrap/src/sha.rs
@@ -21,7 +21,8 @@ pub fn sha256_file_hex(path: &Path) -> io::Result<String> {
     Ok(hex(&h.finalize()))
 }
 
-fn hex(bytes: &[u8]) -> String {
+/// Lowercase hex (64 chars for a SHA-256 digest).
+pub fn hex(bytes: &[u8]) -> String {
     const DIGITS: &[u8; 16] = b"0123456789abcdef";
     let mut s = String::with_capacity(bytes.len() * 2);
     for &b in bytes {

--- a/crates/tebako-bootstrap/tests/chain.rs
+++ b/crates/tebako-bootstrap/tests/chain.rs
@@ -214,6 +214,45 @@ fn v1_legacy_accepted_with_journal_record() {
 }
 
 #[test]
+fn v1_legacy_warns_once_per_package_per_machine() {
+    // tebako#400: the warning was unconditional on every invocation with
+    // no user-side remedy short of signing. Now: first acceptance per
+    // package (path|size|mtime key) warns + marks; later ones are silent
+    // in stderr but journaled as before.
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let dir = scratch("legacy-once");
+    let home = dir.join("home");
+    let (pkg, m) = make_package(&dir, &home, b"the app image payload", true);
+
+    assert!(tebako_bootstrap::legacy_warn_due(&home, &pkg));
+    assert_eq!(
+        std::fs::read_dir(home.join("warned-legacy"))
+            .unwrap()
+            .count(),
+        1,
+        "first acceptance leaves exactly one marker"
+    );
+    assert!(!tebako_bootstrap::legacy_warn_due(&home, &pkg));
+
+    // Through the public path: both runs accepted and journaled; the
+    // marker decision has already been made above, so both are silent.
+    verify_chain_with_home(&pkg, &m, &home).expect("legacy accepted");
+    verify_chain_with_home(&pkg, &m, &home).expect("legacy accepted again");
+    assert_eq!(
+        journal(&home).matches("event=legacy-v1-accepted").count(),
+        2,
+        "every acceptance is journaled"
+    );
+    assert_eq!(
+        std::fs::read_dir(home.join("warned-legacy"))
+            .unwrap()
+            .count(),
+        1,
+        "no duplicate markers"
+    );
+}
+
+#[test]
 fn v1_require_signed_is_hard_fail() {
     let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
     let dir = scratch("require");

--- a/crates/tebako-bootstrap/tests/progress.rs
+++ b/crates/tebako-bootstrap/tests/progress.rs
@@ -106,11 +106,8 @@ fn image_era_fetches_report_per_artifact() {
 
 #[test]
 fn opt_out_envs_keep_the_plain_two_line_mode() {
-    for (k, v) in [
-        ("TEBAKO_NO_PROGRESS", "1"),
-        ("NO_COLOR", "1"),
-        ("TERM", "dumb"),
-    ] {
+    // NO_COLOR / TERM=dumb degrade the rendering to the plain lines…
+    for (k, v) in [("NO_COLOR", "1"), ("TERM", "dumb")] {
         let h = h();
         let pkg = h.lean_pkg("myapp");
         let home = h.home("home");
@@ -120,6 +117,26 @@ fn opt_out_envs_keep_the_plain_two_line_mode() {
         let size = std::fs::metadata(h.cache_exe(&home)).unwrap().len();
         assert_eq!(err, expected_fetch_lines(&h, &home, size), "{k}={v}: {err}");
     }
+}
+
+#[test]
+fn no_progress_silences_the_informational_lines() {
+    // …while TEBAKO_NO_PROGRESS=1 goes further (tebako#400): every
+    // Progress::line — the downloading header, the installed benefit
+    // line, the cache-hit line — is progress, not results, and silences.
+    let h = h();
+    let pkg = h.lean_pkg("myapp");
+    let home = h.home("home");
+    let (rc, _, err) = h.run_raw(&pkg, &home, &[("TEBAKO_NO_PROGRESS", "1")], &[]);
+    assert_eq!(rc, 0, "{err}");
+    assert_eq!(clean(err), "", "TEBAKO_NO_PROGRESS=1 silences all progress");
+    let size = std::fs::metadata(h.cache_exe(&home)).unwrap().len();
+    assert!(size > 0, "the fetch still happened — silence, not skip");
+
+    // …and a warm-cache run is equally silent (the report's main pain).
+    let (rc, _, err) = h.run_raw(&pkg, &home, &[("TEBAKO_NO_PROGRESS", "1")], &[]);
+    assert_eq!(rc, 0, "{err}");
+    assert_eq!(clean(err), "", "cache-hit line silenced too");
 }
 
 #[test]

--- a/crates/tebako-term/src/lib.rs
+++ b/crates/tebako-term/src/lib.rs
@@ -4,8 +4,11 @@
 //! - full rendering iff stderr is a TTY and `TERM != dumb`; opt-outs
 //!   `NO_COLOR` (present at all) and `TEBAKO_NO_PROGRESS` (set, non-empty,
 //!   not "0") force the plain mode;
-//! - plain mode (pipe, CI, opt-out): exactly the start + done single
+//! - plain mode (pipe, CI): exactly the start + done single
 //!   lines, no terminal control sequences;
+//! - `TEBAKO_NO_PROGRESS` additionally QUIETS every [`Progress::line`]
+//!   output (the downloading/installed/cache-hit lines) — progress is
+//!   informational, never results (tebako#400);
 //! - TTY mode: phase lines plus a hand-rolled ANSI bar
 //!   `[=====>    ] 62%  14.2/23.0 MB  3.1 MB/s` throttled to
 //!   ≤ 10 redraws/s; unknown content-length → spinner frames + byte count;
@@ -56,14 +59,19 @@ pub fn detect_mode_with(tty: bool, env: impl Fn(&str) -> Option<OsString>) -> Mo
         Some(v) => v != "dumb",
         None => true,
     };
-    let no_progress = match env("TEBAKO_NO_PROGRESS") {
-        Some(v) => !v.is_empty() && v != "0",
-        None => false,
-    };
-    if tty && term_ok && env("NO_COLOR").is_none() && !no_progress {
+    if tty && term_ok && env("NO_COLOR").is_none() && !no_progress_env(&env) {
         Mode::Tty
     } else {
         Mode::Plain
+    }
+}
+
+/// The `TEBAKO_NO_PROGRESS` opt-out predicate: set, non-empty, not `"0"`.
+/// Shared by mode detection and the quiet gate on [`Progress::line`].
+fn no_progress_env(env: &impl Fn(&str) -> Option<OsString>) -> bool {
+    match env("TEBAKO_NO_PROGRESS") {
+        Some(v) => !v.is_empty() && v != "0",
+        None => false,
     }
 }
 
@@ -128,6 +136,10 @@ fn bar_frame(so_far: u64, total: u64, elapsed: Duration) -> String {
 pub struct Progress<W: Write> {
     out: W,
     mode: Mode,
+    /// `TEBAKO_NO_PROGRESS` gate: when set, [`Progress::line`] prints
+    /// nothing at all (tebako#400 — the cache-hit and installed lines
+    /// were unconditional noise on every invocation).
+    quiet: bool,
     asset: String,
     header_printed: bool,
     line_open: bool,
@@ -141,9 +153,13 @@ pub struct Progress<W: Write> {
 
 impl Progress<io::Stderr> {
     /// A renderer over the real stderr; the mode is auto-detected
-    /// ([`detect_mode`]).
+    /// ([`detect_mode`]) and the quiet gate rides `TEBAKO_NO_PROGRESS`.
     pub fn stderr() -> Progress<io::Stderr> {
-        Progress::with_mode(io::stderr(), detect_mode())
+        Progress::with_mode_and_quiet(
+            io::stderr(),
+            detect_mode(),
+            no_progress_env(&|name| std::env::var_os(name)),
+        )
     }
 }
 
@@ -156,9 +172,15 @@ impl<W: Write> Progress<W> {
 
     /// A renderer over `out` in the given mode.
     pub fn with_mode(out: W, mode: Mode) -> Progress<W> {
+        Progress::with_mode_and_quiet(out, mode, false)
+    }
+
+    /// A renderer over `out` with the quiet gate explicit.
+    pub fn with_mode_and_quiet(out: W, mode: Mode, quiet: bool) -> Progress<W> {
         Progress {
             out,
             mode,
+            quiet,
             asset: String::new(),
             header_printed: false,
             line_open: false,
@@ -208,9 +230,14 @@ impl<W: Write> Progress<W> {
         self.write_str("\n");
     }
 
-    /// An always-printed line (the `downloading` start line, the
-    /// `installed …` benefit line, the quiet cache-hit line).
+    /// A printed line (the `downloading` start line, the `installed …`
+    /// benefit line, the quiet cache-hit line) — in both modes, but
+    /// suppressed entirely when the quiet gate is set
+    /// (`TEBAKO_NO_PROGRESS=1`, tebako#400).
     pub fn line(&mut self, text: &str) {
+        if self.quiet {
+            return;
+        }
         self.close_line();
         self.write_str(text);
         self.write_str("\n");
@@ -552,6 +579,27 @@ mod tests {
             let mut p = Progress::new(Vec::new(), tty);
             p.line("runtime ruby-3.3.7 (cached)");
             assert_eq!(sink_text(p), "runtime ruby-3.3.7 (cached)\n");
+        }
+    }
+
+    #[test]
+    fn quiet_gate_suppresses_lines_and_the_download_header() {
+        // tebako#400: the cache-hit / installed / downloading header lines
+        // are progress, not results — the quiet gate silences them all.
+        for mode in [Mode::Tty, Mode::Plain] {
+            let mut p = Progress::with_mode_and_quiet(Vec::new(), mode, true);
+            p.line("runtime ruby-3.3.7 (cached)");
+            p.download_begin("asset");
+            p.download_tick_at(500, Some(1000), Instant::now());
+            p.download_end();
+            p.line("installed entry (1.0 KB)");
+            let text = sink_text(p);
+            assert!(!text.contains("downloading asset"), "{text:?}");
+            assert!(!text.contains("(cached)"), "{text:?}");
+            assert!(!text.contains("installed entry"), "{text:?}");
+            if mode == Mode::Plain {
+                assert_eq!(text, "");
+            }
         }
     }
 }

--- a/docs/spec/06-launcher-abi.md
+++ b/docs/spec/06-launcher-abi.md
@@ -102,6 +102,9 @@ the benefit. Rules:
   `installed ruby-3.4.2-0.15.9-linux-gnu-x86_64 (23.0 MB) — cached at
   ~/.tebako/runtimes/… and shared by every tebako app on this machine`.
   A cache HIT prints one quiet line: `runtime ruby-3.4.2 (cached)`.
+  `TEBAKO_NO_PROGRESS=1` silences these informational lines entirely
+  (the cache-hit, `installed …`, and `downloading …` lines — progress is
+  not results; tebako#400); the mode selection rule above still applies.
 - Progress output goes to **stderr**, never stdout (stdout belongs to
   the payload).
 - Implementation: a tiny `tebako-term` micro-crate (TTY detect, bar,

--- a/docs/spec/09-trust-and-signing.md
+++ b/docs/spec/09-trust-and-signing.md
@@ -57,8 +57,13 @@ tebako validates below it — see spec 12 §5.
 - **Only the presence of a signature is optional — verification of signed
   packages is always strict** (exits 71/72, spec 06 §4).
 - **v1-legacy rule:** unsigned v1 packages exist in the wild and stay
-  runnable — accepted as LEGACY with a loud stderr warning + audit
-  journal entry. `TEBAKO_REQUIRE_SIGNED=1` is the explicit opt-in
+  runnable — accepted as LEGACY with a loud stderr warning **on first
+  acceptance per machine** (marker
+  `$TEBAKO_HOME/warned-legacy/<sha256(path|size|mtime)>`; a re-pressed or
+  replaced binary warns again) plus an audit-journal entry on **every**
+  acceptance (tebako#400: the per-run repetition was unactionable noise;
+  the durable remedy is `tebako press --sign` — v2-signed trailers never
+  warn). `TEBAKO_REQUIRE_SIGNED=1` is the explicit opt-in
   hard-fail for hardened environments — never the default.
 - **Fail closed everywhere:** no insecure-skip flag.
 - Encryption is likewise per-image opt-in (spec 10).


### PR DESCRIPTION
## What

Two per-invocation stderr outputs reported in #400, both fixed:

1. **`runtime <ref> (cached)` and friends** — `Progress::line` was documented "always-printed"; `TEBAKO_NO_PROGRESS` only forced Plain mode and gated no line. `Progress` gains a **quiet gate**: set from `TEBAKO_NO_PROGRESS` in `Progress::stderr()` (explicit via `with_mode_and_quiet`); `line()` returns early under it. The `no_progress` env predicate is now shared between mode detection and the gate.

2. **The unsigned-v1 legacy warning** — loud on *every* run, and unactionable for users who don't sign. Now **loud on first acceptance per machine per package** (marker `~/.tebako/warned-legacy/<sha256(path|size|mtime)>` — a re-pressed/replaced binary warns again), and **journaled on every acceptance** as before. Best-effort marker: a write failure re-warns next run, never breaks a boot.

## Verification of the report

Both complaints reproduced on main (0.2.6): `detect_mode_with` gates no line; the warning at `verify_chain_with_home` was unconditional `eprintln!`. One correction to the report: `tebako press --sign` **has existed since #349** (in 0.2.5 too) — signing is the durable remedy for the warning and is now named in the spec text.

## Evidence

- `cargo test -p tebako-term`: new quiet-gate test (lines + download header suppressed; Plain+quiet is byte-empty), suite green.
- `cargo test -p tebako-bootstrap --test chain`: new `v1_legacy_warns_once_per_package_per_machine` — marker created exactly once, decision flips, journal records both acceptances through the public `verify_chain_with_home` path.
- clippy clean on both crates.

## Spec sync (same PR)

- `docs/spec/06-launcher-abi.md` §5: `TEBAKO_NO_PROGRESS=1` silences the informational lines.
- `docs/spec/09-trust-and-signing.md`: v1-legacy rule pins the warn-once-per-machine cadence + journal-every-acceptance, names `press --sign` as the remedy.

Closes #400 (the cadence half; the trust posture — loud on first sight, fail-closed under `TEBAKO_REQUIRE_SIGNED=1` — is unchanged).
