### PR TITLE
press: the sign registry setting — press-time package signing (spec 09 §9, spec 23 §14)

### DIFF
--- a/crates/tebako-bootstrap/Cargo.toml
+++ b/crates/tebako-bootstrap/Cargo.toml
@@ -26,7 +26,7 @@ tebako-term = { version = "0.3.0", path = "../tebako-term" }
 # the crypto toolkit payload; until then this feature keeps the full
 # verification path available for dev builds (--features openpgp-verify).
 # With the feature off the bootstrap carries ZERO rnp/botan/json-c/bz2.
-rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"], optional = true }
+rnp = { package = "rnp-rs", version = "0.1.15", features = ["vendored"], optional = true }
 libc = "0.2"
 sha2 = "0.10"
 
@@ -60,4 +60,4 @@ path = "src/lib.rs"
 # every platform (the feature above is unaffected).
 [target.'cfg(not(windows))'.dev-dependencies]
 tebako-signer = { version = "0.3.0", path = "../tebako-signer" }
-rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"] }
+rnp = { package = "rnp-rs", version = "0.1.15", features = ["vendored"] }

--- a/crates/tebako-cli/README.md
+++ b/crates/tebako-cli/README.md
@@ -10,6 +10,7 @@ $ tebako press -r <root> -e <entry> [-o <output>] [-p <prefix>]
                [-l error|warn|debug|trace]
                [--image <path>:<mount>]... [--bootstrap <path>]
                [--tebako-version <v>] [--prefer-local] [--jail <spec>]
+               [--sign[=<keyid>] | --no-sign]
                [--compose <tebako.yaml>] [--carry all|none|<name,...>]
                [--share <name,...>]
 $ tebako run <pkg> [--jail <spec>] [--mount <host:mount:ro|rw>]... [--no-host]
@@ -36,6 +37,27 @@ never loosens (a `--no-host` drops request grants; asking for `open`
 against a `deny` request stays denied). The effective policy rides
 TEBAKO_JAIL to the package's bootstrap; violations journal to the tebako
 audit journal (`$TEBAKO_HOME/journal.log`, spec 08 §2).
+
+## Press signing (spec 09 §9)
+
+Signing is per-package OPT-IN: a press with no signing declaration on any
+channel produces the v1-unsigned trailer, byte-identical to pre-signing
+output, and never touches key material. The declaration is the `sign`
+registry setting (spec 23 §14), resolved **CLI → env → compose document
+→ default (unsigned)**:
+
+- `tebako press --sign` signs the package trailer with the press-local
+  key (generated and cached under `$TEBAKO_HOME/keys` on first explicit
+  use, auto-registered into the local trusted keyring);
+  `--sign=<keyid>` signs with the named secret key from
+  `$TEBAKO_HOME/keys` — a keyid matching no key is a named error (71)
+  raised before any heavy work, never a silent fallback.
+- `TEBAKO_SIGN=1` (machine-wide) and the compose document's `sign: true`
+  (repo-carried) both sign with the press-local key — a keyid is
+  per-machine material and never rides a git-shared document.
+- `--no-sign` / `TEBAKO_SIGN=0` wins over every lower channel; an
+  opt-out that drops a lower channel's declaration is LOUD (a stderr
+  warning plus the audit journal's `event=press-sign-opt-out`).
 
 ## Lean press flow
 

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -769,7 +769,6 @@ pub(crate) fn stitch(
         // spec 09 §9: the resolved `sign` setting. `None` never touches
         // key material and produces the exact v1-unsigned shape.
         sign: flags.sign,
-        ..Default::default()
     };
     tebako_pkg::bundle_exact(bootstrap_path, &pkg_images, output, &pkg_options)
         .map_err(plain_error)?;

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -221,6 +221,14 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     // malformed env value is a named error, never a silent default.
     let quiet_notices = effective_quiet_notices(opts, compose_doc.as_ref())?;
 
+    // spec 09 §9 / spec 23 §14: the `sign` registry setting resolves
+    // through the same channels (CLI > env > compose > default
+    // unsigned). A keyid naming no key in $TEBAKO_HOME/keys is a named
+    // error raised HERE, before any heavy work (runtime download,
+    // imaging) — never a fallback; an opt-out dropping a lower channel's
+    // declaration is loud (stderr + the audit journal).
+    let sign = effective_sign(opts, compose_doc.as_ref())?;
+
     // Cli#bootstrap: the cache version guard runs before the press
     // (skipped in devmode, like the gem).
     if !opts.devmode {
@@ -452,6 +460,7 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
             lean: !runtime_carried,
             no_install: opts.no_install,
             quiet_notices,
+            sign,
         },
     )?;
     println!("Created tebako package at \"{package}\"");
@@ -555,16 +564,76 @@ pub(crate) fn effective_quiet_notices(
     .map_err(|e| packaging_error(65, Some(&e.to_string())))
 }
 
+/// The signature failure exit (the trust family's 71, shared with the
+/// loader and the install/publish surfaces).
+const EX_TEBAKO_SIGNATURE: i32 = 71;
+
+/// spec 09 §9 / spec 23 §14: the `sign` registry setting resolved across
+/// the three channels — CLI > env > compose document > default unsigned
+/// (a suite press rides no document and passes `None`). An opt-out that
+/// drops a lower channel's `sign` declaration is LOUD: a stderr warning
+/// plus the audit journal's `event=press-sign-opt-out`. A `--sign=<keyid>`
+/// naming no key in $TEBAKO_HOME/keys is a NAMED error here — before any
+/// heavy work — never a silent fallback to the press-local key.
+pub(crate) fn effective_sign(
+    opts: &PressOptions,
+    compose: Option<&tpkg::ComposeDoc>,
+) -> Result<tebako_pkg::SignRequest, TebakoError> {
+    let resolved = tpkg::settings::resolve_sign(
+        &tpkg::settings::SIGN,
+        opts.sign.clone(),
+        tpkg::settings::SIGN.env_value(),
+        compose.and_then(|d| d.sign),
+    )
+    .map_err(|e| packaging_error(65, Some(&e.to_string())))?;
+    if let Some(opt_out) = &resolved.opt_out {
+        eprintln!(
+            "tebako: WARNING: the {} channel's sign opt-out overrides the {} channel's sign declaration — the package will be UNSIGNED (journaled: event=press-sign-opt-out)",
+            opt_out.by, opt_out.overridden
+        );
+        // Best-effort, like every journal write: a press that cannot
+        // open the journal still presses (unsigned, as declared).
+        if let Some(journal) = tfs::journal::open_journal() {
+            tfs::journal::journal_press_sign_opt_out(&journal, opt_out.by, opt_out.overridden);
+        }
+    }
+    match resolved.decision {
+        tpkg::settings::SignDecision::Unsigned => Ok(tebako_pkg::SignRequest::None),
+        tpkg::settings::SignDecision::PressLocal => Ok(tebako_pkg::SignRequest::PressLocal),
+        tpkg::settings::SignDecision::Keyid(keyid) => {
+            // Fail fast, before the runtime download and the imaging: a
+            // keyid naming no key in $TEBAKO_HOME/keys is a named error,
+            // never a fallback to the press-local key (spec 09 §9).
+            let home = tebako_signer::default_home()
+                .map_err(|e| TebakoError::new(e.to_string(), EX_TEBAKO_SIGNATURE))?;
+            match tebako_signer::secret_key_by_keyid(&home, &keyid) {
+                Ok(Some(_)) => Ok(tebako_pkg::SignRequest::Keyid(keyid)),
+                Ok(None) => Err(TebakoError::new(
+                    format!(
+                        "no secret key with keyid {keyid} under {}/keys — generate one, or use bare --sign for the press-local key",
+                        home.display()
+                    ),
+                    EX_TEBAKO_SIGNATURE,
+                )),
+                Err(e) => Err(TebakoError::new(e.to_string(), EX_TEBAKO_SIGNATURE)),
+            }
+        }
+    }
+}
+
 /// The trailer flag inputs to [`stitch`] (spec 02): `lean` — the runtime
 /// resolves at run time (TPKG_FLAG_LEAN; CLEAR only for a self-contained
 /// press); `no_install` — publisher-frozen (TPKG_FLAG_NO_INSTALL);
 /// `quiet_notices` — the resolved registry setting (TPKG_FLAG_QUIET_NOTICES,
