### PR TITLE
fix(driver): args_default's single owner is the runtime side (tebako#503)

### DIFF
--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -1109,15 +1109,22 @@ pub fn boot_with_mount_modes(
             }
             Some(_) => {
                 let resolved = resolve_entry(&h, runtime_root, &mounted)?;
-                // The rewritten argv keeps the interpreter's convention:
-                // argv[0] (the program name) first, then the resolved
-                // entry as the script, then the user's args verbatim.
-                // Dropping argv[0] makes the interpreter treat the entry
-                // as its own name and the first user arg as the script.
-                let mut v = Vec::with_capacity(h.user_args.len() + 2);
+                // spec 17 §1 / tebako#503: the entrypoint's declared
+                // `args_default` composes between the interpreter and the
+                // resolved entry — the runtime side is its single owner
+                // (the shim appends it only in the zero-runtime case,
+                // where no driver exists). The rewritten argv keeps the
+                // interpreter's convention: argv[0] (the program name)
+                // first, then the defaults, then the resolved entry as
+                // the script, then the user's args verbatim. Dropping
+                // argv[0] makes the interpreter treat the entry as its
+                // own name and the first user arg as the script.
+                let defaults = crate::wrapper::args_default(&h, runtime_root)?;
+                let mut v = Vec::with_capacity(h.user_args.len() + defaults.len() + 2);
                 if let Some(program) = argv.first() {
                     v.push(program.clone());
                 }
+                v.extend(defaults);
                 v.push(resolved);
                 v.extend(h.user_args.iter().cloned());
                 v

--- a/crates/tebako-driver/src/wrapper.rs
+++ b/crates/tebako-driver/src/wrapper.rs
@@ -247,13 +247,13 @@ fn interpreter_vfs_path(
 /// entrypoint declaring this path all mean an empty list — the
 /// positional-entry form — never an error; a corrupt manifest stays the
 /// named 65 it is everywhere (the image lying).
-fn args_default(h: &Handoff, outcome: &BootOutcome) -> Result<Vec<String>, DriverError> {
+pub(crate) fn args_default(h: &Handoff, runtime_root: &str) -> Result<Vec<String>, DriverError> {
     let entry_case = h.entry.as_deref().is_some_and(|e| e.contains('/'));
     let (Some(first), Some(entry), true) = (h.images.first(), h.entry.as_deref(), entry_case)
     else {
         return Ok(Vec::new());
     };
-    let mount = qualify_mount(&first.mount, &outcome.runtime_root);
+    let mount = qualify_mount(&first.mount, runtime_root);
     let Some(manifest_doc) = mounted_manifest_at(&mount)? else {
         return Ok(Vec::new());
     };
@@ -267,16 +267,17 @@ fn args_default(h: &Handoff, outcome: &BootOutcome) -> Result<Vec<String>, Drive
 }
 
 /// The composition (spec 29 §1): the interpreter at index 0, then the
-/// entrypoint's `args_default`, then the boot's rewritten argv sans the
-/// original program name — `[entry resolved, user args…]` in the entry
-/// case, the interpreter's own args in the bare/smoke forms, the user
-/// args in the interpreter-keyword form (the keyword itself was dropped
-/// by the boot, spec 17 §1).
-fn compose(program: String, defaults: Vec<String>, outcome: &BootOutcome) -> Launch {
+/// boot's rewritten argv sans the original program name. The boot
+/// already composed the entrypoint's declared `args_default` between
+/// argv0 and the resolved entry (spec 17 §1, tebako#503 — single
+/// owner), so `rest` is `[args_default…, entry resolved, user args…]`
+/// in the entry case, the interpreter's own args in the bare/smoke
+/// forms, the user args in the interpreter-keyword form (the keyword
+/// itself was dropped by the boot).
+fn compose(program: String, outcome: &BootOutcome) -> Launch {
     let rest = outcome.argv.get(1..).unwrap_or(&[]);
-    let mut argv = Vec::with_capacity(1 + defaults.len() + rest.len());
+    let mut argv = Vec::with_capacity(1 + rest.len());
     argv.push(program.clone());
-    argv.extend(defaults);
     argv.extend(rest.iter().cloned());
     Launch { program, argv }
 }
@@ -424,14 +425,16 @@ fn tail(h: &Handoff, outcome: &BootOutcome, env: &dyn Env) -> Result<BootAction,
     let vfs = interpreter_vfs_path(&layout, &outcome.runtime_root, &image)?;
     let mech = mechanism(&layout, &image)?;
     let program = materialize(&vfs, mech, &outcome.runtime_root)?;
-    let defaults = args_default(h, outcome)?;
+    let defaults = args_default(h, &outcome.runtime_root)?;
     let entry_index = if h.entry.as_deref().is_some_and(|e| e.contains('/')) {
-        // [program, defaults…, ENTRY, user args…] — fixed at composition.
+        // [program, defaults…, ENTRY, user args…] — the boot composed
+        // the defaults into outcome.argv (tebako#503); the entry's
+        // index is fixed at composition.
         Some(1 + defaults.len())
     } else {
         None
     };
-    let mut launch = compose(program, defaults, outcome);
+    let mut launch = compose(program, outcome);
     bridge_entry(&mut launch, mech, entry_index)?;
     Ok(BootAction::Launch(launch))
 }
@@ -543,20 +546,20 @@ mod tests {
 
     #[test]
     fn compose_puts_the_interpreter_at_index_zero() {
+        // the boot's rewritten argv already carries the entrypoint's
+        // args_default between argv0 and the entry (spec 17 §1,
+        // tebako#503) — compose only swaps in the interpreter program
         let outcome = BootOutcome {
             argv: vec![
                 "wrapper".to_string(),
+                "-jar".to_string(),
                 "/bin/app".to_string(),
                 "-x".to_string(),
             ],
             layout: None,
             runtime_root: "/__tfs__".to_string(),
         };
-        let launch = compose(
-            "/cache/java".to_string(),
-            vec!["-jar".to_string()],
-            &outcome,
-        );
+        let launch = compose("/cache/java".to_string(), &outcome);
         assert_eq!(launch.program, "/cache/java");
         assert_eq!(launch.argv, vec!["/cache/java", "-jar", "/bin/app", "-x"]);
         // no defaults, no entry (the bare form): the interpreter's own args
@@ -565,7 +568,7 @@ mod tests {
             layout: None,
             runtime_root: "/__tfs__".to_string(),
         };
-        let launch = compose("/cache/java".to_string(), vec![], &outcome);
+        let launch = compose("/cache/java".to_string(), &outcome);
         assert_eq!(launch.argv, vec!["/cache/java", "--version"]);
     }
 

--- a/crates/tebako-driver/tests/boot.rs
+++ b/crates/tebako-driver/tests/boot.rs
@@ -2533,6 +2533,48 @@ fn boot_materializes_a_declared_payload_resource() {
     let _ = std::fs::remove_dir_all(&resources);
 }
 
+/// tebako#503: args_default has ONE owner — the runtime side. The
+/// linked driver composes the entrypoint's declared `args_default`
+/// (spec 03 §2.2) between argv[0] and the resolved entry — spec 29 §1's
+/// composition, which the spec-17 §1 rewrite shares ("no
+/// wrapper-specific argv grammar"), read from the app payload's own
+/// manifest.
+#[test]
+fn boot_composes_args_default_between_program_and_entry() {
+    let g = guard("args-default");
+    let manifest = payload_manifest(
+        "app",
+        "provides:\n  entrypoints: [{name: app, path: /bin/app, args_default: [\"-jar\"]}]\n  \
+         platforms: universal\n  capabilities: {exec: true, read: true}",
+    );
+    let p = g.path().join("app.tfs");
+    build_zip(
+        &p,
+        &["bin/", "__tpkg__/"],
+        &[
+            ("bin/app", b"#!/usr/bin/env ruby\n".as_slice()),
+            ("__tpkg__/manifest.yaml", manifest.as_bytes()),
+        ],
+    );
+    let env = MapEnv::new();
+
+    let out = boot(
+        &argv(&[
+            "ruby",
+            "--tebako-image",
+            &format!("{}:0:/", p.display()),
+            "--tebako-entry",
+            "/bin/app",
+            "user-arg",
+        ]),
+        "/__tfs__",
+        &env,
+    )
+    .unwrap();
+
+    assert_eq!(out.argv, argv(&["ruby", "-jar", "/bin/app", "user-arg"]));
+}
+
 #[test]
 fn a_listed_but_absent_path_is_a_named_boot_error() {
     let g = guard("mat-absent");

--- a/crates/tebako-driver/tests/wrapper.rs
+++ b/crates/tebako-driver/tests/wrapper.rs
@@ -692,12 +692,13 @@ fn linked_and_wrapper_boots_compose_identically() {
     let launch = launch_of(run(&wire, WRAPPER_RUNTIME_ROOT, &wrapper_env).unwrap());
 
     // Parity: the handoff env the two boots produce is byte-identical,
-    // and the wrapper's argv tail past the interpreter + args_default is
-    // the linked argv minus its program name (the interpreter stands at
-    // index 0 in the wrapper's composition, spec 29 §1).
+    // and the wrapper's argv tail past the materialized interpreter is
+    // the linked argv minus its program name — BOTH carry the
+    // entrypoint's args_default between the program and the entry (the
+    // boot's single ownership, spec 17 §1 / tebako#503).
     assert_eq!(linked_env.map(), wrapper_env.map(), "the handoff envs");
     let linked_tail: Vec<String> = linked.argv.iter().skip(1).cloned().collect();
-    let wrapper_tail: Vec<String> = launch.argv.iter().skip(2).cloned().collect();
+    let wrapper_tail: Vec<String> = launch.argv.iter().skip(1).cloned().collect();
     assert_eq!(wrapper_tail, linked_tail, "the rewritten argv tails");
     assert_eq!(launch.argv[1], "-jar", "the entrypoint's args_default");
 }

--- a/crates/tebako-shim/src/dispatch.rs
+++ b/crates/tebako-shim/src/dispatch.rs
@@ -223,10 +223,15 @@ pub fn plan(
                 );
             }
             argv.push(entry_host.to_string_lossy().into_owned());
+            // tebako#503: with no runtime there is no driver, so the shim
+            // stays the sole composer of the entrypoint's declared
+            // `args_default` here — as leading args after the entry host
+            // path. The runtime path's driver composes them between the
+            // interpreter and the entry instead (spec 17 §1).
+            argv.extend(entry.args_default.iter().cloned());
             entry_host
         }
     };
-    argv.extend(entry.args_default.iter().cloned());
     argv.extend(user_args.iter().cloned());
 
     // spec 08: the dispatcher's computed jail env always wins over every

--- a/crates/tebako-shim/tests/dispatch.rs
+++ b/crates/tebako-shim/tests/dispatch.rs
@@ -45,14 +45,16 @@ fn runtime_entrypoint_composes_the_abi_v1_handoff() {
 
     assert_eq!(plan.program, exe);
     assert!(matches!(plan.runtime, RuntimeResolution::Ready(_)));
-    // <runtime> --tebako-image <image>:0:/ --tebako-entry <path> <defaults> <user args>
+    // <runtime> --tebako-image <image>:0:/ --tebako-entry <path> <user args>
+    // tebako#503: args_default does NOT ride the handoff — the runtime
+    // side composes it (spec 29 §1 / spec 17 §1); the shim carrying it
+    // doubled the composition on the wrapper path.
     let expected: Vec<String> = vec![
         exe.to_string_lossy().into_owned(),
         "--tebako-image".into(),
         format!("{}:0:/", image.display()),
         "--tebako-entry".into(),
         "/app/bin/metanorma".into(),
-        "--safe".into(),
         "compile".into(),
         "doc.xml".into(),
     ];
@@ -108,6 +110,41 @@ fn zero_runtime_entrypoint_skips_runtime_resolution() {
         "TEBAKO_TFS_MOUNTS must NOT be exported for zero-runtime"
     );
     assert_eq!(plan.mounts.len(), 1);
+}
+
+#[test]
+fn zero_runtime_entrypoint_keeps_args_default_in_the_argv() {
+    // tebako#503: a zero-runtime entry HAS no runtime side to compose
+    // args_default — the shim owns them (the program's leading args).
+    // For a runtime entry the shim appends nothing (the driver
+    // composes, spec 29 §1).
+    let tmp = TempDir::new("zero-runtime-defaults");
+    let home = tmp.path().join("home");
+    let _image = seed_tool(
+        &home,
+        "inkview",
+        "  entrypoints:\n    - name: inkview\n      path: /app/bin/inkview\n      args_default: [\"--batch\"]\n",
+        "8.1.0",
+    );
+    let entry_host = home
+        .join("payloads")
+        .join("inkview")
+        .join("8.1.0.tree")
+        .join("app/bin/inkview");
+    std::fs::create_dir_all(entry_host.parent().unwrap()).unwrap();
+    std::fs::write(&entry_host, b"#!/bin/sh\n").unwrap();
+    let mut ctx = ctx(&home, tmp.path());
+    pin_env(&mut ctx, "inkview", "8.1.0");
+
+    let plan = dispatch::dispatch("inkview", &["file.svg".into()], &ctx).unwrap();
+
+    assert!(matches!(plan.runtime, RuntimeResolution::Zero));
+    let expected: Vec<String> = vec![
+        entry_host.to_string_lossy().into_owned(),
+        "--batch".into(),
+        "file.svg".into(),
+    ];
+    assert_eq!(plan.argv, expected);
 }
 
 #[test]

--- a/docs/spec/03-payload-manifest.md
+++ b/docs/spec/03-payload-manifest.md
@@ -46,7 +46,11 @@ annotations: {…}                      # free-form; unknown keys preserved
 entrypoints:                          # ARRAY — multi-entry suites; N=1 for simple apps
   - name: metanorma                   # the command name (shim registers under this)
     path: /app/bin/metanorma          # inside the image
-    args_default: []
+    args_default: []                    # interpreter-side defaults composed BETWEEN interpreter
+                                        # and entry by the runtime driver (spec 17 §1 — the single
+                                        # owner, tebako#503) — java: ["-jar"]. A ZERO-runtime entry
+                                        # has no driver: the shim appends them as the program's
+                                        # leading args.
     runtime_requirement: {engine: ruby, constraint: ">= 3.3, < 5.0"}
       # OPTIONAL — omit entirely for native entrypoints (see below);
       # range for pure-language; abi-line "~> 3.3.0" for native-extension payloads.

--- a/docs/spec/17-runtime-driver-contract.md
+++ b/docs/spec/17-runtime-driver-contract.md
@@ -109,9 +109,16 @@ learns which pattern a runtime uses.
 - Everything before the first `--tebako-*` is the loader's; everything
   after `--tebako-entry` is the user's, verbatim. On success the driver
   replaces the process argv with
-  `[<original argv0>, <entry resolved in the VFS>, <user args…>]` — the
-  program name stays at index 0 so the interpreter parses its argv
-  conventionally and takes the entry as its script.
+  `[<original argv0>, <args_default…>, <entry resolved in the VFS>, <user args…>]`
+  — the entrypoint's declared `args_default` (spec 03 §2.2), read from
+  the app payload's own manifest, composes between the interpreter and
+  the entry, and the program name stays at index 0 so the interpreter
+  parses its argv conventionally and takes the entry as its script.
+  args_default has ONE owner (tebako#503, 2026-08-31): the runtime side
+  — this rewrite, linked and wrapper patterns alike (spec 29 §1).
+  Loaders (the shim's dispatch, the bootstrap's handoff) never carry
+  it; a zero-runtime entrypoint (no driver exists) is the exception —
+  there the shim appends them as the program's leading args.
 
 ## 2. Environment
 

--- a/docs/spec/29-wrapper-exe-driver.md
+++ b/docs/spec/29-wrapper-exe-driver.md
@@ -63,7 +63,9 @@ the entrypoint's declared `args_default` (spec 03 §2.2) composed
 between, so a jar entry `{path: /app/jing.jar, args_default: ["-jar"]}`
 execs `java -jar <entry> <user args…>`. Entrypoints whose interpreter
 takes the entry positionally declare an empty `args_default`. There is
-no wrapper-specific argv grammar.
+no wrapper-specific argv grammar. The linked driver composes
+identically (tebako#503): args_default's single owner is the runtime
+side — loaders (the shim, the bootstrap) never carry it.
 
 ## 2. The interpreter-path declaration
 


### PR DESCRIPTION
# Fix args_default composition ownership (tebako#503)

Closes #503.

## Problem

An entrypoint's declared `args_default` (spec 03 §2.2 — e.g.
`{path: /app/jing.jar, args_default: ["-jar"]}`) was composed **only by
the shim**, appended after the full handoff:

```
<runtime exe> --tebako-image … --tebako-entry /app/jing.jar -jar <user args…>
```

The driver then rewrote `[--tebako-entry <path>, <user args…>]` into
`[argv0, <entry resolved>, <user args…>]` — and the `-jar` landed
**after** the entry, where interpreters treat it as a user arg, not an
interpreter/launcher flag. Spec 29 §1's normative grammar —
`[interpreter, args_default…, entry, user args…]`, "no wrapper-specific
argv grammar" — was already the contract; the linked driver (spec 17)
never implemented it. Two composers, two positions, one wrong.

## Fix

`args_default`'s single owner is the **runtime side** (the driver):

- The linked driver's entry-case rewrite now composes
  `[<original argv0>, <args_default…>, <entry resolved>, <user args…>]`
  (spec 17 §1). `wrapper::args_default` is shared verbatim — it reads
  the app payload's manifest from the FIRST `--tebako-image` triple's
  mount, matched against the declared entry path; no manifest, a
  non-app payload, or no matching entrypoint all mean an empty list,
  never an error. It now takes `runtime_root` instead of the whole
  `BootOutcome` so both call sites (linked boot, wrapper bridge-index)
  use it.
- The wrapper's `compose` no longer inserts defaults itself — the boot
  outcome already carries them, so the wrapper swaps in the
  materialized interpreter program and nothing more. It still reads
  `args_default` once to compute the entry's fixed index for the
  exec-cache argv bridge (`1 + defaults.len()` — the defaults sit
  inside the composed argv).
- The shim keeps appending `args_default` ONLY in the zero-runtime case
  (no driver exists there; the entry host path is the program, so the
  declared args follow it as leading args). The runtime path no longer
  appends them at all.

All production ruby payloads declare `args_default: []` (metanorma and
fontist feedstock manifests verified), so standardizing the position
changes no ruby-era behavior; the openjdk runtime's `["-jar"]` entry
(tebako-packages/openjdk#23) is the first real consumer.

## Tests (TDD — red first, then green)

- `boot_composes_args_default_between_program_and_entry`
  (tebako-driver, new): boots an app payload whose entrypoint declares
  `args_default: ["-jar"]` with `--tebako-entry /bin/app user-arg`;
  asserts `argv == ["ruby", "-jar", "/bin/app", "user-arg"]`.
  **Red pre-fix**: `["ruby", "/bin/app", "user-arg"]`.
- `runtime_entrypoint_composes_the_abi_v1_handoff` (tebako-shim,
  updated): the shim's runtime-path handoff now carries NO args_default
  (`--safe` gone — **red pre-fix**: left still had it).
- `zero_runtime_entrypoint_keeps_args_default_in_the_argv`
  (tebako-shim, new): zero-runtime entries keep the shim-composed
  position — entry host path, then `--batch`, then user args (passes
  pre-fix; pins the preserved behavior).

## Spec sync (same PR, spec 14 order)

- spec 03 §2.2: `args_default` comment — interpreter-side semantics,
  composed between the interpreter and the entry by the driver; single
  owner tebako#503; zero-runtime → the shim appends as leading args.
- spec 17 §1: rewrite grammar is now
  `[<original argv0>, <args_default…>, <entry resolved>, <user args…>]`
  + the one-owner paragraph.
- spec 29 §1: "The linked driver composes identically (tebako#503)…".

## Evidence

- Red run: both new/updated tests failed pre-fix (driver left:
  `["ruby", "/bin/app", "user-arg"]`; shim left still carried `--safe`).
- Green run: `cargo test -p tebako-shim` + `cargo test -p tebako-driver`
  full suites (see PR checks).
