### PR TITLE
spec 03/07 + toolchain: the per-entrypoint active flag — declared vs PATH-registered

### DIFF
--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -484,7 +484,13 @@ fn install_local_slot(
         }
         let record: PayloadRecord = manifest::payload_record(home, &name, &version);
         let commands = Manifest::load(&record.manifest_mirror)
-            .map(|m| m.entrypoints().iter().map(|e| e.name.clone()).collect())
+            .map(|m| {
+                m.entrypoints()
+                    .iter()
+                    .filter(|e| e.is_active())
+                    .map(|e| e.name.clone())
+                    .collect()
+            })
             .unwrap_or_default();
         return Ok(LocalInstalled {
             name,
@@ -525,6 +531,7 @@ fn install_local_slot(
     let commands: Vec<String> = mirror
         .entrypoints()
         .iter()
+        .filter(|e| e.is_active())
         .map(|e| e.name.clone())
         .collect();
 
@@ -982,11 +989,15 @@ fn finish_install<T: Transport>(
     // install is the explicit verb, spec 07 §2).
     materialize_zero_runtime(home, &entry, &mirror)?;
 
-    // Register every shim the payload PROVIDES declares (spec 07 §1):
-    // app entrypoints ∪ toolkit executables, one dispatchable view.
+    // Register the shims the payload PROVIDES declares ACTIVE (spec 07 §1
+    // + spec 03 §2.2 `active`): app entrypoints ∪ toolkit executables, one
+    // dispatchable view. The FULL declared set rides the manifest mirror;
+    // an inactive-by-default command links on demand (`tebako shim
+    // enable <name>`).
     let commands: Vec<String> = mirror
         .dispatchables()
         .iter()
+        .filter(|e| e.active)
         .map(|e| e.name.clone())
         .collect();
     let shims = if commands.is_empty() {
@@ -1233,6 +1244,7 @@ fn synthesize_manifest(
                         name: n,
                         args_default: Vec::new(),
                         runtime_requirement: requirement.clone(),
+                        active: None,
                     })
                     .collect(),
                 platforms: tpkg::Platforms::Universal,

--- a/crates/tebako-cli/tests/install.rs
+++ b/crates/tebako-cli/tests/install.rs
@@ -871,6 +871,37 @@ fn suite_install_registers_every_entry_shim() {
     assert_eq!(b.path, "/app/bin/mn2pdf");
 }
 
+#[test]
+fn install_links_only_the_active_entrypoints() {
+    // spec 03 §2.2's `active`: the declaration is the complete inventory,
+    // install PATH-registers only the active subset — the mirror still
+    // carries every declared command (enable links the rest on demand).
+    let fx = Fixture::new("activeset");
+    let manifest = "identity:\n  schema_version: 1\n  kind: app\n  name: metasuite\n  version: 2.0.0\n  producer: {tool: tebako, tool_version: 0.15.9}\n  created: \"2026-07-26T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n    blob_sha256: \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"\n  signing: {state: unsigned}\n  encryption: {state: none}\nprovides:\n  entrypoints:\n    - name: metanorma\n      path: /app/bin/metanorma\n      runtime_requirement: {engine: ruby, constraint: \"~> 3.3.0\"}\n    - name: fontist\n      path: /app/bin/fontist\n      active: false\n      runtime_requirement: {engine: ruby, constraint: \"~> 3.3.0\"}\n  platforms: universal\n  capabilities: {exec: true, read: true}\n";
+    let image = zip_image_with_manifest(manifest);
+    let payload_ref = fx.payload("metasuite-2.0.0.tfs", &image);
+    let yaml = format!(
+        "schema_version: 1\npayloads:\n  - name: metasuite\n    kind: app\n    versions:\n      - version: 2.0.0\n        platforms: universal\n        release: {{ref: {payload_ref}}}\n        entrypoints: [metanorma, fontist]\n    default: 2.0.0\n"
+    );
+    install::add_registry(&fx.home, &fx.registry("tpkg-registry.yaml", &yaml)).unwrap();
+
+    let out = install::install(&fx.home, "metasuite", None, Some(&fx.shim_binary)).unwrap();
+    assert_eq!(out.commands, vec!["metanorma"]);
+    assert_eq!(out.shims.len(), 1);
+    assert!(shim_path(&fx.home, "metanorma").exists());
+    assert!(!shim_path(&fx.home, "fontist").exists());
+
+    // the mirror still declares BOTH commands, with the exposure flag
+    let mirror = tebako_shim::manifest::Manifest::load(
+        &fx.payloads_dir().join("metasuite/2.0.0.manifest.yaml"),
+    )
+    .unwrap();
+    assert!(mirror.entrypoint("metanorma").is_some());
+    let inactive = mirror.entrypoint("fontist").unwrap();
+    assert!(!inactive.active);
+    assert_eq!(inactive.path, "/app/bin/fontist");
+}
+
 // ---------------------------------------------------------------------
 // uninstall
 // ---------------------------------------------------------------------

--- a/crates/tebako-shim/src/manage.rs
+++ b/crates/tebako-shim/src/manage.rs
@@ -239,6 +239,30 @@ fn cmd_enable(args: &[String], ctx: &Ctx, enable: bool) -> Result<Action, ShimEr
         (false, true) => format!("disabled {target_desc}\n"),
         (false, false) => format!("{target_desc} was already disabled\n"),
     };
+    // Enabling a DECLARED-but-unlinked command (spec 03 §2.2's
+    // `active: false` — install registered nothing for it) materializes
+    // the link now: the dispatcher links ITSELF (the argv0 model admits
+    // real links/copies only, spec 07 §1). The declaration check is the
+    // suite scan — an undeclared command earns resolve's named error,
+    // never a dangling link.
+    let text = if enable {
+        let link = shims_dir(&ctx.home).join(shim_file_name(&tool));
+        if link.exists() {
+            text
+        } else {
+            resolve::resolve(&tool, ctx)?;
+            let binary = std::env::current_exe().map_err(|e| {
+                ShimError::new(
+                    EX_TEBAKO_IO,
+                    format!("cannot locate the dispatcher binary: {e}"),
+                )
+            })?;
+            let (_shims, _notes) = link_shims(&ctx.home, &binary, &[tool.clone()])?;
+            format!("{text}linked {}", link.display())
+        }
+    } else {
+        text
+    };
     Ok(Action::Print { text, code: 0 })
 }
 

--- a/crates/tebako-shim/src/manage.rs
+++ b/crates/tebako-shim/src/manage.rs
@@ -257,7 +257,7 @@ fn cmd_enable(args: &[String], ctx: &Ctx, enable: bool) -> Result<Action, ShimEr
                     format!("cannot locate the dispatcher binary: {e}"),
                 )
             })?;
