### PR TITLE
tools/stage_link_unit: harvest the KEYED librnp prefix (rnp-src 0.2.3)

### DIFF
--- a/tools/stage_link_unit
+++ b/tools/stage_link_unit
@@ -128,6 +128,20 @@ def harvest(out, src, note)
   puts format("  closure %-28s <= %s", File.basename(src), src.sub(%r{^.*/build/}, "build/"))
 end
 
+# The librnp install prefix inside an rnp-sys out dir, or nil. The prefix
+# is KEYED by rnp-src: plain `rnp` up to 0.2.2, `rnp-0.18.1-b1` from
+# 0.2.3 (the RSA short-MPI backport level — a backport bump renames the
+# prefix so a stale cached librnp never mixes with new headers);
+# `rnp-flavored` under pqc/crypto-refresh (never in this graph). Match
+# `rnp*` and take the newest dir carrying librnp.a. (v0.3.3 release run
+# 33145385769 died here: a floating resolve pulled rnp-src 0.2.3
+# mid-flight.)
+def rnp_prefix_of(out_dir)
+  Dir.glob(File.join(out_dir, "install", "rnp*"))
+     .select { |d| File.file?(File.join(d, "lib", "librnp.a")) }
+     .max_by { |d| File.mtime(d) }
+end
+
 dwarfs = newest_out(File.join(script_out, "dwarfs-t-sys-*", "out"))
 die "no dwarfs-t-sys build under #{script_out}" unless dwarfs
 
@@ -157,15 +171,17 @@ else
   # rnp-sys variants multiply in a reused target dir (a non-vendored
   # graph leaves an out dir WITHOUT the install tree): newest-by-mtime
   # alone picks the stub. Only an out dir with the vendored install tree
-  # qualifies. (rnp-rs >= 0.1.12 has no build script: its build.rs moved
-  # to rnp-sys, which calls rnp_src::build() — the install tree lands in
-  # rnp-sys's OUT_DIR, per the botan-src caller-owns-OUT_DIR pattern.
-  # rnp-src itself is build=false since 0.2.1, so no rnp-src-*/out ever
-  # exists in this graph.)
+  # qualifies — via rnp_prefix_of, so the keyed librnp prefix counts.
+  # (rnp-rs >= 0.1.12 has no build script: its build.rs moved to rnp-sys,
+  # which calls rnp_src::build() — the install tree lands in rnp-sys's
+  # OUT_DIR, per the botan-src caller-owns-OUT_DIR pattern. rnp-src
+  # itself is build=false since 0.2.1, so no rnp-src-*/out ever exists in
+  # this graph.)
   rnp = Dir.glob(File.join(script_out, "rnp-sys-*", "out"))
-           .select { |d| File.file?(File.join(d, "install", "rnp", "lib", "librnp.a")) }
+           .select { |d| rnp_prefix_of(d) }
            .max_by { |d| File.mtime(d) }
   die "no rnp-sys build with an install tree under #{script_out} (rnp with the vendored feature)" unless rnp
+  rnp_prefix = rnp_prefix_of(rnp)
 
   # their vcpkg closure (codecs, boost, crypto — the static triplet):
   # every archive the dwarfs-t link emits, the same rule as the mingw
@@ -193,14 +209,15 @@ else
   harvest(out, File.join(sqfs_vlib, "libsquashfs.a"), "squashfs-tools-ng")
 
   # the rnp family (rnp-sys's install tree, built from rnp-src sources —
-  # never a prebuilt download)
+  # never a prebuilt download; librnp+sexpp ride the keyed rnp prefix,
+  # json-c and botan keep their plain ones)
   {
-    "rnp/lib/librnp.a" => "librnp (rnp-sys)",
-    "rnp/lib/libsexpp.a" => "libsexpp (rnp-sys)",
-    "json-c/lib/libjson-c.a" => "json-c (rnp-sys)",
-    "botan/lib/libbotan-3.a" => "botan (rnp-src via rnp-sys)",
-  }.each do |rel, note|
-    harvest(out, File.join(rnp, "install", rel), note)
+    File.join(rnp_prefix, "lib", "librnp.a") => "librnp (rnp-sys)",
+    File.join(rnp_prefix, "lib", "libsexpp.a") => "libsexpp (rnp-sys)",
+    File.join(rnp, "install", "json-c", "lib", "libjson-c.a") => "json-c (rnp-sys)",
+    File.join(rnp, "install", "botan", "lib", "libbotan-3.a") => "botan (rnp-src via rnp-sys)",
+  }.each do |src, note|
+    harvest(out, src, note)
   end
 end
 


### PR DESCRIPTION
## What

`tools/stage_link_unit` died on the v0.3.3 release run (33145385769, macos-arm64 leg): "no rnp-sys build with an install tree under …/release/build (rnp with the vendored feature)".

## Root cause

- The workspace `Cargo.lock` is gitignored — resolutions float. Between the v0.3.2 release run (green) and v0.3.3's, rnp-src **0.2.3** published (rnp-rs stays pinned `=0.1.12`; its rnp-src requirement floats within 0.2.x).
- rnp-src 0.2.3 keys the librnp install prefix by backport level: plain `install/rnp` → `install/rnp-0.18.1-b1` (the RSA short-MPI backport; the rename is deliberate so a stale cached librnp never mixes with new headers). json-c and botan keep their plain prefixes.
- The harvest checked only `install/rnp/lib/librnp.a` — no qualifying dir → die (exit 64).

## Fix

New `rnp_prefix_of` helper: globs `install/rnp*`, selects the newest dir carrying `librnp.a` (covers `rnp`, `rnp-0.18.1-b1`, future backport bumps, `rnp-flavored`). The install-tree qualification check and the librnp/libsexpp harvests ride it; json-c/botan paths unchanged.

## Validation

- `ruby -c` clean.
- Fabricated-tree harness: keyed prefix selected over plain, a non-vendored stub out-dir rejected, plain-0.2.2-only trees still resolve.
- The full end-to-end proof is the v0.3.3 release pipeline itself after re-tag.
