### PR TITLE
tebako-info: validate cross-checks L2 entries[] against the slot payload's L1 (#494)

### DIFF
--- a/crates/tebako-info/src/payload.rs
+++ b/crates/tebako-info/src/payload.rs
@@ -170,6 +170,33 @@ pub fn inspect_region(
     inspect_mounted(path, Some((offset, size)), size, display)
 }
 
+/// Stat `relpaths` inside the image region in ONE mount (the verify
+/// entry cross-check, tebako#494): entry `i` of the result is true when
+/// `relpaths[i]` stats. Paths are image-relative (a leading `/` is
+/// stripped — an L2 `entries[].entrypoint` resolves against the slot's
+/// mount root, i.e. the image root). A mount failure is the InfoError —
+/// the caller renders its named error.
+pub fn region_paths_exist(
+    path: &Path,
+    offset: u64,
+    size: u64,
+    relpaths: &[&str],
+) -> Result<Vec<bool>, InfoError> {
+    let mounted = tfs::mount::build_from_file_at(&path.to_string_lossy(), offset, size, "/mnt")
+        .map_err(|errno| {
+            let message = std::ffi::CStr::from_bytes_until_nul(tfs::errno::strerror(errno))
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| "unknown error".to_string());
+            err(format!(
+                "cannot mount the image region (errno {errno}): {message}"
+            ))
+        })?;
+    Ok(relpaths
+        .iter()
+        .map(|p| mounted.backend.stat(p.trim_start_matches('/')).is_ok())
+        .collect())
+}
+
 // ---------------------------------------------------------------------
 // JSON document (spec 15 §6)
 // ---------------------------------------------------------------------

--- a/crates/tebako-info/src/verify.rs
+++ b/crates/tebako-info/src/verify.rs
@@ -393,7 +393,161 @@ pub fn verify_package(
         }
     }
 
+    // 6. L2 entries[] ↔ the slot payloads' L1 entrypoints (tebako#494):
+    //    every entries[].entrypoint path must EXIST in the referenced
+    //    slot's image, and every entries[].name must be a DECLARED
+    //    entrypoint of that payload (the name facet is unchecked, never
+    //    failing, when the slot carries no usable L1 manifest —
+    //    pre-manifest packages stay valid).
+    match trailer.package_manifest() {
+        Err(e) => checks.push(Check::fail(
+            "package manifest",
+            format!("extension block: {e}"),
+            exit_code::MALFORMED,
+        )),
+        Ok(None) => {}
+        Ok(Some(pm)) => entry_checks(binary, &pm, &inspection, &mut checks)?,
+    }
+
     Ok((checks, Some(inspection)))
