### PR TITLE
publish: the verify home inherits the publisher's runtime preferences

### DIFF
--- a/crates/tebako-cli/src/publish.rs
+++ b/crates/tebako-cli/src/publish.rs
@@ -1245,6 +1245,7 @@ fn verify_with<T: Transport>(
     fetcher: &Fetcher<T>,
 ) -> Result<String, TebakoError> {
     crate::install::add_registry_with(home, registry_ref, fetcher)?;
+    let prefs_inherited = inherit_runtime_prefs(home, publisher_home)?;
     let mut inherited = 0usize;
     let mut unreachable: Vec<String> = Vec::new();
     if let Ok(cfg) = tebako_shim::config::load_config(publisher_home) {
@@ -1274,15 +1275,43 @@ fn verify_with<T: Transport>(
             unreachable.join(", ")
         ),
     };
+    let prefs = match prefs_inherited {
+        0 => String::new(),
+        n => format!(", {n} publisher runtime pref(s) inherited"),
+    };
     Ok(format!(
-        "verified: clean-cache install of {} {} ({} shim(s): {}{}{})",
+        "verified: clean-cache install of {} {} ({} shim(s): {}{}{}{})",
         opts.name,
         version,
         outcome.commands.len(),
         outcome.commands.join(", "),
         signed,
-        registries
+        registries,
+        prefs
     ))
+}
+
+/// The publisher's runtime preferences (`config.yaml runtimes:`) join the
+/// verify home the same way its registries do (spec 30): the install
+/// proof pre-stages a payload's `kind: runtime` edges, and a pref-less
+/// edge on a non-default engine line can never resolve — the default
+/// runtime line hosts no such engine. A missing/unreadable publisher
+/// config inherits nothing (same posture as the registry join).
+fn inherit_runtime_prefs(home: &Path, publisher_home: &Path) -> Result<usize, TebakoError> {
+    let Ok(cfg) = tebako_shim::config::load_config(publisher_home) else {
+        return Ok(0);
+    };
+    if cfg.runtimes.is_empty() {
+        return Ok(0);
+    }
+    let n = cfg.runtimes.len();
+    tebako_shim::config::set_runtime_prefs(home, &cfg.runtimes).map_err(|e| {
+        err(
+            EX_TEBAKO_IO,
+            format!("the verify home's runtime preferences: {}", e.message),
+        )
+    })?;
+    Ok(n)
 }
 
 #[cfg(test)]
