### PR TITLE
tfs: union members serialize into TEBAKO_TFS_MOUNTS; data-file sibling materialization (spec 17 §2.1, spec 22 Rule E4)

### DIFF
--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -402,18 +402,25 @@ fn init_inner() -> Result<(), String> {
             spec::parse_mounts(&mounts_spec).map_err(|e| format!("TEBAKO_TFS_MOUNTS: {e}"))?;
         for d in &decls {
             let mount = build_decl(d)?;
-            context()
-                .write()
-                .unwrap()
-                .mount_checked(mount)
-                .map_err(|e| {
-                    format!(
-                        "TEBAKO_TFS_MOUNTS: cannot mount {} at {}: {}",
-                        d.image,
-                        d.mount,
-                        errno_text(e)
-                    )
-                })?;
+            let mut guard = context().write().unwrap();
+            // A repeated mount point is a UNION member, not an error:
+            // the driver serializes a union as the incumbent followed by
+            // its members at the same point (spec 17 §2.1) — layer the
+            // later declaration over the incumbent exactly as the
+            // parent's mount_union did.
+            match guard.mount_checked(mount) {
+                Ok(_) => Ok(()),
+                Err(e) if e == libc::EEXIST => guard.mount_union(build_decl(d)?).map(|_| ()),
+                Err(e) => Err(e),
+            }
+            .map_err(|e| {
+                format!(
+                    "TEBAKO_TFS_MOUNTS: cannot mount {} at {}: {}",
+                    d.image,
+                    d.mount,
+                    errno_text(e)
+                )
+            })?;
         }
     }
     let jail_spec = std::env::var("TEBAKO_JAIL").unwrap_or_default();

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -83,10 +83,29 @@ pub struct Mount {
     /// §2.1); `None` for a whole-file mount. Serialized into
     /// `TEBAKO_TFS_MOUNTS` so a spawned child re-mounts the same region.
     pub slot: Option<u32>,
+    /// Union members layered OVER this mount's incumbent (spec 17 §1's
+    /// union mode), in shadow order — each member shadows the ones before
+    /// it. Retained for `mounts_env`: the child rebuilds the union from
+    /// the member list, incumbent first — a union that serialized only
+    /// its incumbent would boot children with half the tree (the
+    /// packed-mn POSIX jing failure: the app payload, unioned over the
+    /// env image at the runtime root, never reached the java child).
+    pub union_tail: Vec<UnionMember>,
     /// The backend.
     pub backend: Box<dyn Backend>,
     /// Mount mode (spec 11 §3; writes on RO mounts fail with EROFS).
     pub mode: MountMode,
+}
+
+/// One union member layered over a mount's incumbent: its serialization
+/// identity (the member's backend moved into the `UnionBackend`
+/// composite; only the rebuild coordinates remain here).
+pub struct UnionMember {
+    /// Archive path on disk (union members in the driver's composition
+    /// are file-backed; optional for parity with `Mount`).
+    pub archive_path: Option<Box<std::ffi::CString>>,
+    /// The package slot the member mounts, when any (spec 17 §2.1).
+    pub slot: Option<u32>,
 }
 
 /// One open file descriptor.
@@ -405,6 +424,14 @@ impl FsContext {
             return Err(libc::ENODEV);
         };
         let mut incumbent = self.mounts.remove(&handle).ok_or(libc::ENODEV)?;
