### PR TITLE
spec: per-engine runtime download base (TODO.v2-1/30)

### DIFF
--- a/docs/spec/04-references-and-registry.md
+++ b/docs/spec/04-references-and-registry.md
@@ -109,6 +109,14 @@ payloads:
   composition's `platforms:` assertion (spec 23 §13.3) CONSTRAINS the
   mirrored coverage — checked fail-closed against it — and NEVER
   extends it.
+- **`kind: runtime` entries are edge-discoverable** (schema MINOR 1;
+  PLANNED — TODO.v2-1/30): the entry carries `engine:` (+ optional
+  `implementation:`), and a payload's `kind: runtime` DEPENDS edge
+  (spec 30 §1) discovers it by (engine, implementation?, constraint);
+  the matched version's `release.ref` derives the download base
+  (spec 05 §2's per-engine chain, the zero-config path for third-party
+  runtimes). Runtime entries predating MINOR 1 carry no `engine:` and
+  stay invisible to edges.
 - `tebako add-registry <ref>` registers one; shipped config has ZERO
   registries (explicit only — spec 16).
 - Install = resolve the registry → select the host entry → download →

--- a/docs/spec/05-resolution-and-cache.md
+++ b/docs/spec/05-resolution-and-cache.md
@@ -62,9 +62,31 @@ recorded for the failure message.
   (coreutils `<sha>  <file>` — the store marker's exact shape). The
   sidecar is the per-asset pin; the shard's sha fields are re-anchored
   to the served bytes at publish time.
-- Base URL:
-  `https://github.com/tamatebako/tebako-runtime-ruby/releases/download`;
-  override `TEBAKO_RUNTIME_MIRROR` (https or file://).
+- **The download base is PER-ENGINE** (the chain below is PLANNED —
+  TODO.v2-1/30; today a single base serves all engines, with
+  `TEBAKO_RUNTIME_MIRROR` as the only override). First hit wins, and
+  every download journals the base AND the channel that supplied it:
+  1. `runtimes: {<engine>: {source: <base>}}` — the authored config pin
+     (spec 07 §0; most specific: an operator who pins an engine's
+     source means exactly that base for that engine).
+  2. `TEBAKO_RUNTIME_MIRROR` (https or file://) — the operator's global
+     override, applying to every engine WITHOUT a `source:` pin. When a
+     pin shadows a differing mirror value the shadowing is journaled,
+     loud — never silent precedence.
+  3. **Registry-derived** — a registered registry (spec 04 §2) carrying
+     a `kind: runtime` entry whose `engine:` (+ `implementation:` when
+     the edge names one) matches, with a version satisfying the
+     edge's constraint: the base derives from that version's
+     `release.ref`. This is the zero-config path — a third-party
+     runtime becomes resolvable from `tebako add-registry <its
+     feedstock>` alone, no authored config required.
+  4. The product default base
+     `https://github.com/tamatebako/tebako-runtime-ruby/releases/download`
+     (the ruby factory line — the back-compat floor every pre-chain
+     consumer already speaks).
+  An edge no channel answers is a NAMED error enumerating the channels
+  tried (never a silent query of a base that hosts no such engine — a
+  wrong-line 404 is diagnosed as what it is).
 - Signing of the index itself: spec 09 §5 (signed manifest closes the
   same-channel-MITM gap).
 

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -22,7 +22,9 @@ in `config.yaml` as the exact ref).
   does not shadow a farther one that does.
 - **`~/.tebako/config.yaml` keys:** `defaults:` (command → version),
   `registries:` (spec 04 refs), `runtimes:` (engine → `{version,
-  tebako}` runtime preference). The shim never writes this file.
+  tebako, source?}` runtime preference; `source:` pins the engine's
+  download base — spec 05 §2's per-engine chain, PLANNED TODO.v2-1/30).
+  The shim never writes this file.
 - **Disabled state** is shim-managed state, not authored config:
   `~/.tebako/shims/.disabled.yaml` (command → `[versions] | [all]`).
 - **Installed payload record** (the dispatcher-visible manifest mirror,

--- a/docs/spec/30-runtime-spawned-dependency.md
+++ b/docs/spec/30-runtime-spawned-dependency.md
@@ -42,8 +42,12 @@ requires:
 ```
 
 Resolution treats the edge like any dependency — but the artifact
-resolves through the RUNTIME index and lands in the store's `runtimes/`
-area (share-once, spec 05 §3). The depended runtime is **NOT co-mounted**
+resolves through the RUNTIME index (whose download base resolves
+PER-ENGINE through spec 05 §2's four-channel chain: config `source:`
+pin → `TEBAKO_RUNTIME_MIRROR` → registry-derived from a matching
+`kind: runtime` entry → the product default) and lands in the store's
+`runtimes/` area (share-once, spec 05 §3). The depended runtime is
+**NOT co-mounted**
 into the parent's VFS: its wrapper exe executes FROM THE STORE (a host
 path, 0755 — kernel-visible by construction; the exe itself is never
 materialized) and mounts its own env image per spec 29. The edge is