@@ -1371,5 +1400,32 @@ mod tests {
         // a name with dashes keeps the version intact
         let p = Path::new("/tmp/my-app-2.0-linux-gnu-x86_64.tfs");
         assert_eq!(version_from_artifact("my-app", p).as_deref(), Some("2.0"));
+    }
+
+    #[test]
+    fn inherit_runtime_prefs_joins_the_publishers_engines() {
+        let root =
+            std::env::temp_dir().join(format!("tebako-publish-prefs-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let publisher = root.join("publisher");
+        let verify = root.join("verify");
+        std::fs::create_dir_all(&publisher).unwrap();
+        std::fs::create_dir_all(&verify).unwrap();
+        std::fs::write(
+            publisher.join("config.yaml"),
+            "registries: []\nruntimes:\n  java:\n    version: \"21.0.12\"\n    tebako: \"2.1.0\"\n",
+        )
+        .unwrap();
+        let n = inherit_runtime_prefs(&verify, &publisher).unwrap();
+        assert_eq!(n, 1);
+        let cfg = tebako_shim::config::load_config(&verify).unwrap();
+        let pref = cfg.runtimes.get("java").expect("the java pref joined");
+        assert_eq!(pref.version, "21.0.12");
+        assert_eq!(pref.tebako, "2.1.0");
+        // no prefs on the publisher = no write, no error
+        let bare = root.join("bare");
+        std::fs::create_dir_all(&bare).unwrap();
+        assert_eq!(inherit_runtime_prefs(&verify, &bare).unwrap(), 0);
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/tebako-shim/src/config.rs
+++ b/crates/tebako-shim/src/config.rs
@@ -40,7 +40,7 @@ pub struct UserConfig {
     pub runtimes: BTreeMap<String, RuntimePref>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, serde::Serialize)]
 pub struct RuntimePref {
     /// Language version, e.g. `4.0.6`.
     pub version: String,
@@ -152,6 +152,83 @@ pub fn add_registry(home: &Path, reg_ref: &str) -> Result<AddRegistryOutcome, Sh
     Ok(AddRegistryOutcome::Added)
 }
 
+/// Merge engine → runtime preferences into `~/.tebako/config.yaml`,
+/// preserving every other key (the same structural-surgery discipline as
+/// [`add_registry`]). A preference for an already-present engine is
+/// REPLACED — the caller is the authority (publish's built-in verify
+/// re-anchors the proof home to the publisher's picks, spec 16 §5).
+/// This is the second authored-config write the toolchain performs;
+/// the dispatcher itself still never writes this file.
+pub fn set_runtime_prefs(
+    home: &Path,
+    prefs: &BTreeMap<String, RuntimePref>,
+) -> Result<(), ShimError> {
+    let path = config_path(home);
+    let mut root: serde_yaml::Value = match std::fs::read_to_string(&path) {
+        Ok(t) => serde_yaml::from_str(&t).map_err(|e| {
+            ShimError::new(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "cannot parse {} ({e}) — fix or remove it; run `tebako-shim doctor`",
+                    path.display()
+                ),
+            )
+        })?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            serde_yaml::Value::Mapping(serde_yaml::Mapping::new())
+        }
+        Err(e) => return fail(EX_TEBAKO_IO, format!("cannot read {}: {e}", path.display())),
+    };
+    let mapping = root.as_mapping_mut().ok_or_else(|| {
+        ShimError::new(
+            EX_TEBAKO_MANIFEST,
+            format!("{} must be a YAML mapping", path.display()),
+        )
+    })?;
+    let key = serde_yaml::Value::String("runtimes".to_string());
+    let entry = mapping
+        .entry(key)
+        .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+    let rt_map = entry.as_mapping_mut().ok_or_else(|| {
+        ShimError::new(
+            EX_TEBAKO_MANIFEST,
+            format!("{}: `runtimes` must be a mapping", path.display()),
+        )
+    })?;
+    for (engine, pref) in prefs {
+        let value = serde_yaml::to_value(pref).map_err(|e| {
+            ShimError::new(
+                EX_TEBAKO_IO,
+                format!("cannot serialize the runtime preference for {engine}: {e}"),
+            )
+        })?;
+        rt_map.insert(serde_yaml::Value::String(engine.clone()), value);
+    }
+    let text = serde_yaml::to_string(&root).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_IO,
+            format!("cannot serialize {}: {e}", path.display()),
+        )
+    })?;
+    std::fs::create_dir_all(home).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_IO,
+            format!("cannot create {}: {e}", home.display()),
+        )
+    })?;
+    let tmp = home.join(format!("config.yaml.{}.tmp", std::process::id()));
+    std::fs::write(&tmp, text).map_err(|e| {
+        ShimError::new(EX_TEBAKO_IO, format!("cannot write {}: {e}", tmp.display()))
+    })?;
+    std::fs::rename(&tmp, &path).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_IO,
+            format!("cannot install {}: {e}", path.display()),
+        )
+    })?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------
 // the registry-default chain link (spec 07 §2.1, last resort)
 // ---------------------------------------------------------------------
