### PR TITLE
spec 28/03/05: the language/implementation split — one ruby engine

### DIFF
--- a/docs/spec/03-payload-manifest.md
+++ b/docs/spec/03-payload-manifest.md
@@ -49,12 +49,17 @@ entrypoints:                          # ARRAY — multi-entry suites; N=1 for si
     args_default: []
     runtime_requirement: {engine: ruby, constraint: ">= 3.3, < 5.0"}
       # OPTIONAL — omit entirely for native entrypoints (see below);
-      # range for pure-language; abi-line "~> 3.3.0" for native-extension payloads
-    # native-extension entrypoints ALSO pin the platform line:
-    runtime_requirement: {engine: ruby, constraint: "~> 3.3.0", abi: "arm64-darwin-23"}
+      # range for pure-language; abi-line "~> 3.3.0" for native-extension payloads.
+      # engine names the LANGUAGE — mri/jruby/truffleruby are all `ruby`;
+      # the OPTIONAL `implementation:` narrows to one (spec 28 §8).
+    # native-extension entrypoints ALSO pin the implementation and the
+    # platform line:
+    runtime_requirement: {engine: ruby, implementation: mri, constraint: "~> 3.3.0", abi: "arm64-darwin-23"}
       # abi = the runtime's own platform string the extensions were built
       # against (ruby: Gem::Platform.local.to_s). The version line and the
       # platform line are ORTHOGONAL — resolution checks both (spec 05 §5).
+      # an `abi:` in force REQUIRES `implementation:` — an ABI is
+      # per-implementation by construction (spec 28 §8).
   platforms: [x86_64-linux-gnu, aarch64-macos]  # native-ext apps are triplet-bound;
                                                 # universal only for pure-language
 capabilities: {exec: true, read: true}
