### PR TITLE
tebako-bench slices 6–8: report renderer, benchmark.yml, README (spec 27 complete)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,136 @@
+name: benchmark
+
+# Spec 27: benchmarks run on manual dispatch and on release publishes ONLY —
+# never per-PR (shared-runner noise + cost, and the harness never sits on
+# the merge critical path). The matrix is GENERATED from
+# benchmarks/platforms.yaml by lib/bench-matrix.rb — no triplet, runner, or
+# container is named in this file (the YAML documents are the SSOT).
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - id: gen
+        run: ruby .github/workflows/lib/bench-matrix.rb benchmarks/platforms.yaml >> "$GITHUB_OUTPUT"
+
+  run:
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+      - name: Run the matrix leg
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          args=(--suite benchmarks/suite.yaml
+                --platforms benchmarks/platforms.yaml
+                --triplet "${{ matrix.triplet }}"
+                --out out
+                --repo-root .)
+          # A release run benchmarks the release that fired it (never the
+          # floating "latest"); dispatch runs take the latest release.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            args+=(--tebako-release "${{ github.event.release.tag_name }}")
+          fi
+          set +e
+          if [ -n "${{ matrix.container }}" ]; then
+            # musl leg: the harness is pure Rust, so it cross-builds to a
+            # static musl binary with no vcpkg and runs the workloads
+            # inside the pinned alpine container (node actions cannot run
+            # on musl — the container is entered via docker run only).
+            target="$(rustc -vV | sed -n 's/^host: //p' | sed 's/-gnu/-musl/')"
+            rustup target add "$target"
+            cargo build -p tebako-bench --target "$target"
+            docker run --rm -v "$PWD:$PWD" -w "$PWD" \
+              -e GITHUB_TOKEN "$GITHUB_TOKEN" \
+              "${{ matrix.container }}" \
+              "./target/$target/debug/tebako-bench" run "${args[@]}"
+            rc=$?
+          else
+            cargo build -p tebako-bench
+            bin="./target/debug/tebako-bench"
+            [ -f "$bin.exe" ] && bin="$bin.exe"
+            "$bin" run "${args[@]}"
+            rc=$?
+          fi
+          set -e
+          # spec 27 §8: 0 ok · 1 red-matrix deliverable (artifacts written,
+          # the leg still succeeds) · 2 operational (harness fault — red leg).
+          if [ "$rc" -eq 2 ]; then exit 2; fi
+          echo "tebako-bench run exit $rc (0 ok / 1 red-matrix deliverable)"
+      - name: Upload the leg's results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bench-${{ matrix.triplet }}
+          path: out/
+          if-no-files-found: error
+
+  report:
+    needs: run
+    if: always()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # the bench-history append (release runs)
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+      - name: Build the harness
+        run: cargo build -p tebako-bench
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: bench-*
+          path: legs/
+      - name: Merge into the report
+        run: |
+          set +e
+          ./target/debug/tebako-bench report legs/bench-*/out/results.json \
+            --md report.md --json dashboard.json
+          rc=$?
+          set -e
+          if [ "$rc" -eq 2 ]; then exit 2; fi
+          echo "tebako-bench report exit $rc"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bench-report
+          path: |
+            report.md
+            dashboard.json
+          if-no-files-found: error
+      - name: Append to the bench-history branch (release runs only)
+        if: github.event_name == 'release'
+        run: |
+          set -e
+          tag="${{ github.event.release.tag_name }}"
+          git config user.name tebako-ci
+          git config user.email tebako@ribose.com
+          git fetch origin bench-history || true
+          if git show-ref --verify --quiet refs/remotes/origin/bench-history; then
+            git worktree add .bench-history -B bench-history origin/bench-history
+          else
+            git worktree add --orphan bench-history .bench-history
+          fi
+          dest=".bench-history/$tag"
+          mkdir -p "$dest"
+          cp report.md dashboard.json "$dest/"
+          git -C .bench-history add "$tag"
+          git -C .bench-history commit -m "bench: $tag (run ${{ github.run_id }})"
+          git -C .bench-history push origin bench-history

