### PR TITLE
ci(bench): check out the dwarfs-rs sibling in the run+report jobs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,21 +31,25 @@ jobs:
       matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     steps:
+      # ci.yml's layout: the repo lands in tebako-rs/ and its sibling path
+      # dependency dwarfs-rs in dwarfs-rs/ — cargo must LOAD every workspace
+      # member's manifest (tfs → dwarfs-t at ../dwarfs-rs) even though
+      # tebako-bench itself is pure Rust. actions/checkout refuses paths
+      # OUTSIDE the workspace, so both go under it (run 33343013677).
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # dwarfs-rs is a sibling path dependency until it has a release —
-      # cargo must LOAD every workspace member's manifest (tfs → dwarfs-t
-      # at ../dwarfs-rs) even though tebako-bench itself is pure Rust.
-      # Same pattern as ci.yml.
+        with:
+          path: tebako-rs
       - name: Checkout dwarfs-rs (sibling path dep)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: tamatebako/dwarfs-rs
-          path: ../dwarfs-rs
+          path: dwarfs-rs
           submodules: recursive
       - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
       - name: Run the matrix leg
         shell: bash
+        working-directory: tebako-rs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -90,7 +94,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-${{ matrix.triplet }}
-          path: out/
+          path: tebako-rs/out/
           if-no-files-found: error
 
   report:
@@ -101,17 +105,20 @@ jobs:
       contents: write # the bench-history append (release runs)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: tebako-rs
       # Same sibling path dep as the run legs: cargo loads the whole
       # workspace's manifests even for `-p tebako-bench`.
       - name: Checkout dwarfs-rs (sibling path dep)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: tamatebako/dwarfs-rs
-          path: ../dwarfs-rs
+          path: dwarfs-rs
           submodules: recursive
       - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
       - name: Build the harness
+        working-directory: tebako-rs
         run: cargo build -p tebako-bench
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -120,7 +127,7 @@ jobs:
       - name: Merge into the report
         run: |
           set +e
-          ./target/debug/tebako-bench report legs/bench-*/out/results.json \
+          tebako-rs/target/debug/tebako-bench report legs/bench-*/out/results.json \
             --md report.md --json dashboard.json
           rc=$?
           set -e
@@ -135,6 +142,7 @@ jobs:
           if-no-files-found: error
       - name: Append to the bench-history branch (release runs only)
         if: github.event_name == 'release'
+        working-directory: tebako-rs
         run: |
           set -e
           tag="${{ github.event.release.tag_name }}"
@@ -148,7 +156,7 @@ jobs:
           fi
           dest=".bench-history/$tag"
           mkdir -p "$dest"
-          cp report.md dashboard.json "$dest/"
+          cp ../report.md ../dashboard.json "$dest/"
           git -C .bench-history add "$tag"
           git -C .bench-history commit -m "bench: $tag (run ${{ github.run_id }})"
           git -C .bench-history push origin bench-history

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,6 +32,16 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # dwarfs-rs is a sibling path dependency until it has a release —
+      # cargo must LOAD every workspace member's manifest (tfs → dwarfs-t
+      # at ../dwarfs-rs) even though tebako-bench itself is pure Rust.
+      # Same pattern as ci.yml.
+      - name: Checkout dwarfs-rs (sibling path dep)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: tamatebako/dwarfs-rs
+          path: ../dwarfs-rs
+          submodules: recursive
       - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
       - name: Run the matrix leg
@@ -91,6 +101,14 @@ jobs:
       contents: write # the bench-history append (release runs)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Same sibling path dep as the run legs: cargo loads the whole
+      # workspace's manifests even for `-p tebako-bench`.
+      - name: Checkout dwarfs-rs (sibling path dep)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: tamatebako/dwarfs-rs
+          path: ../dwarfs-rs
+          submodules: recursive
       - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
       - name: Build the harness

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -141,7 +141,10 @@ jobs:
       - name: Merge into the report
         run: |
           set +e