+}
+
+/// The entries cross-check of [`verify_package`] (one check per L2 entry,
+/// named `entry[<name>]`). Entry paths stat in one mount per referenced
+/// slot; a slot whose image already failed to mount skips (its manifest
+/// check carries the failure — no double jeopardy).
+fn entry_checks(
+    binary: &Path,
+    pm: &tpkg::PackageManifest,
+    inspection: &PackageInspection,
+    checks: &mut Vec<Check>,
+) -> Result<(), InfoError> {
+    use std::collections::{BTreeMap, HashMap};
+
+    // Batch the path stats: one mount per referenced, mountable slot.
+    let mut paths_by_slot: BTreeMap<usize, Vec<String>> = BTreeMap::new();
+    for e in &pm.entries {
+        let Some(slot) = e.slot else { continue };
+        let i = slot as usize;
+        let mountable = inspection.slots.get(i).is_some_and(|s| {
+            s.format_hint != tpkg::TPKG_FORMAT_RUNTIME
+                && s.payload.as_ref().is_some_and(|p| p.mount_error.is_none())
+        });
+        if mountable {
+            paths_by_slot
+                .entry(i)
+                .or_default()
+                .push(e.entrypoint.clone());
+        }
+    }
+    let mut exists: HashMap<(usize, String), bool> = HashMap::new();
+    for (i, paths) in &paths_by_slot {
+        let s = &inspection.slots[*i];
+        let refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+        let found = payload::region_paths_exist(binary, s.offset, s.size, &refs)?;
+        for (p, ok) in paths.iter().zip(found) {
+            exists.insert((*i, p.clone()), ok);
+        }
+    }
+
+    for e in &pm.entries {
+        let name = format!("entry[{}]", e.name);
+        let Some(slot) = e.slot else {
+            checks.push(Check::skip(
+                name,
+                "shared slice — resolved and checked at run time (spec 23 §13)",
+            ));
+            continue;
+        };
+        let i = slot as usize;
+        let Some(s) = inspection.slots.get(i) else {
+            checks.push(Check::fail(
+                name,
+                format!(
+                    "names slot {slot} but the package carries {} slot(s)",
+                    inspection.slots.len()
+                ),
+                exit_code::MALFORMED,
+            ));
+            continue;
+        };
+        if s.format_hint == tpkg::TPKG_FORMAT_RUNTIME {
+            checks.push(Check::fail(
+                name,
+                format!(
+                    "slot {slot} is a runtime (legacy role) slot — a launcher, never an entrypoint image"
+                ),
+                exit_code::MALFORMED,
+            ));
+            continue;
+        }
+        let p = s
+            .payload
+            .as_ref()
+            .ok_or_else(|| err("internal error: slot payload missing at depth 1"))?;
+        if let Some(merr) = &p.mount_error {
+            checks.push(Check::skip(
+                name,
+                format!("slot {slot} unreadable (see slot[{slot}] manifest: {merr})"),
+            ));
+            continue;
+        }
+        if !exists
+            .get(&(i, e.entrypoint.clone()))
+            .copied()
+            .unwrap_or(false)
+        {
+            checks.push(Check::fail(
+                name,
+                format!(
+                    "entrypoint path '{}' does not exist in slot {slot}'s image",
+                    e.entrypoint
+                ),
+                exit_code::MALFORMED,
+            ));
+            continue;
+        }
+        match (&p.manifest, &p.manifest_validation) {
+            (Some(m), None) => {
+                let declared: Vec<&str> = match &m.provides {
+                    tpkg::Provides::App(a) => {
+                        a.entrypoints.iter().map(|ep| ep.name.as_str()).collect()
+                    }
+                    tpkg::Provides::Toolkit(t) => {
+                        t.executables.iter().map(|x| x.name.as_str()).collect()
+                    }
+                    _ => Vec::new(),
+                };
+                if declared.is_empty() {
+                    checks.push(Check::fail(
+                        name,
+                        format!("slot {slot}'s payload declares no entrypoints"),
+                        exit_code::MALFORMED,
+                    ));
+                } else if declared.contains(&e.name.as_str()) {
+                    checks.push(Check::pass(
+                        name,
+                        format!("path exists in slot {slot}; name declared"),
+                    ));
+                } else {
+                    checks.push(Check::fail(
+                        name,
+                        format!(
+                            "'{}' is not a declared entrypoint of slot {slot}'s payload (declared: {})",
+                            e.name,
+                            declared.join(", ")
+                        ),
+                        exit_code::MALFORMED,
+                    ));
+                }
+            }
+            _ => checks.push(Check::pass(
+                name,
+                format!("path exists in slot {slot}; name unchecked (no usable L1 manifest)"),
+            )),
+        }
+    }
+    Ok(())
 }
 
 /// Re-read the raw trailer bytes (the v2 signed region is computed over