--- a/.github/workflows/lib/bench-matrix.rb
+++ b/.github/workflows/lib/bench-matrix.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Generate the benchmark workflow's matrix FROM benchmarks/platforms.yaml
+# (spec 27 §3: the workflow never hardcodes a triplet — the document is
+# the SSOT; adding a platform edits platforms.yaml, never the workflow).
+# Emits `matrix=<json>` to $GITHUB_OUTPUT. Runner-baked ruby; psych/JSON
+# are stdlib.
+
+require "json"
+require "yaml"
+
+doc = YAML.load_file(ARGV.fetch(0))
+legs = doc.fetch("triplets").map do |triplet, cfg|
+  leg = { "triplet" => triplet, "runner" => cfg.fetch("runner") }
+  leg["container"] = cfg["container"] if cfg.key?("container")
+  leg
+end
+
+File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
+  f.puts "matrix=#{JSON.generate({ "include" => legs })}"
+end

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,62 @@
+# benchmarks/ — the spec 27 harness documents
+
+**CI tooling, never shipped.** Nothing here is part of the released
+product; `crates/tebako-bench` is absent from `release.yml`'s binary set
+by design. The contract is `docs/spec/27-benchmarks.md`.
+
+## The documents (SSOT — workflows read these, never hardcode)
+
+- `suite.yaml` — WHAT runs: the workloads (document, argv, expectations,
+  timeout), the three targets (`v1-packed-mn` / `v2-shim` / `v2-fat`),
+  and the run policy (warmup 1, warm 5 interleaved, cold 2).
+- `platforms.yaml` — WHERE: triplet → runner (+ alpine container for musl
+  legs), the packed-mn tag for the v1 arm, and the named gaps
+  (`v1_asset: null`, `v2_payload: false`).
+- `fixtures/` — vendored workload sources, byte-pinned to their upstream
+  commits (see each file's comment in suite.yaml).
+
+Validate either document after editing:
+
+```
+cargo run -p tebako-bench -- validate --kind suite benchmarks/suite.yaml
+```
+
+## Running
+
+Locally (one triplet — the one you're on):
+
+```
+cargo build -p tebako-bench
+./target/debug/tebako-bench run --suite benchmarks/suite.yaml \
+  --platforms benchmarks/platforms.yaml --triplet macos-arm64 --out out
+```
+
+Merging triplet results into the report + dashboard:
+
+```
+./target/debug/tebako-bench report legs/*/out/results.json \
+  --md report.md --json dashboard.json
+```
+
+Exit codes (spec 27 §8): `0` ok · `1` every arm failed/unavailable (the
+artifacts are still written — a red matrix is a deliverable) · `2`
+operational fault.
+
+## CI
+
+`.github/workflows/benchmark.yml` runs on `workflow_dispatch` and
+`release: published` only — never per-PR. The leg matrix is generated
+from `platforms.yaml`; the fan-in job merges the per-triplet
+`results.json` files into `report.md` + `dashboard.json`, and on release
+runs appends both to the `bench-history` branch (the trend record the
+website renders).
+
+## Reading the numbers
+
+Median is the headline; **min is the cross-noise-comparable figure** on
+shared runners (noise inflates, never deflates). Speedups are vs the
+v1-packed-mn arm on the same triplet × workload × mode; a missing v1 arm
+renders "—". Cold runs (caches wiped) are install/first-boot metrics and
+are reported separately from warm runs. The old world is frozen at the
+packed-mn tag's metanorma-cli while the v2 payload is current — compare
+ratios, not absolutes.

--- a/crates/tebako-bench/src/lib.rs
+++ b/crates/tebako-bench/src/lib.rs
@@ -23,6 +23,7 @@ pub mod acquire;
 pub mod engine;
 pub mod error;
 pub mod platforms;
+pub mod report;
 pub mod result;
 pub mod sampler;
 pub mod suite;

--- a/crates/tebako-bench/src/main.rs
+++ b/crates/tebako-bench/src/main.rs
@@ -59,7 +59,7 @@ enum Command {
         repo_root: PathBuf,
     },
     /// Merge N triplet result files into a markdown report + dashboard JSON
-    /// (planned: the report-renderer slice).
+    /// (spec 27 §7: stats re-derived from the merged run records).
     Report {
         /// The per-triplet results.json files to merge.
         #[arg(required = true)]
@@ -144,9 +144,8 @@ fn run(cli: Cli) -> Result<u8, BenchError> {
                 repo_root,
             })
         }
-        Command::Report { .. } => Err(BenchError::not_implemented(
-            "report",
-            "slice 6 (report renderer)",
-        )),
+        Command::Report { results, md, json } => {
+            tebako_bench::report::report(&tebako_bench::report::ReportRequest { results, md, json })
+        }
     }
 }