-/// spec 23 §14).
-#[derive(Debug, Clone, Copy, Default)]
+/// spec 23 §14); `sign` — the resolved `sign` registry setting (spec 09
+/// §9: `None` is the exact v1-unsigned shape, byte-identical to
+/// pre-signing output).
+#[derive(Debug, Clone, Default)]
 pub(crate) struct StitchFlags {
     pub lean: bool,
     pub no_install: bool,
     pub quiet_notices: bool,
+    pub sign: tebako_pkg::SignRequest,
 }
 
 /// Stitcher.stitch (lean three-part): validate per the gem's error codes,
@@ -697,6 +766,9 @@ pub(crate) fn stitch(
         // entry's runtime_ref mirrors the trailer's, so old and new
         // loaders resolve identically (spec 02 §5b).
         package_manifest: package_manifest.cloned(),
+        // spec 09 §9: the resolved `sign` setting. `None` never touches
+        // key material and produces the exact v1-unsigned shape.
+        sign: flags.sign,
         ..Default::default()
     };
     tebako_pkg::bundle_exact(bootstrap_path, &pkg_images, output, &pkg_options)
@@ -1160,6 +1232,7 @@ mod tests {
                 lean: true,
                 no_install: true,
                 quiet_notices: false,
+                sign: tebako_pkg::SignRequest::None,
             },
         )
         .unwrap();
@@ -1179,6 +1252,7 @@ mod tests {
                 lean: true,
                 no_install: false,
                 quiet_notices: false,
+                sign: tebako_pkg::SignRequest::None,
             },
         )
         .unwrap();
@@ -1211,6 +1285,7 @@ mod tests {
                 lean: true,
                 no_install: false,
                 quiet_notices: true,
+                sign: tebako_pkg::SignRequest::None,
             },
         )
         .unwrap();
@@ -1233,6 +1308,7 @@ mod tests {
                 lean: true,
                 no_install: false,
                 quiet_notices: false,
+                sign: tebako_pkg::SignRequest::None,
             },
         )
         .unwrap();
