### PR TITLE
release: v2.1.1 — workspace version bump (2.1.0 → 2.1.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-runtime-launcher", "crates/tebako-arscope", "crates/tebako-bench", "tests/contract"]
 
 [workspace.package]
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"


### PR DESCRIPTION
Patch release bump 2.1.0 → 2.1.1. Carries two commits already on main:

- `e0217502` **publish: the verify home inherits the publisher's runtime preferences** (#510) — without it, `tebako publish` of a payload with a `kind: runtime` edge against a custom `releases_base` (the openjdk java runtime) fails its install-time verify: the verify ran in an isolated home that never saw the publisher's runtime preferences/mirror. This blocks the metanorma feedstock 1.16.9-7 publish (tebako-packages/metanorma#35), whose workflows fetch the RELEASE CLI — so the fix must ride a published release.
- `e60b9b2e` **spec: per-engine runtime download base** (#511) — docs-only (PLANNED), no code.

Single-line workspace version change. The intra-workspace caret pins (`^2.1.0`) accept 2.1.1, so no pin moves are needed (the boundary-bump rule applies to `^0.x.y` lines only).

On merge: annotated tag `v2.1.1` on the merge sha fires release.yml.
