### PR TITLE
release: v2.1.2 — workspace version bump (2.1.1 → 2.1.2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-runtime-launcher", "crates/tebako-arscope", "crates/tebako-bench", "tests/contract"]
 
 [workspace.package]
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"


### PR DESCRIPTION
## What

Workspace version bump 2.1.1 → 2.1.2 (root `Cargo.toml` only — patch
bump, no intra-workspace caret pins move).

## Contents of v2.1.2

- #513: `DEFAULT_TEBAKO_VERSION` 0.16.9 → 0.16.18 — pref-less runtime
  resolution now serves the spec-30 driver grammar; fixes the
  metanorma 1.16.9-8 dogfood first-dispatch failure (the published
  0.16.9 runtime cannot parse `kind: runtime` DEPENDS edges).

## After merge

Tag v2.1.2 at the merge sha → release.yml builds + publishes.
