### PR TITLE
deps: gix 0.87 (bisync yank fix) + limnifs 0.3.3 (windowed-read perf, Windows build fix) — the v0.3.0 release unblock

### DIFF
--- a/crates/tebako-bootstrap/Cargo.toml
+++ b/crates/tebako-bootstrap/Cargo.toml
@@ -26,7 +26,7 @@ tebako-term = { version = "0.3.0", path = "../tebako-term" }
 # the crypto toolkit payload; until then this feature keeps the full
 # verification path available for dev builds (--features openpgp-verify).
 # With the feature off the bootstrap carries ZERO rnp/botan/json-c/bz2.
-rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"], optional = true }
+rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"], optional = true }
 libc = "0.2"
 sha2 = "0.10"
 
@@ -60,4 +60,4 @@ path = "src/lib.rs"
 # every platform (the feature above is unaffected).
 [target.'cfg(not(windows))'.dev-dependencies]
 tebako-signer = { version = "0.3.0", path = "../tebako-signer" }
-rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
+rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"] }

--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -42,7 +42,7 @@ dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
 # — pure Rust, no `limni` binary anywhere. Floor: post-flip line rides
 # 0.2.65's format (see crates/tfs).
-limnifs-write = "0.3.1"
+limnifs-write = "0.3.3"
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tebako-pkg/Cargo.toml
+++ b/crates/tebako-pkg/Cargo.toml
@@ -15,7 +15,7 @@ tpkg = { version = "0.3.0", path = "../tpkg" }
 tebako-json = { version = "0.3.0", path = "../tebako-json" }
 tebako-info = { version = "0.3.0", path = "../tebako-info" }
 tebako-signer = { version = "0.3.0", path = "../tebako-signer" }
-rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
+rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"] }
 libc = "0.2"
 sha2 = "0.10"
 

--- a/crates/tebako-resolve/Cargo.toml
+++ b/crates/tebako-resolve/Cargo.toml
@@ -45,12 +45,11 @@ libc = "0.2"
 # vendored crate exactly like ring; no native-tls, no schannel, no
 # behavior change). All three are the `git` feature's — off for the
 # bootstrap's link.
