### PR TITLE
tebako-cli: RUBY_VERSIONS gains 3.2.11 / 3.3.12 / 3.4.10 (the v0.16.10 slim line)

### DIFF
--- a/crates/tebako-cli/src/scenario.rs
+++ b/crates/tebako-cli/src/scenario.rs
@@ -16,11 +16,15 @@ pub const DEFAULT_RUBY_VERSION: &str = "3.3.7";
 pub const MIN_RUBY_VERSION_WINDOWS: &str = "3.1.6";
 
 /// Ruby versions the CLI can press packages for (the prebuilt runtime
-/// packages published by tebako-runtime-ruby are the operative constraint).
+/// packages published by tebako-runtime-ruby are the operative constraint:
+/// this is the UNION across the published release lines — the 0.16.9 line
+/// ships the full matrix, the 0.16.10 slim line ships 3.1.6/3.2.11/3.3.12/
+/// 3.4.10/4.0.6; a line without the requested version fails at resolution
+/// with the available set named).
 pub const RUBY_VERSIONS: &[&str] = &[
-    "2.7.8", "3.0.7", "3.1.6", "3.2.4", "3.2.5", "3.2.6", "3.2.7", "3.3.3", "3.3.4", "3.3.5",
-    "3.3.6", "3.3.7", "3.4.1", "3.4.2", "4.0.0", "4.0.1", "4.0.2", "4.0.3", "4.0.4", "4.0.5",
-    "4.0.6",
+    "2.7.8", "3.0.7", "3.1.6", "3.2.4", "3.2.5", "3.2.6", "3.2.7", "3.2.11", "3.3.3", "3.3.4",
+    "3.3.5", "3.3.6", "3.3.7", "3.3.12", "3.4.1", "3.4.2", "3.4.10", "4.0.0", "4.0.1", "4.0.2",
+    "4.0.3", "4.0.4", "4.0.5", "4.0.6",
 ];
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
## What

`RUBY_VERSIONS` gains **3.2.11 / 3.3.12 / 3.4.10** — the ruby versions the
tebako-runtime-ruby **v0.16.10 slim line** actually ships
(3.1.6/3.2.11/3.3.12/3.4.10/4.0.6).

## Why

The allowlist predated the slim line (max 3.3.7 / 3.4.2). Pressing against
v0.16.10 with `-R 3.3.12` died at the version gate:

```
Tebako script failed: Ruby version 3.3.12 is not supported [110]
```

— before resolution could name the real constraint (the metanorma
feedstock re-bake, tebako-packages/metanorma tag 1.16.9-4 attempts 2–3).

The list is documented as the **union across published release lines**;
a line without the requested version still fails at resolution with the
available set named (exit 120). `DEFAULT_RUBY_VERSION` stays 3.3.7: the
default line (0.16.9) ships the full matrix including 3.3.7, so the
bare-press path is unchanged.

## Evidence

- `cargo test -p tebako-cli --lib scenario`: 7 passed, 0 failed
  (requirement matching, ruby-directive parsing, version compare).
- v0.16.9 matrix (ships 3.3.7 — default coherence):
  `gh release view v0.16.9 --repo tamatebako/tebako-runtime-ruby`.
- v0.16.10 matrix (3.1.6/3.2.11/3.3.12/3.4.10/4.0.6): release
  manifest.json, run 32921515269.
