### PR TITLE
driver: the windows host tier — dependency executables resolve bare on PATH (spec 22 §3.2)

### DIFF
--- a/crates/tebako-driver/src/path_env.rs
+++ b/crates/tebako-driver/src/path_env.rs
@@ -237,9 +237,7 @@ fn materialize_launchers(
 /// wrapper, nothing to re-arm. The child runs plain-host: its tree is
 /// present by declaration, never through the VFS (the named boundary).
 #[cfg(windows)]
-fn materialize_host_bins(
-    deps: &[(String, PayloadManifest)],
-) -> Result<Vec<String>, DriverError> {
+fn materialize_host_bins(deps: &[(String, PayloadManifest)]) -> Result<Vec<String>, DriverError> {
     // (basename, VFS path) in triple order, first basename wins — the
     // PATH lookup's own rule (the unix launcher tier's shape).
     let mut launches: Vec<(String, String)> = Vec::new();

--- a/crates/tebako-driver/src/path_env.rs
+++ b/crates/tebako-driver/src/path_env.rs
@@ -30,6 +30,15 @@
 //! strip). First triple order wins on a basename collision; a declared
 //! executable that cannot be materialized is the image lying — a named
 //! 65, never a skipped entry.
+//!
+//! The windows host tier (armed unconditionally — no preload shim
+//! exists on the platform): each declared dependency executable is
+//! materialized through the exec cache's exec routing — whole-tree for
+//! a home-layout mount (the in-image `java_home` annotation), the file
+//! itself otherwise — and the materialized parent dirs LEAD the PATH
+//! prepend, so the child's own CreateProcess search resolves the bare
+//! name with no interception. The materialized child runs plain-host:
+//! its home tree is present by declaration, never through the VFS.
 
 use std::ffi::OsStr;
 use std::ffi::OsString;
@@ -40,7 +49,6 @@ use crate::handoff::ImageSpec;
 #[cfg(unix)]
 use crate::EX_TEBAKO_IO;
 use crate::EX_TEBAKO_MANIFEST;
-#[cfg(unix)]
 use tfs::context::context;
 use tpkg::{PayloadManifest, Provides};
 
@@ -69,8 +77,15 @@ pub fn export(
             dirs.push(dir);
         }
     }
-    #[cfg(not(unix))]
-    let _ = shim_host;
+    #[cfg(windows)]
+    {
+        // No preload shim exists on the platform — the host tier IS the
+        // delivery (spec 22 §3.2): the materialized bins LEAD the §3.2
+        // bin dirs, so CreateProcess's own PATH search resolves a bare
+        // name with no interception at all.
+        let _ = shim_host;
+        dirs.extend(materialize_host_bins(&deps)?);
+    }
     for (mount, manifest) in &deps {
         for declared in bin_dirs(&manifest.provides) {
             let dir = join_mount(mount, &declared);
@@ -125,10 +140,10 @@ fn bin_dirs(provides: &Provides) -> Vec<String> {
 }
 
 /// The declared executable paths of one image's PROVIDES, in-image
-/// absolute — the launcher tier's materialization set (the same
+/// absolute — the materialization set of both host tiers (the same
 /// declarations `bin_dirs` flows: app entrypoints and toolkit
 /// executables).
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn executable_paths(provides: &Provides) -> Vec<String> {
     let paths: Vec<&str> = match provides {
         Provides::App(p) => p.entrypoints.iter().map(|e| e.path.as_str()).collect(),
@@ -208,6 +223,62 @@ fn materialize_launchers(
         chmod(&wrap, 0o755)?;
     }
     Ok(Some(wrap_dir.to_string_lossy().into_owned()))
+}
+
+/// The windows host tier (spec 22 §3.2): materialize each declared
+/// dependency executable through the exec cache's own exec routing —
+/// a home-layout mount (the in-image `java_home` annotation) extracts
+/// WHOLE once per boot and answers the executable's in-tree host twin
+/// (a JVM's lib/modules and jmods never ride a linked-library closure);
+/// any other mount answers the file itself, whose DLL bare-name loads
+/// then resolve through §2.1's alias dirs already on PATH. Each
+/// materialized executable's parent dir leads the §3.2 PATH prepend —
+/// the bare name resolves in the child's own CreateProcess search, no
+/// wrapper, nothing to re-arm. The child runs plain-host: its tree is
+/// present by declaration, never through the VFS (the named boundary).
+#[cfg(windows)]
+fn materialize_host_bins(
+    deps: &[(String, PayloadManifest)],
+) -> Result<Vec<String>, DriverError> {
+    // (basename, VFS path) in triple order, first basename wins — the
+    // PATH lookup's own rule (the unix launcher tier's shape).
+    let mut launches: Vec<(String, String)> = Vec::new();
+    for (mount, manifest) in deps {
+        for path in executable_paths(&manifest.provides) {
+            let Some(base) = Path::new(&path).file_name() else {
+                continue;
+            };
+            let base = base.to_string_lossy().into_owned();
+            if launches.iter().any(|(b, _)| *b == base) {
+                continue;
+            }
+            launches.push((base, join_mount(mount, &path)));
+        }
+    }
+    let mut dirs: Vec<String> = Vec::new();
+    if launches.is_empty() {
+        return Ok(dirs);
+    }
+    let mut ctx = context().write().unwrap();
+    for (_base, vfs) in &launches {
+        let host = ctx.exec_materialize_for_spawn(vfs).map_err(|e| {
+            DriverError::new(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "the image declares executable '{vfs}' but it cannot be materialized ({}) — the payload's self-description lies",
+                    crate::driver::errno_text(e)
+                ),
+            )
+        })?;
+        let host = PathBuf::from(host.to_string_lossy().into_owned());
+        if let Some(parent) = host.parent() {
+            let dir = parent.to_string_lossy().into_owned();
+            if !dirs.contains(&dir) {
+                dirs.push(dir);
+            }
+        }
+    }
+    Ok(dirs)
 }
 
 /// The launcher: re-arm the platform's injection var EXPLICITLY (an

--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -441,7 +441,7 @@ pinned empirically in §3.1.
 |---|---|---|---|
 | **ELF (gnu/musl)** | exe-defined Class-L symbols; the runtime itself is never preload-injected | the spawn hook materializes and injects the child (`LD_PRELOAD` + `TEBAKO_TFS_MOUNTS` in its env) | **works unmodified** — the handoff env's `LD_PRELOAD` injects every child at its exec, `/bin/sh` included; the shell's PATH search and `execvp` loop route through the interposed surface |
 | **macOS** | the driver's self-inserted interpose dylib (§2 phase 1) | the same hook; the materialized child is a non-Apple binary, so `DYLD_INSERT_LIBRARIES` is honored | **named boundary, enforced by the spawn hook** — an inherited `DYLD_INSERT_LIBRARIES` is FATAL to Apple platform binaries on darwin24 (dyld TERMINATES `/bin/sh` and `/usr/bin/cc` under a foreign insertion — factory run 31699651270; darwin23 stripped the variable instead), so the interpreter's spawn hook DROPS the variable per spawn whose target is restricted (any shell form; anything resolving into Apple's system binary dirs). The JVM behind a shell string then answers its own `Unable to access jarfile` — an honest host failure, never a tebako-intercepted one. darwin24 x86_64 CI runners HONOR the insertion into sh's exec child (runs 31685052887/31692800485) — a relaxed-SIP artifact the scrub deliberately erases: every host behaves like the strictest one |
-| **windows** | — | deferred — class L's design is §2.1; the windows exec leg phases after it (§7 order) | deferred |
+| **windows** | — | the §3.2 host tier materializes the target through the exec cache (whole-tree for a home-layout mount, the file itself otherwise) and the host copy execs — no injection exists on the platform, so the child runs plain-host against its declared tree | **works through the §3.2 host tier's `PATH` lead** — `CreateProcess`'s own PATH search finds the materialized host copy (a home-layout tool's tree came with it by declaration); nothing re-arms, there is no injection var |
 
 Where the launcher tier (§3.2) is armed, the shell-string form works
 on every macOS host — the launcher's explicit re-arm passes the hook's
@@ -501,10 +501,33 @@ the launcher, and the shim loads into the final binary exactly as on
 ELF (probe 2026-08-13: `/bin/sh -c <launcher>` loads the dylib past
 the strip; the bare-name and shell-string forms both work). On ELF the
 launchers ride over the inherited `LD_PRELOAD` (harmless — the same
-dir leads `PATH`); windows has no launcher tier yet (§7's order).
-Triple order wins on a basename collision; a declared executable that
-cannot be materialized is the image lying (a named 65), never a
-skipped entry.
+dir leads `PATH`).
+
+**The windows host tier** (armed unconditionally on windows — there is
+no preload shim to deliver and no injection var to re-arm, so the tier
+IS the delivery): the driver materializes each dependency's declared
+executables through the exec cache via the same `exec_materialize`
+routing the spawn surface uses — a mount whose in-image manifest
+carries the home annotation (`identity.annotations.java_home`, the
+SSOT for "my home tree must run beside me") extracts WHOLE once per
+boot and answers the executable's in-tree host twin (a JVM's
+`lib/modules`, `jvm.dll`, `jmods/` never ride a linked-library
+closure, so only the tree answer boots a working java); any other
+mount answers the file itself, whose DLL bare-name loads then resolve
+through §2.1's alias dirs already on `PATH`. Each materialized
+executable's PARENT DIR leads the §3.2 `PATH` prepend, in triple order
+(the locked lead stays byte-stable: windows host bins → §3.2 bin dirs
+→ §2.1 alias dirs → inherited). The declared path carries the real
+suffix on the wire (the feedstock writes `/bin/java.exe` — the
+manifest names the in-image byte exactly), so `CreateProcess`'s own
+PATH search finds it; no wrapper script exists because nothing needs
+re-arming. Triple order wins on a basename collision; a declared
+executable that cannot be materialized is the image lying (a named
+65), never a skipped entry. **The named boundary:** a materialized
+windows child runs plain-host — no VFS re-entry exists on the
+platform. Its own home tree is present BY DECLARATION; host resources
+beyond that (a document tree, a fonts dir) reach it only through spec
+23's declared host binds, never through the VFS.
 
 ### 3.3 The class-E proof fixture
 
@@ -708,7 +731,9 @@ runtime releases.
   are all exercised there).
 - Landing order: Class L POSIX → Class E → Class R → windows L (§2.1 —
   the phase-W design: the PE closure walk, the dln-load IAT rebind, the
-  alias bare-name rule). Each lands behind its dogfood
+  alias bare-name rule) → windows exec (§3.2's host tier — no win32
+  spawn hook; the driver materializes by declaration and `PATH` carries
+  the answer). Each lands behind its dogfood
   proof; a failed proof keeps the adapter.
 
 ## 8. Acceptance


### PR DESCRIPTION
## What

The **windows host tier** for dependency executables — spec 22 §3.2's missing windows delivery, amended in this PR (§3.1 matrix row, §3.2 definition, §7 landing order) per the engineering order.

## Why

packed-mn#251's windows leg fails at jing's `spawn("java")` (tamatebako/ruby#101, diagnosis in the issue): the §3.2 PATH prepend carried the dependency bin dirs pointing *into the VFS* — invisible to `CreateProcess` — and the materializing launcher tier is unix-only (no `LD_PRELOAD` exists on windows). macOS/Linux pass the same compile; windows had no delivery.

## How (option (b), owner-approved)

No ruby patch, no new manifest grammar. The driver materializes each co-mounted dependency's declared executables through the exec cache's existing `exec_materialize` routing:

- **Home-layout mounts** (the in-image `java_home` annotation — the SSOT the openjdk payload already declares) extract whole-tree once per boot and answer the in-tree host twin. A JVM's `lib/modules`, `jvm.dll`, `jmods/` never ride a linked-library closure — only the tree answer boots a working java.
- **Other mounts** answer the file itself; its DLL bare-name loads resolve through §2.1's alias dirs already on PATH.

The materialized parent dirs **lead** the §3.2 prepend (locked order stays byte-stable: host bins → §3.2 bins → §2.1 alias dirs → inherited). Triple order wins a basename collision; a lying declaration is a named 65, never a skipped entry. The child runs plain-host — the §3.2 named boundary: its tree is present by declaration, never through the VFS; resources beyond it ride spec 23's declared binds.

## Verified

- `cargo check -p tebako-driver` (host) and `--target x86_64-pc-windows-gnu` — both green locally.
- Full driver suite in debug: 150 tests, 0 failed.
- The §8 acceptance on windows (payload spawning a payload's binary by shell string — metanorma → openjdk) rides the packed-mn#251 PDF leg once the runtime re-cut carries this driver; the chain is PROGRESS/20.

Closes the driver half of tamatebako/ruby#101 (the ruby side needs no patch — the issue documents why).