@@ -234,4 +311,70 @@ pub fn is_disabled(disabled: &Disabled, tool: &str, version: &str) -> bool {
     disabled
         .get(tool)
         .is_some_and(|selectors| selectors.iter().any(|s| s == "all" || s == version))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh_home(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "tebako-shim-config-test-{}-{}",
+            tag,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn pref(version: &str, tebako: &str) -> RuntimePref {
+        RuntimePref {
+            version: version.to_string(),
+            tebako: tebako.to_string(),
+        }
+    }
+
+    #[test]
+    fn set_runtime_prefs_writes_a_fresh_config() {
+        let home = fresh_home("fresh");
+        let mut prefs = BTreeMap::new();
+        prefs.insert("java".to_string(), pref("21.0.12", "2.1.0"));
+        set_runtime_prefs(&home, &prefs).unwrap();
+        let cfg = load_config(&home).unwrap();
+        assert_eq!(cfg.runtimes.get("java"), Some(&pref("21.0.12", "2.1.0")));
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn set_runtime_prefs_preserves_other_keys_and_replaces_the_engine() {
+        let home = fresh_home("merge");
+        add_registry(&home, "tfs:github:acme/app").unwrap();
+        let mut first = BTreeMap::new();
+        first.insert("java".to_string(), pref("21.0.12", "2.1.0"));
+        set_runtime_prefs(&home, &first).unwrap();
+        let mut second = BTreeMap::new();
+        second.insert("java".to_string(), pref("21.0.13", "2.1.0"));
+        second.insert("ruby".to_string(), pref("3.3.12", "0.16.18"));
+        set_runtime_prefs(&home, &second).unwrap();
+        let cfg = load_config(&home).unwrap();
+        assert_eq!(cfg.runtimes.get("java"), Some(&pref("21.0.13", "2.1.0")));
+        assert_eq!(cfg.runtimes.get("ruby"), Some(&pref("3.3.12", "0.16.18")));
+        assert_eq!(cfg.registries, vec!["tfs:github:acme/app".to_string()]);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn set_runtime_prefs_rejects_a_non_mapping_runtimes_key() {
+        let home = fresh_home("badshape");
+        std::fs::write(config_path(&home), "runtimes: [nope]\n").unwrap();
+        let mut prefs = BTreeMap::new();
+        prefs.insert("java".to_string(), pref("21.0.12", "2.1.0"));
+        let err = set_runtime_prefs(&home, &prefs).unwrap_err();
+        assert!(
+            err.message.contains("`runtimes` must be a mapping"),
+            "{err:?}"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
 }

--- a/docs/spec/16-distribution-and-installation.md
+++ b/docs/spec/16-distribution-and-installation.md
@@ -137,8 +137,11 @@ tebako use metanorma@1.2.2                # instant rollback
   registry pin) → upload to the referenced GitHub release (in-process
   HTTP; file:// mirrors for rehearsal/tests) → `tpkg-registry.yaml`
   upsert → tap formula render from the vendored template → built-in
-  clean-cache `tebako install` proof. The GitLab/Bitbucket write legs
-  are their adapters' milestone.
+  clean-cache `tebako install` proof. The proof home inherits the
+  publisher's registered registries AND its `runtimes:` preferences
+  (spec 30: the install pre-stages `kind: runtime` edges; a pref-less
+  edge on a non-default engine line can never resolve). The
+  GitLab/Bitbucket write legs are their adapters' milestone.
 - `tamatebako/homebrew-tap` formula + the app-tap template (the template
   is vendored and rendered by `tebako publish --tap`; the tap repos
   themselves stay manual).


### PR DESCRIPTION
## What

`tebako publish`'s built-in clean-cache verify now inherits the publisher's `config.yaml` `runtimes:` preferences into the proof home — the same join the publisher's registered registries already get (spec 16 §5).

## Why

Spec 30's `kind: runtime` edges pre-stage at **install** time (`install_runtime_edge`, `allow_download=true`), so the publish verify resolves them too. A pref-less edge on a non-default engine line can never resolve:

- the pref-less download line is `DEFAULT_TEBAKO_VERSION` (the runtime factory's 0.16.x line);
- the default base hosts no such engine.

Concretely: a payload declaring the metanorma-style java edge (the `tebako-packages/openjdk` release line, tag `v2.1.0`) would fail its own publish verify with a misleading named error even though the publisher has the preference configured. The verify is supposed to prove the install **exactly as it will run for the publisher's users** — the prefs are part of that.

## Changes

- `tebako-shim::config::set_runtime_prefs(home, prefs)` — the second authored-config write the toolchain performs; same structural-surgery discipline as `add_registry` (other keys preserved, an existing engine's entry replaced, tmp+rename). `RuntimePref` gains `Serialize`.
- `publish::verify_with` joins the publisher's runtime prefs before the install proof; the verified line reports `N publisher runtime pref(s) inherited`. A missing/unreadable publisher config inherits nothing (same posture as the registry join).
- spec 16 §5: the publish bullet records the inheritance.

## Tests

- config layer: fresh write / merge preserving other keys + engine replacement / non-mapping `runtimes:` rejection (3 new).
- publish layer: the join itself, both-homes temp fixtures, no network (1 new).
- Full local gates green: `cargo fmt --check`, `cargo clippy -p tebako-shim -p tebako-cli --all-targets`, `cargo test -p tebako-shim` (78 across suites), `cargo test -p tebako-cli` (lib 152, check 12, publish 7, cli_e2e 14 — the last with the in-workspace `tebako-bootstrap` built per the harness contract).

## Not in this PR

The general per-engine runtime **source** key (`runtimes: {<engine>: {source: <base>}}`, so a cold-cache user resolves a non-default engine without `TEBAKO_RUNTIME_MIRROR`) is a separate spec-05 §2 / spec 07 §4 amendment — tracked in the ecosystem backlog.