--- a/docs/spec/schemas/store-config.yaml
+++ b/docs/spec/schemas/store-config.yaml
@@ -16,7 +16,7 @@
 
 schema: store-config
 schema_version: 1 # MAJOR — breaking changes only
-schema_minor: 0 # MINOR — additive changes only
+schema_minor: 1 # MINOR — additive changes only (1: runtimes.*.source)
 status: normative
 owner: crates/tebako-shim (the config model of record) in tamatebako/tebako
 edge: C13 (everything local → store)
@@ -67,7 +67,7 @@ grammar:
     required: false
     notes: spec 04 §2 registry refs; shipped config has ZERO registries (explicit only — no default service)
   runtimes:
-    type: map(engine → {version, tebako})
+    type: map(engine → {version, tebako, source?})
     required: false
     notes: >-
       Per-engine runtime preference (the download fallback of spec 05 §5
@@ -75,6 +75,9 @@ grammar:
       version = the language version (e.g. "4.0.6"); tebako = the tebako
       (launcher) abi version the runtime was built with — the <ver> of the
       cache layout runtimes/<lang>-<lv>-<ver>-<triplet>/.
+      source (MINOR 1, PLANNED — TODO.v2-1/30) = the per-engine download
+      base override (https or file://), the first channel of spec 05 §2's
+      per-engine base chain; absent → the chain's lower channels answer.
 
 store_layout_marker:
   path: ~/.tebako/layout-version

--- a/docs/spec/schemas/tpkg-registry.yaml
+++ b/docs/spec/schemas/tpkg-registry.yaml
@@ -15,7 +15,7 @@
 
 schema: tpkg-registry
 schema_version: 1 # MAJOR — breaking changes only
-schema_minor: 0 # MINOR — additive changes only
+schema_minor: 1 # MINOR — additive changes only (1: engine/implementation on kind:runtime entries)
 status: normative
 owner: crates/tebako-resolve (the model) in tamatebako/tebako
 edge: C8 (loader → registry), C12 (everything → registries)
@@ -68,6 +68,8 @@ grammar:
     entry:
       name: {type: string, required: true, notes: single non-empty path component (a cache key)}
       kind: {type: enum, values: [app, data, toolkit, runtime, language], required: true}
+      engine: {type: string, required: false, notes: "REQUIRED when kind: runtime (MINOR 1) — the edge-discovery key (spec 30 §1): kind:runtime edges resolve by (engine, implementation?, constraint); a runtime entry without engine: is pre-discovery legacy and invisible to edges"}
+      implementation: {type: string, required: false, notes: "spec 28 §8's implementation axis (e.g. temurin); an edge naming an implementation matches only entries carrying the same value"}
       versions:
         type: list
         required: true
@@ -87,7 +89,7 @@ grammar:
             type: map
             required: true
             fields:
-              ref: {type: string, required: true, notes: "a spec 04 §1 reference (any class)"}
+              ref: {type: string, required: true, notes: "a spec 04 §1 reference (any class); for kind: runtime entries it ALSO derives the per-engine download base (spec 05 §2's chain, registry-derived step)"}
           signature:
             type: map
             required: false


### PR DESCRIPTION
## What

Spec amendment (docs-only, all new behavior marked **PLANNED**): the runtime
download base becomes **per-engine**. Tracks TODO.v2-1/30.

## Why

Spec 30's first consumer — tebako-packages/metanorma#35, the java runtime
edge — proved the gap in production wiring:

- The resolver knows **one** runtime download base for **all** engines: the
  ruby factory line, or the global `TEBAKO_RUNTIME_MIRROR` override.
- The openjdk runtime publishes on **tebako-packages/openjdk's** release
  line. A `kind: runtime, engine: java` edge on a cold cache cannot resolve
  there without pointing the global mirror at openjdk — which then
  **misdirects the primary ruby runtime's** download (the ruby pair is not
  on openjdk's line).
- The feedstock's workaround (step-scoped mirror + config pref) works for CI
  but is not a user-facing answer: installing a java-edged payload on a
  clean machine should not require knowing which release line hosts which
  engine.

## The amendment

**spec 05 §2** — the base URL bullet becomes a four-channel first-hit chain,
every download journaling the base AND the channel that supplied it:

1. `runtimes: {<engine>: {source: <base>}}` — the authored config pin (most
   specific: an operator who pins an engine's source means exactly that).
2. `TEBAKO_RUNTIME_MIRROR` — the operator's global override, applying to
   engines WITHOUT a `source:` pin; a pin shadowing a differing mirror value
   is journaled, loud — never silent precedence.
3. **Registry-derived** — a registered registry's `kind: runtime` entry
   matching (engine, implementation?, constraint); the base derives from the
   matched version's `release.ref`. **This is the zero-config path**:
   `tebako add-registry tfs:github:tebako-packages/openjdk` alone makes the
   java runtime resolvable. The data already ships — the openjdk registry's
   runtime entry carries `release: {ref: tfs:github:tebako-packages/openjdk:v2.1.0}`
   plus per-platform artifact+sha256.
4. The product default base (the ruby factory line) — back-compat floor.

An edge no channel answers is a **named error enumerating the channels
tried** — never a silent query of a base that hosts no such engine.

**schemas/tpkg-registry.yaml (minor 0→1)** + **spec 04 §2** — `kind: runtime`
entries gain `engine:` (the edge-discovery key; required for kind: runtime)
and optional `implementation:` (spec 28 §8). Pre-minor-1 runtime entries
carry no `engine:` and stay invisible to edges — so **the openjdk registry
needs one republication with `engine: java`** once this lands (follow-up on
the feedstock side, noted here).

**schemas/store-config.yaml (minor 0→1)** + **spec 07 §0** — the `runtimes:`
preference gains the optional `source:` key.

**spec 30 §1** — the edge's runtime-index resolution names the chain.

## Precedence rationale (the one real design decision)

`source:` (per-engine, authored) beats `TEBAKO_RUNTIME_MIRROR` (global env)
by **specificity**, not channel — they are different-granularity settings,
not one scalar in two channels (contrast spec 07 §0's version chain, where
env and file pin the SAME key per tool and channel order decides). The
air-gap scenario stays whole: an operator mirroring every engine sets the
env and no pins; a pinned engine means exactly its pin. Every disagreement
journals.

## Verification

- Both schema YAMLs parse; the amendments are additive (evolution law:
  readers ignore unknown fields within the MAJOR).
- Neither `crates/tebako-resolve/src/registry.rs` nor
  `crates/tebako-shim/src/config.rs` asserts a `schema_minor` value — the
  bumps are docs-side until implementation lands.
- No code changes; the chain is marked PLANNED everywhere it appears, per
  the spec-set rule for unshipped behavior.

## Implementation follow-ups (not this PR)

- tebako-resolve: the base chain + journaling + the named error.
- tebako-shim config: `source:` parse + validate (the model of record).
- tebako-packages/openjdk: republish the registry with `engine: java`.
- tebako-packages/metanorma#35's CI wiring simplifies to a single
  `add-registry` once the registry-derived step ships.
