### PR TITLE
tpkg+tebako-cli+bootstrap: quiet_notices — the settings registry's first citizen (tebako#400)

### DIFF
--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -1879,7 +1879,12 @@ pub fn verify_chain_with_home(
                 ),
             );
         }
-        if legacy_warn_due(home, self_path) {
+        // tebako#400: the publisher may bake the notice off
+        // (TPKG_FLAG_QUIET_NOTICES — the fat-binary distribution model,
+        // where the user's trust decision happened at download). User
+        // policy (REQUIRE_SIGNED above) outranks the bit; the acceptance
+        // is journaled either way.
+        if !m.is_quiet_notices() && legacy_warn_due(home, self_path) {
             eprintln!(
                 "tebako-bootstrap: WARNING: {} carries an unsigned v1 (legacy) tpkg trailer\n  — accepted for compatibility; re-bundle the package for integrity protection",
                 self_path.display()
@@ -2065,6 +2070,9 @@ fn resolve_runtime(
 ) -> Result<(PathBuf, Option<String>), BootError> {
     let layout = cache_layout(rr)?;
     let mut ux = BootUx::new();
+    // tebako#400: the package-baked quiet bit silences the same progress
+    // lines TEBAKO_NO_PROGRESS does (OR'd into the gate, never cleared).
+    ux.prog.set_quiet(m.is_quiet_notices());
 
     // spec 19 §6.1 / spec 23 §13.2: a self-contained package carries the
     // runtime pair as ordinary trailer slots — the exe (+ windows dll)

--- a/crates/tebako-bootstrap/tests/chain.rs
+++ b/crates/tebako-bootstrap/tests/chain.rs
@@ -253,6 +253,67 @@ fn v1_legacy_warns_once_per_package_per_machine() {
 }
 
 #[test]
+fn v1_quiet_notices_bit_suppresses_the_warning_but_journals_and_require_signed_wins() {
+    // tebako#400 / spec 23 §14: TPKG_FLAG_QUIET_NOTICES (bit 3) keeps the
+    // legacy warning silent on EVERY run — the developer's press-time
+    // declaration rides the trailer, not the machine. Acceptance stays
+    // journaled; TEBAKO_REQUIRE_SIGNED=1 (user policy) is checked FIRST
+    // and outranks the bit.
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let dir = scratch("legacy-quiet");
+    let home = dir.join("home");
+
+    // A v1 (unsigned, no v2 extension) package with the quiet bit baked.
+    let bootstrap = b"BOOTSTRAP-BYTES";
+    let image = b"the app image payload";
+    let mut bytes = bootstrap.to_vec();
+    bytes.extend_from_slice(image);
+    let mut m = tpkg::Manifest {
+        version: tpkg::TPKG_VERSION,
+        package_flags: tpkg::TPKG_FLAG_QUIET_NOTICES,
+        launcher_abi: 1,
+        ..Default::default()
+    };
+    m.slots.push(tpkg::Slot::new(
+        bootstrap.len() as u64,
+        image.len() as u64,
+        tpkg::TPKG_FORMAT_ZIP,
+        "/app",
+    ));
+    bytes.extend_from_slice(&tpkg::encode_trailer(&m, bytes.len() as u64).unwrap());
+    let pkg = dir.join("package.bin");
+    std::fs::write(&pkg, &bytes).unwrap();
+    let mut f = std::fs::File::open(&pkg).unwrap();
+    let m = tpkg::read_from(&mut f).expect("parse own package");
+    assert!(m.is_quiet_notices());
+
+    // Accepted and journaled — and NO warn marker ever lands (the bit
+    // short-circuits before the warn-once decision).
+    verify_chain_with_home(&pkg, &m, &home).expect("quiet legacy accepted");
+    verify_chain_with_home(&pkg, &m, &home).expect("quiet legacy accepted again");
+    assert_eq!(
+        journal(&home).matches("event=legacy-v1-accepted").count(),
+        2,
+        "every acceptance is journaled, bit or no bit"
+    );
+    assert!(
+        !home.join("warned-legacy").exists(),
+        "the quiet bit never consults the warn-once marker"
+    );
+
+    // User policy outranks the publisher's bit.
+    std::env::set_var("TEBAKO_REQUIRE_SIGNED", "1");
+    let err = verify_chain_with_home(&pkg, &m, &home).unwrap_err();
+    std::env::remove_var("TEBAKO_REQUIRE_SIGNED");
+    assert_eq!(err.code, EX_TEBAKO_SIGNATURE);
+    assert!(
+        err.message.contains("TEBAKO_REQUIRE_SIGNED=1"),
+        "{}",
+        err.message
+    );
+}
+
+#[test]
 fn v1_require_signed_is_hard_fail() {
     let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
     let dir = scratch("require");

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -216,6 +216,11 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
         }
     };
 
+    // spec 23 §14: the `quiet_notices` registry setting resolves across
+    // the three channels — CLI > env > compose document > default; a
+    // malformed env value is a named error, never a silent default.
+    let quiet_notices = effective_quiet_notices(opts, compose_doc.as_ref())?;
+
     // Cli#bootstrap: the cache version guard runs before the press
     // (skipped in devmode, like the gem).
     if !opts.devmode {
@@ -443,8 +448,11 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
         &package,
         &runtime_ref,
         Some(&package_manifest),
-        !runtime_carried,
-        opts.no_install,
+        StitchFlags {
+            lean: !runtime_carried,
+            no_install: opts.no_install,
+            quiet_notices,
+        },
     )?;
     println!("Created tebako package at \"{package}\"");
     ensure_version_file(opts);
@@ -530,6 +538,35 @@ pub(crate) fn press_bootstrap_with(
     store.resolve(platform)
 }
 
+/// spec 23 §14: the `quiet_notices` registry setting resolved across the
+/// three channels — CLI > env > compose document > default (a suite
+/// press rides no document and passes `None`). A malformed env value is
+/// a named error, never a silent default.
+pub(crate) fn effective_quiet_notices(
+    opts: &PressOptions,
+    compose: Option<&tpkg::ComposeDoc>,
+) -> Result<bool, TebakoError> {
+    tpkg::settings::resolve_bool(
+        &tpkg::settings::QUIET_NOTICES,
+        opts.quiet_notices,
+        tpkg::settings::QUIET_NOTICES.env_value(),
+        compose.and_then(|d| d.quiet_notices),
+    )
+    .map_err(|e| packaging_error(65, Some(&e.to_string())))
+}
+
+/// The trailer flag inputs to [`stitch`] (spec 02): `lean` — the runtime
+/// resolves at run time (TPKG_FLAG_LEAN; CLEAR only for a self-contained
+/// press); `no_install` — publisher-frozen (TPKG_FLAG_NO_INSTALL);
+/// `quiet_notices` — the resolved registry setting (TPKG_FLAG_QUIET_NOTICES,
+/// spec 23 §14).
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct StitchFlags {
+    pub lean: bool,
+    pub no_install: bool,
+    pub quiet_notices: bool,
+}
+
 /// Stitcher.stitch (lean three-part): validate per the gem's error codes,
 /// then assemble with tebako-pkg (dense image layout — tpkg slots carry
 /// absolute offsets, so the gem's 8-byte padding is not required), chmod,
@@ -549,8 +586,7 @@ pub(crate) fn stitch(
     package: &str,
     runtime_ref: &str,
     package_manifest: Option<&tpkg::PackageManifest>,
-    lean: bool,
-    no_install: bool,
+    flags: StitchFlags,
 ) -> Result<(), TebakoError> {
     if images.is_empty() {
         return Err(packaging_error(126, Some("at least one image is required")));
@@ -640,12 +676,19 @@ pub(crate) fn stitch(
         runtime_ref: runtime_ref.to_string(),
         // TPKG_FLAG_LEAN unless the press is self-contained;
         // TPKG_FLAG_NO_INSTALL when the press froze the package
-        // (--no-install, TODO.v2-1/12).
-        package_flags: match (lean, no_install) {
-            (true, true) => tpkg::TPKG_FLAG_LEAN | tpkg::TPKG_FLAG_NO_INSTALL,
-            (true, false) => tpkg::TPKG_FLAG_LEAN,
-            (false, true) => tpkg::TPKG_FLAG_NO_INSTALL,
-            (false, false) => 0,
+        // (--no-install, TODO.v2-1/12); TPKG_FLAG_QUIET_NOTICES when
+        // the registry setting resolved true (spec 23 §14).
+        package_flags: {
+            let mut pf = match (flags.lean, flags.no_install) {
+                (true, true) => tpkg::TPKG_FLAG_LEAN | tpkg::TPKG_FLAG_NO_INSTALL,
+                (true, false) => tpkg::TPKG_FLAG_LEAN,
+                (false, true) => tpkg::TPKG_FLAG_NO_INSTALL,
+                (false, false) => 0,
+            };
+            if flags.quiet_notices {
+                pf |= tpkg::TPKG_FLAG_QUIET_NOTICES;
+            }
+            pf
         },
         launcher_abi: LAUNCHER_ABI,
         // The L2 package manifest rides along when the caller declares
@@ -1113,8 +1156,11 @@ mod tests {
             frozen.to_str().unwrap(),
             "ruby@3.3.7;tebako=9.9.9",
             None,
-            true,
-            true,
+            StitchFlags {
+                lean: true,
+                no_install: true,
+                quiet_notices: false,
+            },
         )
         .unwrap();
         let mut f = std::fs::File::open(&frozen).unwrap();
@@ -1129,13 +1175,71 @@ mod tests {
             plain.to_str().unwrap(),
             "ruby@3.3.7;tebako=9.9.9",
             None,
-            true,
-            false,
+            StitchFlags {
+                lean: true,
+                no_install: false,
+                quiet_notices: false,
+            },
         )
         .unwrap();
         let mut f = std::fs::File::open(&plain).unwrap();
         let m = tpkg::read_from(&mut f).unwrap();
         assert_eq!(m.package_flags & tpkg::TPKG_FLAG_NO_INSTALL, 0);
+    }
+
+    #[test]
+    fn stitch_bakes_the_quiet_notices_flag_only_when_asked() {
+        // tebako#400 / spec 23 §14: the resolved `quiet_notices` setting
+        // bakes TPKG_FLAG_QUIET_NOTICES (bit 3); the default press leaves
+        // it clear (the legacy warning + progress lines stand).
+        let dir = std::env::temp_dir().join(format!("tebako-cli-stitch-q-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let base = dir.join("bootstrap");
+        std::fs::write(&base, b"BASE").unwrap();
+        let img = dir.join("img.tfs");
+        std::fs::write(&img, b"IMG").unwrap();
+
+        let quiet = dir.join("quiet");
+        stitch(
+            &base,
+            &[(img.clone(), "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+            quiet.to_str().unwrap(),
+            "ruby@3.3.7;tebako=9.9.9",
+            None,
+            StitchFlags {
+                lean: true,
+                no_install: false,
+                quiet_notices: true,
+            },
+        )
+        .unwrap();
+        let mut f = std::fs::File::open(&quiet).unwrap();
+        let m = tpkg::read_from(&mut f).unwrap();
+        assert!(m.package_flags & tpkg::TPKG_FLAG_QUIET_NOTICES != 0);
+        assert!(m.is_quiet_notices());
+        // The bit composes with the others, never clobbers them.
+        assert!(m.package_flags & tpkg::TPKG_FLAG_LEAN != 0);
+        assert_eq!(m.package_flags & tpkg::TPKG_FLAG_NO_INSTALL, 0);
+
+        let loud = dir.join("loud");
+        stitch(
+            &base,
+            &[(img, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+            loud.to_str().unwrap(),
+            "ruby@3.3.7;tebako=9.9.9",
+            None,
+            StitchFlags {
+                lean: true,
+                no_install: false,
+                quiet_notices: false,
+            },
+        )
+        .unwrap();
+        let mut f = std::fs::File::open(&loud).unwrap();
+        let m = tpkg::read_from(&mut f).unwrap();
+        assert_eq!(m.package_flags & tpkg::TPKG_FLAG_QUIET_NOTICES, 0);
+        assert!(!m.is_quiet_notices());
     }
 
     #[test]
@@ -1232,8 +1336,7 @@ mod tests {
             contained.to_str().unwrap(),
             "ruby@3.3.7;tebako=9.9.9",
             None,
-            false,
-            false,
+            StitchFlags::default(),
         )
         .unwrap();
         let mut f = std::fs::File::open(&contained).unwrap();
@@ -1248,8 +1351,10 @@ mod tests {
             shared.to_str().unwrap(),
             "ruby@3.3.7;tebako=9.9.9",
             None,
-            true,
-            false,
+            StitchFlags {
+                lean: true,
+                ..Default::default()
+            },
         )
         .unwrap();
         let mut f = std::fs::File::open(&shared).unwrap();
@@ -1279,6 +1384,7 @@ mod tests {
             suite: None,
             jail: None,
             no_install: false,
+            quiet_notices: None,
             format: options::PressImageFormat::Dwarfs,
             compose: None,
             carry: None,

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -13,6 +13,7 @@ const USAGE: &str = "Usage:
                [-R <ruby>] [-m self-contained|shared-runtime] [-l error|warn|debug|trace]
                [--image <path>:<mount>]... [--bootstrap <path>]
                [--tebako-version <v>] [--prefer-local] [--jail <spec>]
+               [--no-install] [--quiet-notices]
                [--format dwarfs|limnifs] [--compose <tebako.yaml>]
                [--carry all|none|<name,...>] [--share <name,...>]
                (lean/fat stay accepted as deprecated aliases, spec 23 §13.2)
@@ -692,6 +693,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
     let mut suite: Option<PathBuf> = None;
     let mut jail: Option<String> = None;
     let mut no_install = false;
+    let mut quiet_notices: Option<bool> = None;
     let mut format = tebako_cli::options::PressImageFormat::Limnifs;
     let mut compose: Option<PathBuf> = None;
     let mut carry: Option<String> = None;
@@ -737,6 +739,8 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
             "--suite" => suite = Some(PathBuf::from(take_value(&mut i)?)),
             "--jail" => jail = Some(take_value(&mut i)?),
             "--no-install" => no_install = true,
+            "--quiet-notices" => quiet_notices = Some(true),
+            "--no-quiet-notices" => quiet_notices = Some(false),
             "--format" => {
                 let v = take_value(&mut i)?;
                 format =
@@ -810,6 +814,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
         suite,
         jail,
         no_install,
+        quiet_notices,
         format,
         compose,
         carry,

--- a/crates/tebako-cli/src/options.rs
+++ b/crates/tebako-cli/src/options.rs
@@ -142,6 +142,13 @@ pub struct PressOptions {
     /// `tebako install <path>`) is refused with a named error. Off by
     /// default (installable on explicit request).
     pub no_install: bool,
+    /// --quiet-notices / --no-quiet-notices (spec 23 §14): the CLI channel
+    /// of the `quiet_notices` registry setting — bake
+    /// TPKG_FLAG_QUIET_NOTICES, suppressing the unsigned-legacy-trailer
+    /// warning and the progress lines on every run. Tri-state: `None`
+    /// leaves the env (`TEBAKO_QUIET_NOTICES`) and compose-document
+    /// (`quiet_notices:`) channels to decide.
+    pub quiet_notices: Option<bool>,
     /// --format <dwarfs|limnifs> (spec 20 §6): the application image
     /// format. Limnifs by default; `dwarfs` stays an explicit opt-in.
     pub format: PressImageFormat,

--- a/crates/tebako-cli/src/packager.rs
+++ b/crates/tebako-cli/src/packager.rs
@@ -765,6 +765,7 @@ mod tests {
             suite: None,
             jail: None,
             no_install: false,
+            quiet_notices: None,
             format: crate::options::PressImageFormat::Dwarfs,
             compose: None,
             carry: None,

--- a/crates/tebako-cli/src/suite.rs
+++ b/crates/tebako-cli/src/suite.rs
@@ -391,6 +391,9 @@ pub fn press_suite(
     );
     let package_manifest = suite_package_manifest(spec, &runtime_refs, &created)?;
     let package = suite_package_path(opts, spec);
+    // spec 23 §14: a suite rides no compose document — the CLI and env
+    // channels decide `quiet_notices` (the registry's precedence holds).
+    let quiet_notices = crate::effective_quiet_notices(opts, None)?;
     crate::stitch(
         &bootstrap_path,
         &images,
@@ -399,8 +402,11 @@ pub fn press_suite(
         Some(&package_manifest),
         // Suites never carry the runtime (press_suite refuses the
         // self-contained mode) — the LEAN flag stands.
-        true,
-        opts.no_install,
+        crate::StitchFlags {
+            lean: true,
+            no_install: opts.no_install,
+            quiet_notices,
+        },
     )?;
     println!("Created tebako suite package at \"{package}\"");
     crate::ensure_version_file(opts);

--- a/crates/tebako-cli/tests/cli_e2e.rs
+++ b/crates/tebako-cli/tests/cli_e2e.rs
@@ -435,6 +435,66 @@ fn press_missing_entry_point_is_106() {
     assert!(log.contains("[106]"), "expected the 106 tag:\n{log}");
 }
 
+/// tebako#400 / spec 23 §14: the `quiet_notices` registry setting bakes
+/// TPKG_FLAG_QUIET_NOTICES from ANY channel — CLI flag, env var, compose
+/// key — the CLI's explicit negation outranks the document, and the
+/// default press leaves the bit clear. (Run-side behavior — the
+/// suppressed warning/progress, REQUIRE_SIGNED's precedence — is pinned
+/// by tebako-bootstrap's chain tests.)
+#[test]
+fn press_quiet_notices_bakes_the_bit_from_any_channel() {
+    let _guard = press_lock().lock().unwrap();
+    let Some(env) = press_env("quiet", "test-00") else {
+        return;
+    };
+    let bit = |pkg: &Path| {
+        let mut f = fs::File::open(pkg).unwrap();
+        tpkg::read_from(&mut f).unwrap().package_flags & tpkg::TPKG_FLAG_QUIET_NOTICES != 0
+    };
+
+    // Default: clear.
+    let plain = env.work.join("plain-app");
+    let (code, log) = run(&mut press_command(&env, "test.rb", &plain));
+    assert!(code == 0, "press failed:\n{log}");
+    assert!(!bit(&plain), "default press leaves the bit clear");
+
+    // CLI channel.
+    let cli = env.work.join("quiet-cli");
+    let (code, log) = run(press_command(&env, "test.rb", &cli).arg("--quiet-notices"));
+    assert!(code == 0, "press failed:\n{log}");
+    assert!(bit(&cli), "--quiet-notices bakes the bit");
+
+    // ENV channel.
+    let env_pkg = env.work.join("quiet-env");
+    let (code, log) =
+        run(press_command(&env, "test.rb", &env_pkg).env("TEBAKO_QUIET_NOTICES", "1"));
+    assert!(code == 0, "press failed:\n{log}");
+    assert!(bit(&env_pkg), "TEBAKO_QUIET_NOTICES=1 bakes the bit");
+
+    // Config channel: the compose document's `quiet_notices: true`.
+    let compose = env.work.join("tebako.yaml");
+    fs::write(
+        &compose,
+        "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nquiet_notices: true\n",
+    )
+    .unwrap();
+    let cfg = env.work.join("quiet-cfg");
+    let (code, log) = run(press_command(&env, "test.rb", &cfg)
+        .arg("--compose")
+        .arg(&compose));
+    assert!(code == 0, "compose press failed:\n{log}");
+    assert!(bit(&cfg), "the compose key bakes the bit");
+
+    // The CLI's explicit negation outranks the document (precedence).
+    let neg = env.work.join("loud-cfg");
+    let (code, log) = run(press_command(&env, "test.rb", &neg)
+        .arg("--compose")
+        .arg(&compose)
+        .arg("--no-quiet-notices"));
+    assert!(code == 0, "press failed:\n{log}");
+    assert!(!bit(&neg), "--no-quiet-notices overrides the document");
+}
+
 #[test]
 fn cache_list_and_prune() {
     let work = workdir("cache");

--- a/crates/tebako-cli/tests/suite.rs
+++ b/crates/tebako-cli/tests/suite.rs
@@ -32,6 +32,7 @@ fn opts() -> PressOptions {
         suite: None,
         jail: None,
         no_install: false,
+        quiet_notices: None,
         format: tebako_cli::options::PressImageFormat::Dwarfs,
         compose: None,
         carry: None,

--- a/crates/tebako-term/src/lib.rs
+++ b/crates/tebako-term/src/lib.rs
@@ -193,6 +193,14 @@ impl<W: Write> Progress<W> {
         }
     }
 
+    /// OR `quiet` into the gate (tebako#400): the package-baked
+    /// `TPKG_FLAG_QUIET_NOTICES` bit silences the same notices
+    /// `TEBAKO_NO_PROGRESS` does, after construction (the trailer is
+    /// read after the renderer exists).
+    pub fn set_quiet(&mut self, quiet: bool) {
+        self.quiet |= quiet;
+    }
+
     /// The mode in effect.
     pub fn mode(&self) -> Mode {
         self.mode

--- a/crates/tpkg/src/compose.rs
+++ b/crates/tpkg/src/compose.rs
@@ -29,6 +29,8 @@
 //!   - ref: "openjdk@21"
 //!     platforms: universal      # assertion: fails the press when not universal
 //! entrypoint: mnconvert         # the pointer-package form's entry selector
+//! quiet_notices: true           # optional: bake TPKG_FLAG_QUIET_NOTICES
+//!                               # (registry setting, spec 23 §14 — CLI/env override)
 //! ```
 
 use serde::Deserialize;
@@ -288,6 +290,12 @@ pub struct ComposeDoc {
     /// name of one of the slices). Absent when the press packages a local
     /// root (the app's own entry governs).
     pub entrypoint: Option<String>,
+    /// The config channel of the `quiet_notices` registry setting
+    /// (spec 23 §14): `Some(v)` declares the package's notice policy in
+    /// the repo-carried document — environment-independent, git-
+    /// shareable. CLI and env channels override it at press; the
+    /// resolved value bakes `TPKG_FLAG_QUIET_NOTICES`.
+    pub quiet_notices: Option<bool>,
 }
 
 impl ComposeDoc {
@@ -308,6 +316,9 @@ struct RawDoc {
     #[serde(default)]
     slices: Vec<RawSlice>,
     entrypoint: Option<String>,
+    // The config channel of the `quiet_notices` registry setting
+    // (spec 23 §14) — tri-state; absent lets the CLI/env channels rule.
+    quiet_notices: Option<bool>,
     // Phase-R keys — present ⇒ the named refusal, never a silent drop.
     policy: Option<serde_yml::Value>,
     mounts: Option<serde_yml::Value>,
@@ -371,6 +382,7 @@ pub fn parse_compose(yaml: &str) -> Result<(ComposeDoc, Vec<String>), ComposeErr
             runtime,
             slices,
             entrypoint,
+            quiet_notices: raw.quiet_notices,
         },
         warnings,
     ))
@@ -492,6 +504,25 @@ entrypoint: mnconvert
         assert_eq!(doc.slices[2].carry, Some(false));
         assert_eq!(doc.slices[2].platforms, Some(Platforms::Universal));
         assert_eq!(doc.entrypoint.as_deref(), Some("mnconvert"));
+    }
+
+    #[test]
+    fn quiet_notices_parses_tri_state() {
+        // spec 23 §14: the compose key is the config channel of the
+        // registry setting — present-true, present-false, and absent
+        // (the CLI/env channels then rule) are three distinct states.
+        let yes = parse("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nquiet_notices: true\n")
+            .unwrap()
+            .0;
+        assert_eq!(yes.quiet_notices, Some(true));
+        let no = parse("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nquiet_notices: false\n")
+            .unwrap()
+            .0;
+        assert_eq!(no.quiet_notices, Some(false));
+        let absent = parse("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\n")
+            .unwrap()
+            .0;
+        assert_eq!(absent.quiet_notices, None);
     }
 
     #[test]

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -15,7 +15,7 @@
 //!   offset  size  field
 //!      0    10    magic "TEBAKOTFS\0" (10 bytes, NUL-terminated)
 //!     10     4    u32 version (TPKG_VERSION = 1)
-//!     14     4    u32 package_flags (bit 0: TPKG_FLAG_LEAN, bit 1: TPKG_FLAG_SIGNED_V2, bit 2: TPKG_FLAG_NO_INSTALL)
+//!     14     4    u32 package_flags (bit 0: TPKG_FLAG_LEAN, bit 1: TPKG_FLAG_SIGNED_V2, bit 2: TPKG_FLAG_NO_INSTALL, bit 3: TPKG_FLAG_QUIET_NOTICES)
 //!     18     4    u32 slot_count (1..TPKG_MAX_SLOTS)
 //!     22     8    u64 slot_table_offset (absolute file offset of slot 0 record)
 //!     30   128    char runtime_ref[128] (UTF-8, NUL-padded; empty = classic bundle)
@@ -156,6 +156,7 @@ pub mod merkle_host;
 mod model;
 mod package;
 mod region;
+pub mod settings;
 
 pub use codec::{
     encode_ext_blocks, encode_trailer, parse_ext_blocks, parse_trailer, trailer_len,
@@ -229,6 +230,16 @@ pub const TPKG_FLAG_SIGNED_V2: u32 = 0x2;
 /// Absence means installable-on-request, including packages written
 /// before the install verb existed — pass-through like every flag.
 pub const TPKG_FLAG_NO_INSTALL: u32 = 0x4;
+/// `package_flags` bit 3 (tebako#400): the publisher baked the run-time
+/// notices off — the bootstrap suppresses the unsigned-v1 legacy
+/// warning and the progress/phase lines FOR THIS PACKAGE (the fat-binary
+/// distribution model: the user's trust decision happened at download,
+/// the per-run notice is unactionable for them). User policy still
+/// outranks the bit: `TEBAKO_REQUIRE_SIGNED=1` fails closed regardless,
+/// signed-package verification stays strict, and the acceptance is
+/// journaled as before. Pass-through like every flag — and forging it
+/// onto a signed package breaks the signature.
+pub const TPKG_FLAG_QUIET_NOTICES: u32 = 0x8;
 
 /// `format_id`: auto-detect from image magic.
 pub const TPKG_FORMAT_AUTO: u32 = 0;

--- a/crates/tpkg/src/model.rs
+++ b/crates/tpkg/src/model.rs
@@ -171,6 +171,15 @@ impl Manifest {
         self.package_flags & crate::TPKG_FLAG_LEAN != 0
     }
 
+    /// True when `TPKG_FLAG_QUIET_NOTICES` is set (tebako#400): the
+    /// publisher baked the run-time notices off — the bootstrap
+    /// suppresses the unsigned-v1 legacy warning and the progress lines
+    /// for this package. User policy (`TEBAKO_REQUIRE_SIGNED=1`) still
+    /// outranks the bit.
+    pub fn is_quiet_notices(&self) -> bool {
+        self.package_flags & crate::TPKG_FLAG_QUIET_NOTICES != 0
+    }
+
     /// Magic-independent structural checks, mirroring the C `tpkg_validate()`:
     /// version supported, `1..=TPKG_MAX_SLOTS` slots, `offset+size`
     /// non-overflowing, `format_id <= TPKG_FORMAT_LIMNIFS` (spec 20 raised

--- a/crates/tpkg/src/settings.rs
+++ b/crates/tpkg/src/settings.rs
@@ -1,0 +1,181 @@
+//! The declarative settings registry (spec 23 §14) — the single source
+//! of truth for every user-facing setting, regardless of channel.
+//!
+//! A tebako setting is declarable through up to THREE channels: the CLI
+//! flag, the environment variable, and the compose-document key. Each
+//! channel used to be wired ad-hoc, which is how semantics drift (one
+//! channel learns a behavior the others never hear about). Here every
+//! setting is declared ONCE — all three spellings, the default, and the
+//! one doc line — and every consumer resolves through `resolve_bool`,
+//! so the channels share one semantics by construction (invariant 10:
+//! a second hand-written copy of a contract value is a bug on arrival).
+//!
+//! Precedence is fixed, highest first: **CLI → environment → compose
+//! document → default**. Every channel is tri-state (present-and-true,
+//! present-and-false, absent): a compose-document `quiet_notices: true`
+//! stays overridable per invocation (`--no-quiet-notices`,
+//! `TEBAKO_QUIET_NOTICES=0`), and an environment that names a setting
+//! with an unparseable value is a NAMED error, never a silent default
+//! (invariant 9 — fail-closed).
+//!
+//! The registry also declares WHICH channels a setting supports: a
+//! machine-level knob (a cache root) has no business in a git-shared
+//! compose document, and a package-policy bit the press bakes must be
+//! declarable in the document the repo carries. `None` on a channel
+//! means the setting never rides that channel.
+//!
+//! `--help`, the compose JSON Schema, and the docs table all render
+//! from this registry — adding a setting is one entry here plus one
+//! `resolve_bool` call at the consumer; nothing else can drift.
+
+use std::fmt;
+
+/// One setting's channel spellings and documentation.
+#[derive(Debug, Clone, Copy)]
+pub struct Setting {
+    /// The compose-document key (`None` = never settable from config).
+    pub config: Option<&'static str>,
+    /// The environment spelling (`None` = never settable from the env).
+    pub env: Option<&'static str>,
+    /// The CLI flag (`None` = never settable from the command line).
+    pub cli: Option<&'static str>,
+    /// The one doc line every surface renders (--help, schema, docs).
+    pub doc: &'static str,
+}
+
+impl Setting {
+    /// The environment channel's raw contribution (absent or unset →
+    /// `None`; the value travels verbatim for strict parsing at
+    /// resolution).
+    pub fn env_value(&self) -> Option<String> {
+        self.env.and_then(|name| std::env::var(name).ok())
+    }
+}
+
+/// `quiet_notices` — the package's notice policy (tebako#400). Baked at
+/// press as `TPKG_FLAG_QUIET_NOTICES` (bit 3): every run of the package
+/// suppresses the unsigned-legacy-trailer warning and the progress
+/// lines. The bit lives inside the signed region, so a signed
+/// package's policy is unforgeable; `TEBAKO_REQUIRE_SIGNED=1` is
+/// checked FIRST and always outranks it, and acceptance stays
+/// journaled regardless.
+pub const QUIET_NOTICES: Setting = Setting {
+    config: Some("quiet_notices"),
+    env: Some("TEBAKO_QUIET_NOTICES"),
+    cli: Some("--quiet-notices"),
+    doc: "suppress the unsigned-legacy-trailer warning and the progress \
+          lines for every run of the package (baked as trailer flag bit 3)",
+};
+
+/// Every registered setting (help/schema/docs render from this table).
+pub const SETTINGS: &[Setting] = &[QUIET_NOTICES];
+
+/// A settings resolution failure.
+#[derive(Debug)]
+pub enum SettingsError {
+    /// The environment named a setting with an unparseable value.
+    InvalidEnvValue { env: &'static str, value: String },
+}
+
+impl fmt::Display for SettingsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SettingsError::InvalidEnvValue { env, value } => write!(
+                f,
+                "{env}={value:?} is not a boolean (1/0, true/false, yes/no, on/off)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SettingsError {}
+
+/// Parse one environment channel value, strictly.
+fn parse_env_bool(setting: &Setting, raw: &str) -> Result<bool, SettingsError> {
+    match raw {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => Err(SettingsError::InvalidEnvValue {
+            env: setting.env.expect("env-parsed settings carry an env name"),
+            value: raw.to_string(),
+        }),
+    }
+}
+
+/// Resolve a boolean setting across the three channels. Precedence:
+/// CLI → environment → compose document → default (`false`). Each
+/// channel contributes `Some(v)` when present (explicit true OR false)
+/// or `None` when absent; a malformed env value is a named error.
+pub fn resolve_bool(
+    setting: &Setting,
+    cli: Option<bool>,
+    env: Option<String>,
+    config: Option<bool>,
+) -> Result<bool, SettingsError> {
+    if let Some(v) = cli {
+        return Ok(v);
+    }
+    if let Some(raw) = env {
+        return parse_env_bool(setting, &raw);
+    }
+    if let Some(v) = config {
+        return Ok(v);
+    }
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_beats_everything() {
+        assert!(resolve_bool(&QUIET_NOTICES, Some(true), Some("0".into()), Some(false)).unwrap());
+        assert!(
+            !resolve_bool(&QUIET_NOTICES, Some(false), Some("1".into()), Some(true)).unwrap(),
+            "an explicit --no-<flag> overrides both lower channels"
+        );
+    }
+
+    #[test]
+    fn env_beats_config_and_default() {
+        assert!(resolve_bool(&QUIET_NOTICES, None, Some("yes".into()), Some(false)).unwrap());
+        assert!(!resolve_bool(&QUIET_NOTICES, None, Some("off".into()), Some(true)).unwrap());
+    }
+
+    #[test]
+    fn config_beats_default() {
+        assert!(resolve_bool(&QUIET_NOTICES, None, None, Some(true)).unwrap());
+        assert!(!resolve_bool(&QUIET_NOTICES, None, None, Some(false)).unwrap());
+        assert!(!resolve_bool(&QUIET_NOTICES, None, None, None).unwrap());
+    }
+
+    #[test]
+    fn every_env_spelling_parses() {
+        for (raw, want) in [
+            ("1", true),
+            ("true", true),
+            ("yes", true),
+            ("on", true),
+            ("0", false),
+            ("false", false),
+            ("no", false),
+            ("off", false),
+        ] {
+            assert_eq!(
+                resolve_bool(&QUIET_NOTICES, None, Some(raw.to_string()), None).unwrap(),
+                want,
+                "{raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_garbage_env_value_is_a_named_error_never_a_default() {
+        let err = resolve_bool(&QUIET_NOTICES, None, Some("maybe".into()), Some(true))
+            .expect_err("garbage env must not silently fall through to the config");
+        let msg = err.to_string();
+        assert!(msg.contains("TEBAKO_QUIET_NOTICES"), "{msg}");
+        assert!(msg.contains("maybe"), "{msg}");
+    }
+}

--- a/docs/spec/02-tpkg-wire-format.md
+++ b/docs/spec/02-tpkg-wire-format.md
@@ -22,7 +22,7 @@ container itself stays byte-identical either way.
 |-------:|-----:|-------|
 | 0   | 10  | magic `"TEBAKOTFS\0"` |
 | 10  | 4   | u32 version = **1** (extensions ride flags, not version bumps) |
-| 14  | 4   | u32 package_flags (bit0 LEAN, bit1 SIGNED_V2, bit2 NO_INSTALL) |
+| 14  | 4   | u32 package_flags (bit0 LEAN, bit1 SIGNED_V2, bit2 NO_INSTALL, bit3 QUIET_NOTICES) |
 | 18  | 4   | u32 slot_count (1..=8) |
 | 22  | 8   | u64 slot_table_offset (absolute file offset of slot 0) |
 | 30  | 128 | char runtime_ref[128] — resolution hint (spec 05 §1); empty = classic |
@@ -79,6 +79,19 @@ package: it RUNS standalone
 but every install attempt is refused with a named error. Absence means
 installable-on-request, including packages pressed before the verb
 existed — pass-through like every flag.
+
+## 5a. The quiet-notices flag (bit3 `QUIET_NOTICES`; tebako#400, spec 23 §14)
+
+The developer's declaration that the package's runs suppress the
+unsigned-legacy-trailer warning (spec 09 §v1-legacy) and the progress
+lines (spec 06 §5) — declared through any registry channel (CLI
+`--quiet-notices`, env `TEBAKO_QUIET_NOTICES`, compose key
+`quiet_notices:`), resolved once at press, baked here. Run-time reads
+only the bit: the package behaves identically on every machine. The bit
+rides inside the signed region, so it cannot be forged onto a signed
+package; `TEBAKO_REQUIRE_SIGNED=1` is checked FIRST and outranks it,
+and the audit-journal entry is written regardless. Absence means the
+default notice behavior — pass-through like every flag.
 
 ## 6. Orthogonality note (normative)
 

--- a/docs/spec/06-launcher-abi.md
+++ b/docs/spec/06-launcher-abi.md
@@ -90,7 +90,8 @@ the benefit. Rules:
 
 - **TTY-only:** full progress rendering iff stderr is a TTY and
   `TERM != dumb`; otherwise exactly two single lines (start + done), CI/
-  log-safe. Opt-outs: `NO_COLOR`, `TEBAKO_NO_PROGRESS=1`.
+  log-safe. Opt-outs: `NO_COLOR`, `TEBAKO_NO_PROGRESS=1`, and the
+  package's baked `TPKG_FLAG_QUIET_NOTICES` (bit 3 — spec 23 §14).
 - **Phases, one line each:** `resolving <runtime_ref>` →
   `downloading <asset> (<size>)` with the live bar →
   `verifying sha256` → `installing (locked)` → done.
@@ -105,6 +106,9 @@ the benefit. Rules:
   `TEBAKO_NO_PROGRESS=1` silences these informational lines entirely
   (the cache-hit, `installed …`, and `downloading …` lines — progress is
   not results; tebako#400); the mode selection rule above still applies.
+  `TPKG_FLAG_QUIET_NOTICES` (bit 3 — the developer's press-time
+  declaration via the spec 23 §14 registry) applies the same silence to
+  every run of the package, on every machine.
 - Progress output goes to **stderr**, never stdout (stdout belongs to
   the payload).
 - Implementation: a tiny `tebako-term` micro-crate (TTY detect, bar,

--- a/docs/spec/09-trust-and-signing.md
+++ b/docs/spec/09-trust-and-signing.md
@@ -63,8 +63,14 @@ tebako validates below it — see spec 12 §5.
   replaced binary warns again) plus an audit-journal entry on **every**
   acceptance (tebako#400: the per-run repetition was unactionable noise;
   the durable remedy is `tebako press --sign` — v2-signed trailers never
-  warn). `TEBAKO_REQUIRE_SIGNED=1` is the explicit opt-in
-  hard-fail for hardened environments — never the default.
+  warn). A package whose developer declared `quiet_notices` (spec 23
+  §14) carries `TPKG_FLAG_QUIET_NOTICES` (bit 3) and suppresses this
+  warning and the spec 06 §5 progress lines on every run — the bit
+  rides inside the signed region, so it cannot be forged onto a signed
+  package, and the journal entry is written regardless.
+  `TEBAKO_REQUIRE_SIGNED=1` is the explicit opt-in
+  hard-fail for hardened environments — never the default; it is
+  checked FIRST and outranks the quiet bit.
 - **Fail closed everywhere:** no insecure-skip flag.
 - Encryption is likewise per-image opt-in (spec 10).
 

--- a/docs/spec/23-declarative-composition.md
+++ b/docs/spec/23-declarative-composition.md
@@ -518,3 +518,40 @@ native bytes in a "universal" image fail there, before publication.
 | Lazy-seed mechanics | spec 05 §4 (amended: the scoped exception) |
 | Two-slot carried runtime | spec 19 (amended) + tebako#458 |
 | Lean/fat alias warning | the named-warning vocabulary (invariant 9); exit codes unchanged — carry choices never gate a run |
+
+## 14. The settings registry — one setting, three channels, one SSOT (owner-directed 2026-08-26, tebako#400)
+
+Every user-facing setting is declarable through up to THREE channels:
+the CLI flag, the environment variable, and the compose-document key.
+Ad-hoc per-channel wiring is how the channels drift into two meanings,
+so declaration and resolution each live in exactly one place:
+
+- **Declaration:** `tpkg::settings` (the registry) names each setting
+  ONCE — config key, env spelling, CLI flag, default, one doc line —
+  and declares WHICH channels carry it. A machine-level knob (a cache
+  root) has no business in a git-shared document; a package-policy bit
+  the press bakes MUST be declarable in the repo-carried document.
+  `--help`, the schema, and the docs render from the registry; a
+  setting present on a channel but absent from the registry is a bug on
+  arrival (invariant 10).
+- **Resolution:** `tpkg::settings::resolve_bool`, fixed precedence
+  **CLI → environment → compose document → default**. Every channel is
+  tri-state (present-true / present-false / absent), so a repo-declared
+  `quiet_notices: true` stays overridable per invocation
+  (`--no-quiet-notices`, `TEBAKO_QUIET_NOTICES=0`). An env value that
+  does not parse is a NAMED error, never a silent default
+  (invariant 9).
+- **Baking:** settings whose semantics belong to the PACKAGE (not the
+  machine) bake into the trailer at press; run-time reads the trailer,
+  never the channels — a pressed package behaves identically on every
+  machine (the developer's declaration is environment-independent by
+  construction, and the repo carries it).
+
+The registry's first citizen:
+
+| setting | CLI | env | compose key | baked form |
+|---|---|---|---|---|
+| `quiet_notices` | `--quiet-notices` / `--no-quiet-notices` | `TEBAKO_QUIET_NOTICES` | `quiet_notices:` | `TPKG_FLAG_QUIET_NOTICES` (bit 3, spec 02 §5a) — suppress the unsigned-legacy-trailer warning (spec 09) and the progress lines (spec 06 §5) on every run |
+
+Every NEW setting declares its channels in the registry first; existing
+channels migrate into the registry as they are touched.

--- a/schema/tebako-compose-v1.schema.json
+++ b/schema/tebako-compose-v1.schema.json
@@ -28,6 +28,10 @@
       "type": "string",
       "minLength": 1,
       "description": "The pointer-package form's entry selector — a PROVIDES entrypoint name of one of the slices. Absent when the press packages a local root (the app's own entry governs)."
+    },
+    "quiet_notices": {
+      "type": "boolean",
+      "description": "The config channel of the quiet_notices registry setting (spec 23 §14): bake TPKG_FLAG_QUIET_NOTICES (bit 3) — every run suppresses the unsigned-legacy-trailer warning and the progress lines. Tri-state: absent lets the CLI (--quiet-notices) and env (TEBAKO_QUIET_NOTICES) channels rule; CLI > env > this key > default(false)."
     }
   },
   "$defs": {


### PR DESCRIPTION
## tebako#400 — developer-declared quiet notices, via the new settings registry (spec 23 §14)

The unsigned-legacy-trailer warning and the progress lines are now suppressible by the **package developer at press time**, declared in the repo-carried compose document — environment-independent, git-shareable, and (for signed packages) unforgeable.

### The settings registry (new `tpkg::settings`, spec 23 §14)

Per the owner directive: the CLI flag, the environment variable, and the config-file key must be **three channels over ONE source of truth**, never three ad-hoc wirings.

- **One declaration per setting** (`Setting`): config key, env spelling, CLI flag, default, one doc line, and *which channels carry it*. A machine-level knob has no business in a git-shared document; a package-policy bit the press bakes must be declarable in the repo-carried document. `--help`, the compose JSON Schema, and the docs render from the registry — a setting present on a channel but absent from the registry is a bug on arrival (invariant 10).
- **One resolution** (`resolve_bool`): fixed precedence **CLI → env → compose document → default**. Every channel is tri-state (present-true / present-false / absent), so a repo-declared `quiet_notices: true` stays overridable per invocation. An env value that does not parse is a **named error, never a silent default** (invariant 9).
- **Baking:** package semantics bake into the trailer at press; run-time reads the trailer, never the channels — a pressed package behaves identically on every machine.

Every NEW setting declares its channels in the registry first; existing channels migrate as they are touched.

### `quiet_notices` — the registry's first citizen

| channel | spelling |
|---|---|
| CLI | `--quiet-notices` / `--no-quiet-notices` |
| env | `TEBAKO_QUIET_NOTICES` (1/0, true/false, yes/no, on/off) |
| compose | `quiet_notices: true` |

The resolved value bakes **`TPKG_FLAG_QUIET_NOTICES` (bit 3)** (spec 02 §5a). Run-time behavior:

- the v1-legacy warning (spec 09) stays silent on **every** run — no marker consult, no stderr line;
- the progress lines (spec 06 §5) ride the same quiet gate as `TEBAKO_NO_PROGRESS`;
- **`TEBAKO_REQUIRE_SIGNED=1` is checked FIRST and outranks the bit** — user policy beats publisher preference, always;
- acceptance is **journaled regardless**;
- the bit lives **inside the signed region** — it cannot be forged onto a signed package.

This complements #470 (shipped in v0.2.6): warn-once-per-package marker + `TEBAKO_NO_PROGRESS` were the *user-side* remedies; this is the *developer-side* declaration eggplants asked for.

### Changes

- `tpkg`: `settings.rs` (registry + `resolve_bool` + strict env parse); `TPKG_FLAG_QUIET_NOTICES = 0x8` + `Manifest::is_quiet_notices()`; compose document gains `quiet_notices:` (tri-state).
- `tebako-cli`: `--quiet-notices` / `--no-quiet-notices`; `effective_quiet_notices()` resolves the three channels at press (suites included); `stitch` gains `StitchFlags` (the three trailer-flag inputs travel together — clippy arity).
- `tebako-bootstrap`: the v1 arm honors the bit (REQUIRE_SIGNED first); the progress UX quiets via `BootUx::prog.set_quiet(...)`.
- `tebako-term`: `Progress::set_quiet` (ORs into the existing quiet).
- Specs: **23 §14** (new), **02 §5a** + the header flags row, **09** v1-legacy rule, **06 §5** opt-outs; `schema/tebako-compose-v1.schema.json` gains `quiet_notices`.

### Tests

- `tpkg::settings`: precedence matrix, all 8 env spellings, garbage-env named error.
- `tpkg::compose`: `quiet_notices` tri-state parse.
- `tebako-cli` lib: `stitch` bakes/clears the bit (and `is_quiet_notices()`).
- `tebako-bootstrap` chain: bit ⇒ accepted + journaled ×2 with **no warn marker ever**; REQUIRE_SIGNED=1 still hard-fails.
- `cli_e2e` (5 legs, run locally green): default press clear; `--quiet-notices` bakes; `TEBAKO_QUIET_NOTICES=1` bakes; compose `quiet_notices: true` bakes; `--no-quiet-notices` overrides the document.

Based on v0.3.0 main (`17808b54`).