@@ -1240,6 +1316,283 @@ mod tests {
         let m = tpkg::read_from(&mut f).unwrap();
         assert_eq!(m.package_flags & tpkg::TPKG_FLAG_QUIET_NOTICES, 0);
         assert!(!m.is_quiet_notices());
+    }
+
+    // ---- press signing (spec 09 §9, spec 23 §14) ----
+
+    /// Serializes the signing tests: they mutate the process env
+    /// (TEBAKO_HOME / TEBAKO_SIGN / TEBAKO_JAIL_JOURNAL /
+    /// TEBAKO_REQUIRE_SIGNED), saved and restored by [`SignEnv`].
+    static SIGN_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Pins the signing-relevant env to a temp home and restores the
+    /// prior values on drop.
+    struct SignEnv {
+        saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl SignEnv {
+        fn set(home: &Path, journal: &Path) -> SignEnv {
+            let saved = [
+                "TEBAKO_HOME",
+                "TEBAKO_SIGN",
+                "TEBAKO_JAIL_JOURNAL",
+                "TEBAKO_REQUIRE_SIGNED",
+            ]
+            .into_iter()
+            .map(|k| (k, std::env::var_os(k)))
+            .collect::<Vec<_>>();
+            std::env::set_var("TEBAKO_HOME", home);
+            std::env::set_var("TEBAKO_JAIL_JOURNAL", journal);
+            std::env::remove_var("TEBAKO_SIGN");
+            std::env::remove_var("TEBAKO_REQUIRE_SIGNED");
+            SignEnv { saved }
+        }
+    }
+
+    impl Drop for SignEnv {
+        fn drop(&mut self) {
+            for (k, v) in self.saved.drain(..) {
+                match v {
+                    Some(v) => std::env::set_var(k, v),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    fn sign_scratch(tag: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("tebako-cli-sign-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn effective_sign_resolves_channels_and_names_an_unknown_keyid() {
+        let _guard = SIGN_ENV_LOCK.lock().unwrap();
+        let dir = sign_scratch("resolve");
+        let home = dir.join("home");
+        let journal = dir.join("journal.log");
+        let _env = SignEnv::set(&home, &journal);
+        let compose_signed = tpkg::compose::parse_compose(
+            "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nsign: true\n",
+        )
+        .unwrap()
+        .0;
+
+        // No declaration on any channel: unsigned, no key material.
+        let mut opts = press_opts(None);
+        assert_eq!(
+            effective_sign(&opts, None).unwrap(),
+            tebako_pkg::SignRequest::None
+        );
+
+        // The compose document declares: the press-local key.
+        assert_eq!(
+            effective_sign(&opts, Some(&compose_signed)).unwrap(),
+            tebako_pkg::SignRequest::PressLocal
+        );
+
+        // TEBAKO_SIGN=0 overriding the document is the LOUD opt-out:
+        // the decision is unsigned and the journal records the drop.
+        std::env::set_var("TEBAKO_SIGN", "0");
+        assert_eq!(
+            effective_sign(&opts, Some(&compose_signed)).unwrap(),
+            tebako_pkg::SignRequest::None
+        );
+        let j = std::fs::read_to_string(&journal).unwrap();
+        assert!(
+            j.contains("event=press-sign-opt-out by=env overridden=compose"),
+            "{j}"
+        );
+
+        // TEBAKO_SIGN=1 is the machine-wide declaration (press-local key).
+        std::env::set_var("TEBAKO_SIGN", "1");
+        assert_eq!(
+            effective_sign(&opts, None).unwrap(),
+            tebako_pkg::SignRequest::PressLocal
+        );
+
+        // The CLI beats the env: --no-sign over TEBAKO_SIGN=1 is loud…
+        opts.sign = Some(tpkg::settings::SignCli::NoSign);
+        assert_eq!(
+            effective_sign(&opts, Some(&compose_signed)).unwrap(),
+            tebako_pkg::SignRequest::None
+        );
+        let j = std::fs::read_to_string(&journal).unwrap();
+        assert!(
+            j.contains("event=press-sign-opt-out by=cli overridden=env"),
+            "{j}"
+        );
+        // …and bare --sign over TEBAKO_SIGN=0 signs.
+        std::env::set_var("TEBAKO_SIGN", "0");
+        opts.sign = Some(tpkg::settings::SignCli::PressLocal);
+        assert_eq!(
+            effective_sign(&opts, None).unwrap(),
+            tebako_pkg::SignRequest::PressLocal
+        );
+        // An opt-out over silence stays quiet (no new journal lines).
+        let before = std::fs::read_to_string(&journal).unwrap();
+        opts.sign = Some(tpkg::settings::SignCli::NoSign);
+        std::env::remove_var("TEBAKO_SIGN");
+        effective_sign(&opts, None).unwrap();
+        assert_eq!(std::fs::read_to_string(&journal).unwrap(), before);
+
+        // A malformed env value is a named error, never a silent default.
+        std::env::set_var("TEBAKO_SIGN", "maybe");
+        opts.sign = None;
+        let err = effective_sign(&opts, None).unwrap_err();
+        assert_eq!(err.code, 65);
+        assert!(err.message.contains("TEBAKO_SIGN"), "{}", err.message);
+        std::env::remove_var("TEBAKO_SIGN");
+
+        // --sign=<keyid> naming no key in $TEBAKO_HOME/keys is a NAMED
+        // error (71), raised here — before any heavy work — never a
+        // fallback to the press-local key.
+        opts.sign = Some(tpkg::settings::SignCli::Keyid("0000000000000000".into()));
+        let err = effective_sign(&opts, None).unwrap_err();
+        assert_eq!(err.code, 71);
+        assert!(
+            err.message
+                .contains("no secret key with keyid 0000000000000000"),
+            "{}",
+            err.message
+        );
+        opts.sign = Some(tpkg::settings::SignCli::Keyid("zz".into()));
+        let err = effective_sign(&opts, None).unwrap_err();
+        assert_eq!(err.code, 71);
+        assert!(err.message.contains("invalid keyid"), "{}", err.message);
+
+        // A keyid naming a real key resolves to it.
+        let press = tebako_signer::press_local_key(&home).unwrap();
+        opts.sign = Some(tpkg::settings::SignCli::Keyid(press.keyid_hex()));
+        assert_eq!(
+            effective_sign(&opts, None).unwrap(),
+            tebako_pkg::SignRequest::Keyid(press.keyid_hex())
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn stitch_unsigned_is_byte_identical_and_touches_no_key_material() {
+        // spec 09 §9: a press with no sign declaration on any channel
+        // produces the v1-unsigned trailer — byte-identical to the
+        // pre-signing shape — and never touches key material.
+        let _guard = SIGN_ENV_LOCK.lock().unwrap();
+        let dir = sign_scratch("parity");
+        let home = dir.join("home");
+        let _env = SignEnv::set(&home, &dir.join("journal.log"));
+        let base = dir.join("bootstrap");
+        std::fs::write(&base, b"BASE").unwrap();
+        let img = dir.join("img.tfs");
+        std::fs::write(&img, b"IMG").unwrap();
+
+        let pre_change = dir.join("pre-change");
+        stitch(
+            &base,
+            &[(img.clone(), "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+            pre_change.to_str().unwrap(),
+            "ruby@3.3.7;tebako=9.9.9",
+            None,
+            StitchFlags {
+                lean: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // The resolved-unsigned request (what press now computes with no
+        // channel declaring sign)…
+        let resolved = dir.join("resolved");
+        stitch(
+            &base,
+            &[(img, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+            resolved.to_str().unwrap(),
+            "ruby@3.3.7;tebako=9.9.9",
+            None,
+            StitchFlags {
+                lean: true,
+                sign: tebako_pkg::SignRequest::None,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // …is byte-identical to the pre-change shape…
+        assert_eq!(
+            std::fs::read(&pre_change).unwrap(),
+            std::fs::read(&resolved).unwrap(),
+            "resolved-unsigned must equal the pre-signing output"
+        );
+        // …a plain v1 trailer (no SIGNED_V2, no v2 extension)…
+        let m = tpkg::read_from(&mut std::fs::File::open(&resolved).unwrap()).unwrap();
+        assert_eq!(m.package_flags & tpkg::TPKG_FLAG_SIGNED_V2, 0);
+        assert!(m.v2.is_none());
+        // …and no key material was generated, loaded, or prompted for.
+        assert!(!home.join("keys").exists(), "no keys dir may be created");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn stitch_signed_round_trips_through_the_verifier() {
+        // spec 09 §9: a signed press carries TPKG_FLAG_SIGNED_V2 + the v2
+        // chain-of-trust extension; the bootstrap's verifier path accepts
+        // it and the signature cryptographically verifies against the
+        // auto-registered trusted keyring.
+        use std::io::{Read as _, Seek as _, SeekFrom};
+
+        let _guard = SIGN_ENV_LOCK.lock().unwrap();
+        let dir = sign_scratch("roundtrip");
+        let home = dir.join("home");
+        let _env = SignEnv::set(&home, &dir.join("journal.log"));
+        let base = dir.join("bootstrap");
+        std::fs::write(&base, b"BASE").unwrap();
+        let img = dir.join("img.tfs");
+        std::fs::write(&img, b"IMG").unwrap();
+
+        let out = dir.join("signed");
+        stitch(
+            &base,
+            &[(img, "/".to_string(), tpkg::TPKG_FORMAT_DWARFS)],
+            out.to_str().unwrap(),
+            "ruby@3.3.7;tebako=9.9.9",
+            None,
+            StitchFlags {
+                lean: true,
+                sign: tebako_pkg::SignRequest::PressLocal,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // First explicit use generates + caches the press-local key.
+        assert!(home.join("keys/press-local.key").exists());
+
+        let m = tpkg::read_from(&mut std::fs::File::open(&out).unwrap()).unwrap();
+        assert!(m.package_flags & tpkg::TPKG_FLAG_SIGNED_V2 != 0);
+        let v2 =
+            m.v2.as_ref()
+                .expect("the v2 extension rides a signed press");
+
+        // The bootstrap's chain-of-trust verifier (the run-time path).
+        tebako_bootstrap::verify_chain_with_home(&out, &m, &home).expect("chain verifies");
+
+        // The signature itself verifies against the trusted keyring the
+        // press auto-registered (the strict, cryptographic check).
+        let mut f = std::fs::File::open(&out).unwrap();
+        let tlen = tpkg::trailer_len(&m);
+        f.seek(SeekFrom::End(-(tlen as i64))).unwrap();
+        let mut trailer = vec![0u8; tlen as usize];
+        f.read_exact(&mut trailer).unwrap();
+        let region = tpkg::v2_signed_region(&trailer).unwrap();
+        let keyring = tebako_signer::trusted_keyring_bytes(&home).unwrap();
+        let outcome =
+            tebako_signer::verify_detached(&keyring, &region, &v2.signature, &v2.signer_keyid)
+                .unwrap();
+        assert!(
+            matches!(outcome, tebako_signer::VerifyOutcome::Trusted(_)),
+            "{outcome:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -1385,6 +1738,7 @@ mod tests {
             jail: None,
             no_install: false,
             quiet_notices: None,
+            sign: None,
             format: options::PressImageFormat::Dwarfs,
             compose: None,
             carry: None,

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -13,7 +13,7 @@ const USAGE: &str = "Usage:
                [-R <ruby>] [-m self-contained|shared-runtime] [-l error|warn|debug|trace]
                [--image <path>:<mount>]... [--bootstrap <path>]
                [--tebako-version <v>] [--prefer-local] [--jail <spec>]
-               [--no-install] [--quiet-notices]
+               [--no-install] [--quiet-notices] [--sign[=<keyid>] | --no-sign]
                [--format dwarfs|limnifs] [--compose <tebako.yaml>]
                [--carry all|none|<name,...>] [--share <name,...>]
                (lean/fat stay accepted as deprecated aliases, spec 23 §13.2)
@@ -694,6 +694,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
     let mut jail: Option<String> = None;
     let mut no_install = false;
     let mut quiet_notices: Option<bool> = None;
+    let mut sign: Option<tpkg::settings::SignCli> = None;
     let mut format = tebako_cli::options::PressImageFormat::Limnifs;
     let mut compose: Option<PathBuf> = None;
     let mut carry: Option<String> = None;
@@ -741,6 +742,17 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
             "--no-install" => no_install = true,
             "--quiet-notices" => quiet_notices = Some(true),
             "--no-quiet-notices" => quiet_notices = Some(false),
+            // --sign (the press-local key) or --sign=<keyid> (a secret
+            // key from $TEBAKO_HOME/keys); --no-sign is the opt-out
+            // (spec 09 §9). A bare --sign never eats the next argument
+            // (the tebako-pkg sign command's rule).
+            "--sign" => {
+                sign = Some(match &inline_value {
+                    Some(keyid) => tpkg::settings::SignCli::Keyid(keyid.clone()),
+                    None => tpkg::settings::SignCli::PressLocal,
+                })
+            }
+            "--no-sign" => sign = Some(tpkg::settings::SignCli::NoSign),
             "--format" => {
                 let v = take_value(&mut i)?;
                 format =
@@ -815,6 +827,7 @@ fn parse_press(args: &[String]) -> Result<PressOptions, CliExit> {
         jail,
         no_install,
         quiet_notices,
+        sign,
         format,
         compose,
         carry,

--- a/crates/tebako-cli/src/options.rs
+++ b/crates/tebako-cli/src/options.rs
@@ -149,6 +149,14 @@ pub struct PressOptions {
     /// leaves the env (`TEBAKO_QUIET_NOTICES`) and compose-document
     /// (`quiet_notices:`) channels to decide.
     pub quiet_notices: Option<bool>,
+    /// --sign[=<keyid>] / --no-sign (spec 09 §9, spec 23 §14): the CLI
+    /// channel of the `sign` registry setting — sign the package trailer
+    /// at press (TPKG_FLAG_SIGNED_V2 + the v2 chain-of-trust extension).
+    /// Bare `--sign` takes the press-local key; `--sign=<keyid>` names a
+    /// secret key from $TEBAKO_HOME/keys. Tri-state: `None` leaves the
+    /// env (`TEBAKO_SIGN`) and compose-document (`sign:`) channels to
+    /// decide.
+    pub sign: Option<tpkg::settings::SignCli>,
     /// --format <dwarfs|limnifs> (spec 20 §6): the application image
     /// format. Limnifs by default; `dwarfs` stays an explicit opt-in.
     pub format: PressImageFormat,

--- a/crates/tebako-cli/src/packager.rs
+++ b/crates/tebako-cli/src/packager.rs
@@ -766,6 +766,7 @@ mod tests {
             jail: None,
             no_install: false,
             quiet_notices: None,
+            sign: None,
             format: crate::options::PressImageFormat::Dwarfs,
             compose: None,
             carry: None,

--- a/crates/tebako-cli/src/suite.rs
+++ b/crates/tebako-cli/src/suite.rs
@@ -326,6 +326,12 @@ pub fn press_suite(
     for entry in &spec.entries {
         check_entry_abi(entry, opts)?;
     }
+    // spec 09 §9: the `sign` registry setting resolves BEFORE any heavy
+    // work — a keyid naming no key in $TEBAKO_HOME/keys is the named
+    // error here, not after the per-entry imaging. A suite rides no
+    // compose document: the CLI and env channels decide (the registry's
+    // precedence holds).
+    let sign = crate::effective_sign(opts, None)?;
     if !opts.devmode {
         crate::version_cache_check(opts);
     }
@@ -406,6 +412,7 @@ pub fn press_suite(
             lean: true,
             no_install: opts.no_install,
             quiet_notices,
+            sign,
         },
     )?;
     println!("Created tebako suite package at \"{package}\"");

--- a/crates/tebako-cli/tests/press_sign.rs
+++ b/crates/tebako-cli/tests/press_sign.rs
@@ -1,0 +1,120 @@
+//! Press signing at the CLI surface (spec 09 §9, spec 23 §14): the
+//! `--sign[=<keyid>]` / `--no-sign` flags through the real binary, with
+//! temp TEBAKO_HOMEs and no network —
+//!
+//! - a `--sign=<keyid>` naming no key in $TEBAKO_HOME/keys is the NAMED
+//!   error 71 raised BEFORE any heavy work (the scenario, the bootstrap
+//!   store, the runtime download all come later);
+//! - `--no-sign` overriding `TEBAKO_SIGN=1` is LOUD (stderr warning +
+//!   the audit journal's `event=press-sign-opt-out`) while the press
+//!   itself proceeds unsigned — here it then stops at the offline
+//!   bootstrap/runtime resolution, which changes nothing about the
+//!   opt-out's loudness.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn tebako_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_tebako"))
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "tebako-cli-press-sign-{tag}-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(cmd: &mut Command) -> (i32, String) {
+    let out = cmd.output().unwrap_or_else(|e| panic!("spawn failed: {e}"));
+    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&out.stderr));
+    (out.status.code().unwrap_or(-1), text)
+}
+
+#[test]
+fn sign_with_an_unknown_keyid_fails_before_any_heavy_work() {
+    let dir = scratch("unknown-keyid");
+    let home = dir.join("home");
+    fs::create_dir_all(&home).unwrap();
+
+    // -r/-e deliberately name nothing real: the keyid check must fire
+    // BEFORE the scenario checks, the bootstrap store flow and the
+    // runtime download (spec 09 §9 — never a silent fallback).
+    let (code, log) = run(Command::new(tebako_bin())
+        .args([
+            "press",
+            "-r",
+            "/nonexistent-root",
+            "-e",
+            "start.rb",
+            "-o",
+            &dir.join("pkg").display().to_string(),
+            "-p",
+            &dir.join("prefix").display().to_string(),
+            "--sign=0000000000000000",
+        ])
+        .env("TEBAKO_HOME", &home)
+        .env("TEBAKO_OFFLINE", "1")
+        .env_remove("TEBAKO_BOOTSTRAP")
+        .env_remove("TEBAKO_SIGN"));
+    assert_eq!(code, 71, "{log}");
+    assert!(
+        log.contains("no secret key with keyid 0000000000000000"),
+        "{log}"
+    );
+    // Nothing heavy ran: no key material, no store dirs.
+    assert!(!home.join("keys").exists());
+    assert!(!home.join("runtimes").exists());
+    assert!(!home.join("bootstraps").exists());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn no_sign_over_a_lower_channel_declaration_is_loud() {
+    let dir = scratch("opt-out");
+    let home = dir.join("home");
+    let root = dir.join("root");
+    fs::create_dir_all(&home).unwrap();
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("start.rb"), "puts 'hi'\n").unwrap();
+
+    // --no-sign over TEBAKO_SIGN=1: the press continues UNSIGNED (and
+    // here stops at the offline bootstrap/runtime resolution), but the
+    // dropped declaration is warned about and journaled.
+    let (code, log) = run(Command::new(tebako_bin())
+        .args([
+            "press",
+            "-r",
+            &root.display().to_string(),
+            "-e",
+            "start.rb",
+            "-o",
+            &dir.join("pkg").display().to_string(),
+            "-p",
+            &dir.join("prefix").display().to_string(),
+            "--no-sign",
+        ])
+        .env("TEBAKO_HOME", &home)
+        .env("TEBAKO_SIGN", "1")
+        .env("TEBAKO_OFFLINE", "1")
+        .env_remove("TEBAKO_BOOTSTRAP"));
+    assert_ne!(code, 0, "the offline press cannot complete:\n{log}");
+    assert!(
+        log.contains("sign opt-out") && log.contains("press-sign-opt-out"),
+        "the opt-out warning must name what it dropped:\n{log}"
+    );
+    let journal =
+        fs::read_to_string(home.join("journal.log")).expect("the opt-out must be journaled");
+    assert!(
+        journal.contains("event=press-sign-opt-out by=cli overridden=env"),
+        "{journal}"
+    );
+    // The unsigned path touches no key material.
+    assert!(!home.join("keys").exists());
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/tebako-cli/tests/suite.rs
+++ b/crates/tebako-cli/tests/suite.rs
@@ -33,6 +33,7 @@ fn opts() -> PressOptions {
         jail: None,
         no_install: false,
         quiet_notices: None,
+        sign: None,
         format: tebako_cli::options::PressImageFormat::Dwarfs,
         compose: None,
         carry: None,

--- a/crates/tebako-pkg/Cargo.toml
+++ b/crates/tebako-pkg/Cargo.toml
@@ -15,7 +15,7 @@ tpkg = { version = "0.3.0", path = "../tpkg" }
 tebako-json = { version = "0.3.0", path = "../tebako-json" }
 tebako-info = { version = "0.3.0", path = "../tebako-info" }
 tebako-signer = { version = "0.3.0", path = "../tebako-signer" }
-rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"] }
+rnp = { package = "rnp-rs", version = "0.1.15", features = ["vendored"] }
 libc = "0.2"
 sha2 = "0.10"
 

--- a/crates/tebako-signer/Cargo.toml
+++ b/crates/tebako-signer/Cargo.toml
@@ -9,9 +9,10 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"] }
-# rnp-rs 0.1.12's vendored mode delegates through rnp-sys to rnp-src 0.2.x,
-# which builds librnp + Botan + json-c + zlib + bzip2 from source — nothing
-# external to link. (0.1.12 is the pair for rnp-src 0.2.1: 0.2.1 dropped
-# links::lib_dir_env_var, which breaks 0.1.11's build script.)
+rnp = { package = "rnp-rs", version = "0.1.15", features = ["vendored"] }
+# rnp-rs's vendored mode delegates through rnp-sys to rnp-src 0.2.x, which
+# builds librnp + Botan + json-c + zlib + bzip2 from source — nothing
+# external to link. Floor 0.1.15 is the pair for rnp-src 0.2.3 (Botan
+# unpinned to 3.13.0 with the RSA short-MPI padding backport,
+# rnpgp/rnp#2465); older rnp-rs build scripts break against it.
 sha2 = "0.10"

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -59,7 +59,7 @@ path = "src/lib.rs"
 tebako-contract-tests = { version = "0.3.0", path = "../../tests/contract" }
 # The --verify signature tests mint a press-local key and detached .asc.
 tebako-signer = { version = "0.3.0", path = "../tebako-signer" }
-rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"] }
+rnp = { package = "rnp-rs", version = "0.1.15", features = ["vendored"] }
 # Exec-proof image fixtures (zip backend).
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # The floor-recipe structural test parses the emitted metadata through

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -104,8 +104,8 @@ backend-limnifs = ["dep:limnifs-core"]
 [dev-dependencies]
 # Tempdir scaffolding for backend tests (large-archive RSS fixtures).
 tempfile = "3"
-# ENC tests mint recipient key pairs in-memory (same pin as tebako-signer).
-rnp = { package = "rnp-rs", version = "=0.1.12", features = ["vendored"] }
+# ENC tests mint recipient key pairs in-memory (same floor as tebako-signer).
+rnp = { package = "rnp-rs", version = "0.1.15", features = ["vendored"] }
 # gzip trailer checksums in tar-backend test fixtures.
 crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —

--- a/crates/tfs/src/journal.rs
+++ b/crates/tfs/src/journal.rs
@@ -66,6 +66,12 @@ pub const DECRYPT_EVENT: &str = "decrypt";
 /// §8's record-mode idiom).
 pub const LIB_LOAD_EVENT: &str = "lib-load";
 
+/// The event name of the press-side signing opt-out record (spec 09 §9):
+/// an explicit `--no-sign` / `TEBAKO_SIGN=0` overrode a lower channel's
+/// `sign` declaration — a trust downgrade must never be silent, so the
+/// drop is journaled (and warned on stderr) at press-time resolution.
+pub const PRESS_SIGN_OPT_OUT_EVENT: &str = "press-sign-opt-out";
+
 /// Resolve and open the journal file for append (creating the tebako home
 /// if needed). Call it at POLICY-INSTALL time, BEFORE the context guard is
 /// taken — never from inside a `host_check` (see the module docs). `None`
@@ -206,6 +212,19 @@ pub fn journal_decrypt(file: &std::fs::File, mount: &str, recipient: &str, grant
     journal_fields(
         file,
         &format!("event={DECRYPT_EVENT} mount={mount} recipient={recipient} grants={grants}"),
+    );
+}
+
+/// Append one press-side signing opt-out line (spec 09 §9): `<ts>
+/// event=press-sign-opt-out by=<cli|env> overridden=<env|compose>` — the
+/// channel carrying the winning opt-out and the highest lower channel
+/// whose `sign` declaration it dropped. Emitted where the decision is
+/// MADE (the press's settings resolution), never at run time; same
+/// best-effort discipline as [`journal_deny`].
+pub fn journal_press_sign_opt_out(file: &std::fs::File, by: &str, overridden: &str) {
+    journal_fields(
+        file,
+        &format!("event={PRESS_SIGN_OPT_OUT_EVENT} by={by} overridden={overridden}"),
     );
 }
 
@@ -414,6 +433,35 @@ mod tests {
                 "event=vfs-write path=/app/var/cache/y mount=/app",
                 "event=overlay mount=/app store=/tmp/ov/app source=ephemeral",
                 "event=decrypt mount=/data recipient=pgp:3c8dba971d2b4f01 grants=g1,g2",
+            ]
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn press_sign_opt_out_line_shape() {
+        // spec 09 §9: the loud opt-out's audit record — who opted out and
+        // whose declaration was dropped. No env mutation — the file is
+        // handed in directly.
+        let dir =
+            std::env::temp_dir().join(format!("tfs-journal-optout-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let log = dir.join("journal.log");
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log)
+            .unwrap();
+        journal_press_sign_opt_out(&file, "cli", "env");
+        journal_press_sign_opt_out(&file, "env", "compose");
+        drop(file);
+        let text = std::fs::read_to_string(&log).unwrap();
+        let bodies: Vec<&str> = text.lines().map(|l| l.split_once(' ').unwrap().1).collect();
+        assert_eq!(
+            bodies,
+            vec![
+                "event=press-sign-opt-out by=cli overridden=env",
+                "event=press-sign-opt-out by=env overridden=compose",
             ]
         );
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/tpkg/src/compose.rs
+++ b/crates/tpkg/src/compose.rs
@@ -31,6 +31,8 @@
 //! entrypoint: mnconvert         # the pointer-package form's entry selector
 //! quiet_notices: true           # optional: bake TPKG_FLAG_QUIET_NOTICES
 //!                               # (registry setting, spec 23 §14 — CLI/env override)
+//! sign: true                    # optional: sign the trailer at press (spec 09 §9
+//!                               # — registry setting; the press-local key, CLI/env override)
 //! ```
 
 use serde::Deserialize;
@@ -296,6 +298,13 @@ pub struct ComposeDoc {
     /// shareable. CLI and env channels override it at press; the
     /// resolved value bakes `TPKG_FLAG_QUIET_NOTICES`.
     pub quiet_notices: Option<bool>,
+    /// The config channel of the `sign` registry setting (spec 23 §14,
+    /// spec 09 §9): `Some(true)` declares the press signs the package
+    /// trailer — with the press-local key (boolean only; a keyid is
+    /// per-machine material and never rides a git-shared document, the
+    /// CLI's `--sign=<keyid>` names one). CLI and env channels override
+    /// it at press; unsigned v1 stays the default.
+    pub sign: Option<bool>,
 }
 
 impl ComposeDoc {
@@ -319,6 +328,9 @@ struct RawDoc {
     // The config channel of the `quiet_notices` registry setting
     // (spec 23 §14) — tri-state; absent lets the CLI/env channels rule.
     quiet_notices: Option<bool>,
+    // The config channel of the `sign` registry setting (spec 23 §14,
+    // spec 09 §9) — tri-state, boolean only (never a keyid).
+    sign: Option<bool>,
     // Phase-R keys — present ⇒ the named refusal, never a silent drop.
     policy: Option<serde_yml::Value>,
     mounts: Option<serde_yml::Value>,
@@ -383,6 +395,7 @@ pub fn parse_compose(yaml: &str) -> Result<(ComposeDoc, Vec<String>), ComposeErr
             slices,
             entrypoint,
             quiet_notices: raw.quiet_notices,
+            sign: raw.sign,
         },
         warnings,
     ))
@@ -523,6 +536,25 @@ entrypoint: mnconvert
             .unwrap()
             .0;
         assert_eq!(absent.quiet_notices, None);
+    }
+
+    #[test]
+    fn sign_parses_tri_state() {
+        // spec 09 §9 / spec 23 §14: the compose key is the config channel
+        // of the `sign` registry setting — boolean only (a keyid never
+        // rides the git-shared document), tri-state like every channel.
+        let yes = parse("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nsign: true\n")
+            .unwrap()
+            .0;
+        assert_eq!(yes.sign, Some(true));
+        let no = parse("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nsign: false\n")
+            .unwrap()
+            .0;
+        assert_eq!(no.sign, Some(false));
+        let absent = parse("version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\n")
+            .unwrap()
+            .0;
+        assert_eq!(absent.sign, None);
     }
 
     #[test]

--- a/crates/tpkg/src/settings.rs
+++ b/crates/tpkg/src/settings.rs
@@ -6,9 +6,11 @@
 //! channel used to be wired ad-hoc, which is how semantics drift (one
 //! channel learns a behavior the others never hear about). Here every
 //! setting is declared ONCE — all three spellings, the default, and the
-//! one doc line — and every consumer resolves through `resolve_bool`,
-//! so the channels share one semantics by construction (invariant 10:
-//! a second hand-written copy of a contract value is a bug on arrival).
+//! one doc line — and every consumer resolves through `resolve_bool`
+//! (boolean settings) or `resolve_sign` (the `sign` setting, whose CLI
+//! channel carries an optional `=<keyid>`), so the channels share one
+//! semantics by construction (invariant 10: a second hand-written copy
+//! of a contract value is a bug on arrival).
 //!
 //! Precedence is fixed, highest first: **CLI → environment → compose
 //! document → default**. Every channel is tri-state (present-and-true,
@@ -26,7 +28,8 @@
 //!
 //! `--help`, the compose JSON Schema, and the docs table all render
 //! from this registry — adding a setting is one entry here plus one
-//! `resolve_bool` call at the consumer; nothing else can drift.
+//! `resolve_bool`/`resolve_sign` call at the consumer; nothing else can
+//! drift.
 
 use std::fmt;
 
@@ -67,8 +70,28 @@ pub const QUIET_NOTICES: Setting = Setting {
           lines for every run of the package (baked as trailer flag bit 3)",
 };
 
+/// `sign` — the package's signing declaration (spec 09 §9, tebako#400
+/// S1). Resolved at press; a true resolution signs the package trailer
+/// (`TPKG_FLAG_SIGNED_V2`, bit 1, + the v2 chain-of-trust extension),
+/// unsigned v1 stays the default — byte-identical to pre-signing output,
+/// no key material touched. The CLI channel is the only one that may
+/// name a key (`--sign=<keyid>`): a keyid is per-machine material and
+/// never rides a git-shared document. An explicit opt-out
+/// (`--no-sign` / `TEBAKO_SIGN=0`) that drops a lower channel's
+/// declaration is LOUD — a stderr warning plus the audit journal's
+/// `event=press-sign-opt-out` (a quiet trust downgrade is invariant 9's
+/// named failure).
+pub const SIGN: Setting = Setting {
+    config: Some("sign"),
+    env: Some("TEBAKO_SIGN"),
+    cli: Some("--sign"),
+    doc: "sign the package trailer at press (TPKG_FLAG_SIGNED_V2 + the v2 \
+          chain-of-trust extension); unsigned v1 stays the default, \
+          an opt-out overriding a lower channel is loud",
+};
+
 /// Every registered setting (help/schema/docs render from this table).
-pub const SETTINGS: &[Setting] = &[QUIET_NOTICES];
+pub const SETTINGS: &[Setting] = &[QUIET_NOTICES, SIGN];
 
 /// A settings resolution failure.
 #[derive(Debug)]
@@ -124,6 +147,123 @@ pub fn resolve_bool(
     Ok(false)
 }
 
+/// The `sign` setting's CLI channel contribution (spec 09 §9): bare
+/// `--sign` (the press-local key), `--sign=<keyid>` (a named secret key
+/// from `$TEBAKO_HOME/keys`), `--no-sign` (the explicit opt-out). Only
+/// this channel may carry a keyid — a keyid is per-machine material and
+/// never rides a git-shared document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignCli {
+    /// Bare `--sign`: sign with the press-local key.
+    PressLocal,
+    /// `--sign=<keyid>`: sign with the named key (16 hex chars).
+    Keyid(String),
+    /// `--no-sign`: the explicit opt-out.
+    NoSign,
+}
+
+/// The signing decision one resolution arrives at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignDecision {
+    /// No channel declared signing (or an opt-out won): the v1-unsigned
+    /// trailer — byte-identical to pre-signing output, no key material
+    /// touched.
+    Unsigned,
+    /// Sign with the press-local key (generated and cached under
+    /// `$TEBAKO_HOME/keys` on first explicit use, auto-registered into
+    /// the local trusted keyring).
+    PressLocal,
+    /// Sign with the secret key from `$TEBAKO_HOME/keys` whose keyid
+    /// matches. A keyid naming no key is a NAMED error at the caller,
+    /// raised before any heavy work — never a fallback to the
+    /// press-local key.
+    Keyid(String),
+}
+
+/// An explicit opt-out that dropped a lower channel's `sign`
+/// declaration — the LOUD case (spec 09 §9: stderr warning + the audit
+/// journal's `event=press-sign-opt-out`), because silently dropping an
+/// authored signing declaration would be a quiet trust downgrade. An
+/// opt-out over silence stays quiet (nothing was overridden).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SignOptOut {
+    /// The channel carrying the winning opt-out: `"cli"` (`--no-sign`)
+    /// or `"env"` (`TEBAKO_SIGN=0`).
+    pub by: &'static str,
+    /// The highest lower channel whose sign declaration was dropped:
+    /// `"env"` (`TEBAKO_SIGN=1`) or `"compose"` (`sign: true`).
+    pub overridden: &'static str,
+}
+
+/// The `sign` resolution: the decision plus the loud-opt-out signal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignResolution {
+    pub decision: SignDecision,
+    /// `Some` exactly when an explicit opt-out overrode a lower channel's
+    /// sign declaration (see [`SignOptOut`]).
+    pub opt_out: Option<SignOptOut>,
+}
+
+/// Resolve the `sign` setting across the three channels (spec 09 §9).
+/// Same fixed precedence as [`resolve_bool`] — CLI → environment →
+/// compose document → default (unsigned) — with the CLI channel's
+/// optional `=<keyid>` riding [`SignCli`]. The env and compose channels
+/// are plain booleans and always mean the press-local key. As with
+/// [`resolve_bool`], a malformed env value is a named error when the env
+/// channel rules, and moot when a higher channel is present.
+pub fn resolve_sign(
+    setting: &Setting,
+    cli: Option<SignCli>,
+    env: Option<String>,
+    config: Option<bool>,
+) -> Result<SignResolution, SettingsError> {
+    // The lower channels' declarations, for the loud-opt-out signal. The
+    // env parses strictly only when it rules (below); for the override
+    // check a malformed env simply does not declare (a higher channel
+    // moots it — resolve_bool's precedence).
+    let env_declares = || {
+        env.as_deref()
+            .and_then(|raw| parse_env_bool(setting, raw).ok())
+            == Some(true)
+    };
+    let config_declares = || config == Some(true);
+    let opt_out = |by: &'static str| {
+        if env_declares() {
+            Some(SignOptOut {
+                by,
+                overridden: "env",
+            })
+        } else if config_declares() {
+            Some(SignOptOut {
+                by,
+                overridden: "compose",
+            })
+        } else {
+            None
+        }
+    };
+    let resolved = |decision, opt_out| SignResolution { decision, opt_out };
+    match cli {
+        Some(SignCli::PressLocal) => Ok(resolved(SignDecision::PressLocal, None)),
+        Some(SignCli::Keyid(keyid)) => Ok(resolved(SignDecision::Keyid(keyid), None)),
+        Some(SignCli::NoSign) => Ok(resolved(SignDecision::Unsigned, opt_out("cli"))),
+        None => match &env {
+            Some(raw) => match parse_env_bool(setting, raw)? {
+                true => Ok(resolved(SignDecision::PressLocal, None)),
+                false => Ok(resolved(SignDecision::Unsigned, opt_out("env"))),
+            },
+            None => Ok(resolved(
+                if config == Some(true) {
+                    SignDecision::PressLocal
+                } else {
+                    SignDecision::Unsigned
+                },
+                None,
+            )),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,5 +317,108 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("TEBAKO_QUIET_NOTICES"), "{msg}");
         assert!(msg.contains("maybe"), "{msg}");
+    }
+
+    // ---- the `sign` setting (spec 09 §9) ----
+
+    fn unsigned(resolved: SignResolution) -> SignResolution {
+        assert_eq!(resolved.decision, SignDecision::Unsigned);
+        resolved
+    }
+
+    #[test]
+    fn sign_cli_beats_everything() {
+        // Bare --sign signs with the press-local key, however the lower
+        // channels declare.
+        let r = resolve_sign(
+            &SIGN,
+            Some(SignCli::PressLocal),
+            Some("0".into()),
+            Some(false),
+        )
+        .unwrap();
+        assert_eq!(r.decision, SignDecision::PressLocal);
+        assert_eq!(r.opt_out, None);
+        // --sign=<keyid> carries the keyid through.
+        let r = resolve_sign(
+            &SIGN,
+            Some(SignCli::Keyid("0123456789abcdef".into())),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            r.decision,
+            SignDecision::Keyid("0123456789abcdef".to_string())
+        );
+        // --no-sign wins over every lower channel.
+        let r = resolve_sign(&SIGN, Some(SignCli::NoSign), Some("1".into()), Some(true)).unwrap();
+        assert_eq!(
+            unsigned(r).opt_out.map(|o| (o.by, o.overridden)),
+            Some(("cli", "env"))
+        );
+    }
+
+    #[test]
+    fn sign_env_beats_config_and_default() {
+        let r = resolve_sign(&SIGN, None, Some("1".into()), Some(false)).unwrap();
+        assert_eq!(r.decision, SignDecision::PressLocal);
+        // TEBAKO_SIGN=0 overriding the document's `sign: true` is the
+        // loud opt-out.
+        let r = resolve_sign(&SIGN, None, Some("0".into()), Some(true)).unwrap();
+        assert_eq!(
+            unsigned(r).opt_out.map(|o| (o.by, o.overridden)),
+            Some(("env", "compose"))
+        );
+        // …over the default alone it stays quiet (nothing overridden).
+        let r = resolve_sign(&SIGN, None, Some("0".into()), None).unwrap();
+        assert_eq!(unsigned(r).opt_out, None);
+    }
+
+    #[test]
+    fn sign_config_beats_default() {
+        let r = resolve_sign(&SIGN, None, None, Some(true)).unwrap();
+        assert_eq!(r.decision, SignDecision::PressLocal);
+        // The document never names a key — boolean true is the
+        // press-local key (spec 09 §9).
+        let r = resolve_sign(&SIGN, None, None, Some(false)).unwrap();
+        assert_eq!(unsigned(r.clone()).opt_out, None);
+        let r = resolve_sign(&SIGN, None, None, None).unwrap();
+        assert_eq!(unsigned(r).opt_out, None);
+    }
+
+    #[test]
+    fn sign_opt_out_over_silence_is_quiet() {
+        // --no-sign with no lower declaration is not an override.
+        let r = resolve_sign(&SIGN, Some(SignCli::NoSign), None, None).unwrap();
+        assert_eq!(unsigned(r).opt_out, None);
+        let r = resolve_sign(&SIGN, Some(SignCli::NoSign), Some("0".into()), Some(false)).unwrap();
+        assert_eq!(unsigned(r).opt_out, None);
+        // --no-sign over the document alone names the compose channel.
+        let r = resolve_sign(&SIGN, Some(SignCli::NoSign), None, Some(true)).unwrap();
+        assert_eq!(
+            unsigned(r).opt_out.map(|o| (o.by, o.overridden)),
+            Some(("cli", "compose"))
+        );
+    }
+
+    #[test]
+    fn sign_env_garbage_is_named_only_when_the_env_rules() {
+        // Same discipline as resolve_bool: strict when the env channel
+        // rules, moot when the CLI is present.
+        let err = resolve_sign(&SIGN, None, Some("maybe".into()), Some(true))
+            .expect_err("garbage env must not silently fall through to the config");
+        assert!(err.to_string().contains("TEBAKO_SIGN"), "{err}");
+        let r = resolve_sign(
+            &SIGN,
+            Some(SignCli::NoSign),
+            Some("maybe".into()),
+            Some(true),
+        )
+        .unwrap();
+        assert_eq!(
+            unsigned(r).opt_out.map(|o| (o.by, o.overridden)),
+            Some(("cli", "compose"))
+        );
     }
 }

--- a/crates/tpkg/tests/compose.rs
+++ b/crates/tpkg/tests/compose.rs
@@ -95,6 +95,25 @@ fn the_schema_refuses_the_phase_r_keys_too() {
 }
 
 #[test]
+fn the_sign_key_is_schema_and_crate_aligned() {
+    // spec 09 §9 / spec 23 §14: the `sign` compose key rides both the
+    // versioned JSON Schema and the serde model (this cross-check keeps
+    // them MECE) — boolean only, a keyid never rides the document.
+    let schema: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(schema_path()).expect("read schema"))
+            .expect("schema json");
+    let validator = jsonschema::validator_for(&schema).expect("the schema itself compiles");
+    let yaml = "version: 1\nruntime: {ref: \"ruby@~> 3.3\"}\nsign: true\n";
+    let value: serde_yml::Value = serde_yml::from_str(yaml).expect("yaml parses");
+    validator
+        .validate(&yaml_to_json(&value))
+        .unwrap_or_else(|e| panic!("sign: true against the JSON schema: {e}"));
+    let (doc, warnings) = parse_compose(yaml).expect("the crate parses it");
+    assert!(warnings.is_empty());
+    assert_eq!(doc.sign, Some(true));
+}
+
+#[test]
 fn schema_and_crate_agree_on_the_example() {
     let (doc, warnings) = parse_compose(SPEC_EXAMPLE).expect("the crate parses the example");
     assert!(warnings.is_empty());

--- a/docs/spec/09-trust-and-signing.md
+++ b/docs/spec/09-trust-and-signing.md
@@ -184,11 +184,56 @@ automatically after displaying the chain proof, re-pinning the new key.
   OS-codesign with their own Developer ID — Apple/Microsoft gates then
   vouch at execution time, orthogonally and complementarily (spec 12 §5).
 
+**The two distribution models decide what a warning is worth
+(tebako#400).** Who made the trust decision, and when, differs by
+package shape — the notice policy follows from it:
+
+- **Fat binary (bootstrap + payload downloaded as ONE artifact).** The
+  user's trust decision is explicit and happens ONCE, at download time —
+  fetching the binary from a location they chose, like any binary
+  download. A per-run signature warning on such a package is
+  unactionable noise: the user cannot re-verify at run time what they
+  already decided to fetch and run. The developer may therefore
+  declaratively suppress it for every run of the package
+  (`quiet_notices`, spec 23 §14 — shipped; the bit rides inside the
+  signed region, and `TEBAKO_REQUIRE_SIGNED=1` still outranks it).
+- **Separately-resolved lean payloads.** The package names its runtime
+  and slices; the loader RESOLVES them at first run from whatever the
+  registries serve at that moment. The download-time decision no longer
+  covers the payload bytes — here the signature IS the trust mechanism
+  (§4's verification points), and the warnings on unsigned resolutions
+  stay justified and loud.
+
+**Press signing (shipped — tebako#400 S1).** Signing stays per-package
+OPT-IN (§3): a press with no signing declaration on any channel produces
+the v1-unsigned trailer, byte-identical to pre-signing output, and never
+touches key material. The declaration rides the `sign` registry setting
+(spec 23 §14) through three channels, resolved **CLI → env → compose
+document → default (unsigned)** — auto-sign must never surprise:
+
+- `tebako press --sign` signs the produced package with the press-local
+  key (generated and cached under `$TEBAKO_HOME/keys` on first explicit
+  use, auto-registered into the local trusted keyring);
+  `--sign=<keyid>` signs with the named secret key from
+  `$TEBAKO_HOME/keys` — a keyid matching no key is a NAMED error raised
+  before any heavy work, never a silent fallback to the default key.
+- `TEBAKO_SIGN=1` is the machine-wide declaration and the compose
+  document's `sign: true` the repo-carried one; both sign with the
+  press-local key (a keyid is per-machine material and never rides a
+  git-shared document).
+- `--no-sign` (or `TEBAKO_SIGN=0`) wins over every lower channel. An
+  opt-out that overrides a lower channel's `sign` declaration is LOUD —
+  a stderr warning plus an audit-journal entry (`event=press-sign-opt-out`)
+  — because silently dropping an authored signature declaration would be
+  a quiet trust downgrade (invariant 9).
+
 **Developer ergonomics (target UX; status in braces).** `tebako keygen`
 creates a keypair in `$TEBAKO_HOME/keys/` and prints the fingerprint
 with the exact text to paste into docs + the well-known location
-[partial: key creation exists]; `tebako press` signs automatically when
-a default key exists, `--no-sign` to opt out [partial]; `tebako publish`
+[partial: key creation exists]; `tebako press --sign[=<keyid>]` signs
+the produced package, with `TEBAKO_SIGN` / the compose `sign:` key as
+the machine-wide and repo-carried declarations and `--no-sign` as the
+loud opt-out [shipped]; `tebako publish`
 signs every artifact + the index and writes the `signing:` block into
 the registry index automatically [shipped in install-UX]; `tebako key
 rotate` creates + signs + publishes a successor statement in one command

--- a/docs/spec/23-declarative-composition.md
+++ b/docs/spec/23-declarative-composition.md
@@ -534,7 +534,9 @@ so declaration and resolution each live in exactly one place:
   `--help`, the schema, and the docs render from the registry; a
   setting present on a channel but absent from the registry is a bug on
   arrival (invariant 10).
-- **Resolution:** `tpkg::settings::resolve_bool`, fixed precedence
+- **Resolution:** `tpkg::settings::resolve_bool` (boolean settings) and
+  `tpkg::settings::resolve_sign` (the `sign` setting — its CLI channel
+  carries an optional `=<keyid>`), fixed precedence
   **CLI → environment → compose document → default**. Every channel is
   tri-state (present-true / present-false / absent), so a repo-declared
   `quiet_notices: true` stays overridable per invocation
@@ -547,11 +549,12 @@ so declaration and resolution each live in exactly one place:
   machine (the developer's declaration is environment-independent by
   construction, and the repo carries it).
 
-The registry's first citizen:
+The registry's citizens:
 
 | setting | CLI | env | compose key | baked form |
 |---|---|---|---|---|
 | `quiet_notices` | `--quiet-notices` / `--no-quiet-notices` | `TEBAKO_QUIET_NOTICES` | `quiet_notices:` | `TPKG_FLAG_QUIET_NOTICES` (bit 3, spec 02 §5a) — suppress the unsigned-legacy-trailer warning (spec 09) and the progress lines (spec 06 §5) on every run |
+| `sign` | `--sign[=<keyid>]` / `--no-sign` | `TEBAKO_SIGN` | `sign:` | `TPKG_FLAG_SIGNED_V2` (bit 1) + the v2 chain-of-trust extension (spec 02 §4) — sign the package trailer at press (spec 09 §9); unsigned v1 stays the default, an opt-out that overrides a lower channel is loud (warning + audit journal) |
 
 Every NEW setting declares its channels in the registry first; existing
 channels migrate into the registry as they are touched.

--- a/schema/tebako-compose-v1.schema.json
+++ b/schema/tebako-compose-v1.schema.json
@@ -32,6 +32,10 @@
     "quiet_notices": {
       "type": "boolean",
       "description": "The config channel of the quiet_notices registry setting (spec 23 §14): bake TPKG_FLAG_QUIET_NOTICES (bit 3) — every run suppresses the unsigned-legacy-trailer warning and the progress lines. Tri-state: absent lets the CLI (--quiet-notices) and env (TEBAKO_QUIET_NOTICES) channels rule; CLI > env > this key > default(false)."
+    },
+    "sign": {
+      "type": "boolean",
+      "description": "The config channel of the sign registry setting (spec 23 §14, spec 09 §9): sign the package trailer at press with the press-local key (TPKG_FLAG_SIGNED_V2 + the v2 chain-of-trust extension). Boolean only — a keyid is per-machine material and never rides a git-shared document (the CLI's --sign=<keyid> names one). Tri-state: absent lets the CLI (--sign/--no-sign) and env (TEBAKO_SIGN) channels rule; CLI > env > this key > default(false = v1-unsigned, byte-identical to pre-signing)."
     }
   },
   "$defs": {


### PR DESCRIPTION
## What

Press-time package signing — the `sign` registry setting wired end to end (spec 09 §9, spec 23 §14). Closes the S1 half of #400: `tebako press --sign[=keyid]` now produces a signed package; `--no-sign` / `TEBAKO_SIGN` / the compose `sign:` key resolve through the one SSOT with named-error failure (unknown keyid exits 71 before any heavy work; `--no-sign` over `TEBAKO_SIGN=1` warns + journals).

## Spec surface (folded in, same commit)

- `docs/spec/09` §9 — press-time signing semantics
- `docs/spec/23` §14 — the declarative `sign:` compose key
- `schema/compose-v1` — the `sign:` key

## rnp floor bump (rnp-rs `=0.1.12` → `0.1.15`)

The pin lived in six manifests (tebako-signer, tebako-pkg, tebako-bootstrap ×2, tfs dev-dep, tfs-cli dev-dep); cargo unifies resolution, so all six move together. Final resolution: rnp-rs 0.1.15 → rnp-sys 0.1.1 → rnp-src 0.2.3 → botan-src =0.31300 (Botan 3.13.0, carrying the RSA short-MPI backport — rnpgp/rnp#2465). tebako-pkg's `tests/optional_signing.rs` exercises `rnp::` directly and passes unchanged, proving 0.1.15 API compat.

## Evidence

Local debug run (`/tmp/press-sign-test4.log`, EXIT=0): 70 suites, **910 passed / 0 failed** — press_sign 2/2, cli_e2e 14/14 (incl. real presses), bootstrap chain 8/8, optional_signing 4/4, tpkg lib 132 (5 new `resolve_sign` tests), compose 8/8. `cargo fmt --check` clean on all 7 touched crates.

Refs #400.
