### PR TITLE
libtfs-preload: no IO under the context guard in the constructor mount pass (packed-mn linux-gnu hang)

### DIFF
--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -407,13 +407,21 @@ fn init_inner() -> Result<(), String> {
             // the driver serializes a union as the incumbent followed by
             // its members at the same point (spec 17 §2.1) — layer the
             // later declaration over the incumbent exactly as the
-            // parent's mount_union did.
-            match guard.mount_checked(mount) {
-                Ok(_) => Ok(()),
-                Err(e) if e == libc::EEXIST => guard.mount_union(build_decl(d)?).map(|_| ()),
-                Err(e) => Err(e),
-            }
-            .map_err(|e| {
+            // parent's mount_union did. Decide union-vs-exclusive BEFORE
+            // building: build_decl does host IO (the slot form opens the
+            // package and the backend reader parses the region), and on
+            // ELF targets the shim's own IO re-enters the interposed libc
+            // symbols → the route layer → this same context lock, so a
+            // second build_decl under the guard self-deadlocked the
+            // constructor (the packed-mn linux-gnu hang, 2026-08-29).
+            // mount_union/mount_checked are pure in-memory composition —
+            // no IO — safe under the guard.
+            let result = if guard.mount_point_taken(&mount.mount_point) {
+                guard.mount_union(mount).map(|_| ())
+            } else {
+                guard.mount_checked(mount).map(|_| ())
+            };
+            result.map_err(|e| {
                 format!(
                     "TEBAKO_TFS_MOUNTS: cannot mount {} at {}: {}",
                     d.image,

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -1625,7 +1625,20 @@ pub fn init() {
     // backend worker pool comes into existence at mount time, and the
     // guard must already be registered before any later fork.
     register_fork_guard();
-    if let Err(msg) = route::initialize() {
+    // Enter through engine_call so the whole constructor mount pass runs
+    // with IN_ENGINE set: the route layer's own host IO (opening the
+    // package file, backend metadata reads) then passes through to the
+    // real libc instead of re-entering the route layer and its context
+    // lock — the unguarded direct entry self-deadlocked on ELF targets
+    // when a mount pass under the guard did its own host IO (the
+    // packed-mn linux-gnu hang, 2026-08-29). A fork child or a
+    // re-entrant entry answers None and falls through to the direct
+    // call.
+    let result = match engine_call(route::initialize) {
+        Some(r) => r,
+        None => route::initialize(),
+    };
+    if let Err(msg) = result {
         eprintln!("libtfs-preload: {msg}");
         // SAFETY: plain libc call.
         unsafe { libc::exit(crate::spec::EX_CONFIG) };

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -654,6 +654,31 @@ fn slot_form_failures_are_named_errors() {
     assert!(r.stderr.contains("no slot table"), "stderr: {}", r.stderr);
 }
 
+/// Regression (the packed-mn linux-gnu constructor hang, 2026-08-29): a
+/// union member layered over an incumbent at the SAME mount point must
+/// not deadlock the shim's constructor. Pre-fix, the EEXIST arm ran a
+/// second `build_decl` (host IO that re-enters the interposed libc on
+/// ELF targets) under the context write lock — a same-thread RwLock
+/// self-deadlock; the payload compile parked forever before java ever
+/// spawned. The union here is content-identical (slot 0 IS the zip
+/// bytes), so the read still answers SECRET once. macOS passes either
+/// way (dyld interpose doesn't rebind the shim's own calls); the linux
+/// CI leg is the pin.
+#[test]
+fn union_member_remount_does_not_deadlock() {
+    let Some(f) = fixtures() else { return };
+    let mounts = format!("{}:{MOUNT},{}:0:{MOUNT}", f.zip.display(), f.pkg.display());
+    let r = run_with_mounts(
+        f,
+        "print-data",
+        &[&format!("{MOUNT}/data/secret.txt")],
+        &mounts,
+        None,
+    );
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.matches(SECRET).count(), 1, "stdout: {}", r.stdout);
+}
+
 #[test]
 fn dlopen_memfs_library_via_dlmap2file() {
     let Some(f) = fixtures() else { return };


### PR DESCRIPTION
## What

Fixes the deterministic packed-mn linux-gnu acceptance hang (metanorma/packed-mn#251, debug run 33221649728): the preload shim's constructor self-deadlocked while processing slot-form `TEBAKO_TFS_MOUNTS` declarations.

## Root cause (evidence: full 1154-line strace of the parked process + `/proc` environ + address forensics)

A payload slot mounted at the same point as the env image (packed-mn: `pkg:0:/__tfs__` over `runtime.tfs:/__tfs__`) takes the EEXIST union arm of `init_inner`. That arm ran a **second `build_decl`** — `File::open` + backend region parse + pool spawn — **while holding the context write lock**. On ELF targets the shim's own `File::open` rebinds to the shim's interposed `open` (ELF global-scope interposition), and `IN_ENGINE` was unset because the constructor called `route::initialize()` directly instead of through `engine_call`; the open routed to `vfs_open` → `context().write()` on a thread that already held the write lock → non-reentrant `RwLock` self-deadlock. The `openat` never reached the kernel — exactly why the syscall trace goes silent at the park.

- Why only linux-gnu: macOS dyld interpose does not rebind the dylib's own calls; Windows uses a different mechanism (both legs were green).
- Why factory class-E passed: its declarations are bare images at distinct mount points — no EEXIST arm.
- Same bug class as the 2026-08-21 route_matrix ubuntu hang; that fix guarded the test seam, this is the production seam.

## Fix (two MECE pieces)

1. `route.rs`: decide union-vs-exclusive **before** building via `mount_point_taken`, so `build_decl`'s host IO never runs under the guard (`mount_union`/`mount_checked` are pure in-memory composition — no IO). Side benefit: halves union-mount cost (no double region mmap + metadata parse).
2. `sys::init()`: enter `route::initialize()` through `engine_call` so the whole constructor mount pass runs with `IN_ENGINE` set (engine IO is host IO — the guard's documented purpose). A fork child / re-entrant entry answers `None` and falls through to the direct call.

## Regression test

`union_member_remount_does_not_deadlock` (e2e.rs): layers a slot-form package region over a whole-file image at the **same** mount point in a preload'd child and reads through the union. Deadlocks pre-fix on ELF; macOS passes either way (no rebinding) — the linux CI leg is the pin.

## Verification

- Local (macOS, debug): 16 unit + 23 e2e green, incl. the new test; `cargo fmt --check` and `clippy --all-targets` clean.
- The linux CI leg of this PR exercises the deadlock pin.