@@ -101,7 +106,12 @@ entry names mirror the L1 declaration — one SSOT, cross-checked by
 
 **runtime** (provides an interpreter):
 ```yaml
-provides: {engine: ruby, version: 4.0.6, abi_line: "4.0", platform: x86_64-linux-gnu}
+provides: {engine: ruby, implementation: mri, version: 4.0.6, language_version: "4.0", abi_line: "4.0", platform: x86_64-linux-gnu}
+  # engine = the LANGUAGE; implementation (REQUIRED for kind: runtime) =
+  # which ruby this is (mri/jruby/truffleruby — spec 28 §8).
+  # version = the implementation's OWN version line (jruby: 9.4.8);
+  # language_version = the language level it implements (jruby 9.4 → "3.1";
+  # for mri the two are identical). spec 05 §5 matches on both.
 built_from: {src_sha256: "…", patch_set: "v0.2.8"}
 env: {GEM_PATH: …}
 capabilities: {exec: true, read: true, runtime: true}
@@ -123,6 +133,9 @@ contract; PROVIDES names libraries/tools other payloads DEPEND on.
 requires:
   - kind: language            # a language runtime edge
     engine: ruby
+    implementation: jruby     # OPTIONAL — absent: any implementation of the
+                              # engine whose language_version satisfies the
+                              # constraint (spec 28 §8)
     constraint: "~> 3.3.0"
   - kind: toolkit             # a native toolkit layer
     name: gtk-layer

--- a/docs/spec/05-resolution-and-cache.md
+++ b/docs/spec/05-resolution-and-cache.md
@@ -115,9 +115,10 @@ installs, pre-identity manifests).
 ## 5. Resolution chains
 
 **Runtime for a payload (dispatch time):** payload's declared requirement
-(engine + constraint) → newest COMPATIBLE runtime already cached (no
-download) → else download the newest compatible from the runtime releases
-→ verify → cache. Swapping runtimes never touches the payload.
+(engine + optional implementation + constraint) → newest COMPATIBLE
+runtime already cached (no download) → else download the newest
+compatible from the runtime releases → verify → cache. Swapping runtimes
+never touches the payload.
 
 **Runtime for a shared-runtime package (first run):** trailer
 runtime_ref → cache hit → use; miss → download from the index
@@ -146,3 +147,19 @@ their platform string as the per-package `abi` key in the release index
 (spec 13); cached runtimes installed before the field existed stay
 eligible (the compat window — a payload's abi check never fails against
 an unknown line).
+
+**The implementation axis (spec 28 §8):** `engine` names the LANGUAGE —
+mri, jruby and truffleruby are all `engine: ruby`, told apart by the
+runtime's `provides.implementation`. A requirement WITHOUT
+`implementation` matches any cached runtime of the engine whose
+`language_version` satisfies the constraint (the pure-language case: one
+build, any implementation — jruby 9.4 declares `language_version:
+"3.1"`, so a `>= 3.3` requirement does not match it and a `>= 3.1` one
+does). A requirement WITH `implementation` reads its constraint against
+that implementation's OWN version line (`{engine: ruby, implementation:
+jruby, constraint: "~> 9.4"}`) and matches no other implementation. An
+`abi:` in force requires `implementation` — ABI and platform lines are
+per-implementation by construction; a native requirement naming no
+implementation is a named manifest error (spec 03 §2.2). Compatibility
+never crosses implementations silently: the chosen runtime's
+implementation is journaled with the resolution event.

--- a/docs/spec/28-runtime-variants.md
+++ b/docs/spec/28-runtime-variants.md
@@ -1,11 +1,18 @@
 # Spec 28 — Runtime variants and the run-configuration surface
 
-**Status: PLANNED (drafted 2026-08-26).** Amends spec 04 §2 (registry),
-spec 05 §3/§5 (store layout, selection), spec 07 §0/§2/§4 (the selection
-chains), spec 23 §3 (the D2 `runtime:` key alignment), spec 15 (the info
-surface). No wire-format change; no trailer change; the L1 manifest is
-untouched (the variant key DERIVES from the manifest's existing
-`runtime_requirement`).
+**Status: PLANNED (drafted 2026-08-26; revised 2026-08-30 — the
+language/implementation split: `engine` names the LANGUAGE, so mri,
+jruby and truffleruby are all `ruby`, and the optional `implementation`
+sub-axis distinguishes them).** Amends spec 03 §2 (the requirement and
+`provides` grammars), spec 04 §2 (registry), spec 05 §3/§5 (store
+layout, selection), spec 07 §0/§2/§4 (the selection chains), spec 23 §3
+(the D2 `runtime:` key alignment), spec 15 (the info surface). No
+wire-format change; no trailer change; the L1 manifest change is
+ADDITIVE (the optional `implementation` key; the variant key still
+DERIVES from the manifest's existing `runtime_requirement`). The
+revision lands before any variant machinery shipped — there is nothing
+to migrate; the pre-revision flat-engine spellings are retired, not
+carried.
 
 A payload version is not one build. A native-extension payload is locked
 to the runtime ABI line it was baked against (spec 05 §5), so
@@ -22,42 +29,59 @@ Two laws, extending spec 23's two:
    and nothing else — no labels, no channels, no invented axes. Two
    builds of one version that declare the same requirement are the same
    variant; a registry that carries both is a named authoring error.
-2. **The selection law.** The user selects a PREFERENCE (an engine, a
-   constraint, an exact pin), never an artifact. Resolution maps the
-   preference to the one matching variant, deterministically, or fails
-   with a named error listing the available variants. No silent winner.
+2. **The selection law.** The user selects a PREFERENCE (an engine, an
+   implementation, a constraint, an exact pin), never an artifact.
+   Resolution maps the preference to the one matching variant,
+   deterministically, or fails with a named error listing the available
+   variants. No silent winner.
 
 ## 1. The selector grammar (one grammar, every surface)
 
 ```