-          tebako-rs/target/debug/tebako-bench report legs/bench-*/out/results.json \
+          # upload-artifact places the uploaded directory's CONTENTS at the
+          # artifact root, so each leg lands as legs/bench-<triplet>/results.json
+          # (no out/ level — first-run bug, run 33351849756).
+          tebako-rs/target/debug/tebako-bench report legs/bench-*/results.json \
             --md report.md --json dashboard.json
           rc=$?
           set -e

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -81,10 +81,13 @@ jobs:
             cargo build -p tebako-bench --target "$target"
             [ $? -ne 0 ] && exit 2   # harness build fault, not a workload red
             docker run --rm -v "$PWD:$PWD" -w "$PWD" \
-              -e GITHUB_TOKEN "$GITHUB_TOKEN" \
+              -e "GITHUB_TOKEN=$GITHUB_TOKEN" \
               "${{ matrix.container }}" \
               "./target/$target/debug/tebako-bench" run "${args[@]}"
             rc=$?
+            # docker's own failures are 125/126/127 (daemon/run/exec) — a
+            # harness fault, never a workload verdict.
+            [ "$rc" -ge 125 ] && exit 2
           else
             cargo build -p tebako-bench
             [ $? -ne 0 ] && exit 2   # harness build fault, not a workload red

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,6 +47,8 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          workspaces: tebako-rs
       - name: Run the matrix leg
         shell: bash
         working-directory: tebako-rs
@@ -65,13 +67,19 @@ jobs:
           fi
           set +e
           if [ -n "${{ matrix.container }}" ]; then
-            # musl leg: the harness is pure Rust, so it cross-builds to a
-            # static musl binary with no vcpkg and runs the workloads
-            # inside the pinned alpine container (node actions cannot run
-            # on musl — the container is entered via docker run only).
+            # musl leg: the harness cross-builds to a static musl binary
+            # (no vcpkg) and runs the workloads inside the pinned alpine
+            # container (node actions cannot run on musl — the container
+            # is entered via docker run only). NOT std-only: ring's
+            # build script needs a musl-target C compiler — musl-tools'
+            # musl-gcc (host-arch musl on both x86_64 and arm64 runners),
+            # pointed at via CC_<target> (cc-rs convention).
             target="$(rustc -vV | sed -n 's/^host: //p' | sed 's/-gnu/-musl/')"
             rustup target add "$target"
+            sudo apt-get update && sudo apt-get install -y musl-tools
+            export "CC_$(echo "$target" | tr '-' '_')=musl-gcc"
             cargo build -p tebako-bench --target "$target"
+            [ $? -ne 0 ] && exit 2   # harness build fault, not a workload red
             docker run --rm -v "$PWD:$PWD" -w "$PWD" \
               -e GITHUB_TOKEN "$GITHUB_TOKEN" \
               "${{ matrix.container }}" \
@@ -79,6 +87,7 @@ jobs:
             rc=$?
           else
             cargo build -p tebako-bench
+            [ $? -ne 0 ] && exit 2   # harness build fault, not a workload red
             bin="./target/debug/tebako-bench"
             [ -f "$bin.exe" ] && bin="$bin.exe"
             "$bin" run "${args[@]}"
@@ -117,6 +126,8 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@1.94.1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          workspaces: tebako-rs
       - name: Build the harness
         working-directory: tebako-rs
         run: cargo build -p tebako-bench


### PR DESCRIPTION
## What

benchmark.yml's `run` and `report` jobs now check out `tamatebako/dwarfs-rs` into the sibling path `../dwarfs-rs` (submodules recursive) — the same pattern ci.yml already uses.

## Why

The first post-#501 validation dispatch (run 33340015652) failed **all 8 legs identically**:

```
error: failed to load manifest for workspace member `.../crates/tfs`
  failed to load manifest for dependency `dwarfs-t`
  failed to read `/home/runner/work/tebako/dwarfs-rs/dwarfs/Cargo.toml`
  No such file or directory (os error 2)
```

`cargo build -p tebako-bench` must load every workspace member's manifest; `tfs` carries the path dependency `../dwarfs-rs/dwarfs`, which a lone repo checkout leaves absent. The harness itself is pure Rust and builds nothing from dwarfs-t — the manifest just has to resolve.

## Validation

benchmark.yml runs on dispatch/release only, so this PR's regular CI cannot cover it. Validated by dispatching the workflow on THIS branch head before merge — run id in the checks thread below; all legs must reach the harness (a leg is allowed to exit 1 = red-matrix deliverable per spec 27 §8; exit 2 = harness fault = red leg).
