### PR TITLE
fix(tfs): the per-process dl tree is process-internal — never policy-gated (tebako#502)

### DIFF
--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -709,6 +709,26 @@ impl FsContext {
                 };
             }
         }
+        // tebako#502: a dlmap spelling the image did not answer above
+        // names our own per-process materialized tree (the home-tree
+        // layout `tebako-home-<handle>/…` or a flattened drive-letter
+        // tail). Those bytes are process-internal — they rode in
+        // through the extraction writes, which are likewise ungated —
+        // and the per-process hex leaf is unauthorable as a grant
+        // (bind canonicalizes; the path does not exist at bind time).
+        // The host copy answers without the policy gate; the routing
+        // below could only gate-and-ENOENT it (a tmpdir host path
+        // matches no VFS mount point).
+        if Self::dlmap_tail(path).is_some() {
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(trace::Op::Open, path, "host")
+                        .detail("reason", Value::String("dlmap-tree".to_string()))
+                        .dur(start),
+                );
+            }
+            return Err(libc::ENOENT);
+        }
         let Some(mount) = self.find_mount(path) else {
             // Host-passthrough decision (spec 08): the policy gates the
             // consumer's fall-through to the host fs, for reads AND writes
@@ -966,6 +986,11 @@ impl FsContext {
         if self.mounts.is_empty() {
             return Err(libc::ENODEV);
         }
+        // tebako#502 (see open()): a dlmap spelling names our own
+        // materialized tree — the host directory answers, ungated.
+        if Self::dlmap_tail(path).is_some() {
+            return Err(libc::ENOENT);
+        }
         let Some(mount) = self.find_mount(path) else {
             // Host-passthrough decision (spec 08), see open().
             self.host_check(path, HostAccess::Ro)?;
@@ -1100,6 +1125,19 @@ impl FsContext {
                     return Ok(st);
                 }
             }
+        }
+        // tebako#502 (see open()): a dlmap spelling the image did not
+        // answer is our own materialized tree — the host copy answers,
+        // ungated.
+        if Self::dlmap_tail(path).is_some() {
+            if let Some(start) = trace_start {
+                trace::emit(
+                    trace::Event::new(trace::Op::Stat, path, "host")
+                        .detail("reason", Value::String("dlmap-tree".to_string()))
+                        .dur(start),
+                );
+            }
+            return Err(libc::ENOENT);
         }
         let Some(mount) = self.find_mount(path) else {
             // Host-passthrough decision (spec 08), see open().
@@ -1564,14 +1602,25 @@ impl FsContext {
             eprintln!("[tfs] dlmap2file: {path} (effective {effective})");
         }
         let mut visited = std::collections::HashSet::new();
-        let result = self.extract_for_exec(
-            effective,
-            effective,
-            &ClosureDest::Dlcache,
-            &[],
-            &mut visited,
-            closure.as_mut(),
-        );
+        // tebako#502: a dlmap spelling whose tail the mounts do not
+        // hold IS the materialized host copy already (the home-tree
+        // layout or a flattened drive-letter tail) — the consumer's
+        // fallback answers it from the host. Never gated:
+        // extract_for_exec's host_check exists for GENUINE host paths
+        // (spec 08 §3), and the per-process hex leaf is unauthorable
+        // as a grant.
+        let result = if tail.is_some() && self.find_mount(effective).is_none() {
+            Err(libc::ENOENT)
+        } else {
+            self.extract_for_exec(
+                effective,
+                effective,
+                &ClosureDest::Dlcache,
+                &[],
+                &mut visited,
+                closure.as_mut(),
+            )
+        };
         if let Ok(host) = &result {
             if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
                 eprintln!("[tfs] dlmap2file: {effective} -> {}", host.display());
@@ -3217,6 +3266,99 @@ mod tests {
         // No whole-tree: the home's data file never materializes.
         let root = host.parent().unwrap().parent().unwrap();
         assert!(!root.join("lib/modules").exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// tebako#502: the per-process dl tree (dlmap-marker paths) is
+    /// process-internal storage — the policy NEVER gates it. A deny
+    /// jail cannot name the tree (the hex leaf is per-process and bind
+    /// canonicalizes a not-yet-existing path), and the tree's content
+    /// rode in through the ungated extraction writes. The
+    /// wrapper-runtime pattern (a home-layout mount's materialized
+    /// interpreter reading its own `lib/jvm.cfg` by the host spelling)
+    /// therefore composes with a deny jail — the spec 22 §3.4 authored
+    /// JRE grant is the spelling for an operator-HOST JRE, not for the
+    /// runtime's own materialized home.
+    #[test]
+    fn deny_jail_never_gates_the_dlmap_tree() {
+        let dir = std::env::temp_dir().join(format!("tfs-dlmap-jail-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let image = fixture_home_zip(&dir, false);
+        let mut ctx = FsContext::new();
+        let mount = crate::mount::build_from_file(image.to_str().unwrap(), "/tfs").unwrap();
+        ctx.mount_checked(mount).unwrap();
+        ctx.set_host_policy(
+            crate::policy::HostPolicy::bind(crate::policy::PolicyDefault::Deny, vec![], vec![])
+                .unwrap(),
+            None,
+        );
+
+        // The java/04 dogfood's failing read: the materialized
+        // interpreter's own data file by its host spelling. "Not ours,
+        // pass through" — never a policy verdict.
+        let jvm_cfg = "/tmp/tebako-dl-abcd1234/tebako-home-0/lib/jvm.cfg";
+        assert_eq!(ctx.open(jvm_cfg, libc::O_RDONLY), Err(libc::ENOENT));
+        assert_eq!(ctx.open(jvm_cfg, libc::O_WRONLY), Err(libc::ENOENT));
+        assert_eq!(ctx.stat(jvm_cfg).unwrap_err(), libc::ENOENT);
+        assert_eq!(ctx.opendir(jvm_cfg).unwrap_err(), libc::ENOENT);
+        // The dlopen/fopen route respells to the tail — same verdict.
+        assert_eq!(ctx.dlmap2file(jvm_cfg).unwrap_err(), libc::ENOENT);
+
+        // A genuine host path stays gated under the same policy.
+        assert_eq!(ctx.open("/etc/passwd", libc::O_RDONLY), Err(libc::EPERM));
+        // And a HELD tail still answers from the image under deny — the
+        // dlmap-prefix redirect itself is untouched. The redirect serves
+        // a RAW host fd (mmap-capable — dyld maps what it opens), not a
+        // token fd, so the engine's close() does not own it; process
+        // exit reaps it.
+        ctx.open("/tmp/tebako-dl-abcd1234/tfs/bin/tool", libc::O_RDONLY)
+            .expect("a held tail materializes and serves a real fd");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// tebako#502 × spec 23 §8: under a record policy the journal is the
+    /// `tfs needs` generator's input — it records what the PAYLOAD
+    /// touched on the host. Our own materialized tree is not a need, so
+    /// a dlmap-marker path leaves no journal line.
+    #[test]
+    fn record_policy_does_not_journal_the_dlmap_tree() {
+        let dir = std::env::temp_dir().join(format!("tfs-dlmap-rec-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let image = fixture_home_zip(&dir, false);
+        let log = dir.join("journal.log");
+        let journal = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log)
+            .unwrap();
+        let mut ctx = FsContext::new();
+        let mount = crate::mount::build_from_file(image.to_str().unwrap(), "/tfs").unwrap();
+        ctx.mount_checked(mount).unwrap();
+        ctx.set_host_policy(
+            crate::policy::HostPolicy::bind(crate::policy::PolicyDefault::Record, vec![], vec![])
+                .unwrap(),
+            Some(journal),
+        );
+
+        let jvm_cfg = "/tmp/tebako-dl-abcd1234/tebako-home-0/lib/jvm.cfg";
+        assert_eq!(ctx.open(jvm_cfg, libc::O_RDONLY), Err(libc::ENOENT));
+        // Control: a genuine host read journals as today.
+        assert_eq!(ctx.open("/etc/hosts", libc::O_RDONLY), Err(libc::ENOENT));
+        drop(ctx);
+
+        let text = std::fs::read_to_string(&log).unwrap();
+        assert!(
+            text.contains("event=jail-allow path=/etc/hosts op=read"),
+            "{text}"
+        );
+        assert!(
+            !text.contains("tebako-dl"),
+            "the dl tree is not a host need: {text}"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/docs/spec/08-jails.md
+++ b/docs/spec/08-jails.md
@@ -145,6 +145,17 @@ int tebako_fs_host_policy(int default_open /* 0 = deny */,
   not EROFS, so the consumer's pass-through can perform the write
   (profile 1: "cwd + writes pass through"). Held memfs content is
   byte-for-byte unchanged (write opens on it stay EROFS).
+- The per-process materialization tree is NOT a host path for policy
+  purposes (tebako#502, 2026-08-30): a dlmap-marker path
+  (`…/tebako-dl-<hex>/…` — closure copies and the home-layout
+  whole-tree roots `tebako-home-<handle>/…`) the image does not answer
+  is the runtime's own extraction served by its host copy. Every route
+  (`open`/`stat`/`opendir`/`dlmap2file`) answers it ENOENT without
+  consulting the policy: the hex leaf is per-process (unauthorable at
+  bind — the path does not exist to canonicalize), the content rode in
+  through the ungated extraction writes, and the tree is removed at
+  process exit. This is what lets a wrapper-pattern runtime (spec 22
+  §3's exec cache) compose with a `deny` jail.
 - "Host path" means **any path the mounts do not hold** — outside every
   mount, or covered by a mount but absent from its image (spec 11 §2):
   the app payload mounts at `/` and the host filesystem stays

--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -646,6 +646,17 @@ The floor's promise is the end of the segfault class: every missing
 grant surfaces as the workload's own named error, pinned in the audit
 journal — never a crash in someone else's library.
 
+Amended 2026-08-30 (tebako#502): the acceptance shape above predates
+the wrapper-runtime pattern. A home-annotated runtime payload
+materializes the interpreter's home INTO the per-process dl tree (§3's
+exec cache), and the booted JVM's own reads then name
+`…/tebako-dl-<hex>/tebako-home-<n>/…` — process-internal storage that
+never reaches the gate (spec 08 §3's exemption). A wrapper runtime
+therefore composes with a `deny` jail with NO tool-tree grant at all;
+the authored `<jre>:ro` ingredient remains the spelling for an
+operator-INSTALLED host JRE (the non-wrapper pattern this section was
+locked on).
+
 ## 4. Class R — declarative boot materialization
 
 **Rule R1.** An image manifest MAY declare `materialize: [paths]`

--- a/docs/spec/23-declarative-composition.md
+++ b/docs/spec/23-declarative-composition.md
@@ -205,8 +205,11 @@ the bytes come from, never WHAT runs.
      surface, our declaration, in code — never a payload's burden. The
      load-time materialization writes (spec 22's dlmap surfaces,
      windows' leave-in-place dll map included, spec 22 §2.1) are
-     process-internal and never policy-gated — the cache stays
-     read-only to payload IO;
+     process-internal and never policy-gated — and neither are the
+     reads-back of that same tree (a materialized interpreter's own
+     home reads; tebako#502, 2026-08-30 — the per-process hex leaf is
+     unauthorable as a grant, and the tree's content is image content
+     by construction); the cache stays read-only to payload IO;
   4. the union of declared needs (§2), symbolic atoms resolved;
   5. the composition's `mounts:`/`needs:` (D2/D5) and operator config;
   6. `argument_files: auto` — payload arguments naming existing host
@@ -288,7 +291,9 @@ guess:
   per observed path, aggregated on the atom-SUBSTITUTED form so raw
   variants of one path (`/T/x` vs `/T//x`) merge; access = the
   strongest observed op (any write ⇒ `rw`); floor, store, and
-  exec-cache paths EXCLUDED (they are automatic — never declared);
+  exec-cache paths EXCLUDED (they are automatic — never declared; since
+  tebako#502 the exec-cache tree is not even journaled — the exclusion
+  covers pre-fix journals);
   symbolic atoms re-substituted (`/Users/alice/…` → `$HOME/…`,
   longest prefix wins); relative and empty paths (cwd- or
   dirfd-relative probes — not declarable) OMITTED and counted in the

--- a/docs/spec/schemas/trace-event.yaml
+++ b/docs/spec/schemas/trace-event.yaml
@@ -119,7 +119,7 @@ grammar:
           from (dlmap-prefix redirect; the preload's fopen routing) — the
           spec 25 §4 materialize-candidate signal.
         effective: "the memfs path, when the presented spelling was a dlmap-prefix path"
-        reason: "no-mounts — the degenerate passthrough with an empty mount table"
+        reason: "no-mounts — the degenerate passthrough with an empty mount table; dlmap-tree — a dlmap-marker path the image did not answer: the runtime's own materialization tree, passed through ungated (spec 08 §3, tebako#502)"
         closure: "the closure-walk record (see dlopen), on the fopen surface"
       notes: >-
         denied:<rule> carries the policy source label, or `write-gate`


### PR DESCRIPTION
# Fix deny jail × exec-cache runtime composition (tebako#502)

Closes #502.

## Problem

A runtime whose interpreter is materialized to the exec cache (the
wrapper-exe pattern, spec 22 §3/§6 — e.g. the openjdk runtime payload,
tebako-packages/openjdk#23) could not run under a **deny jail**: the run
failed closed.

Mechanism, confirmed in code:

1. The materialized interpreter reads its own home by host paths
   (`<dl-tmpdir>/tebako-home-<handle>/lib/jvm.cfg`).
2. The preload shim routes those reads into the engine, where
   `dlmap_tail` strips the `tebako-dl-<hex>` marker and the tail
   (`/tebako-home-0/lib/jvm.cfg`) matches no mount.
3. The miss fell through to the host-passthrough policy check
   (`open`/`stat`/`opendir`/`dlmap2file` — `crates/tfs/src/context.rs`).
4. `HostPolicy::check` matches only canonical host prefixes; the
   per-process hex leaf is unauthorable as a grant (bind canonicalizes,
   and the path does not exist at bind time → exit 73). Under a deny
   default the verdict is EPERM — fail-closed, exactly as the dogfood
   journaled (`event=jail-deny path=/tebako-home-0/lib/jvm.cfg`).

## Fix

The per-process dl tree is **process-internal storage**, on every route:

- `open`/`stat`: a dlmap spelling the image did not answer (redirect
  miss) now returns ENOENT ("not ours, pass through" — the host copy
  answers) without consulting the policy, traced as `host` with
  `reason: dlmap-tree`.
- `opendir`: same bypass (it had no redirect at all; a deny jail broke
  directory listing of the tree the same way).
- `dlmap2file`: a spelling whose tail the mounts do not hold IS the
  materialized host copy already — answers ENOENT for the consumer's
  fallback without entering `extract_for_exec`. Genuine host paths keep
  the spec 08 §3 gate (the only change is for marker-spelled paths).

Rationale: the tree's content rode in through the extraction writes,
which are already process-internal and ungated; the hex leaf is
per-process and unauthorable at bind; the tree is removed at exit. A
jailed payload cannot place anything into the tree (host writes stay
gated), so the bypass exposes nothing beyond image content the payload
already has.

Behavior under `open` is byte-identical (the gate allowed these paths
anyway). Under `record`, these paths are no longer journaled — they are
not a payload `needs:` entry (spec 23 §8's generator already excluded
exec-cache paths; the exclusion now covers pre-fix journals only).

## Tests (TDD — red first, then green)

- `deny_jail_never_gates_the_dlmap_tree` — open (ro AND wr), stat,
  opendir, dlmap2file of a home-tree spelling all answer ENOENT under a
  deny jail (were EPERM); a genuine host path stays EPERM; a HELD tail
  still materializes and serves a real fd under deny (the redirect is
  untouched).
- `record_policy_does_not_journal_the_dlmap_tree` — no `jail-allow` line
  for the tree; a genuine host read still journals.

## Spec sync (same PR, spec 14 order)

- spec 08 §3: new shipped-semantics bullet — the exemption.
- spec 22 §3.4: amendment — the wrapper-runtime pattern needs NO
  tool-tree grant under deny; the authored `<jre>:ro` ingredient remains
  the spelling for an operator-installed host JRE.
- spec 23 §6 step 3 + §8: the internal status extends to reads-back;
  the generator note covers pre-fix journals.
- trace-event.yaml: `reason: dlmap-tree` documented.

## Evidence

- Red run: both new tests failed pre-fix (`Err(EPERM)`; journal carried
  `jail-allow path=/tmp/tebako-dl-abcd1234/…`).
- Green run: `cargo test -p tfs --lib` — full suite (see PR checks).