-            let (_shims, _notes) = link_shims(&ctx.home, &binary, &[tool.clone()])?;
+            let (_shims, _notes) = link_shims(&ctx.home, &binary, std::slice::from_ref(&tool))?;
             format!("{text}linked {}", link.display())
         }
     } else {

--- a/crates/tebako-shim/src/manifest.rs
+++ b/crates/tebako-shim/src/manifest.rs
@@ -27,6 +27,10 @@ pub struct Dispatchable {
     pub path: String,
     pub args_default: Vec<String>,
     pub runtime_requirement: Option<tpkg::RuntimeRequirement>,
+    /// The payload's default PATH exposure (spec 03 §2.2 `active`):
+    /// install links only active dispatchables; an inactive one is still
+    /// declared — `tebako shim enable <name>` links it on demand.
+    pub active: bool,
 }
 
 /// The dispatcher-visible half of an installed payload record: the parsed
@@ -69,6 +73,7 @@ impl Manifest {
                     path: e.path.clone(),
                     args_default: e.args_default.clone(),
                     runtime_requirement: e.runtime_requirement.clone(),
+                    active: e.is_active(),
                 })
                 .collect(),
             Provides::Toolkit(tk) => tk
@@ -79,6 +84,7 @@ impl Manifest {
                     path: e.path.clone(),
                     args_default: Vec::new(),
                     runtime_requirement: None,
+                    active: true,
                 })
                 .collect(),
             _ => Vec::new(),

