### PR TITLE
release: v2.1.0 — workspace version bump (2.0.0 → 2.1.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-runtime-launcher", "crates/tebako-arscope", "crates/tebako-bench", "tests/contract"]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"


### PR DESCRIPTION
## release: v2.1.0 — workspace version bump (2.0.0 → 2.1.0)

The v2-era minor tag shipping **spec 30 — runtime as a spawned
dependency** (merged as #508: the `kind:runtime` DEPENDS edge, the
runtime-store SSOT in `tpkg`, shim edge resolution + the expose tier,
cli install/compose arms, the driver spawn surface — plan FFI, PATH
launchers, jail union — and the spec set 30 + 03/07/17/23/29
amendments).

### Shape

- One line: `[workspace.package] version` in the root `Cargo.toml`.
  Member crates ride `version.workspace = true`.
- **No intra-workspace pin churn**: all 63 path-dep pins are caret
  `version = "2.0.0"`; `^2.0.0` spans the minor boundary (AGENTS.md
  "Releases and tag eras" requires same-commit pin moves only for
  boundary-crossing bumps — `^0.x` rejecting the next boundary; `^2`
  accepts 2.1.0). Verified: `cargo metadata` resolves all 21 member
  crates at 2.1.0.
- Test-fixture `"2.0.0"` strings (payload versions in shim/cli/bootstrap
  tests) are not the workspace version — untouched by design.

### Chain this tag fires (owner-nod 2026-08-31, PROGRESS/00-INDEX)

tebako **v2.1.0** ships the spec-30 spawn surface + the
`tebako-runtime-launcher` release asset → tamatebako/ruby patch PR
(`tfs_spawn_prepare` calls the FFI first) → factory scoped re-cut →
tebako-packages/openjdk#23 → java/05 feedstock + packed-mn.

### Evidence

- `cargo metadata --no-deps`: all 21 member crates at 2.1.0, resolution
  clean (pin acceptance proven).
- `cargo check --workspace --all-targets` green locally (macOS arm64;
  invocation per AGENTS.md env).
- CI is the authoritative gate; release.yml fires on the `v*` tag push
  after merge.