--- a/crates/tebako-pkg/tests/info.rs
+++ b/crates/tebako-pkg/tests/info.rs
@@ -51,13 +51,45 @@ const DATA_MANIFEST: &str = include_str!("../../tpkg/tests/fixtures/manifests/da
 
 /// A dwarfs-t image built in-process (optionally carrying a manifest).
 fn mk_image(w: &TempDir, name: &str, manifest: Option<&str>) -> PathBuf {
+    mk_image_files(w, name, manifest, &[])
+}
+
+/// mk_image plus extra files (`(path, bytes)` pairs, parent dirs created).
+fn mk_image_files(
+    w: &TempDir,
+    name: &str,
+    manifest: Option<&str>,
+    files: &[(&str, &[u8])],
+) -> PathBuf {
     let src = w.0.join(format!("src-{name}"));
     std::fs::create_dir_all(&src).unwrap();
     std::fs::write(src.join("hello.txt"), b"hi").unwrap();
+    for (rel, bytes) in files {
+        let p = src.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, bytes).unwrap();
+    }
     if let Some(text) = manifest {
         std::fs::create_dir_all(src.join("__tpkg__")).unwrap();
         std::fs::write(src.join("__tpkg__/manifest.yaml"), text).unwrap();
     }
+    let img = w.0.join(name);
+    let mut writer = dwarfs_t::Writer::new(dwarfs_t::WriterOptions::default()).unwrap();
+    writer.add_tree(&src, "/").unwrap();
+    writer.write(&img).unwrap();
+    img
+}
+
+/// The app-suite image (APP_MANIFEST declares the `metanorma` and
+/// `metanorma-nokogiri` entrypoints) WITH both entry files present — the
+/// shape the entries cross-check (tebako#494) can fully pass on.
+fn mk_suite_image(w: &TempDir, name: &str) -> PathBuf {
+    let src = w.0.join(format!("src-{name}"));
+    std::fs::create_dir_all(src.join("bin")).unwrap();
+    std::fs::write(src.join("bin/metanorma"), b"#!/bin/sh\n").unwrap();
+    std::fs::write(src.join("bin/metanorma-nokogiri"), b"#!/bin/sh\n").unwrap();
+    std::fs::create_dir_all(src.join("__tpkg__")).unwrap();
+    std::fs::write(src.join("__tpkg__/manifest.yaml"), APP_MANIFEST).unwrap();
     let img = w.0.join(name);
     let mut writer = dwarfs_t::Writer::new(dwarfs_t::WriterOptions::default()).unwrap();
     writer.add_tree(&src, "/").unwrap();
@@ -293,7 +325,9 @@ fn full_report_signed_lean_and_depths() {
 #[test]
 fn full_report_runtime_legacy_role_slot() {
     let w = TempDir::new("pfat");
-    let app = mk_image(&w, "app.tfs", None);
+    // Slot 0 carries the `probe` file the package manifest's entry names
+    // (the entries cross-check stats it — tebako#494).
+    let app = mk_image_files(&w, "app.tfs", None, &[("probe", b"#!/bin/sh\n")]);
     let rt = mk_image(&w, "runtime.tfs", None);
     let boot = bootstrap(&w);
     let pkg = w.0.join("fat");
@@ -515,7 +549,11 @@ fn validate_signed_plain_slots_passes() {
     let w = TempDir::new("pok");
     let home = test_home("pok");
     let z = w.0.join("z.zip");
-    tebako_contract_tests::build_zip(&z, &["content/"], &[("content/a.txt", b"a")]);
+    tebako_contract_tests::build_zip(
+        &z,
+        &["content/"],
+        &[("content/a.txt", b"a"), ("probe", b"#!/bin/sh\n")],
+    );
     let sqfs = fixture("simple.sqfs");
     let pm = package_manifest_file(&w);
     let pkg = w.0.join("pkg");
@@ -544,6 +582,14 @@ fn validate_signed_plain_slots_passes() {
     assert!(out.contains("  signature: ok — trusted, signer "), "{out}");
     assert!(out.contains("  slot[0] manifest: skip"), "{out}");
     assert!(out.contains("  slot[1] manifest: skip"), "{out}");
+    // The entries cross-check (tebako#494): `probe` stats in slot 0's zip;
+    // the name facet is unchecked (the plain image carries no L1 manifest).
+    assert!(
+        out.contains(
+            "  entry[probe]: ok — path exists in slot 0; name unchecked (no usable L1 manifest)\n"
+        ),
+        "{out}"
+    );
     assert!(out.contains("result: PASS\n"), "{out}");
 
     // info --verify is the same machinery with the same code.
@@ -577,7 +623,11 @@ fn validate_tampered_slot_is_70() {
     let w = TempDir::new("p70");
     let home = test_home("p70");
     let z = w.0.join("z.zip");
-    tebako_contract_tests::build_zip(&z, &["content/"], &[("content/a.txt", b"a")]);
+    tebako_contract_tests::build_zip(
+        &z,
+        &["content/"],
+        &[("content/a.txt", b"a"), ("probe", b"#!/bin/sh\n")],
+    );
     let pm = package_manifest_file(&w);
     let pkg = w.0.join("pkg");
     bundle(
@@ -610,7 +660,11 @@ fn validate_unsigned_require_signed_is_71() {
     let w = TempDir::new("p71");
     let home = test_home("p71");
     let z = w.0.join("z.zip");
-    tebako_contract_tests::build_zip(&z, &["content/"], &[("content/a.txt", b"a")]);
+    tebako_contract_tests::build_zip(
+        &z,
+        &["content/"],
+        &[("content/a.txt", b"a"), ("probe", b"#!/bin/sh\n")],
+    );
     let pm = package_manifest_file(&w);
     let pkg = w.0.join("pkg");
     bundle(
@@ -648,7 +702,11 @@ fn validate_unknown_signer_is_72() {
     let w = TempDir::new("p72");
     let home_a = test_home("p72a");
     let z = w.0.join("z.zip");
-    tebako_contract_tests::build_zip(&z, &["content/"], &[("content/a.txt", b"a")]);
+    tebako_contract_tests::build_zip(
+        &z,
+        &["content/"],
+        &[("content/a.txt", b"a"), ("probe", b"#!/bin/sh\n")],
+    );
     let pm = package_manifest_file(&w);
     let pkg = w.0.join("pkg");
     bundle(
@@ -682,7 +740,11 @@ fn validate_malformed_is_65() {
 
     // Corrupt trailer (magic ok, crc bad).
     let z = w.0.join("z.zip");
-    tebako_contract_tests::build_zip(&z, &["content/"], &[("content/a.txt", b"a")]);
+    tebako_contract_tests::build_zip(
+        &z,
+        &["content/"],
+        &[("content/a.txt", b"a"), ("probe", b"#!/bin/sh\n")],
+    );
     let pkg = w.0.join("pkg");
     bundle(&home, &w, &[], &[&z], &pkg);
     let mut bytes = std::fs::read(&pkg).unwrap();
@@ -739,6 +801,192 @@ fn validate_digest_agreement_is_70() {
 }
 
 // ---------------------------------------------------------------------
+// validate: the L2 entries[] ↔ L1 entrypoints cross-check (tebako#494)
+// ---------------------------------------------------------------------
+
+/// Write `text` as the package-manifest file of a test.
+fn pm_file(w: &TempDir, text: &str) -> PathBuf {
+    let f = w.0.join(format!(
+        "pm-{}.yaml",
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::write(&f, text).unwrap();
+    f
+}
+
+/// A valid L2 manifest whose two entries mirror the app-suite L1 (names
+/// declared, paths present in the suite image).
+const SUITE_PACKAGE_MANIFEST_YAML: &str = "schema_version: 1\n\
+     package: {name: mn, version: 1.0.0, producer: {tool: tebako-pkg, tool_version: 0.1.0}, created: 2026-08-01T00:00:00Z}\n\
+     entries:\n  - {name: metanorma, slot: 0, entrypoint: bin/metanorma, runtime_ref: ruby@3.4.2;tebako=0.15.9}\n  - {name: metanorma-nokogiri, slot: 0, entrypoint: bin/metanorma-nokogiri, runtime_ref: ruby@3.4.2;tebako=0.15.9}\n";
+
+// The app-suite manifest's blob_sha256 can never name the image that
+// embeds it (the check-5 note in verify.rs), so the suite packages below
+// exit 70 on digest agreement — the entry checks are asserted by their
+// report lines.
+
+#[test]
+fn validate_entries_crosscheck_name_and_path() {
+    let w = TempDir::new("pxc");
+    let home = test_home("pxc");
+    let app = mk_suite_image(&w, "suite.tfs");
+    let pm = pm_file(&w, SUITE_PACKAGE_MANIFEST_YAML);
+    let pkg = w.0.join("mn");
+    bundle(
+        &home,
+        &w,
+        &["--package-manifest", pm.to_str().unwrap()],
+        &[&app],
+        &pkg,
+    );
+
+    let (rc, out, _) = run(&["validate", pkg.to_str().unwrap()], &w.0, &home);
+    assert_eq!(rc, 70, "{out}"); // digest agreement (check 5), see above
+    assert!(
+        out.contains("  entry[metanorma]: ok — path exists in slot 0; name declared\n"),
+        "{out}"
+    );
+    assert!(
+        out.contains("  entry[metanorma-nokogiri]: ok — path exists in slot 0; name declared\n"),
+        "{out}"
+    );
+}
+
+#[test]
+fn validate_entries_dangling_path_is_65() {
+    let w = TempDir::new("pxd");
+    let home = test_home("pxd");
+    // No L1 manifest: the name facet skips; the path facet still decides.
+    // PACKAGE_MANIFEST_YAML's entry `probe` has no `probe` file here.
+    let app = mk_image(&w, "plain.tfs", None);
+    let pm = package_manifest_file(&w);
+    let pkg = w.0.join("pkg");
+    bundle(
+        &home,
+        &w,
+        &["--package-manifest", pm.to_str().unwrap()],
+        &[&app],
+        &pkg,
+    );
+
+    let (rc, out, _) = run(&["validate", pkg.to_str().unwrap()], &w.0, &home);
+    assert_eq!(rc, 65, "{out}");
+    assert!(
+        out.contains(
+            "  entry[probe]: FAILED — entrypoint path 'probe' does not exist in slot 0's image\n"
+        ),
+        "{out}"
+    );
+    assert!(out.contains("result: FAILED (exit 65)\n"), "{out}");
+}
+
+#[test]
+fn validate_entries_dangling_name_fails() {
+    let w = TempDir::new("pxn");
+    let home = test_home("pxn");
+    let app = mk_suite_image(&w, "suite.tfs");
+    // `fontist`'s path exists (bin/metanorma is in the image) but no
+    // declared entrypoint of the suite payload carries the name.
+    let pm = pm_file(
+        &w,
+        "schema_version: 1\n\
+         package: {name: mn, version: 1.0.0, producer: {tool: tebako-pkg, tool_version: 0.1.0}, created: 2026-08-01T00:00:00Z}\n\
+         entries:\n  - {name: fontist, slot: 0, entrypoint: bin/metanorma, runtime_ref: ruby@3.4.2;tebako=0.15.9}\n",
+    );
+    let pkg = w.0.join("mn");
+    bundle(
+        &home,
+        &w,
+        &["--package-manifest", pm.to_str().unwrap()],
+        &[&app],
+        &pkg,
+    );
+
+    let (rc, out, _) = run(&["validate", pkg.to_str().unwrap()], &w.0, &home);
+    assert_eq!(rc, 70, "{out}"); // digest agreement precedes the entry check
+    assert!(
+        out.contains(
+            "  entry[fontist]: FAILED — 'fontist' is not a declared entrypoint of slot 0's payload (declared: metanorma, metanorma-nokogiri)\n"
+        ),
+        "{out}"
+    );
+}
+
+#[test]
+fn press_refuses_an_entry_slot_beyond_the_container() {
+    let w = TempDir::new("pxs");
+    let home = test_home("pxs");
+    let app = mk_suite_image(&w, "suite.tfs");
+    // The PRESS refuses an entry slot beyond the container's slots with a
+    // named error; the verify-side range check (verify.rs entry_checks) is
+    // the backstop for hand-built containers that bypass the press.
+    let pm = pm_file(
+        &w,
+        "schema_version: 1\n\
+         package: {name: mn, version: 1.0.0, producer: {tool: tebako-pkg, tool_version: 0.1.0}, created: 2026-08-01T00:00:00Z}\n\
+         entries:\n  - {name: ghost, slot: 3, entrypoint: bin/metanorma, runtime_ref: ruby@3.4.2;tebako=0.15.9}\n",
+    );
+    let boot = bootstrap(&w);
+    let pkg = w.0.join("mn");
+    let (rc, _, err) = run(
+        &[
+            "bundle",
+            "--bootstrap",
+            boot.to_str().unwrap(),
+            "--image",
+            app.to_str().unwrap(),
+            "-o",
+            pkg.to_str().unwrap(),
+            "--package-manifest",
+            pm.to_str().unwrap(),
+        ],
+        &w.0,
+        &home,
+    );
+    assert_eq!(rc, 1, "{err}");
+    assert!(
+        err.contains(
+            "package manifest entry 0 (ghost) references slot 3 but the package has 1 slot(s)"
+        ),
+        "{err}"
+    );
+}
+
+#[test]
+fn validate_entries_shared_slice_skips() {
+    let w = TempDir::new("pxl");
+    let home = test_home("pxl");
+    let app = mk_image(&w, "plain.tfs", None);
+    // A slot-less entry (spec 23 §13 — the pointer-package form): the
+    // slice is shared, so there is nothing local to cross-check.
+    let pm = pm_file(
+        &w,
+        "schema_version: 1\n\
+         package: {name: ptr, version: 1.0.0, producer: {tool: tebako-pkg, tool_version: 0.1.0}, created: 2026-08-01T00:00:00Z}\n\
+         entries:\n  - {name: probe, entrypoint: bin/probe, runtime_ref: ruby@3.4.2;tebako=0.15.9}\n\
+         lock:\n  slices:\n    - {name: probe, version: 1.0.0, carry: false, sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef, source: \"tfs:github:acme/probe@1.0.0\"}\n",
+    );
+    let pkg = w.0.join("ptr");
+    bundle(
+        &home,
+        &w,
+        &["--package-manifest", pm.to_str().unwrap()],
+        &[&app],
+        &pkg,
+    );
+
+    let (rc, out, _) = run(&["validate", pkg.to_str().unwrap()], &w.0, &home);
+    assert_eq!(rc, 0, "{out}");
+    assert!(
+        out.contains(
+            "  entry[probe]: skip — shared slice — resolved and checked at run time (spec 23 §13)\n"
+        ),
+        "{out}"
+    );
+    assert!(out.contains("result: PASS\n"), "{out}");
+}
+
+// ---------------------------------------------------------------------
 // Format detection per slot (never trusting format_id alone)
 // ---------------------------------------------------------------------
 
@@ -752,7 +1000,11 @@ fn format_detection_per_slot() {
     let dwarfs = mk_image(&w, "app.tfs", Some(DATA_MANIFEST));
     let sqfs = fixture("simple.sqfs");
     let z = w.0.join("z.zip");
-    tebako_contract_tests::build_zip(&z, &["content/"], &[("content/a.txt", b"a")]);
+    tebako_contract_tests::build_zip(
+        &z,
+        &["content/"],
+        &[("content/a.txt", b"a"), ("probe", b"#!/bin/sh\n")],
+    );
     let t = w.0.join("t.tar");
     build_tar(&t, "hello.txt", b"hi from tar");
     let pkg = w.0.join("pkg");

--- a/docs/spec/15-info-command.md
+++ b/docs/spec/15-info-command.md
@@ -151,7 +151,18 @@ Two verbs on the product CLI (both SHIPPED; `--json` on every view,
 
 Checks: tpkg structural validation (spec 02 §6) → per-slot sha256 (v2) →
 signature (v2) → manifest schema validation per slot → digest agreement
-(manifest blob_sha256 vs image bytes when declared).
+(manifest blob_sha256 vs image bytes when declared) → **entries
+cross-check** (the L2 package manifest's `entries[]` against the
+referenced slot payload: every `entries[].entrypoint` path must exist in
+the slot's image — one read-only mount per referenced slot — and every
+`entries[].name` must match a DECLARED entrypoint of that payload's L1
+`provides.entrypoints[]` / toolkit `provides.executables[]`; the name
+facet is reported "unchecked", never failing, when the slot carries no
+usable L1 manifest — pre-manifest packages stay valid. A slot-less entry
+(the spec 23 §13 pointer-package form) skips: its shared slice is
+resolved and checked at run time. Exit 65 on a dangling path, an
+undeclared name, a slot index beyond the container's slots, or an entry
+naming a runtime-role slot).
 
 > **Digest-agreement note (implementation finding).** The agreement check
 > compares the declared `blob_sha256` against the actual image bytes. A


### PR DESCRIPTION
Closes #494.

## What

`tebako-pkg validate` / `info --verify` gain the missing cross-check between the L2 package manifest's `entries[]` and the referenced slot payload — a new check 6 in `crates/tebako-info/src/verify.rs`, one report line per entry (`entry[<name>]`):

1. **Path exists.** Every `entries[].entrypoint` is stated inside the referenced slot's image (one read-only tfs mount per referenced slot, via the new `payload::region_paths_exist` — nothing is extracted). A dangling path fails 65 with the named error.
2. **Name declared.** Every `entries[].name` must match a declared `provides.entrypoints[].name` (kind `app`) or `provides.executables[].name` (kind `toolkit`) of that slot's L1 manifest. **Unchecked, never failing, when the slot carries no usable L1 manifest** — pre-manifest packages stay valid (the report says so: `path exists …; name unchecked (no usable L1 manifest)`).

Failure modes, all named, exit 65: dangling path · undeclared name · slot index beyond the container's slots · an entry naming a runtime-role (legacy format 4) slot. A slot whose image failed to mount **skips** the entry check (its `slot[N] manifest` check already carries the failure — no double jeopardy). A slot-less entry (the spec 23 §13 pointer-package form) **skips** — its shared slice is resolved and checked at run time. The reverse direction (an L1 entrypoint unmirrored by L2) stays informational per the issue.

## Semantics pinned to the wire contract

`entries[].entrypoint` is the **in-image path**: the bootstrap passes it verbatim as `--tebako-entry` (`tebako-bootstrap/src/lib.rs:3490`) and the driver resolves it mount-relative (`join_mount`, spec 17 §1). The stat therefore strips a leading `/` and reads image-relative.

**Drift observed, not fixed here** (follow-up material): `tebako-cli/src/check.rs:1549` carries a comment reading the same field as the PROVIDES entrypoint *name*, and `suite.rs:281` presses `entrypoint: e.name` — both work today only because suite fixtures make the name coincide with the root-relative path. The wire contract (bootstrap → driver) is the authority this check encodes; real drift between the two spellings now fails validation loudly instead of at run time.

## Layering

The press already refuses an entry slot beyond the container's slot count (`bundle failed: package manifest entry 0 (ghost) references slot 3 but the package has 1 slot(s)`) — covered here by a test asserting that named error. The verify-side range check remains as the backstop for hand-built containers that bypass the press.

Exit-code ordering is unchanged: first failing check decides, so on packages whose slots carry self-embedded manifests the (pre-existing, spec-noted) digest-agreement 70 surfaces before an entries 65. The entries check fails loudly whenever earlier stages pass.

## Tests (crates/tebako-pkg/tests/info.rs)

- `validate_entries_crosscheck_name_and_path` — the two-entry suite package (mirrors the metanorma L1): both entries `ok — path exists in slot 0; name declared`.
- `validate_entries_dangling_path_is_65` — plain image, missing path → 65 with the named error.
- `validate_entries_dangling_name_fails` — existing path, undeclared name → the FAILED line names the declared set.
- `press_refuses_an_entry_slot_beyond_the_container` — the press-time named error (see Layering).
- `validate_entries_shared_slice_skips` — slot-less pointer-package entry skips.
- Existing verify fixtures updated: their `probe` entry now finds a `probe` file in the slot image (previously the entry was dangling and nothing checked it — the gap this PR closes); `validate_signed_plain_slots_passes` gains the `entry[probe]` skip-detail assertion.

Local: `cargo test -p tebako-info -p tebako-pkg` — 14/14 suites green (info.rs 19/19). `cargo fmt` clean.

## Spec

`docs/spec/15-info-command.md` §5 documents the check in the same PR (spec 14 rule).
