### PR TITLE
resolve: advance the default runtime line to 0.16.18 (the spec-30 grammar)

### DIFF
--- a/crates/tebako-resolve/src/lib.rs
+++ b/crates/tebako-resolve/src/lib.rs
@@ -69,8 +69,13 @@ pub use transport::{HttpTransport, Transport};
 /// preload interpose dylib nor the driver's micro dylib reaches a
 /// child process — dyld's arm64e insertion termination can no longer
 /// kill runtime-spawned children; the 0.16.7/0.16.8 native-ext press
-/// regression).
-pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.9";
+/// regression). From 0.16.18 the runtimes link the v2.1.0 driver unit
+/// (the spec-30 spawn FFI): the driver's manifest grammar accepts the
+/// `kind: runtime` DEPENDS edge — a pref-less resolution landing on an
+/// older line fails closed at the payload's first dispatch with the
+/// driver's named manifest error, so the default line must never trail
+/// the newest published factory line.
+pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.18";
 
 /// Fetch `reference` (pin-verified at the fetch boundary) and install it
 /// as `payloads/<name>/<version>.tfs` — or return the existing entry.


### PR DESCRIPTION
## What

`DEFAULT_TEBAKO_VERSION` 0.16.9 → **0.16.18**.

## Why

Pref-less runtime resolution (`tebako install`, shim dispatch with no
`runtimes:` pref) queries the factory release named by this constant.
The 0.16.9 line's driver predates spec 30: a payload declaring a
`kind: runtime` DEPENDS edge (schema_minor 4) fails closed at first
dispatch:

```
tebako-driver: corrupt /__tpkg__/manifest.yaml in the image mounted at '/'
(payload manifest yaml error: requires.[2].kind: unknown variant `runtime`,
expected one of `language`, `toolkit`, `data`)
```

Reproduced byte-exact locally: the published 0.16.9 macos-arm64 exe
rejects a minimal kind:runtime-edge payload with the identical message;
the published 0.16.18 exe boots the same image cleanly.

Real-world instance: tebako-packages/metanorma's 1.16.9-8 dogfood
(run 33545355536) — every leg's first dispatch downloaded 0.16.9 and
died at the parse. The 0.16.18 factory line (v2.1.0 link unit) carries
the spec-30 grammar; the default line must never trail the newest
published factory line.

## What this is NOT

Not a factory re-publish — 0.16.18 verifiably carries the grammar (the
published exe + link unit were strings-checked for the spec-30 surface).
Not a payload change — 1.16.9-8 is correct as published.

## Follow-ups (recorded, not in this PR)

- The process rule "factory line publish ⇒ advance the product default
  line" wants a home in the release checklist.
- A payload-declared driver floor on `runtime_requirement` (so an old
  runtime fails with "runtime too old", not "corrupt manifest") is a
  spec-05 follow-up candidate.

## Test plan

Local (debug): `cargo test -p tebako-resolve` green; `-p tebako-shim`
green (152+12); `-p tebako-cli` green incl. **cli_e2e 14/14** — the
press flows now dogfood the 0.16.18 runtime end-to-end (740s suite).
CI: full workspace matrix.
