### PR TITLE
driver: the unix launcher tier routes exec materialization through the home tree

### DIFF
--- a/crates/tebako-driver/src/path_env.rs
+++ b/crates/tebako-driver/src/path_env.rs
@@ -202,7 +202,14 @@ fn materialize_launchers(
         )
     })?;
     for (base, vfs) in &launches {
-        let host = ctx.dlmap2file(vfs).map_err(|e| {
+        // The SAME home-tree routing decision a spawn makes (Rule E2 /
+        // §3.2 — the windows host tier's call): a home-annotated mount
+        // (the JDK shape, `annotations.java_home`) materializes its
+        // whole tree and the wrapper execs the home copy. The closure
+        // mirror would strand the binary's self-located prefix — a
+        // materialized JVM's java.home without conf/ dies at JCE boot
+        // listing conf/security/policy (the packed-mn ISO leg).
+        let host = ctx.exec_materialize_for_spawn(vfs).map_err(|e| {
             DriverError::new(
                 EX_TEBAKO_MANIFEST,
                 format!(

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -1999,6 +1999,42 @@ fn write_toolkit_image_with_java(dir: &Path, java: &[u8]) -> PathBuf {
     p
 }
 
+/// The HOME-annotated toolkit fixture (the openjdk shape exactly:
+/// `identity.annotations.java_home` plus a `conf/` data tree the
+/// linked-library closure walk would never carry — the JCE policy
+/// layout). The launcher tier must route its exec materialization
+/// through the whole-tree home, not the closure mirror.
+#[cfg(unix)]
+fn write_home_toolkit_image(dir: &Path) -> PathBuf {
+    let manifest = payload_manifest(
+        "toolkit",
+        "  annotations: {java_home: /}\n\
+         provides:\n  executables:\n    - {name: java, path: /bin/java}\n  \
+         platforms: [aarch64-macos]\n  capabilities: {exec: true, read: true}",
+    );
+    let p = dir.join("home-toolkit.tfs");
+    build_zip(
+        &p,
+        &[
+            "bin/",
+            "conf/",
+            "conf/security/",
+            "conf/security/policy/",
+            "conf/security/policy/unlimited/",
+            "__tpkg__/",
+        ],
+        &[
+            ("bin/java", b"#!/bin/sh\n"),
+            (
+                "conf/security/policy/unlimited/default_local.policy",
+                b"// test\n",
+            ),
+            ("__tpkg__/manifest.yaml", manifest.as_bytes()),
+        ],
+    );
+    p
+}
+
 fn joined_path(dirs: &[&str]) -> String {
     std::env::join_paths(dirs.iter().map(std::path::PathBuf::from))
         .unwrap()
@@ -2243,6 +2279,70 @@ fn dependency_executables_materialize_as_self_injecting_launchers() {
     assert_ne!(
         std::fs::metadata(&target).unwrap().permissions().mode() & 0o111,
         0
+    );
+}
+
+/// The home-mount case (Rule E2 / §3.2, the packed-mn JCE regression):
+/// a home-annotated dependency's launcher execs the WHOLE-TREE home
+/// copy — `<dl-root>/tebako-home-<N>/bin/java` — never the closure
+/// mirror, whose self-located prefix would lack the image's data tree
+/// (a materialized JVM's java.home without conf/ dies at JCE boot
+/// listing conf/security/policy).
+#[cfg(unix)]
+#[test]
+fn a_home_mounts_launcher_execs_the_whole_tree_home() {
+    let g = guard("path-env-home");
+    let env_image = write_env_image_with_shim(g.path());
+    let payload = write_payload_image(g.path());
+    let toolkit = write_home_toolkit_image(g.path());
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+    env.set("PATH", "/usr/bin:/bin");
+    boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:-:/app", payload.display()),
+            "--tebako-image",
+            &format!("{}:-:/opt/openjdk", toolkit.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap();
+
+    let path = env.var("PATH").unwrap();
+    let wrap_dir = std::env::split_paths(std::ffi::OsStr::new(&path))
+        .next()
+        .unwrap();
+    let text = std::fs::read_to_string(wrap_dir.join("java")).unwrap();
+    let target = text
+        .lines()
+        .find_map(|l| {
+            l.strip_prefix("exec '")
+                .and_then(|r| r.strip_suffix("' \"$@\""))
+        })
+        .expect("the wrapper's exec line");
+    let target = PathBuf::from(target);
+    let home = target.parent().and_then(|p| p.parent()).unwrap();
+    assert!(
+        home.file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("tebako-home-"),
+        "the launcher execs the home-tree copy, not the closure mirror: {}",
+        target.display()
+    );
+    // The whole tree came with it — the closure walk would carry only
+    // the binary.
+    assert!(target.is_file(), "{}", target.display());
+    assert!(
+        home.join("conf/security/policy/unlimited/default_local.policy")
+            .is_file(),
+        "the home tree carries the image's data tree: {}",
+        home.display()
     );
 }
 

--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -522,7 +522,13 @@ the launcher, and the shim loads into the final binary exactly as on
 ELF (probe 2026-08-13: `/bin/sh -c <launcher>` loads the dylib past
 the strip; the bare-name and shell-string forms both work). On ELF the
 launchers ride over the inherited `LD_PRELOAD` (harmless — the same
-dir leads `PATH`).
+dir leads `PATH`). The tier's materialization routes through the SAME
+`exec_materialize` home-tree decision the spawn surface and the windows
+host tier use: a home-annotated mount's executable execs from its
+materialized whole-tree home, never the closure mirror — the mirror
+strands a self-locating prefix (a materialized JVM's `java.home` without
+`conf/` dies at JCE boot listing `conf/security/policy`; the packed-mn
+ISO leg, 2026-08-28).
 
 **The windows host tier** (armed unconditionally on windows — there is
 no preload shim to deliver and no injection var to re-arm, so the tier


### PR DESCRIPTION
## The bug

The unix host-launcher tier (spec 22 §3.2) materialized each dependency's declared executables through `dlmap2file` — the linked-library closure walk — while the spawn surface (`exec_materialize_for_spawn`) and the windows host tier both route through the home-aware decision. For a **home-annotated mount** (`identity.annotations.java_home`, the JDK shape) the closure mirror strands the binary's self-located prefix:

- the wrapper exec'd `<exec-cache>/opt/openjdk/bin/java` (closure-mirror layout);
- the JVM derived `java.home = <exec-cache>/opt/openjdk` — which has `bin/` + the linked `lib/` closure but **no `conf/`**;
- `javax.crypto.JceSecurity` initialization lists `<java.home>/conf/security/policy/{limited,unlimited}` → `java.nio.file.NoSuchFileException` → `SecurityException: Can not initialize cryptographic mechanism` → mn2pdf dies, and no PDF is possible on the POSIX legs (metanorma's worker pool prints the stack but still exits 0 — the pipeline only catches it by asserting the output file).

Reproduced end-to-end locally against the pinned packed-mn payload set (metanorma 1.16.9-4 / openjdk 21.0.12-2 / inkscape 1.4.3-2, runtime 0.16.15): the ISO `compile -x pdf` fails with exactly the CI signature; the OIML `xml,html` leg passes (jing never lists `java.home` directories, so the closure mirror sufficed for it).

## The fix (one call site)

`path_env.rs::materialize_launchers` now calls `ctx.exec_materialize_for_spawn(vfs)` — the identical call the windows host tier makes (its doc comment already carries the lesson: "a JVM's lib/modules and jmods never ride a linked-library closure"). A home mount's launcher now execs `<dl-root>/tebako-home-<N>/bin/java` with the image's whole tree materialized beside it (`conf/` included); every non-home mount keeps the closure mirror, unchanged.

Trade-off, stated honestly: when the launcher tier arms (shim delivered + a dependency declares executables), a home mount's whole tree extracts at boot even if the run never spawns it — for packed-mn that is the ~200 MB openjdk tree, a one-shot ~1–3 s per process. The persistent write-once exec-cache upgrade (spec 22 §6's planned form) retires even that.

## Tests

- New `a_home_mounts_launcher_execs_the_whole_tree_home` (driver boot tests): a home-annotated toolkit fixture carrying a `conf/security/policy/unlimited/` data tree asserts the wrapper's exec target lives under `tebako-home-<N>` **and** that the data tree materialized next to the binary.
- The existing `dependency_executables_materialize_as_self_injecting_launchers` is untouched and pins the unchanged closure-mirror route for a plain (unannotated) toolkit.
- Local gate: `cargo fmt --check` clean, `cargo test -p tebako-driver` 68/68 boot + full package green, `cargo clippy -p tebako-driver --all-targets -- -D warnings` clean.

## Spec sync

spec 22 §3.2's host-launcher paragraph now pins the route: the tier materializes through the same `exec_materialize` home-tree decision as the spawn surface and the windows host tier.
