### PR TITLE
limnifs 0.3.6 floor + v0.3.1 — create-path perf, format unchanged

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-arscope", "crates/tebako-bench", "tests/contract"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"

--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -42,7 +42,7 @@ dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
 # — pure Rust, no `limni` binary anywhere. Floor: post-flip line rides
 # 0.2.65's format (see crates/tfs).
-limnifs-write = "0.3.3"
+limnifs-write = "0.3.6"
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tebako-cli/README.md
+++ b/crates/tebako-cli/README.md
@@ -102,7 +102,10 @@ flock'd, `.sdk-complete` marker — never the runtime cache):
 
 1. the pre-patched ruby src release the runtime was built from
    (`tfs-ruby-<ver>-src.tar.gz` from `tamatebako/ruby` releases,
-   `TEBAKO_SDK_SRC_RELEASE` default `v0.2.1`,
+   `TEBAKO_SDK_SRC_RELEASE` default `v0.2.27` (the pin must carry the
+   src tarball for every ruby on the current runtime matrix — v0.2.1
+   stops at 3.3.7/3.4.2, so 3.3.12/3.4.10 presses failed closed at
+   exit 135, tebako#482),
    `TEBAKO_SDK_SRC_MIRROR` for mirrors — `file://` works offline) is
    downloaded in-process and sha256-verified against the release's
    SHA256SUMS;

--- a/crates/tebako-cli/src/sdk.rs
+++ b/crates/tebako-cli/src/sdk.rs
@@ -39,7 +39,14 @@ use crate::error::{packaging_error, plain_error, TebakoError};
 use crate::fetch::{fetch_bytes, fetch_text, FetchError};
 use crate::options::host_platform;
 
-pub const DEFAULT_SRC_RELEASE: &str = "v0.2.1";
+// The tamatebako/ruby source-factory release the SDK's ruby src tarball
+// comes from. Must carry the src tarball for every ruby version on the
+// current runtime matrix: v0.2.1 (the historic pin) stops at 3.3.7/3.4.2,
+// so presses against the 0.16.11 line (3.3.12/3.4.10) failed closed at
+// exit 135 (tebako#482). v0.2.27 carries the full matrix. Rolling-release
+// tarballs are NOT content-stable (tamatebako/ruby#100); the durable SSOT
+// fix is resolving the pointer from the runtime manifest's built_from.
+pub const DEFAULT_SRC_RELEASE: &str = "v0.2.27";
 pub const DEFAULT_MIRROR: &str = "https://github.com/tamatebako/ruby/releases/download";
 const SUMS_FILE: &str = "SHA256SUMS";
 const MARKER_FILE: &str = ".sdk-complete";
@@ -851,7 +858,7 @@ mod tests {
             host_tag().unwrap()
         ));
         assert!(root.starts_with(deps));
-        assert!(root.to_string_lossy().contains("3.3.7-v0.2.1-"));
+        assert!(root.to_string_lossy().contains("3.3.7-v0.2.27-"));
     }
 
     #[test]

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -35,7 +35,7 @@ dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
 # §6) — pure Rust, no `limni` binary anywhere. Floor: post-flip line
 # rides 0.2.65's format (see crates/tfs).
-limnifs-write = "0.3.3"
+limnifs-write = "0.3.6"
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is
@@ -66,4 +66,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # the reader (spec 20 §5 constraint 1: no SharedInline handle anywhere)
 # — test-only, never linked into the shipped binary. Floor: see the
 # limnifs-write pin above (post-flip line is >= 0.3.0).
-limnifs-core = "0.3.3"
+limnifs-core = "0.3.6"

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -62,7 +62,7 @@ sqfs-sys = { version = "0.3.0", path = "../sqfs-sys", optional = true }
 # rides the flip: images pressed by >= 0.3.0 need a >= 0.3.0-reader
 # runtime and vice versa; sha256 is the anchor (spec 20 §8's
 # format-evolution rule).
-limnifs-core = { version = "0.3.3", optional = true }
+limnifs-core = { version = "0.3.6", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
@@ -111,5 +111,5 @@ crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —
 # test-only, never linked into the shipped library. Floor: see the
 # limnifs-core pin above (post-flip line is >= 0.3.0).
-limnifs-write = "0.3.3"
+limnifs-write = "0.3.6"
 

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -26,4 +26,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 # The limnifs backend-pair golden class builds its fixture image
 # in-process (spec 20 §8) — never a `limni` binary.
-limnifs-write = "0.3.3"
+limnifs-write = "0.3.6"


### PR DESCRIPTION
## What

1. **limnifs floor 0.3.3 → 0.3.6** — six pins: `tfs` (core optional + write dev-dep), `tfs-cli` (write + core), `tebako-cli` (write), `tests/contract` (write).
2. **Workspace version 0.3.0 → 0.3.1** — the floor bump rides into the shipped binaries as a patch release; intra-workspace caret pins (`^0.3.0`) span the patch boundary untouched.

## Why — limnifs 0.3.4–0.3.6 (2026-08-26/27), verified from the limnifs changelog + source

- **0.3.4**: the writer's create path borrows its mmap instead of `Vec::from(&mmap[..])`-copying every ≥ 1 MiB file — halves peak RSS on big-file trees. This is the feedstock/packed-mn press path (metanorma-size payloads).
- **0.3.5**: `FilterCodecComposite` — one deep `Codec` impl serves all seven composites, **wire format proven byte-equal**; per-codec tunables OCP proof; cross-image sparse index wired behind the `sparse-index` feature (we don't enable it).
- **0.3.6**: whole-file specialized codecs route through `compress_with_tunables` (output-neutral pin test); real-workload BCJ benchmark; extended Windows PR check (all features except fuse on MSVC).

**Format floor unmoved**: `SLAB_FORMAT_VERSION = 1`, `EPOCH_FORMAT_VERSION = 1` — drop-in. No payload re-presses, no reader-compat risk, either direction. (Fresh resolutions already float here — the v0.16.11 runtime build resolved 0.3.5 — this PR makes 0.3.6 the *guaranteed* floor.)

## Verification (local, macOS arm64)

- `cargo check --workspace --all-targets` — clean (5m04s).
- `cargo test -p tfs --lib` — 190/0.
- `cargo test -p tfs-cli -p tebako-cli --lib` — 137/0 + 19/0.
- `cargo test -p tebako-contract-tests --test limnifs_backend` — 3/3 (golden parity vs dwarfs, offset+memory mounts, corrupt-image named error — riding the 0.3.6-written fixture).

## After merge

Tag `v0.3.1` at the merge commit → release run (44-asset contract). Sequenced after the tebako-runtime-ruby v0.16.11 publish completes; feedstocks then press with the v0.3.1 CLI against v0.16.11 runtimes — one bake, no double cycle.


## Added mid-flight (970ff5e5): SDK src-release fix rides this patch release

`DEFAULT_SRC_RELEASE` v0.2.1 → **v0.2.27** in `crates/tebako-cli/src/sdk.rs` (+ the `sdk_root_naming` test string + the README's env-var doc line). Fixes #482: the v0.2.1 factory release predates the 3.3.12/3.4.10 src tarballs, so every POSIX press of a Gemfile payload against the 0.16.11 runtime matrix failed closed at exit 135. Verified: v0.2.27's SHA256SUMS carries all five matrix rubies; 15/15 sdk unit tests green locally. One-PR-per-repo rule — folded in here rather than queuing a second tebako PR. The durable SSOT direction (resolve from runtime-manifest `built_from`) is blocked on factory provenance stability (tamatebako/ruby#100) and recorded in the const comment.