-<engine>                        — any build for that engine (default rule §4)
-<engine> <constraint>           — the variant whose requirement it satisfies
-                                  ("ruby ~> 4.0.0"; the version classes of
-                                  spec 05 §5: "~> X.Y.0" ABI-line,
-                                  ">= A, < B" range)
-<engine>@<version>              — sugar: the variant baked against that
-                                  runtime LINE ("ruby@4.0.6" ≡ "ruby ~> 4.0.0"
+<engine>                        — any implementation of that language
+                                  (default rule §4)
+<engine>:<implementation>       — one implementation of the language, any
+                                  line ("ruby:jruby")
+<engine>[:<implementation>] <constraint>
+                                — the variant whose requirement it satisfies
+                                  ("ruby ~> 4.0.0", "ruby:jruby ~> 9.4";
+                                  the version classes of spec 05 §5:
+                                  "~> X.Y.0" ABI-line, ">= A, < B" range)
+<engine>[:<implementation>]@<version>
+                                — sugar: the variant baked against that
+                                  runtime LINE ("ruby@4.0.6" ≡ "ruby:mri ~> 4.0.0"
                                   for a native build; ≡ the containing range
                                   for a pure-language build)
-<engine>-<line>                 — the variant id verbatim (§2)
+<engine>[-<implementation>]-<line>
+                                — the variant id verbatim (§2)
 ;tebako=<line>                  — OPTIONAL suffix on any form: the runtime
                                   release line preference (spec 05 §2),
                                   e.g. "ruby ~> 4.0.0 ;tebako=0.16.10"
 ```
 
-Unparseable = a named error listing the grammar (invariant 9). The
-selector NEVER names a triplet — platform selection stays the registry's
-declarative job (spec 04 §2) — and never names an artifact filename.
+`engine` names the LANGUAGE: mri, jruby and truffleruby are all
+`engine: ruby`, one engine with three implementations (spec 03 §2.2's
+`provides.implementation`; §8 is normative). The implementation is the
+ONLY sub-axis; it never appears without its engine (`jruby` alone is
+unparseable), and an implementation unknown for the engine is a named
+resolution error listing the known ones. Unparseable = a named error
+listing the grammar (invariant 9). The selector NEVER names a triplet —
+platform selection stays the registry's declarative job (spec 04 §2) —
+and never names an artifact filename.
 
 ## 2. The variant id (derived, canonical)
 
-From the variant's `runtime_requirement` `{engine, constraint, abi?}`:
+From the variant's `runtime_requirement` `{engine, implementation?,
+constraint, abi?}`:
 
-- No requirement (a data slice) or a pure-language range constraint:
-  the variant id is `universal` (there is exactly one such variant —
-  the law of §1 makes a second one a named error).
-- An ABI-line constraint `~> X.Y[.0]`: `<engine>-<X.Y>`
-  (`ruby-3.3`, `ruby-4.0`, `jruby-9.4`).
+- No requirement (a data slice) or a pure-language constraint with no
+  `abi:` in force: the variant id is `universal` (there is exactly one
+  such variant — the law of §1 makes a second one a named error). The
+  implementation axis does NOT fork a pure variant: one build serves
+  every implementation its requirement matches (§8).
+- An ABI-line constraint `~> X.Y[.0]` (`implementation` is REQUIRED
+  whenever `abi:` is in force, §8): `<engine>-<implementation>-<X.Y>`
+  (`ruby-mri-3.3`, `ruby-mri-4.0`, `ruby-jruby-9.4`).
 - Anything else (a constraint the id rule cannot canonize): the
   registry entry is a named validation error — the grammar does not
   guess.
@@ -78,17 +102,17 @@ payloads:
   - name: metanorma
     kind: app
     default: 1.16.9
-    default_variant: ruby-3.3        # OPTIONAL; absent → §4's newest rule
+    default_variant: ruby-mri-3.3      # OPTIONAL; absent → §4's newest rule
     versions:
       - version: 1.16.9
         release: {ref: tfs:github:tebako-packages/metanorma:1.16.9-4}
         entrypoints: [metanorma]
         variants:
-          - runtime_requirement: {engine: ruby, constraint: "~> 3.3.0", abi: "@@ABI@@"}
+          - runtime_requirement: {engine: ruby, implementation: mri, constraint: "~> 3.3.0", abi: "@@ABI@@"}
             platforms:
               aarch64-macos: {artifact: metanorma-1.16.9-ruby3.3-macos-arm64.tfs, sha256: "…"}
               x86_64-linux-gnu: {artifact: metanorma-1.16.9-ruby3.3-linux-gnu-x86_64.tfs, sha256: "…"}
-          - runtime_requirement: {engine: ruby, constraint: "~> 4.0.0", abi: "@@ABI@@"}
+          - runtime_requirement: {engine: ruby, implementation: mri, constraint: "~> 4.0.0", abi: "@@ABI@@"}
             platforms:
               aarch64-macos: {artifact: metanorma-1.16.9-ruby4.0-macos-arm64.tfs, sha256: "…"}
 ```
@@ -109,10 +133,10 @@ Given `(name, version, selector?)`:
 
 1. No selector: the payload entry's `default_variant` if declared; else
    the variant whose requirement's line is NEWEST by version order
-   (engine considered only when variants span engines — then the
-   registry MUST declare `default_variant`; spanning engines without it
-   is a named authoring error). The choice is journaled
-   (`event=variant-selected name=… id=… source=default`).
+   (implementation considered only when variants span implementations —
+   then the registry MUST declare `default_variant`; spanning
+   implementations without it is a named authoring error). The choice is
+   journaled (`event=variant-selected name=… id=… source=default`).
 2. A selector: the variants whose requirement it satisfies, per the §1
    forms. Zero matches → a named error listing every available variant
    id + its requirement (exit 69's spec 06 shape, payload class). More
@@ -171,13 +195,16 @@ the rename — the spec 23 MECE discipline, no dual-key read). The runtime
 row gains the optional `prefer: "<runtime ref>"` (an exact spec 05 §1
 ref inside the constraint — the pin packed-mn's `versions.yaml` already
 authors by hand) and `policy: newest-compatible` (the default, the only
-value for now — a second value is a future spec, not a silent key).
+value for now — a second value is a future spec, not a silent key). The
+runtime row's `implementation` pins which implementation of the language
+the composition builds against; absent, the §4 default rule decides at
+press time and the choice is journaled.
 
 ```yaml
 version: 1
-runtime: {engine: ruby, constraint: "~> 3.3", prefer: "ruby@3.3.12;tebako=0.16.10;image"}
+runtime: {engine: ruby, implementation: mri, constraint: "~> 3.3", prefer: "ruby@3.3.12;tebako=0.16.10;image"}
 slices:
-  - {name: metanorma, requirement: ">= 1.16", runtime: "ruby ~> 3.3.0"}   # the variant pick
+  - {name: metanorma, requirement: ">= 1.16", runtime: "ruby:mri ~> 3.3.0"}   # the variant pick
   - {name: openjdk, requirement: "21"}
 entrypoint: metanorma
 ```
