### PR TITLE
tools/stage_link_unit: harvest the rnp family from rnp-sys-*/out (unbreak v0.3.0 release legs)

### DIFF
--- a/tools/stage_link_unit
+++ b/tools/stage_link_unit
@@ -15,7 +15,7 @@
 #   dwarfs-t-sys-*/out/dwarfs-build/                    the dwarfs-t libraries
 #   dwarfs-t-sys-*/out/dwarfs-build/vcpkg_installed/…   their vcpkg closure
 #   sqfs-sys-*/out/                                      the squashfs pair
-#   rnp-src-*/out/install/                               the rnp family
+#   rnp-sys-*/out/install/                               the rnp family
 #
 # No shell-outs to anything but cargo (dev-side tooling, never a shipped
 # artifact).
@@ -154,13 +154,18 @@ else
   sqfs = newest_out(File.join(script_out, "sqfs-sys-*", "out"))
   die "no sqfs-sys build under #{script_out}" unless sqfs
 
-  # rnp-src variants multiply in a reused target dir (a non-vendored
-  # graph leaves an EMPTY out dir): newest-by-mtime alone picks the
-  # stub. Only an out dir with the vendored install tree qualifies.
-  rnp = Dir.glob(File.join(script_out, "rnp-src-*", "out"))
+  # rnp-sys variants multiply in a reused target dir (a non-vendored
+  # graph leaves an out dir WITHOUT the install tree): newest-by-mtime
+  # alone picks the stub. Only an out dir with the vendored install tree
+  # qualifies. (rnp-rs >= 0.1.12 has no build script: its build.rs moved
+  # to rnp-sys, which calls rnp_src::build() — the install tree lands in
+  # rnp-sys's OUT_DIR, per the botan-src caller-owns-OUT_DIR pattern.
+  # rnp-src itself is build=false since 0.2.1, so no rnp-src-*/out ever
+  # exists in this graph.)
+  rnp = Dir.glob(File.join(script_out, "rnp-sys-*", "out"))
            .select { |d| File.file?(File.join(d, "install", "rnp", "lib", "librnp.a")) }
            .max_by { |d| File.mtime(d) }
-  die "no rnp-src build with an install tree under #{script_out} (rnp with the vendored feature)" unless rnp
+  die "no rnp-sys build with an install tree under #{script_out} (rnp with the vendored feature)" unless rnp
 
   # their vcpkg closure (codecs, boost, crypto — the static triplet):
   # every archive the dwarfs-t link emits, the same rule as the mingw
@@ -187,12 +192,13 @@ else
   die "no vcpkg static lib dir under #{sqfs}" unless sqfs_vlib
   harvest(out, File.join(sqfs_vlib, "libsquashfs.a"), "squashfs-tools-ng")
 
-  # the rnp family (rnp-src's own install tree — never a prebuilt download)
+  # the rnp family (rnp-sys's install tree, built from rnp-src sources —
+  # never a prebuilt download)
   {
-    "rnp/lib/librnp.a" => "librnp (rnp-src)",
-    "rnp/lib/libsexpp.a" => "libsexpp (rnp-src)",
-    "json-c/lib/libjson-c.a" => "json-c (rnp-src)",
-    "botan/lib/libbotan-3.a" => "botan (botan-src via rnp-src)",
+    "rnp/lib/librnp.a" => "librnp (rnp-sys)",
+    "rnp/lib/libsexpp.a" => "libsexpp (rnp-sys)",
+    "json-c/lib/libjson-c.a" => "json-c (rnp-sys)",
+    "botan/lib/libbotan-3.a" => "botan (rnp-src via rnp-sys)",
   }.each do |rel, note|
     harvest(out, File.join(rnp, "install", rel), note)
   end


### PR DESCRIPTION
## What

`tools/stage_link_unit` harvests the vendored rnp install tree from `rnp-src-*/out/install/` — but **rnp-rs 0.1.12** (merged in #479) restructured the stack: `rnp-src` 0.2.1 is now `build = false` (a pure library exposing `rnp_src::build()`), and the build script moved to **rnp-sys 0.1.0**, whose build.rs calls `rnp_src::build()` — which compiles into the *caller's* `OUT_DIR` (the botan-src pattern). The install tree therefore now lives at `target/**/build/rnp-sys-<hash>/out/install/`, and no `rnp-src-*/out` directory can exist in this graph again.

One-glob fix: harvest from `rnp-sys-*/out` instead. The stub-filter logic (select only out dirs containing `install/rnp/lib/librnp.a`, newest by mtime) is unchanged — a non-vendored rnp-sys graph still leaves no install tree. Provenance-map header comment and harvest notes updated to name the new owner.

## Evidence

- Release run 33026976676: macos-arm64 + linux-gnu-arm64 legs exit 64 at link-unit-stage with "no rnp-src build with an install tree under …/release/build" (the stage only runs in release.yml — PR CI green could not see it). Run cancelled after root-cause; the remaining POSIX legs would have died identically.
- Local end-to-end on macOS arm64 (same platform as a failed leg): `cargo build --release -p tfs -p tebako-driver -p libtfs-preload`, then `ruby tools/stage_link_unit out/link-unit-macos-arm64 --skip-build` → **exit 0**, with the rnp family harvested from the new location:
  - `closure librnp.a <= build/rnp-sys-7fac4ade…/out/install/rnp/lib/librnp.a`
  - `closure libsexpp.a <= build/rnp-sys-…/out/install/rnp/lib/libsexpp.a`
  - `closure libjson-c.a <= build/rnp-sys-…/out/install/json-c/lib/libjson-c.a`
  - `closure libbotan-3.a <= build/rnp-sys-…/out/install/botan/lib/libbotan-3.a`
  - staged: 2 scoped staticlibs + 42 closure archives (required-set contract passed).
- Verified no other repo reference to `rnp-src-*` build dirs (grep over tools/, ci/, .github/). Stale version mentions in `ci/musl-build.sh` / `release.yml` comments are documentation-only follow-ups — and rnp-sys shipping pregenerated bindings may make the musl container's clang19-libclang unnecessary; not touched here.

## After merge

Re-cut tag `v0.3.0` at the merge commit and re-fire the release (delete the release object first if drafted; fresh tag delete+push — tag updates don't fire the workflow).
