### PR TITLE
ci(release): ship the tebako-runtime-launcher asset on all seven platforms

### DIFF
--- a/.github/workflows/lib/finalize.sh
+++ b/.github/workflows/lib/finalize.sh
@@ -23,7 +23,7 @@ mkdir -p out/sidecars
 for platform_dir in "$FRAG"/frag-*; do
   platform="${platform_dir##*/frag-}"
   exe=""; case "$platform" in windows-*) exe=".exe" ;; esac
-  for tool in tebako-bootstrap tfs tebako-pkg tebako tebako-shim; do
+  for tool in tebako-bootstrap tfs tebako-pkg tebako tebako-shim tebako-runtime-launcher; do
     sha=$(cat "$platform_dir/${tool}-${platform}.sha256")
     name="${tool}-${VERSION}-${platform}${exe}"
     echo "$sha  $name" >> out/SHA256SUMS
@@ -37,7 +37,8 @@ sort -k2 -o out/SHA256SUMS out/SHA256SUMS
 #   "name": "tebako-rs",
 #   "version": "<VERSION>",
 #   "assets": [ {platform, file, sha256, size_bytes}, ... ],   # tebako-bootstrap
-#   "tools": { "tfs": [...], "tebako-pkg": [...], "tebako": [...], "tebako-shim": [...] }
+#   "tools": { "tfs": [...], "tebako-pkg": [...], "tebako": [...],
+#              "tebako-shim": [...], "tebako-runtime-launcher": [...] }
 # }
 # The `assets` array is exactly the BootstrapManager's consumed shape, so
 # the gem/tebako-cli resolve the Rust bootstrap unchanged. Windows asset
@@ -64,6 +65,7 @@ tfs_json=$(jq_entries tfs | jq -s 'sort_by(.platform)')
 pkg_json=$(jq_entries tebako-pkg | jq -s 'sort_by(.platform)')
 cli_json=$(jq_entries tebako | jq -s 'sort_by(.platform)')
 shim_json=$(jq_entries tebako-shim | jq -s 'sort_by(.platform)')
+launcher_json=$(jq_entries tebako-runtime-launcher | jq -s 'sort_by(.platform)')
 
 jq -n \
   --arg version "$VERSION" \
@@ -72,6 +74,7 @@ jq -n \
   --argjson pkg "$pkg_json" \
   --argjson cli "$cli_json" \
   --argjson shim "$shim_json" \
+  --argjson launcher "$launcher_json" \
   '{
     name: "tebako-rs",
     version: $version,
@@ -80,7 +83,8 @@ jq -n \
       "tfs": $tfs,
       "tebako-pkg": $pkg,
       "tebako": $cli,
-      "tebako-shim": $shim
+      "tebako-shim": $shim,
+      "tebako-runtime-launcher": $launcher
     }
   }' > out/manifest.json
 
@@ -98,7 +102,7 @@ cat out/manifest.json
   echo "|---|---|---|"
   for platform_dir in $(ls -d "$FRAG"/frag-* | sort); do
     platform="${platform_dir##*/frag-}"
-    for tool in tebako-bootstrap tfs tebako-pkg tebako tebako-shim; do
+    for tool in tebako-bootstrap tfs tebako-pkg tebako tebako-shim tebako-runtime-launcher; do
       size=$(cat "$platform_dir/${tool}-${platform}.size")
       echo "| $platform | $tool | $size |"
     done

--- a/.github/workflows/lib/ship-gate.sh
+++ b/.github/workflows/lib/ship-gate.sh
@@ -86,6 +86,11 @@ bad() {
 expected_rc() {
   case $1 in
     tebako-bootstrap*) echo 65 ;;  # named bare-trailer error (EX_TEBAKO_MANIFEST)
+    # The spec-29 wrapper exe with no handoff answers its named
+    # no-env-image error (spec 29 §2) — pinned: bare AND --version both
+    # exit 65 (the interpreter lives in the env image; there is no
+    # --version without one). Must precede the tebako-* catch-all.
+    tebako-runtime-launcher*) echo 65 ;;
     tebako-shim*)      echo 0 ;;   # --help
     tebako-pkg*)       echo 0 ;;   # --help
     tebako-*)          echo 0 ;;   # --version
@@ -99,6 +104,7 @@ expected_rc() {
 smoke_args() {
   case $1 in
     tebako-bootstrap*) echo "" ;;
+    tebako-runtime-launcher*) echo "" ;;
     tebako-shim*)      echo "--help" ;;
     tebako-pkg*)       echo "--help" ;;
     tebako-*)          echo "--version" ;;

--- a/.github/workflows/lib/stage.sh
+++ b/.github/workflows/lib/stage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# stage.sh — stage the five release binaries for one platform, strip
+# stage.sh — stage the six release binaries for one platform, strip
 # them, publish the size table, gate the bootstrap size, and write the
 # sha/size fragments the finalize job merges into SHA256SUMS +
 # manifest.json.