@@ -189,30 +216,53 @@ lean is orthogonal (spec 23). The spec 27 bench harness's managed arm
 selects per invocation through S2 (`TEBAKO_METANORMA_RUNTIME`), the
 pressed arms through two packages.
 
-## 8. Multi-engine payloads ((4) — MRI vs JRuby)
+## 8. The implementation axis — one language, many implementations ((4))
 
-Engine is a first-class axis of the requirement, not a new concept:
+**The law (owner-locked 2026-08-30):** mri, jruby and truffleruby are
+one engine — `engine: ruby`. The implementation is a sub-axis of the
+requirement, never an engine of its own; a user of an executable
+payload may run it on ANY implementation the requirement admits. The
+same law applies to every future multi-implementation language.
 
-- A NATIVE-extension payload supports a second engine by carrying a
-  second VARIANT (`{engine: jruby, constraint: "~> 9.4"}` → variant id
-  `jruby-9.4`). The build differs, the grammar does not.
-- A PURE-language payload whose ONE build runs on several engines
-  declares `runtime_requirement` as a list — `any_of` semantics, OR in
-  declaration order:
+- The RUNTIME declares what it is: `provides: {engine: ruby,
+  implementation: jruby, version: 9.4.8, language_version: "3.1", …}`
+  (spec 03 §2.2). `implementation` is REQUIRED for `kind: runtime`;
+  `language_version` is the language level the runtime implements (for
+  mri it equals `version`).
+- A PURE-language payload's ONE build serves every implementation whose
+  `language_version` satisfies its constraint — the requirement simply
+  omits `implementation` (`{engine: ruby, constraint: ">= 3.3, < 5.0"}`)
+  and the user's implementation choice defers to runtime resolution
+  (spec 05 §5). When the admissible set differs per implementation, the
+  requirement is a list — `any_of` semantics, OR in declaration order:
 
   ```yaml
   runtime_requirement:
-    - {engine: ruby, constraint: ">= 3.3, < 5.0"}
-    - {engine: jruby, constraint: "~> 9.4"}
+    - {engine: ruby, constraint: ">= 3.3, < 5.0"}                 # any implementation at that language level
+    - {engine: ruby, implementation: jruby, constraint: "~> 9.5"} # jruby's own version line
   ```
 
