### PR TITLE
bootstrap: build alone in its own cargo invocation — fix the size-gate failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,9 +224,17 @@ jobs:
         # --skip-build — they must be explicit -p packages or no .a/cdylib
         # is emitted (run 30742821370). tebako-cli already unifies tfs's
         # default features on POSIX, so one invocation serves both.
+        # tebako-bootstrap builds in its OWN invocation: cargo unifies
+        # features within one invocation, and sharing one with
+        # tebako-cli/tebako-shim re-enables tebako-resolve's `git`
+        # feature (gix/reqwest/rustls) inside the size-gated loader —
+        # run 32940980101 failed the 3 MiB gate on every leg for exactly
+        # this reason. A separate invocation = separate feature
+        # resolution = the bootstrap's `default-features = false` holds.
         run: |
+          cargo build --release --target ${{ matrix.target }} -p tebako-bootstrap
           cargo build --release --target ${{ matrix.target }} \
-            -p tebako-bootstrap -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim \
+            -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim \
             -p tfs -p tebako-driver -p libtfs-preload
 
       - name: Stage, strip, size-gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@ These rules are owner-locked (2026-07-27). They apply to humans and agents alike
   (`git worktree add <path> -b <branch> origin/main`). **Never share the
   main checkout** — agents checking out branches in it clobber each
   other (this caused real bugs: commits landing on the wrong branch).