+        // The member's serialization identity outlives its backend (which
+        // moves into the composite): mounts_env hands the child the full
+        // member list — incumbent first, then members in shadow order —
+        // so the union is rebuilt, not halved (spec 17 §2.1).
+        let member = UnionMember {
+            archive_path: mount.archive_path,
+            slot: mount.slot,
+        };
         let union = match crate::backends_union::UnionBackend::new(vec![
             incumbent.backend,
             mount.backend,
@@ -417,6 +444,7 @@ impl FsContext {
                 return Err(e);
             }
         };
+        incumbent.union_tail.push(member);
         incumbent.backend = Box::new(union);
         self.mounts.insert(handle, incumbent);
         if let Some((point, image)) = &subject {
@@ -1301,20 +1329,29 @@ impl FsContext {
     /// field, so the child mounts the same region — never the whole
     /// package file.
     pub fn mounts_env(&self) -> Option<std::ffi::CString> {
-        let decls: Vec<crate::mount_spec::MountDecl> = self
-            .mounts
-            .values()
-            .filter_map(|mount| {
-                mount
-                    .archive_path
-                    .as_ref()
-                    .map(|archive| crate::mount_spec::MountDecl {
+        // Establishment order (handles ascend in mount order); a union's
+        // members follow their incumbent in shadow order, so the child's
+        // repeated-point-as-union rebuild (spec 17 §2.1) layers exactly
+        // this union.
+        let mut decls: Vec<crate::mount_spec::MountDecl> = Vec::new();
+        for mount in self.mounts.values() {
+            if let Some(archive) = mount.archive_path.as_ref() {
+                decls.push(crate::mount_spec::MountDecl {
+                    image: archive.to_string_lossy().into_owned(),
+                    slot: mount.slot,
+                    mount: mount.mount_point.clone(),
+                });
+            }
+            for member in &mount.union_tail {
+                if let Some(archive) = member.archive_path.as_ref() {
+                    decls.push(crate::mount_spec::MountDecl {
                         image: archive.to_string_lossy().into_owned(),
-                        slot: mount.slot,
+                        slot: member.slot,
                         mount: mount.mount_point.clone(),
-                    })
-            })
-            .collect();
+                    });
+                }
+            }
+        }
         if decls.is_empty() {
             None
         } else {
@@ -1845,6 +1882,99 @@ impl FsContext {
     /// materialization was decided). `closure_trace`, when Some, records
     /// the walk — format + per-dep verdicts — for the top frame's
     /// dlopen event (recursion passes None; only the top frame records).
+    /// The data-file companion rule: a bridged data file carries no
+    /// parseable dependency closure, but its consumer can resolve
+    /// sibling resources by RELATIVE path — a RelaxNG `<include
+    /// href="other.rng">` against the schema's directory (the
+    /// packed-mn#251 jing failure: `isostandard-compile.rng` materialized
+    /// alone, its same-dir includes absent, jing answered `fatal: file
+    /// not found`). Materialize the parent directory's FILES into the
+    /// same mirrored host tree so relative resolution lands.
+    /// Non-recursive, count/byte-capped; an over-cap dir or a failing
+    /// sibling is a debug note, never the token's failure — the primary
+    /// file already landed and the consumer's own error stands.
+    fn materialize_data_siblings(&self, path: &str, owner: i32, root: &std::path::Path) {
+        const MAX_DATA_SIBLINGS: usize = 512;
+        const MAX_DATA_SIBLING_BYTES: u64 = 64 * 1024 * 1024;
+        let debug = std::env::var_os("TEBAKO_DEBUG_TFS").is_some();
+        let parent = memfs_dirname(path);
+        let Some(mount) = self.mounts.get(&owner) else {
+            return;
+        };
+        let parent_rel = Self::relative_path(mount, &parent);
+        let entries = match mount.backend.read_dir(parent_rel) {
+            Ok(entries) => entries,
+            Err(e) => {
+                if debug {
+                    eprintln!(
+                        "[tfs] siblings: {parent} — readdir failed errno={e}, the data file rides alone"
+                    );
+                }
+                return;
+            }
+        };
+        let own = path.rsplit('/').next().unwrap_or("");
+        let mut written = 0usize;
+        let mut bytes = 0u64;
+        for entry in entries {
+            if entry.is_dir || entry.name == own {
+                continue;
+            }
+            if written >= MAX_DATA_SIBLINGS {
+                if debug {
+                    eprintln!(
+                        "[tfs] siblings: {parent} — count cap ({MAX_DATA_SIBLINGS}); the rest stay image-only"
+                    );
+                }
+                break;
+            }
+            let sib_rel = if parent_rel.is_empty() {
+                entry.name.clone()
+            } else {
+                format!("{parent_rel}/{}", entry.name)
+            };
+            let size = mount
+                .backend
+                .stat(&sib_rel)
+                .map(|st| st.size.max(0) as u64)
+                .unwrap_or(0);
+            if bytes.saturating_add(size) > MAX_DATA_SIBLING_BYTES {
+                if debug {
+                    eprintln!(
+                        "[tfs] siblings: {parent}/{} — {size} bytes over the {MAX_DATA_SIBLING_BYTES}-byte cap, skipped",
+                        entry.name
+                    );
+                }
+                continue;
+            }
+            let sib_vfs = format!("{parent}/{}", entry.name);
+            let host = root.join(Self::host_tail(&sib_vfs));
+            let dir_ok = host
+                .parent()
+                .is_some_and(|dir| std::fs::create_dir_all(dir).is_ok());
+            if !dir_ok {
+                continue;
+            }
+            match extract_file(mount.backend.as_ref(), &sib_rel, &host) {
+                Ok(ExtractStep::Written) => {
+                    written += 1;
+                    bytes += size;
+                    if debug {
+                        eprintln!("[tfs] siblings: {sib_vfs} -> {}", host.display());
+                    }
+                }
+                Ok(ExtractStep::SkippedSymlink) => {}
+                Err(e) => {
+                    if debug {
+                        eprintln!(
+                            "[tfs] siblings: {sib_vfs} — extraction failed errno={e} (the consumer's own error stands)"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     fn extract_for_exec(
         &mut self,
         path: &str,
@@ -2049,8 +2179,33 @@ impl FsContext {
             }
             exec_closure::parse(&head)
         })() else {
-            if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+            let debug = std::env::var_os("TEBAKO_DEBUG_TFS").is_some();
+            if debug {
                 eprintln!("[tfs] closure: {path} — header parse unsupported, no dep walk");
+            }
+            // A file the parser REJECTS splits two ways on its magic
+            // (spec 22 Rule E4 — the data-file sibling rule): a genuine data file has no parseable
+            // closure, but its consumer can address sibling resources
+            // RELATIVE to it (a RelaxNG `<include href="other.rng">`
+            // against the schema's dir — the packed-mn#251 jing
+            // failure), so the parent directory's files materialize
+            // into the same mirrored host tree. A file WITH load-module
+            // magic that failed to parse is a malformed module — its
+            // consumer is a platform loader that raises its own error;
+            // it rides alone exactly as before the sibling rule.
+            let magic = std::fs::File::open(&host_path)
+                .and_then(|mut f| {
+                    use std::io::Read as _;
+                    let mut b = [0u8; 4];
+                    f.read_exact(&mut b).map(|()| b)
+                })
+                .unwrap_or([0u8; 4]);
+            if exec_closure::sniffs_load_module(&magic) {
+                if debug {
+                    eprintln!("[tfs] closure: {path} — load-module magic but malformed, rides alone");
+                }
+            } else {
+                self.materialize_data_siblings(path, owner, &root);
             }
             return Ok(host_path);
         };
@@ -2718,6 +2873,7 @@ mod tests {
             mount_point_c: Box::new(std::ffi::CString::new("/tfs").unwrap()),
             archive_path: None,
             slot: None,
+            union_tail: Vec::new(),
             backend: Box::new(backend),
             mode: crate::mount::MountMode::ReadOnly,
         };
@@ -3063,6 +3219,58 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// The data-file companion rule: a bridged data file's consumer can
+    /// resolve sibling resources relative to it (RelaxNG `<include
+    /// href>` — the packed-mn#251 jing failure), so materialization
+    /// brings the parent directory's files along into the mirrored host
+    /// tree. Non-recursive: a nested subdirectory stays image-only.
+    #[test]
+    fn exec_materialize_brings_a_data_files_siblings() {
+        let dir = std::env::temp_dir().join(format!("tfs-data-sib-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let image = dir.join("data.zip");
+        {
+            let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+            let options = zip::write::SimpleFileOptions::default();
+            for d in ["schemas/", "schemas/nested/"] {
+                writer.add_directory(d, options).unwrap();
+            }
+            writer.start_file("schemas/main.rng", options).unwrap();
+            writer
+                .write_all(b"<grammar><include href=\"included.rng\"/></grammar>\n")
+                .unwrap();
+            writer.start_file("schemas/included.rng", options).unwrap();
+            writer.write_all(b"<grammar/>\n").unwrap();
+            writer
+                .start_file("schemas/nested/deep.rng", options)
+                .unwrap();
+            writer.write_all(b"<grammar><!-- nested --></grammar>\n").unwrap();
+            let bytes = writer.finish().unwrap().into_inner();
+            std::fs::write(&image, bytes).unwrap();
+        }
+        let mut ctx = FsContext::new();
+        let mount = crate::mount::build_from_file(image.to_str().unwrap(), "/tfs").unwrap();
+        ctx.mount_checked(mount).unwrap();
+
+        let answer = ctx.exec_materialize("/tfs/schemas/main.rng").unwrap();
+        let host = std::path::PathBuf::from(answer.to_string_lossy().into_owned());
+        assert!(host.is_file(), "the data twin lands: {host:?}");
+        let host_dir = host.parent().unwrap();
+        assert_eq!(
+            std::fs::read(host_dir.join("included.rng")).unwrap(),
+            b"<grammar/>\n",
+            "the same-dir include resolves against the host twin"
+        );
+        assert!(
+            !host_dir.join("nested/deep.rng").exists()
+                && !host_dir.join("nested").exists(),
+            "non-recursive: a nested subdirectory stays image-only"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     // ---------------------------------------------------------------
     // PE exec-closure walk (spec 22 §2.1)
     // ---------------------------------------------------------------
@@ -3160,6 +3368,7 @@ mod tests {
             mount_point_c: Box::new(std::ffi::CString::new(point).unwrap()),
             archive_path: None,
             slot: None,
+            union_tail: Vec::new(),
             backend: Box::new(backend),
             mode: crate::mount::MountMode::ReadOnly,
         };
@@ -3189,6 +3398,7 @@ mod tests {
                     std::ffi::CString::new(archive.to_string_lossy().into_owned()).unwrap(),
                 )),
                 slot,
+                union_tail: Vec::new(),
                 backend: Box::new(backend),
                 mode: crate::mount::MountMode::ReadOnly,
             };
@@ -3198,6 +3408,55 @@ mod tests {
         assert_eq!(
             env.to_string_lossy(),
             format!("{}:0:/app,{}:/data", pkg.display(), img.display())
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mounts_env_serializes_a_union_in_shadow_order() {
+        // spec 17 §1/§2.1: the runtime root's union — the env image with
+        // the app payload layered over it — serializes as BOTH members at
+        // the same point, incumbent first (the child's shim rebuilds the
+        // union from the member list; the packed-mn POSIX jing failure
+        // was the payload half never reaching the child).
+        let dir = std::env::temp_dir().join(format!("tfs-mounts-env-u-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let env_img = dir.join("env.tfs");
+        let pkg = dir.join("pkg.tebako");
+        let mut ctx = FsContext::new();
+        let file_mount = |archive: &std::path::Path, slot: Option<u32>, point: &str| {
+            let backend = crate::backends_hostdir::HostDirBackend::new(&dir).unwrap();
+            Mount {
+                handle: 0,
+                mount_point: point.to_string(),
+                mount_point_c: Box::new(std::ffi::CString::new(point).unwrap()),
+                archive_path: Some(Box::new(
+                    std::ffi::CString::new(archive.to_string_lossy().into_owned()).unwrap(),
+                )),
+                slot,
+                union_tail: Vec::new(),
+                backend: Box::new(backend),
+                mode: crate::mount::MountMode::ReadOnly,
+            }
+        };
+        ctx.mount_checked(file_mount(&env_img, None, "/__tfs__"))
+            .unwrap();
+        ctx.mount_union(file_mount(&pkg, Some(0), "/__tfs__"))
+            .unwrap();
+        // A plain exclusive mount elsewhere keeps its single declaration.
+        ctx.mount_checked(file_mount(&pkg, Some(1), "/opt/jdk"))
+            .unwrap();
+
+        let env = ctx.mounts_env().unwrap();
+        assert_eq!(
+            env.to_string_lossy(),
+            format!(
+                "{}:/__tfs__,{}:0:/__tfs__,{}:1:/opt/jdk",
+                env_img.display(),
+                pkg.display(),
+                pkg.display()
+            )
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -2202,7 +2202,9 @@ impl FsContext {
                 .unwrap_or([0u8; 4]);
             if exec_closure::sniffs_load_module(&magic) {
                 if debug {
-                    eprintln!("[tfs] closure: {path} — load-module magic but malformed, rides alone");
+                    eprintln!(
+                        "[tfs] closure: {path} — load-module magic but malformed, rides alone"
+                    );
                 }
             } else {
                 self.materialize_data_siblings(path, owner, &root);
@@ -3245,7 +3247,9 @@ mod tests {
             writer
                 .start_file("schemas/nested/deep.rng", options)
                 .unwrap();
-            writer.write_all(b"<grammar><!-- nested --></grammar>\n").unwrap();
+            writer
+                .write_all(b"<grammar><!-- nested --></grammar>\n")
+                .unwrap();
             let bytes = writer.finish().unwrap().into_inner();
             std::fs::write(&image, bytes).unwrap();
         }
@@ -3263,8 +3267,7 @@ mod tests {
             "the same-dir include resolves against the host twin"
         );
         assert!(
-            !host_dir.join("nested/deep.rng").exists()
-                && !host_dir.join("nested").exists(),
+            !host_dir.join("nested/deep.rng").exists() && !host_dir.join("nested").exists(),
             "non-recursive: a nested subdirectory stays image-only"
         );
 

--- a/crates/tfs/src/exec_closure.rs
+++ b/crates/tfs/src/exec_closure.rs
@@ -68,6 +68,26 @@ pub fn parse(bytes: &[u8]) -> Option<ImageDeps> {
         .or_else(|| parse_pe(bytes))
 }
 
+/// Cheap magic-number answer: does this file CLAIM to be a load module?
+/// Mirrors exactly the magics parse() recognizes (MZ, ELF, Mach-O fat
+/// big-endian and thin little-endian). Used to split parse() failures
+/// into "malformed load module" (its consumer is a platform loader that
+/// raises its own error — the module rides alone, no sibling sweep) and
+/// "genuine data file" (whose consumer can address sibling resources
+/// relative to it, so the directory's files materialize with it).
+pub fn sniffs_load_module(head: &[u8]) -> bool {
+    let Some(magic) = head.get(..4) else {
+        return false;
+    };
+    if magic.starts_with(b"MZ") || magic == b"\x7FELF" {
+        return true;
+    }
+    if u32be(magic).is_some_and(|m| m == FAT_MAGIC || m == FAT_MAGIC_64) {
+        return true;
+    }
+    u32le(magic).is_some_and(|m| m == MH_MAGIC || m == MH_MAGIC_64)
+}
+
 // ---------------------------------------------------------------------
 // Mach-O
 // ---------------------------------------------------------------------

--- a/crates/tfs/src/mount.rs
+++ b/crates/tfs/src/mount.rs
@@ -111,6 +111,7 @@ fn make_mount(
         mount_point_c: cstring(mount_point),
         archive_path: archive_path.map(cstring),
         slot: None,
+        union_tail: Vec::new(),
         backend,
         mode,
     }

--- a/crates/tfs/src/mount_spec.rs
+++ b/crates/tfs/src/mount_spec.rs
@@ -4,6 +4,12 @@
 //! validates and re-serializes it for the exec'd child). One grammar, one
 //! parser, one serializer.
 //!
+//! A REPEATED mount point declares union members in shadow order — the
+//! serialization of a spec 17 §1 union mount is the incumbent's
+//! declaration followed by each member's at the same point. Consumers
+//! that can union (the preload shim) layer each later declaration over
+//! the earlier; consumers that cannot fail closed.
+//!
 //! Pure safe Rust; named errors on malformed input (spec 14 §3).
 
 use std::fmt;

--- a/docs/spec/17-runtime-driver-contract.md
+++ b/docs/spec/17-runtime-driver-contract.md
@@ -163,6 +163,17 @@ mount      = "/" *path-char              ; a VFS-absolute mount point
   spawned child MUST preserve the slot form, so the child mounts the same
   region — never the whole package file (mounting a packaged file whole
   sniffs the trailer and fails; spec 22's spawn re-entry is the victim).
+- **Union serialization.** A union mount (§1's `mode: union`) serializes
+  as MULTIPLE entries at the same mount point: the incumbent first, then
+  each member in shadow order (the order they were unioned on). A
+  consumer that can union (the preload shim) MUST treat a repeated mount
+  point as a union member — layered over the earlier declaration with
+  this spec's §1 semantics — never as a duplicate-point error. A
+  consumer that cannot union MUST fail closed with a named error.
+  Serializing only the incumbent is a wire bug: the child boots with
+  half the tree (the packed-mn POSIX failure — the app payload unioned
+  over the env image at the runtime root never reached spawned
+  children).
 
 ## 3. File IO semantics
 

--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -470,6 +470,27 @@ covers the array-form chain and the runtime's own surface covers
 in-process exec callers. Children of materialized binaries keep the
 VFS view — never a silent host fallback.
 
+**Rule E4 (the data-file sibling rule).** A covered materialization
+target that parses as NO load module (no Mach-O/ELF/PE magic — a
+genuine data file: a schema, a keystore, a native tool's resource) has
+no dependency closure to walk, but its consumer can address sibling
+resources RELATIVE to the materialized host path — a JVM resolving a
+RelaxNG `<include href="other.rng">` against the schema's directory
+(the packed-mn#251 jing failure: the bridged schema landed alone and
+its same-dir include chain never did) — on the HOST, where the VFS
+view does not reach (§3.1's named boundary). The parent in-image
+directory's FILES therefore materialize alongside the target into the
+same mirrored host tree: non-recursive (subdirectories never sweep —
+no proven consumer; the §3.2 whole-tree answer already exists for
+that shape), capped (512 files / 64 MiB per sweep, each cap noted
+under `TEBAKO_DEBUG_TFS`), and never fatal to the target's own
+materialization (a sibling's extraction failure is noted, not raised
+— the consumer's own error stands). A file WITH load-module magic
+that fails to parse is a malformed module, not a data file: it rides
+alone exactly as before this rule — its consumer is the OS loader,
+which raises its own honest error (the exec-side analogue of §2.1's
+truncated-header contract).
+
 ### 3.2 Bare-name resolution — the composition layer wires PATH
 
 A bare command name (`system("java …")`, mnconvert's form) resolves


### PR DESCRIPTION
## What

Two coordinated fixes in the exec-materialization / mount-serialization layer, root-caused from packed-mn#251 (metanorma v2 packaging) failing legs, each with a local reproduction as evidence.

### 1. Union members never reached spawned children (POSIX legs)

`tfs::context::mount_union` replaced the incumbent `Mount`'s backend with a `UnionBackend` but dropped the newcomer's identity. `mounts_env()` (the `TEBAKO_TFS_MOUNTS` composer) serializes one declaration per `Mount`, so the runtime-root union (env image + app payload slot 0 at the runtime root) reached injected children as ONLY the env image — every app-payload path answered ENOENT in grandchildren.

Evidence: local repro on macOS arm64 (lean package pressed from published assets, tebako-pkg 0.3.1, runtime v0.16.14) reproduced CI exactly: `Unable to access jarfile /__tfs__/…` from jing's java child. The child's shim WAS active and routed into tfs — the child's tfs just had half the tree.

Fix:

- `Mount` gains `union_tail: Vec<UnionMember>` (archive_path/slot pairs); `mount_union` records the newcomer's identity after the `UnionBackend` layers on.
- `mounts_env` serializes the incumbent's declaration followed by each member's at the same mount point, in shadow order.
- `libtfs-preload`'s `init_inner` treats a repeated mount point as a union member (`mount_union` on `EEXIST`) instead of a duplicate-point error.
- Grammar documented in `mount_spec.rs`; **spec 17 §2.1 amended** — repeated mount point = union member in shadow order; consumers that cannot union fail closed. Serializing only the incumbent is named as the wire bug it is.

### 2. Data files materialized alone (windows leg; all platforms once (1) lands)

`extract_for_exec`'s parse-failure branch returned the materialized file with no sibling handling. A data file's consumer can address sibling resources RELATIVE to the materialized host path — jing resolving RelaxNG `<include href="relaton-iso.rng">` against the bridged schema's directory (the #251 windows failure: `fatal: file not found: …\tebako-dl-…\relaton-iso.rng`; the schema's same-dir include chain never landed).

Fix (spec 22 **Rule E4**, added in this PR):

- Parse-rejected files split on magic (`exec_closure::sniffs_load_module` — MZ / ELF / Mach-O fat+thin, exactly the magics `parse()` recognizes):
  - **No load-module magic** → genuine data file: the parent in-image directory's FILES materialize alongside it into the same mirrored host tree. Non-recursive, capped (512 files / 64 MiB per sweep), `TEBAKO_DEBUG_TFS`-noted, never fatal to the target's own materialization.
  - **Load-module magic but unparseable** → malformed module: rides alone exactly as before (its consumer is the OS loader, which raises its own honest error — the exec-side analogue of spec 22 §2.1's truncated-header contract).

## Tests

- `tfs`: new `exec_materialize_brings_a_data_files_siblings` (sibling lands, nested dir doesn't) and `mounts_env_serializes_a_union_in_shadow_order`; the pre-existing `pe_closure_treats_a_malformed_image_as_dependency_free` pins the malformed-module half of the magic gate.
- `cargo test -p tfs -p libtfs-preload`: full green.
- Integration proof (this machine): `DYLD_INSERT_LIBRARIES=<built shim> TEBAKO_TFS_MOUNTS=<env-image>:/__tfs__,<pkg>:0:/__tfs__,<pkg>:1:/opt/openjdk,<pkg>:2:/opt/inkscape` into a foreign (non-tebako) ruby reads an app-payload file through the reconstituted union.

## Out of scope (follow-ups, tracked in PROGRESS/)

- packed-mn#251 re-pin lands only after a factory re-cut carries this (runtime 0.16.15).
- `tfs exec` CLI deliberately unchanged: duplicate points stay a named error there.