-  The list form is the only new L1 grammar (additive; schema_minor). A
-  native-extension payload (an `abi:` in force) carrying the list form
-  is a named manifest error — an ABI lock is single-engine by
-  construction. The payload still stores as the ONE `universal`
-  variant; the selector's engine picks among the `any_of` entries at
-  runtime-resolution time, and an engine matching no entry is the §4
-  rule-2 named error.
+  The list form is the only new L1 grammar (additive; schema_minor).
+  The payload still stores as the ONE `universal` variant; the
+  selector's implementation picks among the `any_of` entries at
+  runtime-resolution time, and an implementation matching no entry is
+  the §4 rule-2 named error.
+- A NATIVE-extension payload (an `abi:` in force) is locked to ONE
+  implementation's ABI by construction: `implementation` is REQUIRED
+  alongside `abi` — a native requirement without it is a named manifest
+  error — and the list form is forbidden (a second implementation means
+  a second build, i.e. a second VARIANT: `{engine: ruby,
+  implementation: mri, constraint: "~> 3.3.0", abi: …}` → variant id
+  `ruby-mri-3.3`; the truffleruby build of the same payload version is
+  a sibling variant `ruby-truffleruby-24.1`, published when its
+  toolchain exists — TODO.truffleruby).
+- truffleruby's native and jvm modes are two runtime ARTIFACTS of one
+  implementation (they differ in which dependencies they can host, not
+  in the language they speak): mode is NOT a selector axis — selection
+  rides the release-line preference (`;tebako=`) or per-entry pins
+  (spec 17). A payload needing jvm-mode interop declares that edge in
+  DEPENDS (spec 03 §2.3), where the runtime-on-runtime composition spec
+  pins it (TODO.jruby/01, TODO.truffleruby/03).
 
 ## 9. CLI and info surface (spec 15 amendment)
 
@@ -230,11 +280,14 @@ Engine is a first-class axis of the requirement, not a new concept:
 
 - Registry load: duplicate variant key inside one version; `variants:`
   plus the top-level shorthand; `default_variant` naming no variant;
-  engine-spanning variants with no `default_variant` — all named
+  implementation-spanning variants with no `default_variant`; a variant
+  requirement carrying `abi:` with no `implementation` — all named
   registry validation errors naming the payload and version.
 - Resolution: zero-match and no-triplet errors name the selector and