@@ -23,7 +23,9 @@ SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
 # Tool list: binary names equal the artifact tool names (no mapping
 # table — this script must also run under bash 3.2 / POSIX sh, which
 # have no `declare -A`). tebako-shim is the dispatcher (TODO.testing/07).
-TOOLS="tebako-bootstrap tfs tebako-pkg tebako tebako-shim"
+# tebako-runtime-launcher is the spec-29 wrapper exe (the repacked-
+# runtime ship form — tebako-packages/openjdk#23's download).
+TOOLS="tebako-bootstrap tfs tebako-pkg tebako tebako-shim tebako-runtime-launcher"
 
 mkdir -p out "fragments/frag-$PLATFORM"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
             --overlay-ports crates/sqfs-sys/vcpkg_ports
           echo "SQFS_SYS_VCPKG_INSTALLED_DIR=${{ github.workspace }}/.sqfs-installed/${{ matrix.triplet }}" >> "$GITHUB_ENV"
 
-      - name: Build the five binaries + the link-unit libs (release)
+      - name: Build the six binaries + the link-unit libs (release)
         working-directory: tebako-rs
         env:
           DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
@@ -224,6 +224,8 @@ jobs:
         # --skip-build — they must be explicit -p packages or no .a/cdylib
         # is emitted (run 30742821370). tebako-cli already unifies tfs's
         # default features on POSIX, so one invocation serves both.
+        # tebako-runtime-launcher (the spec-29 wrapper exe) rides the
+        # same invocation — it links tebako-driver anyway.
         # tebako-bootstrap builds in its OWN invocation: cargo unifies
         # features within one invocation, and sharing one with
         # tebako-cli/tebako-shim re-enables tebako-resolve's `git`
@@ -235,6 +237,7 @@ jobs:
           cargo build --release --target ${{ matrix.target }} -p tebako-bootstrap
           cargo build --release --target ${{ matrix.target }} \
             -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim \
+            -p tebako-runtime-launcher \
             -p tfs -p tebako-driver -p libtfs-preload
 
       - name: Stage, strip, size-gate
@@ -303,6 +306,12 @@ jobs:
       - name: Upload tebako-shim
         if: needs.prepare.outputs.upload_url != ''
         run: gh release upload "${{ needs.prepare.outputs.tag_name }}" "tebako-rs/out/tebako-shim-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload tebako-runtime-launcher
+        if: needs.prepare.outputs.upload_url != ''
+        run: gh release upload "${{ needs.prepare.outputs.tag_name }}" "tebako-rs/out/tebako-runtime-launcher-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -437,6 +446,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload tebako-runtime-launcher
+        if: needs.prepare.outputs.upload_url != ''
+        run: gh release upload "${{ needs.prepare.outputs.tag_name }}" "tebako-rs/out/tebako-runtime-launcher-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # ==========================================================================
   # Linux musl (Alpine container via docker run from the glibc host —
   # node actions cannot run on musl; the proven native-musl path:
@@ -561,6 +576,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload tebako-runtime-launcher
+        if: needs.prepare.outputs.upload_url != ''
+        run: gh release upload "${{ needs.prepare.outputs.tag_name }}" "tebako-rs/out/tebako-runtime-launcher-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload link-unit
         if: needs.prepare.outputs.upload_url != ''
         run: gh release upload "${{ needs.prepare.outputs.tag_name }}" "tebako-rs/out/link-unit-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}.tar.gz" --clobber
@@ -622,7 +643,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag_name }}
         run: |
-          EXPECTED=$(( 5 * 7 + 7 + 2 + 5 * 7 ))   # 5 tools x 7 platforms (incl. windows-ucrt64) + 7 link-unit tarballs + SHA256SUMS + manifest.json + 35 per-asset sidecars (tebako#493)
+          EXPECTED=$(( 6 * 7 + 7 + 2 + 6 * 7 ))   # 6 tools x 7 platforms (incl. windows-ucrt64; +tebako-runtime-launcher, the spec-29 wrapper exe) + 7 link-unit tarballs + SHA256SUMS + manifest.json + 42 per-asset sidecars (tebako#493)
           COUNT=$(gh release view "$TAG" --json assets --jq '.assets | length')
           echo "release assets: $COUNT / $EXPECTED expected"
           gh release view "$TAG" --json assets --jq '.assets[].name' | sort
@@ -897,5 +918,11 @@ jobs:
       - name: Upload tebako-shim
         if: needs.prepare.outputs.upload_url != ''
         run: gh release upload "${{ needs.prepare.outputs.tag_name }}" "tebako-rs/out/tebako-shim-${{ needs.prepare.outputs.version }}-windows-ucrt64.exe" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload tebako-runtime-launcher
+        if: needs.prepare.outputs.upload_url != ''
+        run: gh release upload "${{ needs.prepare.outputs.tag_name }}" "tebako-rs/out/tebako-runtime-launcher-${{ needs.prepare.outputs.version }}-windows-ucrt64.exe" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/gnu-floor-build.sh
+++ b/ci/gnu-floor-build.sh
@@ -169,7 +169,7 @@ export RUSTFLAGS="-C linker=$WS/tebako-rs/ci/linux-link-wrap.sh"
 # (run 32940980101 failed the 3 MiB gate on every leg for this reason).
 cargo build --release --target "$TARGET" -p tebako-bootstrap
 cargo build --release --target "$TARGET" \