--- a/crates/tebako-shim/tests/manage.rs
+++ b/crates/tebako-shim/tests/manage.rs
@@ -108,6 +108,54 @@ fn disable_and_enable_roundtrip_through_run() {
 }
 
 #[test]
+fn enable_links_a_declared_but_unlinked_command() {
+    // spec 03 §2.2's `active: false` shape: the command is declared in the
+    // mirror, install linked nothing for it; `enable` materializes the
+    // link (the dispatcher links itself) and clears the gate.
+    let tmp = TempDir::new("enable-links");
+    let home = tmp.path().join("home");
+    seed(&home);
+    let ctx = pinned_ctx(&home, tmp.path());
+
+    let link = home
+        .join("shims")
+        .join(if cfg!(windows) { "metanorma.exe" } else { "metanorma" });
+    assert!(!link.exists(), "seed links nothing");
+
+    let (text, code) = printed(run_ok(
+        &["tebako-shim".into(), "enable".into(), "metanorma".into()],
+        &ctx,
+    ));
+    assert_eq!(code, 0);
+    assert!(text.contains("linked"), "{text}");
+    assert!(link.exists(), "enable materialized the link");
+
+    // idempotent: a second enable finds the link present — no relink note
+    let (text, _) = printed(run_ok(
+        &["tebako-shim".into(), "enable".into(), "metanorma".into()],
+        &ctx,
+    ));
+    assert!(!text.contains("linked"), "{text}");
+}
+
+#[test]
+fn enable_an_undeclared_command_is_the_named_error_and_links_nothing() {
+    let tmp = TempDir::new("enable-undeclared");
+    let home = tmp.path().join("home");
+    seed(&home);
+    let ctx = pinned_ctx(&home, tmp.path());
+
+    let err = tebako_shim::run(&["tebako-shim".into(), "enable".into(), "phantom".into()], &ctx)
+        .unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_MANIFEST);
+    assert!(err.message.contains("phantom"), "{}", err.message);
+    let link = home
+        .join("shims")
+        .join(if cfg!(windows) { "phantom.exe" } else { "phantom" });
+    assert!(!link.exists(), "no dangling link for an undeclared command");
+}
+
+#[test]
 fn which_reports_the_full_resolution() {
     let tmp = TempDir::new("which");
     let home = tmp.path().join("home");

--- a/crates/tebako-shim/tests/manage.rs
+++ b/crates/tebako-shim/tests/manage.rs
@@ -117,9 +117,11 @@ fn enable_links_a_declared_but_unlinked_command() {
     seed(&home);
     let ctx = pinned_ctx(&home, tmp.path());
 
-    let link = home
-        .join("shims")
-        .join(if cfg!(windows) { "metanorma.exe" } else { "metanorma" });
+    let link = home.join("shims").join(if cfg!(windows) {
+        "metanorma.exe"
+    } else {
+        "metanorma"
+    });
     assert!(!link.exists(), "seed links nothing");
 
     let (text, code) = printed(run_ok(
@@ -145,13 +147,18 @@ fn enable_an_undeclared_command_is_the_named_error_and_links_nothing() {
     seed(&home);
     let ctx = pinned_ctx(&home, tmp.path());
 
-    let err = tebako_shim::run(&["tebako-shim".into(), "enable".into(), "phantom".into()], &ctx)
-        .unwrap_err();
+    let err = tebako_shim::run(
+        &["tebako-shim".into(), "enable".into(), "phantom".into()],
+        &ctx,
+    )
+    .unwrap_err();
     assert_eq!(err.code, tebako_shim::EX_TEBAKO_MANIFEST);
     assert!(err.message.contains("phantom"), "{}", err.message);
-    let link = home
-        .join("shims")
-        .join(if cfg!(windows) { "phantom.exe" } else { "phantom" });
+    let link = home.join("shims").join(if cfg!(windows) {
+        "phantom.exe"
+    } else {
+        "phantom"
+    });
     assert!(!link.exists(), "no dangling link for an undeclared command");
 }
 

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -746,6 +746,20 @@ pub struct Entrypoint {
     /// payloads). Omit the key entirely on the wire for those.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_requirement: Option<RuntimeRequirement>,
+    /// The payload's default PATH exposure (spec 03 §2.2 completeness):
+    /// `Some(false)` = declared and dispatchable (`tebako shim enable`
+    /// links it on demand) but NOT registered at install. Absent/true =
+    /// registered. Additive: pre-flag readers ignore the key and register
+    /// every entrypoint (the pre-flag behavior).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active: Option<bool>,
+}
+
+impl Entrypoint {
+    /// Whether install registers this command by default (spec 03 §2.2).
+    pub fn is_active(&self) -> bool {
+        self.active != Some(false)
+    }
 }
 
 /// PROVIDES of kind `app`.
@@ -1746,6 +1760,36 @@ mod tests {
     }
 
     #[test]
+    fn entrypoint_active_flag_defaults_true_and_roundtrips() {
+        // spec 03 §2.2: absent/true = registered at install; explicit
+        // false = declared-but-inactive. The key is additive on the wire
+        // (a pre-flag reader ignores it — serde's unknown-field default).
+        let text = format!(
+            "identity:\n  schema_version: 1\n  kind: app\n  name: x\n  version: 1.0.0\n\
+             \x20 producer: {{tool: t, tool_version: 1}}\n  created: now\n\
+             \x20 digest: {{tree_hash: \"sha256:{}\", blob_sha256: {}}}\n\
+             \x20 signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+             provides:\n  entrypoints:\n    - name: metanorma\n      path: /bin/metanorma\n\
+             \x20   - name: fontist\n      path: /bin/fontist\n      active: false\n\
+             \x20 platforms: universal\n  capabilities: {{exec: true, read: true}}\n",
+            sha(1),
+            sha(2),
+        );
+        let m = PayloadManifest::from_yaml(&text).unwrap();
+        let Provides::App(app) = &m.provides else {
+            panic!("expected app provides");
+        };
+        assert!(app.entrypoints[0].is_active());
+        assert!(!app.entrypoints[1].is_active());
+        assert_eq!(app.entrypoints[1].active, Some(false));
+
+        // the wire form omits the key unless explicitly false
+        let out = serde_yml::to_string(app).unwrap();
+        assert!(!out.contains("active: true"), "{out}");
+        assert!(out.contains("active: false"), "{out}");
+    }
+
+    #[test]
     fn platform_release_asset_name_roundtrip() {
         for p in Platform::ALL {
             assert_eq!(
@@ -1971,6 +2015,7 @@ mod tests {
                     constraint: Constraint::new(">= 3.3, < 5.0").unwrap(),
                     abi: None,
                 }),
+                active: None,
             }],
             platforms: Platforms::Universal,
             capabilities: c,
@@ -1994,6 +2039,7 @@ mod tests {
                     constraint: Constraint::new(">= 3.3, < 5.0").unwrap(),
                     abi: None,
                 }),
+                active: None,
             }],
             platforms: Platforms::Universal,
             capabilities: Capabilities {

--- a/crates/tpkg/tests/manifest_props.rs
+++ b/crates/tpkg/tests/manifest_props.rs
@@ -279,6 +279,7 @@ fn arb_provides(kind: PayloadKind) -> impl Strategy<Value = Provides> {
                 constraint: c,
                 abi: None,
             }),
+            active: None,
         });
     let app = (prop::collection::vec(entrypoint, 1..=3), arb_platforms()).prop_map(
         |(entrypoints, platforms)| {

--- a/docs/spec/03-payload-manifest.md
+++ b/docs/spec/03-payload-manifest.md
@@ -78,11 +78,26 @@ requirement (spec 07).
 the image carries that a user may invoke directly — it is the payload's
 command declaration, not a primary-executable field. A bundled CLI (a
 font manager, a bibliography tool) is as much a provided command as the
-app's namesake. Each declared name becomes a registered command at
-install (spec 07 §1) and is the only set a self-contained package's
-`entries[]` may draw from (§6): the L2 entry names mirror the L1
-declaration — one SSOT, cross-checked by `tebako-pkg validate`
-(tebako#494).
+app's namesake. The declaration is the COMPLETE inventory; exposure is
+an orthogonal per-entrypoint key:
+
+```yaml
+  - name: fontist
+    path: /bin/fontist
+    active: false     # OPTIONAL (default true) — declared but NOT
+                      # PATH-registered at install
+```
+
+`active` is the payload author's default exposure. Install registers only
+the active set (spec 07 §1); an inactive-but-declared command stays
+dispatchable — `tebako shim enable <name>` links it on demand, `tebako
+run <name>` reaches it directly, and the user's per-machine
+enable/disable always overrides the manifest default (spec 07 §3).
+Additive on the wire: pre-flag readers ignore the key and register every
+entrypoint (the pre-flag behavior). The declared names are also the only
+set a self-contained package's `entries[]` may draw from (§6): the L2
+entry names mirror the L1 declaration — one SSOT, cross-checked by
+`tebako-pkg validate` (tebako#494).
 
 **runtime** (provides an interpreter):
 ```yaml

--- a/docs/spec/03-payload-manifest.md
+++ b/docs/spec/03-payload-manifest.md
@@ -74,6 +74,16 @@ A SUITE is one package with N entrypoints — the shim layer exposes one
 command per entry, each dispatching to its own image and its own runtime
 requirement (spec 07).
 
+**Completeness (locked 2026-08-29):** `entrypoints` declares EVERY command
+the image carries that a user may invoke directly — it is the payload's
+command declaration, not a primary-executable field. A bundled CLI (a
+font manager, a bibliography tool) is as much a provided command as the
+app's namesake. Each declared name becomes a registered command at
+install (spec 07 §1) and is the only set a self-contained package's
+`entries[]` may draw from (§6): the L2 entry names mirror the L1
+declaration — one SSOT, cross-checked by `tebako-pkg validate`
+(tebako#494).
+
 **runtime** (provides an interpreter):
 ```yaml
 provides: {engine: ruby, version: 4.0.6, abi_line: "4.0", platform: x86_64-linux-gnu}
@@ -271,6 +281,12 @@ mounts:                           # per-slot mount semantics (locked 2026-08-04)
 
 - `runtime_ref` per entry kills the 128-byte single-field limit (suites,
   multi-runtime packages); the trailer's v1 field stays for v1 loaders.
+- `entries[].name` / `entries[].entrypoint` mirror the slot payload's L1
+  `provides.entrypoints[]` (§2.2 completeness — one SSOT): every L2 entry
+  names a DECLARED L1 entrypoint of its slot, enforced by `tebako-pkg
+  validate` (tebako#494). Two entries MAY share one slot — same image,
+  different in-image entrypoints: the multi-command single-payload form
+  (one app slice carrying several CLIs, e.g. metanorma + fontist).
 - v1-era packages without the block behave exactly as today (stub.rb /
   local conventions); the block is additive.
 - `mounts` is optional; a slot without a `mounts` row mounts

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -49,6 +49,16 @@ jobs:
   the thing on PATH that picks version + runtime per invocation and hands
   off.
 
+**argv0 integrity (locked 2026-08-29):** command selection rides argv0 —
+the invoked name must reach the process as its own argv[0]. Symlinks,
+hardlinks, and byte copies preserve it. Wrapper generators that spawn the
+target under the TARGET's own path (chocolatey's shimgen —
+`Install-BinFile`; a shell wrapper that `exec`s the real path) silently
+defeat selection: every invocation then falls back to the primary entry
+(`entries[0]`) and the other declared commands are unreachable. A
+distributor exposes a multi-command package as real links or copies, one
+per declared entrypoint name — never as re-exec wrappers.
+
 ## 2. The dispatch chain (per invocation of `~/.tebako/shims/<tool>`)
 
 0. **argv0 is the selector.** One tebako-shim binary, linked per command

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -38,8 +38,10 @@ in `config.yaml` as the exact ref).
 
 Tebako manages shims for **every executable every installed payload
 provides** (spec 03 `entrypoints`). One payload may carry MULTIPLE
-executables — each becomes a registered command. Four artifacts, four
-jobs:
+executables — each is dispatchable; the ACTIVE subset (spec 03 §2.2's
+per-entrypoint `active`, default true) is PATH-registered at install,
+and an inactive-but-declared command links on demand (`tebako shim
+enable <name>`). Four artifacts, four jobs:
 
 - **payload** — a signed `.tfs` image (versioned, runtime-independent).
 - **runtime** — a signed runtime payload (versioned, cached,
@@ -97,6 +99,13 @@ per declared entrypoint name — never as re-exec wrappers.
   itself (the mise model, not the rbenv `eval "$(… init -)"` model).
 - `tebako use / disable / list / doctor` manage shims
   (link/remove/inspect/diagnose); enable/disable specific versions.
+  **Enable links on demand** (locked 2026-08-29): `enable <tool>` whose
+  command is declared by an installed payload but was never linked
+  (spec 03 §2.2's `active: false` default) materializes the shim link
+  then — the dispatcher links ITSELF (argv0 integrity above); enabling an
+  undeclared command is the suite scan's named error, never a dangling
+  link. `disable` gates per version (`.disabled.yaml`) without removing
+  the link.
 
 ## 4. Configuration
 


### PR DESCRIPTION
## The problem

A payload can bundle many CLIs — the metanorma closure carries **66 executables from 52 gems** (fontist, suma, relaton, plurimath, … down to wisper's `console`/`setup` dev tools). Spec 03 §2.2 already says every user-invocable command is declared, but the toolchain had a gap: **install registered a shim for every declared entrypoint**, so a complete declaration meant flooding the user's PATH shims with library-bundled helper commands.

## The change — declared vs PATH-registered are now orthogonal

Spec 03 §2.2 gains the optional per-entrypoint **`active`** key (default `true`):

- The declaration stays the **complete inventory** (completeness unchanged).
- Install PATH-registers only the **active** subset (`tebako-cli/src/install.rs` — all three command-list sites).
- An inactive-but-declared command stays **dispatchable**: `tebako shim enable <name>` materializes the link on demand (the dispatcher links ITSELF per argv0 integrity, spec 07 §1), `tebako run <name>` reaches it directly, and the manifest mirror still carries the full declaration.
- **Additive on the wire**: pre-flag readers ignore the key and register every entrypoint — the pre-flag behavior. No format version bump.

`disable` is unchanged (per-version gate via `.disabled.yaml`, link untouched); the user's per-machine enable/disable always overrides the manifest default.

## Commits

1. **spec 03/07: the command declaration** — completeness wording, the L1↔L2 lockstep (a self-contained package's `entries[]` draws only from declared names, cross-checked by `tebako-pkg validate` → #494), argv0 integrity (the shimgen/`Install-BinFile` hazard: wrapper-generators break argv0 selection — real links/copies only).
2. **spec 03/07 + install/shim: the per-entrypoint active flag** — the implementation:

   - `tpkg`: `Entrypoint.active: Option<bool>` + `is_active()`
   - `tebako-shim`: `Dispatchable.active`; `enable` links a declared-but-unlinked command on demand; enabling an **undeclared** command is the suite scan's named error (`EX_TEBAKO_MANIFEST`), never a dangling link
   - `tebako-cli` install: registers only the active set; the mirror keeps the full declaration

## Tests

- `tpkg::manifest::entrypoint_active_flag_defaults_true_and_roundtrips` — parse + wire form (key omitted unless explicitly false)
- `tebako-shim`: `enable_links_a_declared_but_unlinked_command` (incl. idempotent re-enable), `enable_an_undeclared_command_is_the_named_error_and_links_nothing`
- `tebako-cli`: `install_links_only_the_active_entrypoints` — one shim linked, mirror still declares both

Local evidence: `cargo test -p tpkg -p tebako-shim -p tebako-cli` green — tpkg 133 lib + all shim suites + install 31/31 + cli_e2e 14/14 (the e2e suite needs `cargo build -p tebako-bootstrap` first in a fresh worktree, else the press tests poison-cascade — pre-existing harness requirement, unrelated).

## Downstream

The metanorma feedstock declares the full 66-command inventory with active flags (the generic one-stub-per-command launcher), packed-mn mirrors the set in L2, and chocolatey-metanorma#89's OIML fix rides the packaged `fontist` command instead of a host `gem install`.