--- a/crates/tebako-bench/src/report.rs
+++ b/crates/tebako-bench/src/report.rs
@@ -1,0 +1,381 @@
+//! Slice 6 — the report renderer (spec 27 §7): merge N per-triplet result
+//! files into one markdown report + one site-ingestible dashboard JSON.
+//!
+//! The merge laws (§7):
+//!
+//! - one result file per triplet; every file must name the SAME suite —
+//!   violations are operational errors, never silent picks;
+//! - statistics are RE-DERIVED from the merged run records via the
+//!   engine's own `compute_stats`; a file's carried stats are ignored, so
+//!   a hand-edited record cannot smuggle a stale stat past the report;
+//! - speedups are always "vs the v1 arm on the same triplet × workload ×
+//!   mode". The report receives no suite file, so the v1 baseline is the
+//!   cell whose target id starts with `v1` (the authored suite's v1-exe
+//!   target is `v1-packed-mn`); a cell with no v1 arm renders "—", never
+//!   an invented ratio;
+//! - a merge whose every arm failed or was unavailable still writes both
+//!   artifacts and exits 1 — a red matrix is a deliverable, not a crash
+//!   (§8).
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+use crate::engine::compute_stats;
+use crate::error::BenchError;
+use crate::exit;
+use crate::result::{ResultFile, RunMode, RunRecord, RunStatus, StatRecord};
+
+pub struct ReportRequest {
+    pub results: Vec<PathBuf>,
+    pub md: PathBuf,
+    pub json: PathBuf,
+}
+
+/// One input file with its stats re-derived from its own run records.
+struct TripletReport {
+    file: ResultFile,
+    stats: Vec<StatRecord>,
+}
+
+/// The dashboard document (§7: "site-ingestible"; no schema gate — the
+/// shape is pinned by tests/report.rs snapshots instead).
+#[derive(Serialize)]
+struct Dashboard {
+    suite: String,
+    generated_by: &'static str,
+    triplets: Vec<DashboardTriplet>,
+}
+
+#[derive(Serialize)]
+struct DashboardTriplet {
+    triplet: String,
+    runner: crate::result::RunnerMeta,
+    versions: crate::result::Versions,
+    cells: Vec<DashboardCell>,
+    unavailable: Vec<DashboardRow>,
+    failed: Vec<DashboardRow>,
+}
+
+#[derive(Serialize)]
+struct DashboardCell {
+    workload: String,
+    target: String,
+    mode: RunMode,
+    n: u32,
+    median_wall_s: f64,
+    min_wall_s: f64,
+    max_wall_s: f64,
+    stdev_wall_s: Option<f64>,
+    mean_wall_s: f64,
+    median_cpu_s: f64,
+    median_peak_rss_bytes: u64,
+    /// v1 median / this median on the same triplet × workload × mode;
+    /// null when the cell has no v1 arm (the named-gap shape).
+    speedup_vs_v1: Option<f64>,
+}
+
+#[derive(Serialize)]
+struct DashboardRow {
+    workload: String,
+    target: String,
+    mode: Option<RunMode>,
+    iteration: Option<u32>,
+    status: RunStatus,
+    error: Option<String>,
+    reason: Option<String>,
+}
+
+pub fn report(req: &ReportRequest) -> Result<u8, BenchError> {
+    let mut triplets: Vec<TripletReport> = Vec::new();
+    let mut suite: Option<String> = None;
+    for path in &req.results {
+        let text = std::fs::read_to_string(path).map_err(|e| {
+            BenchError::operational(format!("cannot read {}: {e}", path.display()))
+        })?;
+        let file = ResultFile::from_json(&text).map_err(|e| {
+            BenchError::operational(format!("cannot parse {}: {e}", path.display()))
+        })?;
+        let violations = file.semantic_violations();
+        if !violations.is_empty() {
+            return Err(BenchError::operational(format!(
+                "{}: invalid result document: {}",
+                path.display(),
+                violations.join("; ")
+            )));
+        }
+        match &suite {
+            None => suite = Some(file.suite.clone()),
+            Some(s) if *s == file.suite => {}
+            Some(s) => {
+                return Err(BenchError::operational(format!(
+                    "report merges one suite only: {} is '{}', expected '{s}'",
+                    path.display(),
+                    file.suite
+                )))
+            }
+        }
+        if triplets.iter().any(|t: &TripletReport| t.file.triplet == file.triplet) {
+            return Err(BenchError::operational(format!(
+                "one result file per triplet (§7): '{}' given twice ({})",
+                file.triplet,
+                path.display()
+            )));
+        }
+        let stats = compute_stats(&file.runs);
+        triplets.push(TripletReport { file, stats });
+    }
+    triplets.sort_by(|a, b| a.file.triplet.cmp(&b.file.triplet));
+    let suite = suite.unwrap_or_default();
+
+    let md = render_markdown(&suite, &triplets);
+    std::fs::write(&req.md, md).map_err(|e| {
+        BenchError::operational(format!("cannot write {}: {e}", req.md.display()))
+    })?;
+    let dash = dashboard(&suite, &triplets);
+    let json = serde_json::to_string_pretty(&dash)
+        .map_err(|e| BenchError::operational(format!("dashboard serialize: {e}")))?;
+    std::fs::write(&req.json, json).map_err(|e| {
+        BenchError::operational(format!("cannot write {}: {e}", req.json.display()))
+    })?;
+
+    let any_ok = triplets
+        .iter()
+        .any(|t| t.file.runs.iter().any(|r| r.status == RunStatus::Ok));
+    if any_ok {
+        Ok(exit::OK)
+    } else {
+        eprintln!("tebako-bench: every arm failed or was unavailable — the red matrix is written [benchmark]");
+        Ok(exit::INVALID)
+    }
+}
+
+/// The v1 baseline of a (workload × mode) cell: the row whose target id
+/// starts with "v1" (see the module doc for the convention).
+fn baseline<'a>(stats: &'a [StatRecord], s: &StatRecord) -> Option<&'a StatRecord> {
+    stats
+        .iter()
+        .find(|b| b.workload == s.workload && b.mode == s.mode && b.target.starts_with("v1"))
+}
+
+fn speedup(stats: &[StatRecord], s: &StatRecord) -> Option<f64> {
+    baseline(stats, s).map(|b| b.median_wall_s / s.median_wall_s)
+}
+
+fn mib(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+fn render_markdown(suite: &str, triplets: &[TripletReport]) -> String {
+    let mut out = format!("# tebako benchmark report — {suite}\n");
+    for t in triplets {
+        let f = &t.file;
+        out.push_str(&format!("\n## {}\n", f.triplet));
+        out.push_str(&format!(
+            "\nRunner: {} · {} · {} cpus · {:.1} GiB\n",
+            f.runner.runs_on,
+            f.runner.arch,
+            f.runner.cpus,
+            mib(f.runner.ram_bytes) * 1024.0 / 1024.0
+        ));
+        let mut versions = Vec::new();
+        if let Some(v) = &f.versions.tebako {
+            versions.push(format!("tebako {v}"));
+        }
+        if let Some(v) = &f.versions.runtime {
+            versions.push(format!("runtime {v}"));
+        }
+        if let Some(v) = &f.versions.payload {
+            versions.push(format!("payload {v}"));
+        }
+        if let Some(v) = &f.versions.packed_mn {
+            versions.push(format!("packed-mn {v}"));
+        }
+        if let Some(v) = &f.versions.image_format {
+            versions.push(format!("image {}", format!("{v:?}").to_lowercase()));
+        }
+        if !versions.is_empty() {
+            out.push_str(&format!("Versions: {}\n", versions.join(" · ")));
+        }
+
+        // (workload, mode) sections in deterministic order, warm before cold.
+        let mut sections: BTreeMap<(String, RunMode), Vec<&StatRecord>> = BTreeMap::new();
+        for s in &t.stats {
+            sections
+                .entry((s.workload.clone(), s.mode))
+                .or_default()
+                .push(s);
+        }
+        for ((workload, mode), mut cells) in sections {
+            cells.sort_by(|a, b| a.target.cmp(&b.target));
+            let mode_label = match mode {
+                RunMode::Warm => "warm".to_string(),
+                RunMode::Cold => "cold (install/first-boot)".to_string(),
+            };
+            out.push_str(&format!("\n### {workload} — {mode_label}\n\n"));
+            out.push_str("| target | n | median s | min s | max s | stdev s | mean s | cpu median s | peak RSS MiB | vs v1 |\n");
+            out.push_str("|--------|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n");
+            for s in cells {
+                let stdev = s
+                    .stdev_wall_s
+                    .map(|v| format!("{v:.3}"))
+                    .unwrap_or_else(|| "—".to_string());
+                let ratio = speedup(&t.stats, s)
+                    .map(|v| format!("{v:.2}×"))
+                    .unwrap_or_else(|| "—".to_string());
+                out.push_str(&format!(
+                    "| {} | {} | {:.3} | {:.3} | {:.3} | {} | {:.3} | {:.3} | {:.1} | {} |\n",
+                    s.target,
+                    s.n,
+                    s.median_wall_s,
+                    s.min_wall_s,
+                    s.max_wall_s,
+                    stdev,
+                    s.mean_wall_s,
+                    s.median_cpu_s,
+                    mib(s.median_peak_rss_bytes),
+                    ratio
+                ));
+            }
+        }
+
+        let gaps: Vec<&RunRecord> = f
+            .runs
+            .iter()
+            .filter(|r| r.status == RunStatus::Unavailable)
+            .collect();
+        if !gaps.is_empty() {
+            out.push_str("\nUnavailable arms:\n\n");
+            for r in gaps {
+                out.push_str(&format!(
+                    "- {} / {}{}: unavailable — {}\n",
+                    r.workload,
+                    r.target,
+                    mode_suffix(r),
+                    r.reason.as_deref().unwrap_or("(no reason given)")
+                ));
+            }
+        }
+        let failed: Vec<&RunRecord> = f
+            .runs
+            .iter()
+            .filter(|r| matches!(r.status, RunStatus::Failed | RunStatus::Timeout))
+            .collect();
+        if !failed.is_empty() {
+            out.push_str("\nFailed runs:\n\n");
+            for r in failed {
+                let status = match r.status {
+                    RunStatus::Failed => "failed",
+                    RunStatus::Timeout => "timeout",
+                    _ => unreachable!(),
+                };
+                let detail = r
+                    .error
+                    .as_deref()
+                    .map(|e| format!(" — {e}"))
+                    .unwrap_or_default();
+                out.push_str(&format!(
+                    "- {} / {}{} #{}{}: {status}{}\n",
+                    r.workload,
+                    r.target,
+                    mode_suffix(r),
+                    r.iteration.unwrap_or(0),
+                    r.exit.map(|c| format!(" (exit {c})")).unwrap_or_default(),
+                    detail
+                ));
+            }
+        }
+    }
+
+    out.push_str("\n---\n\nRunner metadata:");
+    for t in triplets {
+        let f = &t.file;
+        out.push_str(&format!(
+            " {} = {} / {} / {} cpus / {:.1} GiB;",
+            f.triplet,
+            f.runner.runs_on,
+            f.runner.arch,
+            f.runner.cpus,
+            mib(f.runner.ram_bytes) * 1024.0 / 1024.0
+        ));
+    }
+    out.push_str(
+        "\n\nGitHub-hosted runners are shared, multi-tenant machines; treat differences under \
+         ~10% as noise and read min alongside median — min is the cross-noise-comparable figure \
+         (noise inflates, never deflates).\n\n\
+         Version skew: the old world is frozen at the packed-mn tag's metanorma-cli while the v2 \
+         payload is current — compare ratios, not absolutes. Numbers across image formats are \
+         never mixed (spec 27 §1, §7).\n",
+    );
+    out
+}
+
+fn mode_suffix(r: &RunRecord) -> String {
+    r.mode
+        .map(|m| match m {
+            RunMode::Warm => " [warm]",
+            RunMode::Cold => " [cold]",
+        })
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn dashboard(suite: &str, triplets: &[TripletReport]) -> Dashboard {
+    Dashboard {
+        suite: suite.to_string(),
+        generated_by: "tebako-bench report (spec 27 §7)",
+        triplets: triplets
+            .iter()
+            .map(|t| {
+                let cells = t
+                    .stats
+                    .iter()
+                    .map(|s| DashboardCell {
+                        workload: s.workload.clone(),
+                        target: s.target.clone(),
+                        mode: s.mode,
+                        n: s.n,
+                        median_wall_s: s.median_wall_s,
+                        min_wall_s: s.min_wall_s,
+                        max_wall_s: s.max_wall_s,
+                        stdev_wall_s: s.stdev_wall_s,
+                        mean_wall_s: s.mean_wall_s,
+                        median_cpu_s: s.median_cpu_s,
+                        median_peak_rss_bytes: s.median_peak_rss_bytes,
+                        speedup_vs_v1: speedup(&t.stats, s),
+                    })
+                    .collect();
+                let row = |r: &RunRecord| DashboardRow {
+                    workload: r.workload.clone(),
+                    target: r.target.clone(),
+                    mode: r.mode,
+                    iteration: r.iteration,
+                    status: r.status,
+                    error: r.error.clone(),
+                    reason: r.reason.clone(),
+                };
+                DashboardTriplet {
+                    triplet: t.file.triplet.clone(),
+                    runner: t.file.runner.clone(),
+                    versions: t.file.versions.clone(),
+                    cells,
+                    unavailable: t
+                        .file
+                        .runs
+                        .iter()
+                        .filter(|r| r.status == RunStatus::Unavailable)
+                        .map(row)
+                        .collect(),
+                    failed: t
+                        .file
+                        .runs
+                        .iter()
+                        .filter(|r| matches!(r.status, RunStatus::Failed | RunStatus::Timeout))
+                        .map(row)
+                        .collect(),
+                }
+            })
+            .collect(),
+    }
+}

--- a/crates/tebako-bench/src/report.rs
+++ b/crates/tebako-bench/src/report.rs
@@ -91,9 +91,8 @@ pub fn report(req: &ReportRequest) -> Result<u8, BenchError> {
     let mut triplets: Vec<TripletReport> = Vec::new();
     let mut suite: Option<String> = None;
     for path in &req.results {
-        let text = std::fs::read_to_string(path).map_err(|e| {
-            BenchError::operational(format!("cannot read {}: {e}", path.display()))
-        })?;
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| BenchError::operational(format!("cannot read {}: {e}", path.display())))?;
         let file = ResultFile::from_json(&text).map_err(|e| {
             BenchError::operational(format!("cannot parse {}: {e}", path.display()))
         })?;
@@ -116,7 +115,10 @@ pub fn report(req: &ReportRequest) -> Result<u8, BenchError> {
                 )))
             }
         }