-  the available variants (§4). No fallback across variants — a 4.0
-  selector never silently runs the 3.3 build.
+  the available variants (§4); an implementation unknown for the engine
+  is a named error listing the known ones (§1). No fallback across
+  variants — a 4.0 selector never silently runs the 3.3 build — and no
+  fallback across implementations.
 - The variant id is derived, so no authoring surface exists for it;
   the store migration (§6) journals every move.
 - Exit codes: the spec 05/07 shapes (69 runtime/payload resolution,
@@ -245,25 +298,34 @@ Engine is a first-class axis of the requirement, not a new concept:
 Bake (the feedstock matrix — one pipeline, two passes):
 
 ```
-recipe.yml build.runtime: [{engine: ruby, version: "3.3.12", tebako: "0.16.10"},
-                           {engine: ruby, version: "4.0.6",  tebako: "0.16.10"}]
+recipe.yml build.runtime: [{engine: ruby, implementation: mri, version: "3.3.12", tebako: "0.16.10"},
+                           {engine: ruby, implementation: mri, version: "4.0.6",  tebako: "0.16.10"}]
 → metanorma-1.16.9-ruby3.3-*.tfs and …-ruby4.0-*.tfs, one registry
-  version entry, two variants (§3)
+  version entry, two variants (§3): ruby-mri-3.3, ruby-mri-4.0
 ```
 
 Operator (managed mode):
 
 ```
-tebako install metanorma@1.16.9 --runtime "ruby ~> 3.3.0"
-tebako install metanorma@1.16.9 --runtime "ruby ~> 4.0.0"
-~/.tebako/payloads/metanorma/1.16.9/{ruby-3.3.tfs, ruby-4.0.tfs} (+anchors)
+tebako install metanorma@1.16.9 --runtime "ruby:mri ~> 3.3.0"
+tebako install metanorma@1.16.9 --runtime "ruby:mri ~> 4.0.0"
+~/.tebako/payloads/metanorma/1.16.9/{ruby-mri-3.3.tfs, ruby-mri-4.0.tfs} (+anchors)
 
-metanorma compile site.adoc                         # the default variant (ruby-3.3 per default_variant)
-TEBAKO_METANORMA_RUNTIME="ruby ~> 4.0.0" metanorma compile site.adoc   # the same shim, the 4.0 build
-tebako use metanorma --runtime "ruby ~> 4.0.0"      # persist the flip (S5)
+metanorma compile site.adoc                             # the default variant (ruby-mri-3.3 per default_variant)
+TEBAKO_METANORMA_RUNTIME="ruby:mri ~> 4.0.0" metanorma compile site.adoc   # the same shim, the 4.0 build
+tebako use metanorma --runtime "ruby:mri ~> 4.0.0"      # persist the flip (S5)
 ```
 
 The two runs differ in exactly one store path and one runtime
 resolution; every other byte of the world — registry, composition,
 jail, mounts — is unchanged. That is the benchmark A/B the variant
 dimension exists for.
+
+A PURE-language payload on the same registry carries the single
+`universal` variant; the operator flips implementations with no second
+install at all:
+
+```
+TEBAKO_TOOL_RUNTIME="ruby:jruby" tool …    # any jruby line the requirement admits
+TEBAKO_TOOL_RUNTIME="ruby" tool …          # back to the §4 default
+```


### PR DESCRIPTION
## Summary

Revises spec 28 (PLANNED, unshipped) with the **language/implementation split**, owner decision 2026-08-30:

> mri-ruby, jruby and truffleruby are all considered `ruby` — the user of an executable payload can run it on any one of them (pure-ruby payloads: any implementation the constraint admits; native/bound payloads: per-implementation builds).

### The model

- `engine` names the **language** — mri/jruby/truffleruby are all `engine: ruby`.
- `implementation` is the optional sub-axis. Selector: `ruby`, `ruby:jruby`, `ruby:jruby@9.4.8`, `ruby:mri ~> 3.3.0`.
- Runtimes declare `provides: {engine: ruby, implementation: jruby, version: 9.4.8, language_version: "3.1"}` — `version` is the implementation's own line, `language_version` the language level it implements (for mri the two coincide).
- **Pure-language payload:** one `universal` variant; requirement without `implementation` matches any implementation whose `language_version` satisfies the constraint. Per-implementation differences use the `any_of` list form.
- **Native-extension payload (`abi:` in force):** `implementation` REQUIRED (named manifest error otherwise); a second implementation means a second variant (`ruby-mri-3.3`, `ruby-truffleruby-24.1`).
- Variant ids become `<engine>-<implementation>-<line>`. Pre-revision flat-engine spellings retired before any variant machinery shipped — nothing to migrate.
- truffleruby native/jvm modes are two runtime artifacts of one implementation; mode is NOT a selector axis (rides `;tebako=` / per-entry pins).

### Files

- `docs/spec/28-runtime-variants.md` — the home of the change (status header, §1 grammar, §2 ids, §3 registry, §4 defaults, §7 D2, §8 rewritten as the implementation-axis law, §10 errors, §11 examples).
- `docs/spec/03-payload-manifest.md` — §2.2 app/runtime grammars: optional `implementation:` on requirements, REQUIRED `implementation` + `language_version` on runtime `provides`; §2.3 DEPENDS language edge.
- `docs/spec/05-resolution-and-cache.md` — §5 dispatch chain + the implementation matching rule (constraint reads `language_version` without an implementation, the implementation's own version line with one; journaled, never a silent cross-implementation fallback).

Docs-only; the spec stays PLANNED until the variant machinery lands (the java/jruby/truffleruby streams — ecosystem TODO trees — implement against this revision).

### MECE check

The implementation concept lives in exactly one place per layer: L1 grammar in spec 03, matching semantics in spec 05 §5, selection/registry/store in spec 28. Specs 17/22/23 untouched and unaffected (the driver never sees the axis — it receives a resolved runtime).