-  -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim
+  -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim -p tebako-runtime-launcher
 
 echo "== stage / strip / size-gate =="
 export TARGET

--- a/ci/musl-build.sh
+++ b/ci/musl-build.sh
@@ -135,7 +135,7 @@ export SQFS_SYS_VCPKG_INSTALLED_DIR="$WS/.sqfs-musl/$TRIPLET"
 # (run 32940980101 failed the 3 MiB gate on every leg for this reason).
 cargo build --release -p tebako-bootstrap
 cargo build --release \
-  -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim
+  -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim -p tebako-runtime-launcher
 
 echo "== stage / strip / size-gate =="
 export TARGET

--- a/ci/windows-gnu-release.sh
+++ b/ci/windows-gnu-release.sh
@@ -85,7 +85,7 @@ TARGET=x86_64-pc-windows-gnu
 # other three build sites and missed this one).
 cargo build --release --target "$TARGET" -p tebako-bootstrap
 cargo build --release --target "$TARGET" \
-  -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim
+  -p tfs-cli -p tebako-pkg -p tebako-cli -p tebako-shim -p tebako-runtime-launcher
 
 # --- 2. stage (strip, size gate, fragments) ---------------------------------
 # stage.sh strips, enforces the bootstrap size budget and writes the

--- a/docs/spec/29-wrapper-exe-driver.md
+++ b/docs/spec/29-wrapper-exe-driver.md
@@ -157,9 +157,12 @@ honors it or fails closed — never a silent fallback (invariant 9):
   loader gate (spec 00 invariant 2). A budget is declared and measured
   in CI: single-digit MB per platform artifact, reported on every
   release; a regression past the budget fails the release build. The
-  wrapper embeds the driver plus the TFS backends; it is static-musl on
-  linux targets, platform-native elsewhere — the audience rule is
-  unchanged (nothing of ours compiles on a user's machine).
+  wrapper embeds the driver plus the TFS backends; the release ships it
+  per-platform like the other tools — static-musl and the gnu-floor
+  build on linux targets, platform-native elsewhere (the openjdk
+  promotion, TODO.java/04, consumes the per-platform assets) — the
+  audience rule is unchanged (nothing of ours compiles on a user's
+  machine).
 - Rust discipline per spec 14: `#![forbid(unsafe_code)]` outside the FFI
   boundary modules; named errors on every mount/exec/materialize path
   (no unwraps there); the bootstrap size profile (`opt-level="z"`, fat


### PR DESCRIPTION
# Ship the tebako-runtime-launcher asset on all seven platforms

Unblocks tebako-packages/openjdk#23 (TODO.java/04): the spec-29 wrapper
exe is the repacked-runtime ship form — the openjdk promotion downloads
`tebako-runtime-launcher-<ver>-<platform>[.exe]` + its `.sha256`
sidecar (tebako#493 era) from the tebako release. Until now the release
pipeline never built or uploaded it.

## Changes

- **Build**: `-p tebako-runtime-launcher` joins the non-bootstrap cargo
  invocation on every binary leg (macOS matrix, `ci/gnu-floor-build.sh`,
  `ci/musl-build.sh`, `ci/windows-gnu-release.sh`) — never the
  bootstrap's own invocation (the feature-unification rule).
- **stage.sh**: the tool joins `TOOLS` — strip + sha/size fragments
  follow automatically; the bootstrap-only size gate is untouched.
- **ship-gate.sh**: the launcher's bare launch is its named spec-29 §2
  no-env-image error — **exit 65** (pinned locally: bare and
  `--version` both). The case precedes the `tebako-*` catch-all. The
  per-leg globs pick the binary up automatically → smoke + dylib/PE
  audit run on the exact shipped bytes.
- **Uploads**: one step per binary leg (4 blocks).
- **finalize.sh**: SHA256SUMS, per-asset sidecars, the manifest.json
  `tools` map, and the release-notes size table all gain the tool.
- **Completeness gate**: `6 tools × 7 platforms + 7 link-units + 2 + 42
  sidecars = 93`.
- **spec 29 §5**: the ship-form sentence now says per-platform
  (static-musl AND gnu-floor on linux), matching what the release
  ships.

## Validation

- Local: ship-gate.sh against a staged-name launcher — smoke exit 65 +
  otool whitelist PASS.
- **Acceptance gate: workflow_dispatch dry run 33365251094 on this
  branch — SUCCESS on all 7 platform legs + finalize** (build + ship
  gate; zero uploads). The stage step's hard `test -x` proves the
  launcher built on every leg; the ship-gate glob proves the exit-65
  smoke + dependency whitelist on the exact staged bytes
  (windows-ucrt64 included).