-        if triplets.iter().any(|t: &TripletReport| t.file.triplet == file.triplet) {
+        if triplets
+            .iter()
+            .any(|t: &TripletReport| t.file.triplet == file.triplet)
+        {
             return Err(BenchError::operational(format!(
                 "one result file per triplet (§7): '{}' given twice ({})",
                 file.triplet,
@@ -130,9 +132,8 @@ pub fn report(req: &ReportRequest) -> Result<u8, BenchError> {
     let suite = suite.unwrap_or_default();
 
     let md = render_markdown(&suite, &triplets);
-    std::fs::write(&req.md, md).map_err(|e| {
-        BenchError::operational(format!("cannot write {}: {e}", req.md.display()))
-    })?;
+    std::fs::write(&req.md, md)
+        .map_err(|e| BenchError::operational(format!("cannot write {}: {e}", req.md.display())))?;
     let dash = dashboard(&suite, &triplets);
     let json = serde_json::to_string_pretty(&dash)
         .map_err(|e| BenchError::operational(format!("dashboard serialize: {e}")))?;

--- a/crates/tebako-bench/tests/report.rs
+++ b/crates/tebako-bench/tests/report.rs
@@ -1,0 +1,209 @@
+//! Report-renderer tests (spec 27 slice 6): the merge rules (same-suite,
+//! one file per triplet), the re-derived-never-carried statistics rule,
+//! the v1-baseline speedup convention, named-gap rendering, and the
+//! red-matrix exit-1 contract. All offline: result files are written to a
+//! tempdir and the real report path renders them.
+
+use std::path::Path;
+
+use tebako_bench::report::{self, ReportRequest};
+use tebako_bench::result::{
+    ResultFile, RunMode, RunRecord, RunStatus, RunnerMeta, StatRecord, Versions,
+};
+
+fn ok_run(workload: &str, target: &str, mode: RunMode, iteration: u32, wall: f64) -> RunRecord {
+    RunRecord {
+        workload: workload.to_string(),
+        target: target.to_string(),
+        mode: Some(mode),
+        iteration: Some(iteration),
+        status: RunStatus::Ok,
+        wall_s: Some(wall),
+        cpu_user_s: Some(wall / 2.0),
+        cpu_sys_s: Some(wall / 4.0),
+        peak_rss_bytes: Some(512 * 1024 * 1024),
+        exit: Some(0),
+        error: None,
+        reason: None,
+    }
+}
+
+fn runner() -> RunnerMeta {
+    RunnerMeta {
+        runs_on: "ubuntu-24.04".to_string(),
+        arch: "x86_64".to_string(),
+        cpus: 4,
+        ram_bytes: 16 * 1024 * 1024 * 1024,
+    }
+}
+
+/// A result file whose CARRIED stats are garbage on purpose: the report
+/// must re-derive from the run records, so an emitted 999.0 anywhere in
+/// the markdown or dashboard is a test failure.
+fn triplet_file(triplet: &str, runs: Vec<RunRecord>) -> ResultFile {
+    ResultFile {
+        schema_version: 1,
+        suite: "metanorma-v1-vs-v2".to_string(),
+        triplet: triplet.to_string(),
+        runner: runner(),
+        versions: Versions {
+            tebako: Some("0.3.0".to_string()),
+            runtime: Some("0.16.11-3.3.12".to_string()),
+            payload: Some("1.16.9-3".to_string()),
+            packed_mn: Some("v1.14.4 (metanorma-cli 1.14.4)".to_string()),
+            image_format: None,
+        },
+        stats: vec![StatRecord {
+            workload: "compile-small-iso".to_string(),
+            target: "v1-packed-mn".to_string(),
+            mode: RunMode::Warm,
+            n: 99,
+            median_wall_s: 999.0,
+            min_wall_s: 999.0,
+            max_wall_s: 999.0,
+            stdev_wall_s: Some(999.0),
+            mean_wall_s: 999.0,
+            median_cpu_s: 999.0,
+            median_peak_rss_bytes: 999,
+        }],
+        runs,
+    }
+}
+
+fn write_result(dir: &Path, name: &str, file: &ResultFile) -> std::path::PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, file.to_json().unwrap()).unwrap();
+    p
+}
+
+fn run_report(dir: &Path, results: &[std::path::PathBuf]) -> (Result<u8, String>, String, String) {
+    let md = dir.join("report.md");
+    let json = dir.join("dashboard.json");
+    let rc = report::report(&ReportRequest {
+        results: results.to_vec(),
+        md: md.clone(),
+        json: json.clone(),
+    })
+    .map_err(|e| e.message);
+    let md_text = std::fs::read_to_string(&md).unwrap_or_default();
+    let json_text = std::fs::read_to_string(&json).unwrap_or_default();
+    (rc, md_text, json_text)
+}
+
+/// The standard two-triplet fixture: v1 walls 9/10/11 (median 10),
+/// v2-fat 4/5/6 (median 5 → 2.00×), v2-shim 2/2.5/3 (median 2.5 → 4.00×).
+fn standard_runs() -> Vec<RunRecord> {
+    let mut v = Vec::new();
+    for (i, w) in [9.0, 10.0, 11.0].iter().enumerate() {
+        v.push(ok_run("compile-small-iso", "v1-packed-mn", RunMode::Warm, i as u32 + 1, *w));
+    }
+    for (i, w) in [4.0, 5.0, 6.0].iter().enumerate() {
+        v.push(ok_run("compile-small-iso", "v2-fat", RunMode::Warm, i as u32 + 1, *w));
+    }
+    for (i, w) in [2.0, 2.5, 3.0].iter().enumerate() {
+        v.push(ok_run("compile-small-iso", "v2-shim", RunMode::Warm, i as u32 + 1, *w));
+    }
+    v.push(ok_run("compile-small-iso", "v1-packed-mn", RunMode::Cold, 1, 20.0));
+    v.push(ok_run("compile-small-iso", "v2-shim", RunMode::Cold, 1, 8.0));
+    v
+}
+
+#[test]
+fn merges_triplets_re_deriving_stats_and_speedups() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", standard_runs()));
+    let b = write_result(dir.path(), "b.json", &triplet_file("macos-arm64", standard_runs()));
+    let (rc, md, json) = run_report(dir.path(), &[a, b]);
+    assert_eq!(rc, Ok(0));
+    // re-derived, never carried: the 999.0 garbage stats must not appear
+    assert!(!md.contains("999"), "carried stats leaked into the report");
+    assert!(md.contains("# tebako benchmark report — metanorma-v1-vs-v2"));
+    assert!(md.contains("## linux-gnu-x86_64"));
+    assert!(md.contains("## macos-arm64"));
+    // warm medians: v1 = 10.000, v2-fat = 5.000 at 2.00×, v2-shim 2.500 at 4.00×
+    assert!(md.contains("| v1-packed-mn | 3 | 10.000 |"), "{md}");
+    assert!(md.contains("2.00×"), "{md}");
+    assert!(md.contains("4.00×"), "{md}");
+    // cold reported separately
+    assert!(md.contains("cold (install/first-boot)"), "{md}");
+    // the dashboard parses and carries the re-derived median + speedup
+    let dash: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let cell = dash["triplets"][0]["cells"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["target"] == "v2-fat" && c["mode"] == "warm")
+        .unwrap()
+        .clone();
+    assert_eq!(cell["median_wall_s"], 5.0);
+    assert_eq!(cell["speedup_vs_v1"], 2.0);
+}
+
+#[test]
+fn suite_mismatch_is_operational() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", standard_runs()));
+    let mut other = triplet_file("macos-arm64", standard_runs());
+    other.suite = "another-suite".to_string();
+    let b = write_result(dir.path(), "b.json", &other);
+    let (rc, _, _) = run_report(dir.path(), &[a, b]);
+    let msg = rc.expect_err("mismatched suites must refuse to merge");
+    assert!(msg.contains("suite"), "{msg}");
+}
+
+#[test]
+fn duplicate_triplet_is_operational() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", standard_runs()));
+    let b = write_result(dir.path(), "b.json", &triplet_file("linux-gnu-x86_64", standard_runs()));
+    let (rc, _, _) = run_report(dir.path(), &[a, b]);
+    let msg = rc.expect_err("one result file per triplet");
+    assert!(msg.contains("linux-gnu-x86_64"), "{msg}");
+}
+
+#[test]
+fn every_arm_unavailable_writes_artifacts_and_exits_1() {
+    let dir = tempfile::tempdir().unwrap();
+    let gap = RunRecord {
+        workload: "compile-small-iso".to_string(),
+        target: "v1-packed-mn".to_string(),
+        mode: None,
+        iteration: None,
+        status: RunStatus::Unavailable,
+        wall_s: None,
+        cpu_user_s: None,
+        cpu_sys_s: None,
+        peak_rss_bytes: None,
+        exit: None,
+        error: None,
+        reason: Some("no packed-mn asset for this triplet".to_string()),
+    };
+    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", vec![gap]));
+    let (rc, md, json) = run_report(dir.path(), &[a]);
+    assert_eq!(rc, Ok(1), "a red matrix is a deliverable, exit 1");
+    assert!(md.contains("unavailable — no packed-mn asset for this triplet"), "{md}");
+    assert!(json.contains("no packed-mn asset"), "{json}");
+}
+
+#[test]
+fn missing_v1_arm_renders_dash_never_an_invented_ratio() {
+    let dir = tempfile::tempdir().unwrap();
+    let runs = vec![ok_run("compile-small-iso", "v2-shim", RunMode::Warm, 1, 2.5)];
+    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", runs));
+    let (rc, md, _) = run_report(dir.path(), &[a]);
+    assert_eq!(rc, Ok(0));
+    assert!(md.contains("| v2-shim | 1 | 2.500 |"), "{md}");
+    let row = md.lines().find(|l| l.contains("v2-shim")).unwrap();
+    assert!(row.ends_with("| — |"), "{row}");
+}
+
+#[test]
+fn semantically_invalid_input_is_operational() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut bad = ok_run("compile-small-iso", "v2-shim", RunMode::Warm, 1, 2.5);
+    bad.wall_s = None; // an ok run without its wall violates the §6 rules
+    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", vec![bad]));
+    let (rc, _, _) = run_report(dir.path(), &[a]);
+    let msg = rc.expect_err("invalid input must be an operational error");
+    assert!(msg.contains("wall_s"), "{msg}");
+}