+- **Never grep/patch against the main checkout assuming it is the
+  head** — it may be arbitrarily behind `origin/main`. Investigate in a
+  fresh worktree. A stale-tree grep once "proved" a load-bearing
+  dependency unused.
 - `GIT_EDITOR=true` for every git operation (no interactive editors).
 - Before pushing in a shared repo, check `git branch --show-current` and
   `git fetch origin`; push the intended ref (`git push origin <sha>:refs/heads/main`
@@ -37,6 +41,18 @@ These rules are owner-locked (2026-07-27). They apply to humans and agents alike
   HTTP (ureq+rustls+webpki-roots bundled), in-process imaging (dwarfs-t
   Writer), in-process crypto (rnp-rs vendored). No curl/git/mkdwarfs/PATH
   lookups at runtime.
+- **Optional capability = cargo feature on the owning crate** — default ON
+  for the toolchain, OFF for the size-gated `tebako-bootstrap`, and a
+  NAMED error when compiled out (first instance: tebako-resolve's `git` →
+  `GitAdapterDisabled`). Consequence: **the bootstrap always builds in its
+  own `cargo build` invocation** — cargo unifies features within one
+  invocation, and building the bootstrap beside tebako-cli/tebako-shim
+  silently re-enables opted-out features in it (v0.2.7 release run
+  32940980101 failed the 3 MiB gate on every leg for this reason).
+- **The workspace `Cargo.lock` is gitignored — resolutions float.**
+  Dependencies that evolve incompatibly inside one semver line get an
+  explicit upper bound on stable branches; the bump branch raises the
+  floor and drops the bound in the same change.
 - **YAML for all authored config/manifests**, with versioned JSON Schemas.
 - **MECE reference syntax, no default service**: `tfs:github:/tfs:gitlab:/
   tfs:bb:` / `tfs+git://` / `tfs+https://` / `file://`, `?sha256=` pins.

--- a/ci/gnu-floor-build.sh
+++ b/ci/gnu-floor-build.sh
@@ -163,8 +163,13 @@ export CARGO_NET_GIT_FETCH_WITH_CLI=true
 # one mechanism for both). The release leg's ship gate (the ldd
 # whitelist in .github/workflows/lib/ship-gate.sh) is the enforcement.
 export RUSTFLAGS="-C linker=$WS/tebako-rs/ci/linux-link-wrap.sh"
+# tebako-bootstrap builds in its OWN invocation — cargo feature
+# unification with tebako-cli/tebako-shim would re-enable tebako-resolve's
+# `git` feature (gix/reqwest/rustls) inside the size-gated loader
+# (run 32940980101 failed the 3 MiB gate on every leg for this reason).
+cargo build --release --target "$TARGET" -p tebako-bootstrap
 cargo build --release --target "$TARGET" \
-  -p tebako-bootstrap -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim
+  -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim
 
 echo "== stage / strip / size-gate =="
 export TARGET

--- a/ci/musl-build.sh
+++ b/ci/musl-build.sh
@@ -129,8 +129,13 @@ export DWARFS_RS_VCPKG_ROOT="$WS/.vcpkg-musl"
 export DWARFS_RS_VCPKG_TRIPLET="$TRIPLET"
 export SQFS_SYS_VCPKG_TRIPLET="$TRIPLET"
 export SQFS_SYS_VCPKG_INSTALLED_DIR="$WS/.sqfs-musl/$TRIPLET"
+# tebako-bootstrap builds in its OWN invocation — cargo feature
+# unification with tebako-cli/tebako-shim would re-enable tebako-resolve's
+# `git` feature (gix/reqwest/rustls) inside the size-gated loader
+# (run 32940980101 failed the 3 MiB gate on every leg for this reason).
+cargo build --release -p tebako-bootstrap
 cargo build --release \
-  -p tebako-bootstrap -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim
+  -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim
 
 echo "== stage / strip / size-gate =="
 export TARGET

--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -68,6 +68,7 @@ pub(crate) fn map_resolve(e: ResolveError) -> TebakoError {
         | ResolveError::AmbiguousAssets { .. }
         | ResolveError::ServiceFailed { .. }
         | ResolveError::Git { .. }
+        | ResolveError::GitAdapterDisabled { .. }
         | ResolveError::Offline { .. } => EX_TEBAKO_UNAVAILABLE,
         ResolveError::Registry(_) | ResolveError::InvalidCacheKey { .. } => EX_TEBAKO_MANIFEST,
         ResolveError::LockTimeout { .. } | ResolveError::CacheIo { .. } => EX_TEBAKO_IO,

--- a/crates/tebako-resolve/src/error.rs
+++ b/crates/tebako-resolve/src/error.rs
@@ -129,6 +129,10 @@ pub enum ResolveError {
     /// A `tfs+git:` reference without `#path` names a registry repo, not a
     /// payload file (spec 04 §1) — fetching payload bytes needs the path.
     GitPathRequired { url: String },
+    /// A `tfs+git:` reference reached a build without the git adapter
+    /// (feature `git` off — the size-capped tebako-bootstrap, spec 04 §3):
+    /// a named refusal, never a silent skip.
+    GitAdapterDisabled { url: String },
     /// TEBAKO_OFFLINE is set and the entry is not cached (spec 05 §4:
     /// cache hit or hard error).
     Offline { what: String },
@@ -200,6 +204,11 @@ impl fmt::Display for ResolveError {
             ResolveError::GitPathRequired { url } => write!(
                 f,
                 "tfs+git://{url} names a repository, not a payload: add #path to select the image file"
+            ),
+            ResolveError::GitAdapterDisabled { url } => write!(
+                f,
+                "tfs+git://{url} needs the git adapter, which is not compiled into this build: \
+                 fetch it in managed mode (tebako install / the shim) or mirror the payload to tfs+https"
             ),
             ResolveError::Offline { what } => write!(
                 f,

--- a/crates/tebako-resolve/src/fetch.rs
+++ b/crates/tebako-resolve/src/fetch.rs
@@ -102,10 +102,7 @@ impl<T: Transport> Fetcher<T> {
                 #[cfg(not(feature = "git"))]
                 {
                     let _ = (git_ref, path);
-                    return Err(ResolveError::Git {
-                        url: url.clone(),
-                        reason: "this build was compiled without the 'git' feature — tfs+git: references are unsupported".to_string(),
-                    });
+                    return Err(ResolveError::GitAdapterDisabled { url: url.clone() });
                 }
             }
         };

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,119 @@
 # Tebako Architecture
 
-The normative architecture of the tebako ecosystem lives in the
+The normative behavior of the tebako ecosystem lives in the
 **specification set**: [docs/spec/](spec/00-INDEX.md) — indexed, layered,
 and per-topic. Start there.
+
+This file is the **map**: which components ship, what each one links and
+can do, what is deliberately absent, and the build invariants that have
+bitten before. When code disagrees with this file, the code is wrong or
+the file is stale — fix one of them in the same PR.
+
+## The four tiers
+
+### Tier 0 — the loader
+
+**`tebako-bootstrap`** (`crates/tebako-bootstrap`) — the process entry
+point of every stitched package. Reads the tpkg trailer, fetches the
+lock's concrete pinned sources, seeds carried slices into the machine
+cache, verifies sha256 sidecars, hands off to the runtime via the
+launcher ABI. It resolves **pinned, concrete references only** — no
+registries, no version ranges (those were resolved at press time and
+frozen into the lock).
+
+- Hard size gate: **< 3 MiB per platform**, enforced in the release
+  pipeline (`BOOTSTRAP_SIZE_BUDGET`, `.github/workflows/lib/stage.sh`).
+- Links: `tpkg`, `tebako-http`, `tebako-term`, `tebako-resolve`
+  (**`default-features = false`** — the `git` feature stays OFF), no
+  tfs, no imaging stack.
+- `openpgp-verify` is an optional dev feature; shipped builds are
+  unverified-first (`TEBAKO_REQUIRE_SIGNED=1` fails closed).
+
+### Tier 1 — the toolchain (managed mode, full capability)
+
+| binary | crate | role |
+|--------|-------|------|
+| `tebako` | `tebako-cli` | press, install, check, inspect — the packager's tool; carries the limnifs writer |
+| `tebako-shim` | `tebako-shim` | argv0 dispatcher on PATH; per-invocation version chain (env → `.tebako-tools.yaml` → `config.yaml` → registry default) |
+| `tfs` | `tfs-cli` | image toolbox: mkimage / extract / ls / cat / exec / needs |
+
+The toolchain links the **full** tebako-resolve (the `git` feature ON),
+the registry walk, and version-range resolution. This is where
+resolution *happens*: press-time resolution writes the L2 lock that the
+bootstrap later consumes verbatim.
+
+Libraries: `tebako-pkg` (packaging), `tpkg` (wire container + manifest
+model, `#![forbid(unsafe_code)]`), `tebako-resolve` (references,
+registry, cache), `tebako-http` (ureq + rustls + webpki-roots),
+`tebako-signer` (opt-in trust), `tebako-info`, `tebako-json`,
+`tebako-term`.
+
+### Tier 2 — the runtime pair (factory artifacts, not built here)
+
+Every runtime is TWO artifacts from the runtime factory
+(`tebako-runtime-ruby` today): the **runtime exe** (interpreter +
+embedded `tebako-driver`) and the **env image** (`.tfs`). The driver
+mounts exactly what the loader hands it — env image first, then payload
+slices in order — applies the jail, rewrites argv. **The runtime
+resolves nothing.**
+
+### Tier 3 — payload slices
+
+Bare `.tfs` images with in-image L1 manifests (`/__tpkg__/manifest.yaml`):
+executable / data / runtime / toolkit kinds. Payloads **declare** needs,
+entrypoints, and `runtime_requirement`; they never resolve.
+
+## Reference-scheme capability matrix
+
+Per spec 04. MECE: a scheme a binary cannot resolve is a **named
+error**, never a guess and never a silent skip.
+
+| scheme | `tebako-bootstrap` | toolchain (CLI / shim / tfs) |
+|--------|--------------------|------------------------------|
+| `tfs:github:` / `tfs:gitlab:` / `tfs:bb:` | ✓ (service API via tebako-http) | ✓ |
+| `tfs+https://` | ✓ (`?sha256=` pin rules apply) | ✓ |
+| `file://` | ✓ | ✓ |
+| `tfs+git://` | **compiled out** → `GitAdapterDisabled` | ✓ (tebako-resolve feature `git`) |
+
+## What is NOT used (the anti-map)
+
+- **The bootstrap never**: touches registries, evaluates version ranges,
+  fetches `tfs+git:`, links tfs/limnifs/dwarfs, or runs the OpenPGP
+  stack (dev-only feature).
+- **The runtime exe never** resolves references or fetches anything.
+- **`libtfs` (the C++ library)** is a legacy parity oracle in a separate
+  repo — nothing in this workspace consumes it.
+- **v1 artifacts** (the C99 bootstrap, the C++ `tebako-main.cpp` driver,
+  the gem orchestrator, merged env+app images) are dead — do not read
+  them for guidance; the spec set is the truth.
+- No shell-outs, no system dependencies in any shipped artifact
+  (spec 00 invariant 1).
+
+## Build invariants (learned the hard way — do not regress)
+
+1. **`tebako-bootstrap` always builds in its OWN `cargo build`
+   invocation**, in every workflow and script. Cargo unifies features
+   within one invocation: building the bootstrap together with
+   `tebako-cli`/`tebako-shim` silently re-enables tebako-resolve's `git`
+   feature inside the size-gated loader (v0.2.7 release run 32940980101
+   failed the 3 MiB gate on every leg for exactly this reason).
+2. **Optional capability = cargo feature on the owning crate**: default
+   ON for the toolchain, OFF for the bootstrap, named error when
+   compiled out. First instance: tebako-resolve's `git`.
+3. **The workspace `Cargo.lock` is gitignored — resolutions float.** A
+   dependency line that evolves incompatibly within one semver line
+   (prerelease limnifs is the case) needs an explicit upper bound on
+   stable branches; the flip branch raises the floor and drops the
+   bound in the same change.
+4. **Never trust the main checkout.** Work in a fresh
+   `git worktree add … -b <branch> origin/main`; the shared checkout
+   may be arbitrarily behind (a stale-tree grep once produced a wrong
+   "unused dependency" root cause).
+5. Never `cargo test --release` locally (the panic=abort double-compile
+   stamps a colliding `libtfs.rlib` — AGENTS.md). Test in debug, the
+   CI shape.
+
+## The specification set
 
 - What tebako is (packaging + loading ecosystem, any runtime / platform /
   payload / composition): [spec 01](spec/01-overview.md)

--- a/docs/spec/04-references-and-registry.md
+++ b/docs/spec/04-references-and-registry.md
@@ -125,6 +125,15 @@ payloads:
   tests and air-gapped sites.
 - Git protocol via `gix` (gitoxide) when `tfs+git:` needs smart-protocol
   fetch — never the git CLI.
+- The capability is per-binary, not per-ecosystem. The shipped
+  `tebako-bootstrap` (the 3 MiB-gated loader) links tebako-resolve with
+  the `git` feature OFF: `tfs+git:` lock sources fail closed with the
+  named `GitAdapterDisabled` error (steer to managed mode — `tebako
+  install` / the shim — or mirror to `tfs+https:`). The toolchain
+  (tebako CLI, tebako-shim, tfs CLI) always carries the full surface.
+  General rule: an optional capability is a cargo feature on the owning
+  crate — default ON for the toolchain, OFF for the bootstrap, named
+  error when compiled out.
 - Atomic fetch: download to tmp, verify digest, rename; concurrent
   fetchers coordinate via the cache lock (spec 05); a partial fetch is
   invisible. `TEBAKO_OFFLINE=1`: cache hit or hard error.


### PR DESCRIPTION
## Why

The v0.2.7 release run ([32940980101](https://github.com/tamatebako/tebako/actions/runs/32940980101)) failed the bootstrap size gate on 7 of 8 legs: the linux-x86_64 bootstrap came out at **4,377,600 B** against the 3,145,728 B gate — v0.2.6 shipped **1,662,352 B**.

Root cause: **cargo feature unification**. `release.yml`, `ci/musl-build.sh` and `ci/gnu-floor-build.sh` built all five binaries in ONE `cargo build` invocation. `tebako-cli` and `tebako-shim` depend on `tebako-resolve` with default features (the `git` adapter: gix + reqwest + rustls); `tebako-bootstrap` depends on it with `default-features = false`. In one invocation the features unify across the workspace build, and the git stack silently linked into the bootstrap. PR CI never caught it because the PR-tier size gate builds the bootstrap alone.

## What

- **The fix (3 build sites):** each now builds `tebako-bootstrap` in its own cargo invocation first, then the rest of the toolchain in a second. Comments at each site cite run 32940980101 so nobody "simplifies" it back.
- **Fail-closed named error:** `tebako-resolve` compiled without the `git` feature now returns the new `ResolveError::GitAdapterDisabled { url }` instead of the overloaded `Git { reason }` string — the capability-feature convention (spec 04 §3, docs/ARCHITECTURE.md).
- **docs/ARCHITECTURE.md:** rewritten from a stub into the actual architecture map — the four tiers (system slices / runtime slices / payload slices / bootstrap), the capability matrix, an anti-map ("What is NOT used") so dead v1 components stop being resurrected, and the five build invariants (including this unification trap).
- **AGENTS.md:** gains the stale-checkout rule (work from `origin/main` worktrees), the capability = cargo-feature convention, and the floating-resolution upper-bound rule.

## Evidence

- Bootstrap built alone (release, stripped): **1,504,896 B** — comfortably under the 3,145,728 B gate.
- `cargo test -p tebako-resolve -p tebako-bootstrap`: all green (23+7+8 tests, 0 failed).
- `cargo clippy -p tebako-resolve -p tebako-bootstrap --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.

This unblocks the v0.3.0 release cut (the size gate will now pass on the release workflow's own shape).