-gix = { version = "0.86", default-features = false, optional = true, features = [
+gix = { version = "0.87", default-features = false, optional = true, features = [
     "sha1",
     "blocking-network-client",
     "blocking-http-transport-reqwest",
     "revision",
-    "tree-editor",
 ] }
 reqwest = { version = "0.13", default-features = false, optional = true, features = ["rustls-no-provider"] }
 
@@ -73,7 +72,7 @@ path = "src/lib.rs"
 proptest = "1"
 # The git fixtures are built with gix itself — no git CLI anywhere, tests
 # included (spec 14 §3).
-gix = { version = "0.86", default-features = false, features = ["sha1", "tree-editor"] }
+gix = { version = "0.87", default-features = false, features = ["sha1"] }
 
 # The per-entry cache flock on Windows (cache.rs — LockFileEx on one byte
 # at offset 0, the tebako-bootstrap platform.rs shape). Unix uses libc's

--- a/crates/tebako-signer/Cargo.toml
+++ b/crates/tebako-signer/Cargo.toml
@@ -9,8 +9,9 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
-# rnp-rs 0.1.11's vendored mode delegates to rnp-src 0.2.x, which builds
-# librnp + Botan + json-c + zlib + bzip2 from source — nothing external
-# to link.
+rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"] }
+# rnp-rs 0.1.12's vendored mode delegates through rnp-sys to rnp-src 0.2.x,
+# which builds librnp + Botan + json-c + zlib + bzip2 from source — nothing
+# external to link. (0.1.12 is the pair for rnp-src 0.2.1: 0.2.1 dropped
+# links::lib_dir_env_var, which breaks 0.1.11's build script.)
 sha2 = "0.10"

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -35,7 +35,7 @@ dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
 # §6) — pure Rust, no `limni` binary anywhere. Floor: post-flip line
 # rides 0.2.65's format (see crates/tfs).
-limnifs-write = "0.3.1"
+limnifs-write = "0.3.3"
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is
@@ -66,4 +66,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # the reader (spec 20 §5 constraint 1: no SharedInline handle anywhere)
 # — test-only, never linked into the shipped binary. Floor: see the
 # limnifs-write pin above (post-flip line is >= 0.3.0).
-limnifs-core = "0.3.1"
+limnifs-core = "0.3.3"

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -59,7 +59,7 @@ path = "src/lib.rs"
 tebako-contract-tests = { version = "0.3.0", path = "../../tests/contract" }
 # The --verify signature tests mint a press-local key and detached .asc.
 tebako-signer = { version = "0.3.0", path = "../tebako-signer" }
-rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
+rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"] }
 # Exec-proof image fixtures (zip backend).
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # The floor-recipe structural test parses the emitted metadata through

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -62,7 +62,7 @@ sqfs-sys = { version = "0.3.0", path = "../sqfs-sys", optional = true }
 # rides the flip: images pressed by >= 0.3.0 need a >= 0.3.0-reader
 # runtime and vice versa; sha256 is the anchor (spec 20 §8's
 # format-evolution rule).
-limnifs-core = { version = "0.3.1", optional = true }
+limnifs-core = { version = "0.3.3", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
@@ -111,5 +111,5 @@ crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —
 # test-only, never linked into the shipped library. Floor: see the
 # limnifs-core pin above (post-flip line is >= 0.3.0).
-limnifs-write = "0.3.1"
+limnifs-write = "0.3.3"
 

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -105,7 +105,7 @@ backend-limnifs = ["dep:limnifs-core"]
 # Tempdir scaffolding for backend tests (large-archive RSS fixtures).
 tempfile = "3"
 # ENC tests mint recipient key pairs in-memory (same pin as tebako-signer).
-rnp = { package = "rnp-rs", version = "=0.1.11", features = ["vendored"] }
+rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"] }
 # gzip trailer checksums in tar-backend test fixtures.
 crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -26,4 +26,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 # The limnifs backend-pair golden class builds its fixture image
 # in-process (spec 20 §8) — never a `limni` binary.
-limnifs-write = "0.2.62"
+limnifs-write = "0.3.3"


### PR DESCRIPTION
## What

Two dependency unblock/refresh items, one release-blocking branch:

1. **`gix` 0.86 → 0.87** in `crates/tebako-resolve` (the only gix pins in the workspace: the optional `git`-feature dep and the dev-dep), dropping the `tree-editor` feature from both.
2. **limnifs 0.3.1 → 0.3.3** everywhere it's pinned: `tfs` (core reader + write dev-dep), `tfs-cli` (write + core), `tebako-cli` (write), and `tests/contract` (write — was floating on a stale `0.2.62` pin).

## Why 1 — v0.3.0 release run 33014550153 failed on all 8 legs

gitoxide **yanked every published version of `bisync`** (0.2.x, 0.3.0, 0.3.1 — the latter published and yanked on 2026-08-24). `gix-protocol 0.64.0` (what `gix ^0.86` resolves to) requires `bisync ^0.3.0`, so fresh resolution fails. No committed `Cargo.lock` (resolutions float — AGENTS.md), so every fresh build of main was broken, not just the release. Earlier runs passed only by resolving before the yank propagated.

- gix 0.87.1 / gix-protocol 0.65.1 (2026-08-24, not yanked) no longer depend on bisync — verified via the crates.io dependency API.
- `tree-editor` was removed from gix in 0.87; nothing in `crates/tebako-resolve` references its API (grep-verified) — dead weight, dropped.

## Why 2 — limnifs 0.3.2/0.3.3 landed (2026-08-26) with read-path perf

- 0.3.2: windowed reads — zero-copy, precomputed seekable footer starts, `MADV_RANDOM` on reader slabs; an unused unsafe pipeline-parallelism module removed.
- 0.3.3: cfg(unix)-gates that hint — **0.3.2 broke the Windows build**, so the floor skips straight to 0.3.3.
- Format floor unchanged (0.3.0): no payload re-presses, no runtime rebuild beyond the planned v0.16.11 re-cut (which picks 0.3.3 up through this pin).
- `tests/contract`'s pin floated `0.2.62 → 0.2.65` (post-flip by luck — 0.2.65 *is* the flipped format), but it dragged a **second full limnifs stack** into every workspace build. Aligned to 0.3.3; the era-rejection contract isn't served by this pin (the only rejection test uses a truncated image).

## Verification (local, macOS arm64)

- `cargo check --workspace --all-targets` — clean on limnifs 0.3.3 + gix 0.87.1 / gix-protocol 0.65.1 / reqwest 0.13.4 (7m04s).
- `cargo test -p tebako-resolve --all-features` — green (exit 0; git fixtures built with gix itself).
- `cargo test -p tebako-contract-tests --test limnifs_backend` — 3/3 green with the 0.3.3-written fixture (`backend_pair_golden_parity_vs_dwarfs`, `offset_and_memory_mounts`, `corrupt_image_mount_fails_named`).
- `cargo test -p tfs -p tfs-cli -p tebako-cli` — green.

## After merge

Re-cut tag `v0.3.0` at the merge commit and re-fire the release (delete the release object if drafted; fresh tag delete+push — tag *updates* don't reliably fire the workflow).


## Why 3 — rnp-rs `=0.1.11` → `=0.1.12` (second same-day upstream break, found by this branch's CI)

The first push's CI went red on all 7 rnp-compiling legs (`dogfood` kernel/libc, `parity`, `test --no-default-features`, macos-14, ubuntu-24.04, windows-gnu cli/pkg): `E0425: cannot find function lib_dir_env_var in module links` at `rnp-rs-0.1.11/build.rs:123`.

- We pin `rnp-rs = "=0.1.11"` ×6 manifests (`vendored`); its build script calls `rnp_src::links::lib_dir_env_var` and `rnp-src = "0.2"` **floats**.
- Upstream shipped a coordinated triple release on 2026-08-26 ~22:31Z: **rnp-src 0.2.1** (dropped `lib_dir_env_var` for `Deps::lib_dirs()`), **rnp-sys 0.1.0** (new linking crate), **rnp-rs 0.1.12** (the pair: `build = false` — pre-generated bindings, linking via rnp-sys). Verified from the published `.crate` files.
- Local runs were green only because the local registry still had rnp-src 0.2.0 cached. Branch-independent: any fresh resolution of main hits this too.

Verified locally: `cargo check --all-features` on all five rnp consumers (rnp-src 0.2.1 vendored build green, 3m44s) + `cargo test -p tebako-signer` green (the static link resolves and sign/verify runs against it).
