### PR TITLE
release: windows-gnu-release.sh builds the bootstrap alone too — the site #475 missed

### DIFF
--- a/ci/windows-gnu-release.sh
+++ b/ci/windows-gnu-release.sh
@@ -77,8 +77,15 @@ export BINDGEN_EXTRA_CLANG_ARGS="--target=x86_64-w64-mingw32 -isystem $(cygpath 
 TARGET=x86_64-pc-windows-gnu
 
 # --- 1. release build -------------------------------------------------------
+# tebako-bootstrap builds in its OWN invocation — cargo feature
+# unification with tebako-cli/tebako-shim would re-enable tebako-resolve's
+# `git` feature (gix/reqwest/rustls, aws-lc-rs on mingw) inside the
+# size-gated loader (v0.3.0 release run 32975547796 failed the 3 MiB gate
+# on this leg at 5,449,216 B for exactly this reason; #475 fixed the
+# other three build sites and missed this one).
+cargo build --release --target "$TARGET" -p tebako-bootstrap
 cargo build --release --target "$TARGET" \
-  -p tebako-bootstrap -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim
+  -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim
 
 # --- 2. stage (strip, size gate, fragments) ---------------------------------
 # stage.sh strips, enforces the bootstrap size budget and writes the


### PR DESCRIPTION
## What

One-line-class fix: `ci/windows-gnu-release.sh` now builds `tebako-bootstrap` in its **own cargo invocation**, then the toolchain in a second — the same split #475 (e6fb8d41) applied to the other three release build sites.

## Why — v0.3.0 release run 32975547796 failed on exactly one leg

| Leg | Build site | Split? | Result |
|---|---|---|---|
| macOS ×2 | `release.yml` macOS job | ✅ #475 | green, gate passed |
| linux-gnu ×2 | `ci/gnu-floor-build.sh` | ✅ #475 | green, gate passed |
| linux-musl ×2 | `ci/musl-build.sh` | ✅ #475 | green, gate passed |
| **windows-ucrt64** | **`ci/windows-gnu-release.sh`** | ❌ **missed** | **5,449,216 B > 3,145,728 B budget** |

The failing leg's build log is the #475 mechanism verbatim: `gix-discover/gix-odb/gix-filter/gix` + `limnifs-*` + `omnizip-*` compile in the same invocation as `tebako-bootstrap`. One cargo invocation = one feature resolution, so tebako-cli/tebako-shim's `tebako-resolve` edge (default features, `git` ON) unifies into the bootstrap build and silently defeats its `default-features = false` edge. The mingw leg is the fattest because the HTTP stack rides rustls/**aws-lc-rs** there (ring doesn't compile under mingw — ci.yml:294).

PR CI cannot catch this: `ci/windows-gnu-bootstrap.sh` builds the bootstrap alone, so the gate goes green on PRs while the release script drifts — same blind spot #475 documented for the other sites.

## Verification

- `git grep "cargo build --release" origin/main -- ci/ .github/` — after this change, **no build site carries tebako-bootstrap beside another package** (release.yml:235, ci/windows-gnu-bootstrap.sh:67, the three #475 sites, and now this one all build it alone; release.yml:723 is the link-unit leg, tfs+driver only).
- `bash -n` clean.
- Behavior proof is the release run itself: the other three fixed sites passed the gate in run 32975547796 on the same commit; this leg was the sole outlier.

## After merge

Re-cut `v0.3.0` at the merge commit and re-run the release (the current v0.3.0 release object is public but incomplete — 7/8 platforms, no SHA256SUMS/manifest until Finalize runs).