--- a/crates/tebako-bench/tests/report.rs
+++ b/crates/tebako-bench/tests/report.rs
@@ -95,24 +95,62 @@ fn run_report(dir: &Path, results: &[std::path::PathBuf]) -> (Result<u8, String>
 fn standard_runs() -> Vec<RunRecord> {
     let mut v = Vec::new();
     for (i, w) in [9.0, 10.0, 11.0].iter().enumerate() {
-        v.push(ok_run("compile-small-iso", "v1-packed-mn", RunMode::Warm, i as u32 + 1, *w));
+        v.push(ok_run(
+            "compile-small-iso",
+            "v1-packed-mn",
+            RunMode::Warm,
+            i as u32 + 1,
+            *w,
+        ));
     }
     for (i, w) in [4.0, 5.0, 6.0].iter().enumerate() {
-        v.push(ok_run("compile-small-iso", "v2-fat", RunMode::Warm, i as u32 + 1, *w));
+        v.push(ok_run(
+            "compile-small-iso",
+            "v2-fat",
+            RunMode::Warm,
+            i as u32 + 1,
+            *w,
+        ));
     }
     for (i, w) in [2.0, 2.5, 3.0].iter().enumerate() {
-        v.push(ok_run("compile-small-iso", "v2-shim", RunMode::Warm, i as u32 + 1, *w));
+        v.push(ok_run(
+            "compile-small-iso",
+            "v2-shim",
+            RunMode::Warm,
+            i as u32 + 1,
+            *w,
+        ));
     }
-    v.push(ok_run("compile-small-iso", "v1-packed-mn", RunMode::Cold, 1, 20.0));
-    v.push(ok_run("compile-small-iso", "v2-shim", RunMode::Cold, 1, 8.0));
+    v.push(ok_run(
+        "compile-small-iso",
+        "v1-packed-mn",
+        RunMode::Cold,
+        1,
+        20.0,
+    ));
+    v.push(ok_run(
+        "compile-small-iso",
+        "v2-shim",
+        RunMode::Cold,
+        1,
+        8.0,
+    ));
     v
 }
 
 #[test]
 fn merges_triplets_re_deriving_stats_and_speedups() {
     let dir = tempfile::tempdir().unwrap();
-    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", standard_runs()));
-    let b = write_result(dir.path(), "b.json", &triplet_file("macos-arm64", standard_runs()));
+    let a = write_result(
+        dir.path(),
+        "a.json",
+        &triplet_file("linux-gnu-x86_64", standard_runs()),
+    );
+    let b = write_result(
+        dir.path(),
+        "b.json",
+        &triplet_file("macos-arm64", standard_runs()),
+    );
     let (rc, md, json) = run_report(dir.path(), &[a, b]);
     assert_eq!(rc, Ok(0));
     // re-derived, never carried: the 999.0 garbage stats must not appear
@@ -142,7 +180,11 @@ fn merges_triplets_re_deriving_stats_and_speedups() {
 #[test]
 fn suite_mismatch_is_operational() {
     let dir = tempfile::tempdir().unwrap();
-    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", standard_runs()));
+    let a = write_result(
+        dir.path(),
+        "a.json",
+        &triplet_file("linux-gnu-x86_64", standard_runs()),
+    );
     let mut other = triplet_file("macos-arm64", standard_runs());
     other.suite = "another-suite".to_string();
     let b = write_result(dir.path(), "b.json", &other);
@@ -154,8 +196,16 @@ fn suite_mismatch_is_operational() {
 #[test]
 fn duplicate_triplet_is_operational() {
     let dir = tempfile::tempdir().unwrap();
-    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", standard_runs()));
-    let b = write_result(dir.path(), "b.json", &triplet_file("linux-gnu-x86_64", standard_runs()));
+    let a = write_result(
+        dir.path(),
+        "a.json",
+        &triplet_file("linux-gnu-x86_64", standard_runs()),
+    );
+    let b = write_result(
+        dir.path(),
+        "b.json",
+        &triplet_file("linux-gnu-x86_64", standard_runs()),
+    );
     let (rc, _, _) = run_report(dir.path(), &[a, b]);
     let msg = rc.expect_err("one result file per triplet");
     assert!(msg.contains("linux-gnu-x86_64"), "{msg}");
@@ -178,18 +228,35 @@ fn every_arm_unavailable_writes_artifacts_and_exits_1() {
         error: None,
         reason: Some("no packed-mn asset for this triplet".to_string()),
     };
-    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", vec![gap]));
+    let a = write_result(
+        dir.path(),
+        "a.json",
+        &triplet_file("linux-gnu-x86_64", vec![gap]),
+    );
     let (rc, md, json) = run_report(dir.path(), &[a]);
     assert_eq!(rc, Ok(1), "a red matrix is a deliverable, exit 1");
-    assert!(md.contains("unavailable — no packed-mn asset for this triplet"), "{md}");
+    assert!(
+        md.contains("unavailable — no packed-mn asset for this triplet"),
+        "{md}"
+    );
     assert!(json.contains("no packed-mn asset"), "{json}");
 }
 
 #[test]
 fn missing_v1_arm_renders_dash_never_an_invented_ratio() {
     let dir = tempfile::tempdir().unwrap();
-    let runs = vec![ok_run("compile-small-iso", "v2-shim", RunMode::Warm, 1, 2.5)];
-    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", runs));
+    let runs = vec![ok_run(
+        "compile-small-iso",
+        "v2-shim",
+        RunMode::Warm,
+        1,
+        2.5,
+    )];
+    let a = write_result(
+        dir.path(),
+        "a.json",
+        &triplet_file("linux-gnu-x86_64", runs),
+    );
     let (rc, md, _) = run_report(dir.path(), &[a]);
     assert_eq!(rc, Ok(0));
     assert!(md.contains("| v2-shim | 1 | 2.500 |"), "{md}");
@@ -202,7 +269,11 @@ fn semantically_invalid_input_is_operational() {
     let dir = tempfile::tempdir().unwrap();
     let mut bad = ok_run("compile-small-iso", "v2-shim", RunMode::Warm, 1, 2.5);
     bad.wall_s = None; // an ok run without its wall violates the §6 rules
-    let a = write_result(dir.path(), "a.json", &triplet_file("linux-gnu-x86_64", vec![bad]));
+    let a = write_result(
+        dir.path(),
+        "a.json",
+        &triplet_file("linux-gnu-x86_64", vec![bad]),
+    );
     let (rc, _, _) = run_report(dir.path(), &[a]);
     let msg = rc.expect_err("invalid input must be an operational error");
     assert!(msg.contains("wall_s"), "{msg}");

--- a/docs/spec/27-benchmarks.md
+++ b/docs/spec/27-benchmarks.md
@@ -1,10 +1,10 @@
 # Spec 27 — Benchmarks: the tebako-bench harness contract
 
-Status: PLANNED (spec-first per spec 14; slice 0 spikes executed
+Status: IMPLEMENTED (spec-first per spec 14; slice 0 spikes executed
 2026-08-25 — §9 records the evidence; the suite/platforms documents,
 schemas, the `tebako-bench validate` surface, the sampler, the
-acquisition slice, and the run engine have landed; the report renderer
-and workflow are later slices)
+acquisition slice, the run engine, the report renderer, and
+`.github/workflows/benchmark.yml` have landed)
 Depends on: 00 (locked invariants), 02 (tpkg wire format), 05
 (resolution and cache), 14 (engineering process), 16 (distribution —
 slim/fat), 17 (runtime driver contract), 19 (bootstrap distribution),


### PR DESCRIPTION
## What

Spec 27's remaining slices — the benchmark harness is complete:

- **slice 6 — the report renderer** (`tebako-bench report`): merges N per-triplet `results.json` into one markdown report + one site-ingestible `dashboard.json`. Same-suite and one-file-per-triplet are operational errors; **stats are re-derived from the merged run records** via the engine's own `compute_stats` (carried stats are never trusted, so a hand-edited record cannot smuggle a stale stat past the report); speedups are vs the `v1-*` baseline cell, rendering "—" for a missing v1 arm, never an invented ratio; cold runs are reported separately as install/first-boot metrics; unavailable/failed runs are listed explicitly; the footer carries the runner metadata, the shared-runner noise caveat, and the version-skew note. A red matrix (every arm failed/unavailable) writes both artifacts and exits 1 — a deliverable, not a crash (§8).
- **slice 7 — `.github/workflows/benchmark.yml`**: dispatch + `release: published` triggers only (never per-PR). The leg matrix is **generated from `benchmarks/platforms.yaml`** by `lib/bench-matrix.rb` — no triplet, runner, or container is named in the workflow (the YAML documents are the SSOT). musl legs cross-build the pure-Rust harness to a static musl binary and enter alpine via `docker run` (node actions cannot run on musl). A release run pins `--tebako-release` to the firing tag. The fan-in job merges `legs/bench-*/out/results.json` and, on release runs, appends `report.md` + `dashboard.json` to the `bench-history` branch (the trend record).
- **slice 8 — docs**: `benchmarks/README.md` (operator's entry: documents, invocations, exit codes, how-to-read) and spec 27 flips to IMPLEMENTED.

Slices 1–5 (suite/platforms/schemas, validate, sampler, acquisition, run engine) are already on main via #454 and #457.

## Evidence

- `cargo test -p tebako-bench`: 42 passed / 0 failed (6 new report tests, offline, incl. garbage-carried-stats proving re-derivation, and the semantic-invalid-input → exit 2 gate).
- `cargo clippy -p tebako-bench --all-targets -- -D warnings`: clean.
- `bench-matrix.rb` executed against `platforms.yaml`: emits all 7 legs (incl. both alpine-container musl legs).
- `benchmark.yml` YAML-parses; all three inline scripts pass `bash -n`.

## Remaining gate

Validated end-to-end by a full `workflow_dispatch` run before merge. Draft per the hard rule.
