### PR TITLE
preload: interpose the realpath family + the vfork pid gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
           name: libtfs-preload-tests-linux-gnu-x86_64-debug
           retention-days: 1
           path: |
-            tebako-rs/target/debug/deps/libtfs_preload-*
+            tebako-rs/target/debug/deps/tfs_preload-*
             !tebako-rs/target/debug/deps/*.d
           if-no-files-found: error
 
@@ -286,7 +286,14 @@ jobs:
         working-directory: tebako-rs
         env:
           DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
-        run: timeout 2400 cargo test --workspace --exclude libtfs-preload
+        # timeout(1) is GNU-only — macOS runners lack it (the sweep's
+        # 40 min backstop simply degrades to the job timeout there).
+        run: |
+          if command -v timeout >/dev/null; then
+            timeout 2400 cargo test --workspace --exclude libtfs-preload
+          else
+            cargo test --workspace --exclude libtfs-preload
+          fi
 
       - name: cargo test (libtfs-preload, per-test watchdog)
         working-directory: tebako-rs
@@ -302,12 +309,15 @@ jobs:
           # SIGTERM to the test child, so `timeout cargo test …` reaps
           # the very process we need to inspect.)
           BINS=()
-          for b in target/debug/deps/libtfs_preload-* target/debug/deps/e2e-*; do
+          for b in target/debug/deps/tfs_preload-* target/debug/deps/e2e-*; do
             case "$b" in *.d) continue;; esac
             [ -x "$b" ] && BINS+=("$b")
           done
           for BIN in "${BINS[@]}"; do
-            mapfile -t TESTS < <("$BIN" --list 2>/dev/null | sed -n 's/: test$//p')
+            # (3.2-portable read loop — macOS runners ship bash 3.2,
+            # which has no mapfile)
+            TESTS=()
+            while IFS= read -r line; do TESTS+=("$line"); done < <("$BIN" --list 2>/dev/null | sed -n 's/: test$//p')
             echo "== $BIN: ${#TESTS[@]} tests"
             for t in "${TESTS[@]}"; do
               echo "=== START $BIN :: $t"
@@ -333,7 +343,11 @@ jobs:
               [ "$rc" = 0 ] || { echo "=== FAIL (rc=$rc) $BIN :: $t"; exit "$rc"; }
             done
           done
-          timeout 300 cargo test -p libtfs-preload --doc
+          if command -v timeout >/dev/null; then
+            timeout 300 cargo test -p libtfs-preload --doc
+          else
+            cargo test -p libtfs-preload --doc
+          fi
 
       - name: clippy
         working-directory: tebako-rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,14 @@ jobs:
           DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
         run: cargo build --workspace
 
+      # Test binaries too, so the proof artifacts below are runnable
+      # (cargo build alone leaves them unbuilt).
+      - name: cargo build (libtfs-preload test binaries)
+        working-directory: tebako-rs
+        env:
+          DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
+        run: cargo test -p libtfs-preload --no-run
+
       # The built preload shim as a downloadable artifact (linux-gnu):
       # the container-proof path for preload changes — a foreign-libc
       # repro rig (usrmerge, Rosetta, …) downloads exactly this .so
@@ -251,6 +259,21 @@ jobs:
         with:
           name: libtfs_preload-linux-gnu-x86_64-debug
           path: tebako-rs/target/debug/libtfs_preload.so
+          if-no-files-found: error
+
+      # The libtfs-preload unit-test binary as a runnable artifact: a
+      # hang repro rig then iterates at container speed (TEBAKO_DEBUG_TFS
+      # traces, env variations) instead of 10-minute CI cycles. Short
+      # retention — a diagnostic aid, not a product artifact.
+      - name: Upload the libtfs-preload test binaries (linux-gnu diagnosis)
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: libtfs-preload-tests-linux-gnu-x86_64-debug
+          retention-days: 1
+          path: |
+            tebako-rs/target/debug/deps/libtfs_preload-*
+            !tebako-rs/target/debug/deps/*.d
           if-no-files-found: error
 
       # Split so a hang names itself: the workspace sweep is wrapped in a
@@ -271,16 +294,44 @@ jobs:
           DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
         run: |
           set -e
-          mapfile -t TESTS < <(cargo test -p libtfs-preload -- --list 2>/dev/null | sed -n 's/: test$//p')
-          echo "discovered ${#TESTS[@]} libtfs-preload tests"
-          for t in "${TESTS[@]}"; do
-            echo "=== START $t"
-            timeout 180 cargo test -p libtfs-preload -- --exact "$t" --nocapture || {
-              rc=$?
-              echo "=== FAIL/HANG (rc=$rc) $t"
-              ps auxf || true
-              exit "$rc"
-            }
+          shopt -s nullglob
+          # Run the test BINARIES directly (unit + e2e), not via cargo:
+          # a wedged test must stay alive past its 180 s budget so gdb
+          # can dump every thread BEFORE the kill — the log then carries
+          # the deadlock's lock graph, not just a name. (cargo forwards
+          # SIGTERM to the test child, so `timeout cargo test …` reaps
+          # the very process we need to inspect.)
+          BINS=()
+          for b in target/debug/deps/libtfs_preload-* target/debug/deps/e2e-*; do
+            case "$b" in *.d) continue;; esac
+            [ -x "$b" ] && BINS+=("$b")
+          done
+          for BIN in "${BINS[@]}"; do
+            mapfile -t TESTS < <("$BIN" --list 2>/dev/null | sed -n 's/: test$//p')
+            echo "== $BIN: ${#TESTS[@]} tests"
+            for t in "${TESTS[@]}"; do
+              echo "=== START $BIN :: $t"
+              "$BIN" --exact "$t" --nocapture &
+              TPID=$!
+              (
+                sleep 180
+                if kill -0 "$TPID" 2>/dev/null; then
+                  echo "=== HANG $BIN :: $t — full thread dump:"
+                  gdb -p "$TPID" -batch -ex 'set pagination off' -ex 'thread apply all bt' || true
+                  kill -9 "$TPID" 2>/dev/null
+                fi
+              ) &
+              WDOG=$!
+              wait "$TPID" && rc=0 || rc=$?
+              kill "$WDOG" 2>/dev/null || true
+              wait "$WDOG" 2>/dev/null || true
+              if [ "$rc" -gt 128 ]; then
+                echo "=== HANG/SIGNAL (rc=$rc) $BIN :: $t"
+                ps auxf || true
+                exit 124
+              fi
+              [ "$rc" = 0 ] || { echo "=== FAIL (rc=$rc) $BIN :: $t"; exit "$rc"; }
+            done
           done
           timeout 300 cargo test -p libtfs-preload --doc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,18 @@ jobs:
           DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # The built preload shim as a downloadable artifact (linux-gnu):
+      # the container-proof path for preload changes — a foreign-libc
+      # repro rig (usrmerge, Rosetta, …) downloads exactly this .so
+      # instead of needing a local cross toolchain.
+      - name: Upload the preload shim (linux-gnu proof artifact)
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: libtfs_preload-linux-gnu-x86_64-debug
+          path: tebako-rs/target/debug/libtfs_preload.so
+          if-no-files-found: error
+
   test-pure-cargo:
     name: test (--no-default-features, ubuntu)
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,22 +240,11 @@ jobs:
           DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
         run: cargo build --workspace
 
-      - name: cargo test
-        working-directory: tebako-rs
-        env:
-          DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
-        run: cargo test --workspace
-
-      - name: clippy
-        working-directory: tebako-rs
-        env:
-          DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
-        run: cargo clippy --workspace --all-targets -- -D warnings
-
       # The built preload shim as a downloadable artifact (linux-gnu):
       # the container-proof path for preload changes — a foreign-libc
       # repro rig (usrmerge, Rosetta, …) downloads exactly this .so
-      # instead of needing a local cross toolchain.
+      # instead of needing a local cross toolchain. Uploaded BEFORE the
+      # test step: a hung test must not withhold the proof artifact.
       - name: Upload the preload shim (linux-gnu proof artifact)
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -263,6 +252,43 @@ jobs:
           name: libtfs_preload-linux-gnu-x86_64-debug
           path: tebako-rs/target/debug/libtfs_preload.so
           if-no-files-found: error
+
+      # Split so a hang names itself: the workspace sweep is wrapped in a
+      # hard timeout (norm ~20 min; a wedge otherwise burns the 6 h job
+      # limit and live logs are unfetchable mid-run), and libtfs-preload
+      # — where preload interposes can deadlock a fixture — runs
+      # test-by-test with a per-test watchdog so the log's last START
+      # line IS the culprit.
+      - name: cargo test (workspace sweep)
+        working-directory: tebako-rs
+        env:
+          DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
+        run: timeout 2400 cargo test --workspace --exclude libtfs-preload
+
+      - name: cargo test (libtfs-preload, per-test watchdog)
+        working-directory: tebako-rs
+        env:
+          DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
+        run: |
+          set -e
+          mapfile -t TESTS < <(cargo test -p libtfs-preload -- --list 2>/dev/null | sed -n 's/: test$//p')
+          echo "discovered ${#TESTS[@]} libtfs-preload tests"
+          for t in "${TESTS[@]}"; do
+            echo "=== START $t"
+            timeout 180 cargo test -p libtfs-preload -- --exact "$t" --nocapture || {
+              rc=$?
+              echo "=== FAIL/HANG (rc=$rc) $t"
+              ps auxf || true
+              exit "$rc"
+            }
+          done
+          timeout 300 cargo test -p libtfs-preload --doc
+
+      - name: clippy
+        working-directory: tebako-rs
+        env:
+          DWARFS_RS_VCPKG_ROOT: ${{ github.workspace }}/.vcpkg-root
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   test-pure-cargo:
     name: test (--no-default-features, ubuntu)

--- a/crates/libtfs-preload/src/lib.rs
+++ b/crates/libtfs-preload/src/lib.rs
@@ -43,7 +43,13 @@
 //! `readdir_r`, `rewinddir`/`telldir`/`seekdir`, `dirfd`, `closedir`,
 //! `pread`, `read`, `lseek` (additive — stdio fseek on a memfs fd must
 //! stay on the VFS), `close`, `mkdir`, `unlink`, `rename`, `dlopen`,
-//! `fopen` (read modes), and
+//! `fopen` (read modes), the `realpath` family (`realpath` + macOS's
+//! `realpath$DARWIN_EXTSN`; linux's `canonicalize_file_name` and
+//! `__realpath_chk` — spec 07 §8: glibc's realpath walks the path
+//! with libc-INTERNAL aliases no PLT interpose sees, so covered paths
+//! are answered by the shim with the MOUNT spelling, lexically
+//! normalized — a host canonicalization must never rewrite a VFS path,
+//! the 2026-09-03 dogfood jing ClassNotFound), and
 //! `execve`/`posix_spawn`/`posix_spawnp` (memfs paths materialize through
 //! the `dlmap2file` host cache; roadmap 39). Memfs paths are served by
 //! the engine; host paths pass through, gated by the SAME `host_policy`
@@ -92,7 +98,16 @@
 //!   pool dies at `fork`, so a backend-touching call in the child (e.g.
 //!   the execve materialization probe under a `/` mount) would wait on
 //!   threads that no longer exist (the 2026-08-22 git-clone deadlock,
-//!   runtime 0.16.4). A fork child that goes on to `exec` re-enters a
+//!   runtime 0.16.4). glibc runs NO atfork handlers for `vfork(2)`, and a
+//!   vfork child shares the parent's whole address space with the parent
+//!   thread suspended in the kernel — so the guard carries a PID backstop
+//!   (`INIT_PID`, stored by the constructor): an engine entry whose
+//!   `getpid` differs from the initializing pid is a fork/vfork child in
+//!   its pre-exec window and passes through (the 2026-09-03 dash
+//!   vfork+lazy-init deadlock in the dogfood repro). `exec` preserves the
+//!   pid, so the exec'd image's constructor re-stores the same value and
+//!   the gate re-opens exactly at exec. A fork child that goes on to
+//!   `exec` re-enters a
 //!   fresh, healthy shim through the inherited preload env, so the
 //!   child-namespace propagation above is unaffected; a child that never
 //!   execs sees the host filesystem only — memfs fds it inherited answer

--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -621,32 +621,38 @@ mod tests {
         // canonicalization gate; the dogfood linux-gnu jing
         // ClassNotFound). A path the VFS HAS answers with its normalized
         // VFS spelling — never the host walk, whose symlink prefixes
-        // (usrmerge /lib→usr/lib) are the leak.
-        let PathRoute::Vfs(rp) = vfs_realpath(&secret) else {
+        // (usrmerge /lib→usr/lib) are the leak. Enter through the
+        // production seam (engine_call) exactly like the interposed
+        // realpath shim does: a direct unguarded entry leaves IN_ENGINE
+        // unset, and the policy layer's realpath re-validation
+        // (canonicalize_lenient, policy.rs) then re-enters the
+        // INTERPOSED realpath in-process — under a held write lock that
+        // self-deadlocks the context lock on glibc (the 2026-09-02
+        // ubuntu CI hang of this test; only linux test binaries
+        // interpose in-process, so macOS runs never saw it).
+        let guarded_rp = |p: &str| crate::sys::engine_call(|| vfs_realpath(p)).unwrap();
+        let PathRoute::Vfs(rp) = guarded_rp(&secret) else {
             panic!("memfs realpath should route Vfs");
         };
         assert_eq!(rp.to_str().unwrap(), secret);
         // Lexical normalization rides (`.`/`..`/duplicate slashes).
-        let PathRoute::Vfs(rp) = vfs_realpath(&format!("{mp}//data/./sub/../secret.txt")) else {
+        let PathRoute::Vfs(rp) = guarded_rp(&format!("{mp}//data/./sub/../secret.txt")) else {
             panic!("memfs realpath with dot components should route Vfs");
         };
         assert_eq!(rp.to_str().unwrap(), secret);
         // A mount root itself canonicalizes to its own spelling.
-        let PathRoute::Vfs(rp) = vfs_realpath(&format!("{mp}/")) else {
+        let PathRoute::Vfs(rp) = guarded_rp(&format!("{mp}/")) else {
             panic!("the mount root's realpath should route Vfs");
         };
         assert_eq!(rp.to_str().unwrap(), mp);
         // Covered-but-missing stays Host (a legit host file under a `/`
         // mount must still reach the host realpath — /etc/localtime
         // discipline).
-        assert_eq!(
-            vfs_realpath(&format!("{mp}/data/nope.txt")),
-            PathRoute::Host
-        );
+        assert_eq!(guarded_rp(&format!("{mp}/data/nope.txt")), PathRoute::Host);
         // Uncovered spellings forward, and the empty path is glibc's
         // ENOENT.
-        assert_eq!(vfs_realpath("/etc"), PathRoute::Host);
-        assert_eq!(vfs_realpath(""), PathRoute::Denied(libc::ENOENT));
+        assert_eq!(guarded_rp("/etc"), PathRoute::Host);
+        assert_eq!(guarded_rp(""), PathRoute::Denied(libc::ENOENT));
 
         let PathRoute::Vfs(dir_id) = vfs_opendir(&format!("{mp}/dir")) else {
             panic!("memfs opendir should route Vfs");
@@ -671,17 +677,27 @@ mod tests {
         assert!(!dir_is_embedded(dir_id));
 
         // ---- host passthrough (open policy), incl. mount-claimed-missing ----
+        // These hold the context lock while the policy layer realpath
+        // re-validates the host path — with realpath interposed that
+        // re-enters this crate in-process, so they must ride the
+        // production guard (see guarded_rp above) or glibc deadlocks.
         assert_eq!(
-            vfs_open("/etc/definitely-host", libc::O_RDONLY),
+            crate::sys::engine_call(|| vfs_open("/etc/definitely-host", libc::O_RDONLY)).unwrap(),
             PathRoute::Host
         );
-        assert_eq!(vfs_stat("/etc/definitely-host"), PathRoute::Host);
         assert_eq!(
-            vfs_open(&format!("{mp}/missing"), libc::O_RDONLY),
+            crate::sys::engine_call(|| vfs_stat("/etc/definitely-host")).unwrap(),
+            PathRoute::Host
+        );
+        assert_eq!(
+            crate::sys::engine_call(|| vfs_open(&format!("{mp}/missing"), libc::O_RDONLY)).unwrap(),
             PathRoute::Host,
             "a mount-claimed path absent from the image keeps the ENOENT pass-through"
         );
-        assert_eq!(vfs_write_path("/tmp/libtfs-preload-route-write"), Ok(()));
+        assert_eq!(
+            crate::sys::engine_call(|| vfs_write_path("/tmp/libtfs-preload-route-write")).unwrap(),
+            Ok(())
+        );
 
         // ---- exec/spawn trace surfaces (spec 25 §2, phase T2) ----
         // execve and posix_spawn share the engine's routing answer; the

--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -155,6 +155,11 @@ pub fn vfs_fopen(path: &str) -> PathRoute<std::ffi::CString> {
 /// resolve in-image links at lookup), so the normalized spelling IS the
 /// honest VFS canonical form.
 pub fn vfs_realpath(path: &str) -> PathRoute<std::ffi::CString> {
+    // Temporary wedge forensics (2026-09-02): stage prints, TEBAKO_DEBUG_TFS.
+    let dbg = std::env::var_os("TEBAKO_DEBUG_TFS").is_some();
+    if dbg {
+        eprintln!("[route] vfs_realpath enter path={path}");
+    }
     // realpath(3) on an empty path answers ENOENT.
     if path.is_empty() {
         return PathRoute::Denied(libc::ENOENT);
@@ -171,7 +176,13 @@ pub fn vfs_realpath(path: &str) -> PathRoute<std::ffi::CString> {
         }
     };
     let normalized = normalize_lexical(&absolute);
+    if dbg {
+        eprintln!("[route] vfs_realpath stat({normalized}) — taking context read");
+    }
     let st = { context().read().unwrap().stat(&normalized) };
+    if dbg {
+        eprintln!("[route] vfs_realpath stat answered");
+    }
     match route_answer(st, &normalized, HostAccess::Ro) {
         PathRoute::Vfs(_) => match std::ffi::CString::new(normalized) {
             Ok(c) => PathRoute::Vfs(c),

--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -136,6 +136,73 @@ pub fn vfs_fopen(path: &str) -> PathRoute<std::ffi::CString> {
     route_answer(answer, path, HostAccess::Ro)
 }
 
+/// realpath routing (spec 07 §8). glibc's realpath(3) walks the path
+/// with libc-INTERNAL stat/readlink aliases that LD_PRELOAD cannot
+/// interpose, so an un-interposed realpath canonicalizes a VFS path
+/// against the HOST root: on usrmerge hosts (`/lib -> usr/lib`) a
+/// root-mounted payload's `/lib/…` comes back as `/usr/lib/…`, a spelling
+/// the VFS cannot serve — the JDK's `File.getCanonicalFile` canonicalizes
+/// every `-jar`/`-cp` classpath entry exactly this way, which dropped the
+/// payload's jing jar from the classpath (the dogfood linux-gnu
+/// ClassNotFoundException, 2026-09-03; PROGRESS/31).
+///
+/// The discipline: a path that EXISTS in the VFS is answered with its
+/// lexically normalized VFS spelling — the host walk never runs, so no
+/// host symlink prefix can leak into it. A path the VFS lacks (a legit
+/// host file sitting under a `/` mount, `/etc/…` style) forwards to the
+/// real realpath, exactly like the open/stat passthrough. VFS symlink
+/// resolution: none (memfs has no symlink duality, and image backends
+/// resolve in-image links at lookup), so the normalized spelling IS the
+/// honest VFS canonical form.
+pub fn vfs_realpath(path: &str) -> PathRoute<std::ffi::CString> {
+    // realpath(3) on an empty path answers ENOENT.
+    if path.is_empty() {
+        return PathRoute::Denied(libc::ENOENT);
+    }
+    // realpath is absolute-only: a relative input resolves against the
+    // cwd first. The kernel never lets a process chdir into the VFS (the
+    // VFS has no host directory entries), so the cwd is always host.
+    let absolute = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        match std::env::current_dir() {
+            Ok(cwd) => format!("{}/{}", cwd.to_string_lossy(), path),
+            Err(e) => return PathRoute::Denied(e.raw_os_error().unwrap_or(libc::EIO)),
+        }
+    };
+    let normalized = normalize_lexical(&absolute);
+    let st = { context().read().unwrap().stat(&normalized) };
+    match route_answer(st, &normalized, HostAccess::Ro) {
+        PathRoute::Vfs(_) => match std::ffi::CString::new(normalized) {
+            Ok(c) => PathRoute::Vfs(c),
+            // Unreachable: `normalized` derives from a NUL-free C string
+            // and the transform never introduces one.
+            Err(_) => PathRoute::Denied(libc::EINVAL),
+        },
+        PathRoute::Host => PathRoute::Host,
+        PathRoute::Denied(e) => PathRoute::Denied(e),
+    }
+}
+
+/// The lexical normalizer for the realpath answer — the same discipline
+/// as `tfs::context`'s private `normalize` (`.` dropped, `a/..` resolved
+/// lexically, `..` at the root clamped, duplicate slashes collapsed). The
+/// input is absolute by construction (see the caller), so the result
+/// always keeps its leading `/`.
+fn normalize_lexical(path: &str) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    for component in path.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                out.pop();
+            }
+            c => out.push(c),
+        }
+    }
+    format!("/{}", out.join("/"))
+}
+
 /// Write-class routing (mkdir/unlink/rename). A path a mount HOLDS is
 /// EROFS (payload images are always ro; path-level writes would route
 /// through a COW overlay, which the shim never mounts). A path merely
@@ -549,6 +616,38 @@ mod tests {
             vfs_access(&secret, libc::X_OK),
             PathRoute::Denied(libc::EACCES)
         );
+
+        // ---- realpath routing (spec 07 §8 — the JDK
+        // canonicalization gate; the dogfood linux-gnu jing
+        // ClassNotFound). A path the VFS HAS answers with its normalized
+        // VFS spelling — never the host walk, whose symlink prefixes
+        // (usrmerge /lib→usr/lib) are the leak.
+        let PathRoute::Vfs(rp) = vfs_realpath(&secret) else {
+            panic!("memfs realpath should route Vfs");
+        };
+        assert_eq!(rp.to_str().unwrap(), secret);
+        // Lexical normalization rides (`.`/`..`/duplicate slashes).
+        let PathRoute::Vfs(rp) = vfs_realpath(&format!("{mp}//data/./sub/../secret.txt")) else {
+            panic!("memfs realpath with dot components should route Vfs");
+        };
+        assert_eq!(rp.to_str().unwrap(), secret);
+        // A mount root itself canonicalizes to its own spelling.
+        let PathRoute::Vfs(rp) = vfs_realpath(&format!("{mp}/")) else {
+            panic!("the mount root's realpath should route Vfs");
+        };
+        assert_eq!(rp.to_str().unwrap(), mp);
+        // Covered-but-missing stays Host (a legit host file under a `/`
+        // mount must still reach the host realpath — /etc/localtime
+        // discipline).
+        assert_eq!(
+            vfs_realpath(&format!("{mp}/data/nope.txt")),
+            PathRoute::Host
+        );
+        // Uncovered spellings forward, and the empty path is glibc's
+        // ENOENT.
+        assert_eq!(vfs_realpath("/etc"), PathRoute::Host);
+        assert_eq!(vfs_realpath(""), PathRoute::Denied(libc::ENOENT));
+
         let PathRoute::Vfs(dir_id) = vfs_opendir(&format!("{mp}/dir")) else {
             panic!("memfs opendir should route Vfs");
         };

--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -155,11 +155,6 @@ pub fn vfs_fopen(path: &str) -> PathRoute<std::ffi::CString> {
 /// resolve in-image links at lookup), so the normalized spelling IS the
 /// honest VFS canonical form.
 pub fn vfs_realpath(path: &str) -> PathRoute<std::ffi::CString> {
-    // Temporary wedge forensics (2026-09-02): stage prints, TEBAKO_DEBUG_TFS.
-    let dbg = std::env::var_os("TEBAKO_DEBUG_TFS").is_some();
-    if dbg {
-        eprintln!("[route] vfs_realpath enter path={path}");
-    }
     // realpath(3) on an empty path answers ENOENT.
     if path.is_empty() {
         return PathRoute::Denied(libc::ENOENT);
@@ -176,13 +171,7 @@ pub fn vfs_realpath(path: &str) -> PathRoute<std::ffi::CString> {
         }
     };
     let normalized = normalize_lexical(&absolute);
-    if dbg {
-        eprintln!("[route] vfs_realpath stat({normalized}) — taking context read");
-    }
     let st = { context().read().unwrap().stat(&normalized) };
-    if dbg {
-        eprintln!("[route] vfs_realpath stat answered");
-    }
     match route_answer(st, &normalized, HostAccess::Ro) {
         PathRoute::Vfs(_) => match std::ffi::CString::new(normalized) {
             Ok(c) => PathRoute::Vfs(c),
@@ -549,6 +538,21 @@ mod tests {
     /// must not race parallel tests.
     #[test]
     fn route_matrix() {
+        // The 2026-09-02 discipline (supersedes the 08-21 per-call wraps):
+        // the WHOLE matrix runs inside ONE engine_call — the production
+        // re-entrancy guard. Route calls inside then behave exactly like a
+        // production shim entry: the engine's own host IO (mount reads,
+        // extraction writes, the policy layer's realpath re-validation —
+        // canonicalize_lenient, policy.rs) re-enters the interposed symbols
+        // in-process on linux, sees IN_ENGINE armed, and forwards to the
+        // host. Unguarded direct entries self-deadlock the context RwLock
+        // (write held → canonicalize → interposed realpath → vfs_realpath →
+        // read request) — the 08-21 and 09-02 ubuntu CI hangs; macOS test
+        // binaries do not interpose in-process, so only ubuntu CI saw them.
+        crate::sys::engine_call(route_matrix_body);
+    }
+
+    fn route_matrix_body() {
         // ---- fixture: a zip image in a private temp dir ----
         let dir = std::env::temp_dir().join(format!("libtfs-preload-route-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
@@ -632,38 +636,35 @@ mod tests {
         // canonicalization gate; the dogfood linux-gnu jing
         // ClassNotFound). A path the VFS HAS answers with its normalized
         // VFS spelling — never the host walk, whose symlink prefixes
-        // (usrmerge /lib→usr/lib) are the leak. Enter through the
-        // production seam (engine_call) exactly like the interposed
-        // realpath shim does: a direct unguarded entry leaves IN_ENGINE
-        // unset, and the policy layer's realpath re-validation
-        // (canonicalize_lenient, policy.rs) then re-enters the
-        // INTERPOSED realpath in-process — under a held write lock that
-        // self-deadlocks the context lock on glibc (the 2026-09-02
-        // ubuntu CI hang of this test; only linux test binaries
-        // interpose in-process, so macOS runs never saw it).
-        let guarded_rp = |p: &str| crate::sys::engine_call(|| vfs_realpath(p)).unwrap();
-        let PathRoute::Vfs(rp) = guarded_rp(&secret) else {
+        // (usrmerge /lib→usr/lib) are the leak. The re-entrancy guard
+        // discipline lives at the top of route_matrix now (one
+        // engine_call for the whole body); these calls are plain route
+        // entries, exactly what a production shim does inside its guard.
+        let PathRoute::Vfs(rp) = vfs_realpath(&secret) else {
             panic!("memfs realpath should route Vfs");
         };
         assert_eq!(rp.to_str().unwrap(), secret);
         // Lexical normalization rides (`.`/`..`/duplicate slashes).
-        let PathRoute::Vfs(rp) = guarded_rp(&format!("{mp}//data/./sub/../secret.txt")) else {
+        let PathRoute::Vfs(rp) = vfs_realpath(&format!("{mp}//data/./sub/../secret.txt")) else {
             panic!("memfs realpath with dot components should route Vfs");
         };
         assert_eq!(rp.to_str().unwrap(), secret);
         // A mount root itself canonicalizes to its own spelling.
-        let PathRoute::Vfs(rp) = guarded_rp(&format!("{mp}/")) else {
+        let PathRoute::Vfs(rp) = vfs_realpath(&format!("{mp}/")) else {
             panic!("the mount root's realpath should route Vfs");
         };
         assert_eq!(rp.to_str().unwrap(), mp);
         // Covered-but-missing stays Host (a legit host file under a `/`
         // mount must still reach the host realpath — /etc/localtime
         // discipline).
-        assert_eq!(guarded_rp(&format!("{mp}/data/nope.txt")), PathRoute::Host);
+        assert_eq!(
+            vfs_realpath(&format!("{mp}/data/nope.txt")),
+            PathRoute::Host
+        );
         // Uncovered spellings forward, and the empty path is glibc's
         // ENOENT.
-        assert_eq!(guarded_rp("/etc"), PathRoute::Host);
-        assert_eq!(guarded_rp(""), PathRoute::Denied(libc::ENOENT));
+        assert_eq!(vfs_realpath("/etc"), PathRoute::Host);
+        assert_eq!(vfs_realpath(""), PathRoute::Denied(libc::ENOENT));
 
         let PathRoute::Vfs(dir_id) = vfs_opendir(&format!("{mp}/dir")) else {
             panic!("memfs opendir should route Vfs");
@@ -689,26 +690,21 @@ mod tests {
 
         // ---- host passthrough (open policy), incl. mount-claimed-missing ----
         // These hold the context lock while the policy layer realpath
-        // re-validates the host path — with realpath interposed that
-        // re-enters this crate in-process, so they must ride the
-        // production guard (see guarded_rp above) or glibc deadlocks.
+        // re-validates the host path — with realpath interposed, that
+        // re-enters this crate in-process; the whole-test engine_call
+        // (top of route_matrix) is what forwards that re-entry to the
+        // host instead of self-deadlocking the context lock.
         assert_eq!(
-            crate::sys::engine_call(|| vfs_open("/etc/definitely-host", libc::O_RDONLY)).unwrap(),
+            vfs_open("/etc/definitely-host", libc::O_RDONLY),
             PathRoute::Host
         );
+        assert_eq!(vfs_stat("/etc/definitely-host"), PathRoute::Host);
         assert_eq!(
-            crate::sys::engine_call(|| vfs_stat("/etc/definitely-host")).unwrap(),
-            PathRoute::Host
-        );
-        assert_eq!(
-            crate::sys::engine_call(|| vfs_open(&format!("{mp}/missing"), libc::O_RDONLY)).unwrap(),
+            vfs_open(&format!("{mp}/missing"), libc::O_RDONLY),
             PathRoute::Host,
             "a mount-claimed path absent from the image keeps the ENOENT pass-through"
         );
-        assert_eq!(
-            crate::sys::engine_call(|| vfs_write_path("/tmp/libtfs-preload-route-write")).unwrap(),
-            Ok(())
-        );
+        assert_eq!(vfs_write_path("/tmp/libtfs-preload-route-write"), Ok(()));
 
         // ---- exec/spawn trace surfaces (spec 25 §2, phase T2) ----
         // execve and posix_spawn share the engine's routing answer; the
@@ -716,24 +712,19 @@ mod tests {
         // armed for this block only, disarmed right after.
         let capture = dir.join("trace.jsonl");
         assert!(tfs::trace::arm(&capture), "the bus arms");
-        // Enter through the production seam (engine_call — the shims'
-        // re-entrancy guard): a direct unguarded route call leaves
-        // IN_ENGINE unset, and the extraction's host writes then
-        // re-enter the shims and deadlock the context lock on glibc
-        // (the 2026-08-21 ubuntu CI hang of this test).
-        let PathRoute::Vfs(exec_host) =
-            crate::sys::engine_call(|| vfs_materialize_exec(&tool)).unwrap()
-        else {
+        // The extraction's host writes re-enter the shims in-process on
+        // linux — safe here because the whole test rides the one
+        // engine_call at the top of route_matrix (the 2026-08-21 ubuntu
+        // CI hang was the unguarded form of exactly this entry).
+        let PathRoute::Vfs(exec_host) = vfs_materialize_exec(&tool) else {
             panic!("memfs exec should route Vfs");
         };
-        let PathRoute::Vfs(spawn_host) =
-            crate::sys::engine_call(|| vfs_materialize_spawn(&tool)).unwrap()
-        else {
+        let PathRoute::Vfs(spawn_host) = vfs_materialize_spawn(&tool) else {
             panic!("memfs spawn should route Vfs");
         };
         assert_eq!(exec_host, spawn_host, "one routing answer, two surfaces");
         assert_eq!(
-            crate::sys::engine_call(|| vfs_materialize_spawn("/etc/definitely-host")).unwrap(),
+            vfs_materialize_spawn("/etc/definitely-host"),
             PathRoute::Host
         );
         tfs::trace::disarm();

--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -295,7 +295,7 @@ real_fn!(
 );
 real_fn!(real___chk_fail, c"__chk_fail", unsafe extern "C" fn() -> !);
 // realpath(3) itself: the JDK's libjava canonicalization calls it through
-// the PLT (the spec 22 class-F dogfood jing ClassNotFound) — the walk
+// the PLT (the spec 07 §8 dogfood jing ClassNotFound) — the walk
 // INSIDE glibc is unreachable, so the shim answers VFS paths itself and
 // forwards host paths here.
 real_fn!(

--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -42,11 +42,23 @@
 //! `BIO_new_file` / `X509_LOOKUP_load_file` choke point — binds
 //! `fopen64`, never `fopen`) are interposed as delegations to their
 //! plain-name bodies, as is `__fxstatat64` (to `__fxstatat` — the
-//! versioned stat family's last *64 form). Remaining documented gaps:
+//! versioned stat family's last *64 form). The realpath family is
+//! interposed too (`realpath`, `canonicalize_file_name`, and the fortified
+//! `__realpath_chk` — spec 07 §8): glibc's realpath walks the path
+//! with libc-INTERNAL stat/readlink aliases that no PLT interpose sees,
+//! so a covered path answered by the host resolver leaked the
+//! HOST-canonicalized spelling (usrmerge /lib → usr/lib) into the JDK's
+//! URLClassPath — the 2026-09-03 dogfood linux-gnu jing ClassNotFound.
+//! The shim answers covered paths with the mount spelling, lexically
+//! normalized (the VFS is already canonical), and passes everything else
+//! to the host. Remaining documented gaps:
 //! the rest of the fortify open family (`__open_2`/`__open64_2`/
 //! `__openat64_2` — no importer observed in the 0.16.6 linux-gnu
-//! runtime), `readv`/`preadv`/`sendfile`/`copy_file_range`, and the
-//! write-side `pwrite64`/`ftruncate64`/`statvfs64` family on memfs fds. A
+//! runtime), `readv`/`preadv`/`sendfile`/`copy_file_range`, the
+//! write-side `pwrite64`/`ftruncate64`/`statvfs64` family on memfs fds,
+//! and the internal-walk family `glob`/`nftw`/`ftw`/`wordexp` (the same
+//! libc-internal-alias bypass class as realpath — UNAUDITED, no observed
+//! importer; pinned debt). A
 //! pre-existing landmine OUTSIDE the JDK path: the plain
 //! `stat`/`lstat`/`fstat`/`stat64`/`lstat64`/`fstat64` host passthroughs
 //! resolve dynamic symbols glibc only exports ≥ 2.33 — on an older
@@ -282,6 +294,15 @@ real_fn!(
     unsafe extern "C" fn(c_int, *mut c_void, usize, usize) -> libc::ssize_t
 );
 real_fn!(real___chk_fail, c"__chk_fail", unsafe extern "C" fn() -> !);
+// realpath(3) itself: the JDK's libjava canonicalization calls it through
+// the PLT (the spec 22 class-F dogfood jing ClassNotFound) — the walk
+// INSIDE glibc is unreachable, so the shim answers VFS paths itself and
+// forwards host paths here.
+real_fn!(
+    real_realpath,
+    c"realpath",
+    unsafe extern "C" fn(*const c_char, *mut c_char) -> *mut c_char
+);
 real_fn!(
     real_rewinddir,
     c"rewinddir",

--- a/crates/libtfs-preload/src/sys/macos.rs
+++ b/crates/libtfs-preload/src/sys/macos.rs
@@ -341,6 +341,33 @@ interpose!(
         *const *mut c_char,
     ) -> c_int
 );
+// realpath + realpath$DARWIN_EXTSN (spec 07 §8): xnu's realpath(3)
+// walks the path with internal syscalls the interpose tuples never see —
+// the same host-leak class as glibc (a payload path under a host symlink
+// prefix, `/tmp`/`/etc`/`/var` on macOS, canonicalizes to the host
+// spelling). The JDK's `File.getCanonicalFile` calls it through the PLT,
+// which the tuple DOES redirect; the VFS answer lives in the shim body.
+interpose!(
+    INTERPOSE_REALPATH,
+    real_realpath,
+    super::realpath,
+    libc::realpath,
+    unsafe extern "C" fn(*const c_char, *mut c_char) -> *mut c_char
+);
+// `realpath$DARWIN_EXTSN`: the SDK's stdlib.h maps `realpath` here under
+// _DARWIN_C_FULL_SOURCE (the default) — no libc crate binding, declared
+// so its address can seed the tuple (the fopen$DARWIN_EXTSN pattern).
+unsafe extern "C" {
+    #[link_name = "realpath$DARWIN_EXTSN"]
+    fn realpath_extsn(path: *const c_char, resolved: *mut c_char) -> *mut c_char;
+}
+interpose!(
+    INTERPOSE_REALPATH_EXTSN,
+    real_realpath_extsn,
+    super::realpath_darwin_extsn,
+    realpath_extsn,
+    unsafe extern "C" fn(*const c_char, *mut c_char) -> *mut c_char
+);
 
 /// Library constructor: establish the namespace before the program's main.
 #[used]

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -1020,13 +1020,30 @@ pub unsafe extern "C" fn mmap64(
 /// `resolved` must name a caller buffer of `PATH_MAX` bytes (the
 /// realpath(3) contract).
 unsafe fn realpath_impl(path: *const c_char, resolved: *mut c_char) -> *mut c_char {
-    if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
-        eprintln!("[preload] realpath");
+    // Temporary wedge forensics (2026-09-02, route_matrix ubuntu hang):
+    // the debug lines name the path, the IN_ENGINE state, and each stage
+    // boundary, so a wedge's last printed line IS the wedged stage.
+    let dbg = std::env::var_os("TEBAKO_DEBUG_TFS").is_some();
+    if dbg {
+        let p = if path.is_null() {
+            std::ffi::CString::default()
+        } else {
+            unsafe { CStr::from_ptr(path) }.to_owned()
+        };
+        eprintln!(
+            "[preload] realpath enter path={p:?} in_engine={} foreign={}",
+            IN_ENGINE.with(|c| c.get()),
+            in_foreign_process()
+        );
     }
     let Some(p) = (unsafe { c_path(path) }) else {
         return unsafe { plat::real_realpath()(path, resolved) };
     };
-    match engine_call(|| route::vfs_realpath(p)) {
+    let routed = engine_call(|| route::vfs_realpath(p));
+    if dbg {
+        eprintln!("[preload] realpath routed={}", routed.is_some());
+    }
+    match routed {
         Some(PathRoute::Vfs(c)) => {
             let bytes = c.as_bytes_with_nul();
             if bytes.len() > libc::PATH_MAX as usize {
@@ -1055,7 +1072,16 @@ unsafe fn realpath_impl(path: *const c_char, resolved: *mut c_char) -> *mut c_ch
             set_errno(e);
             std::ptr::null_mut()
         }
-        Some(PathRoute::Host) | None => unsafe { plat::real_realpath()(path, resolved) },
+        Some(PathRoute::Host) | None => {
+            if dbg {
+                eprintln!("[preload] realpath forwarding to host");
+            }
+            let out = unsafe { plat::real_realpath()(path, resolved) };
+            if dbg {
+                eprintln!("[preload] realpath host answered null={}", out.is_null());
+            }
+            out
+        }
     }
 }
 

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -34,7 +34,7 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::ffi::{c_char, c_int, c_void, CStr};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::Mutex;
 
 use tfs::context::TebakoCDirent;
@@ -105,6 +105,33 @@ thread_local! {
 /// copies of parent engine state even if served).
 static IN_FORK_CHILD: AtomicBool = AtomicBool::new(false);
 
+/// The pid the shim initialized in (stored by [`init`], the library
+/// constructor). An interposed call carrying a DIFFERENT pid belongs to a
+/// fork/vfork child in its pre-exec window. `pthread_atfork` covers
+/// `fork(2)` (the `IN_FORK_CHILD` guard above) but glibc runs NO atfork
+/// handlers for `vfork(2)` — and a vfork child shares the parent's whole
+/// address space, so an engine entry there does not merely wait on dead
+/// worker threads: its lazy initialization MUTATES memory the blocked
+/// parent still owns. dash's `execvp` PATH search hits exactly this (the
+/// 2026-09-03 dogfood-repro deadlock: the parent dash slept in
+/// `kernel_clone`, the vfork child in `futex_wait` — deterministic under
+/// Rosetta, a latent corruption/wedge natively). The pid gate is the
+/// vfork backstop: one `getpid` per engine entry, truthful in a vfork
+/// child because glibc ≥ 2.25 keeps no TLS pid cache. `exec` preserves
+/// the pid, so the exec'd image's constructor re-stores the SAME value
+/// and the gate re-opens exactly at exec.
+static INIT_PID: AtomicI32 = AtomicI32::new(0);
+
+/// True when the current process is not the one the shim initialized in
+/// (a fork/vfork child before its exec). The `p != 0` arm keeps calls
+/// made BEFORE the constructor ran (an early-loading dependency's own
+/// constructor) on the historical ungated path.
+fn in_foreign_process() -> bool {
+    let p = INIT_PID.load(Ordering::Relaxed);
+    // SAFETY: plain libc call; no glibc pid cache exists to go stale.
+    p != 0 && unsafe { libc::getpid() } != p
+}
+
 /// The atfork CHILD handler: arm the fork-child guard. Runs in the child,
 /// on the forking thread, before the child's `fork` caller resumes.
 ///
@@ -153,7 +180,10 @@ pub(crate) fn register_fork_guard() {
 /// route_matrix ubuntu hang; macOS test binaries do not interpose
 /// in-process, so only Linux CI saw it).
 pub(crate) fn engine_call<T>(f: impl FnOnce() -> T) -> Option<T> {
-    engine_call_inner(IN_FORK_CHILD.load(Ordering::Relaxed), f)
+    engine_call_inner(
+        IN_FORK_CHILD.load(Ordering::Relaxed) || in_foreign_process(),
+        f,
+    )
 }
 
 /// The gate body with the fork-child flag as an explicit input, so the
@@ -966,6 +996,113 @@ pub unsafe extern "C" fn mmap64(
     unsafe { mmap_memfs_or_host(addr, len, prot, flags, fd, offset) }
 }
 
+// ---------------------------------------------------------------------
+// realpath family (spec 07 §8). glibc's realpath(3) walks the path
+// with libc-INTERNAL stat/readlink aliases — invisible to LD_PRELOAD —
+// so an un-interposed realpath canonicalizes a VFS path against the HOST
+// root and leaks host symlink prefixes into the result (usrmerge
+// `/lib -> usr/lib` turned a root-mounted payload's `/lib/…` jing jar
+// into `/usr/lib/…`, which the VFS then could not serve — the JDK's
+// `File.getCanonicalFile` canonicalizes every -jar/-cp classpath entry
+// exactly this way: the dogfood linux-gnu ClassNotFoundException,
+// 2026-09-03). The caller-side call from libjava.so rides the PLT, so
+// this export DOES win for it; only libc's own internal realpath users
+// stay uncovered. Semantics live in `route::vfs_realpath`: a path the
+// VFS has is answered with its normalized VFS spelling; anything else
+// forwards to the real call.
+// ---------------------------------------------------------------------
+
+/// The shared realpath body (macOS's `realpath$DARWIN_EXTSN` delegates
+/// here; linux's `canonicalize_file_name` and `__realpath_chk` too).
+///
+/// # Safety
+/// `path`/`resolved` follow the intercepted-call contract; a non-NULL
+/// `resolved` must name a caller buffer of `PATH_MAX` bytes (the
+/// realpath(3) contract).
+unsafe fn realpath_impl(path: *const c_char, resolved: *mut c_char) -> *mut c_char {
+    if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+        eprintln!("[preload] realpath");
+    }
+    let Some(p) = (unsafe { c_path(path) }) else {
+        return unsafe { plat::real_realpath()(path, resolved) };
+    };
+    match engine_call(|| route::vfs_realpath(p)) {
+        Some(PathRoute::Vfs(c)) => {
+            let bytes = c.as_bytes_with_nul();
+            if bytes.len() > libc::PATH_MAX as usize {
+                set_errno(libc::ENAMETOOLONG);
+                return std::ptr::null_mut();
+            }
+            if resolved.is_null() {
+                // The glibc extension: a NULL buffer gets a malloc'd
+                // result. `strdup` allocates from libc's malloc, so the
+                // caller's `free(3)` is honored.
+                unsafe { libc::strdup(c.as_ptr()) }
+            } else {
+                // SAFETY: `resolved` is the caller's PATH_MAX buffer and
+                // `bytes` fits (checked above).
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        bytes.as_ptr().cast::<c_char>(),
+                        resolved,
+                        bytes.len(),
+                    )
+                };
+                resolved
+            }
+        }
+        Some(PathRoute::Denied(e)) => {
+            set_errno(e);
+            std::ptr::null_mut()
+        }
+        Some(PathRoute::Host) | None => unsafe { plat::real_realpath()(path, resolved) },
+    }
+}
+
+/// Interposed `realpath`.
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn realpath(path: *const c_char, resolved: *mut c_char) -> *mut c_char {
+    unsafe { realpath_impl(path, resolved) }
+}
+
+/// macOS: `realpath$DARWIN_EXTSN` — the extended-variant twin the SDK's
+/// stdio.h routes modern builds to (same contract as `realpath`; the
+/// `$DARWIN_EXTSN` difference lives in the UNIX03 legacy behavior the
+/// VFS answer never had). Delegates exactly like the LFS aliases.
+#[cfg(target_os = "macos")]
+pub unsafe extern "C" fn realpath_darwin_extsn(
+    path: *const c_char,
+    resolved: *mut c_char,
+) -> *mut c_char {
+    unsafe { realpath_impl(path, resolved) }
+}
+
+/// Linux: `canonicalize_file_name` — the always-allocating realpath
+/// spelling (glibc). Delegates; the NULL-buffer arm of `realpath_impl`
+/// does the allocation.
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn canonicalize_file_name(path: *const c_char) -> *mut c_char {
+    unsafe { realpath_impl(path, std::ptr::null_mut()) }
+}
+
+/// Linux: `__realpath_chk` — the `_FORTIFY_SOURCE` realpath. glibc's
+/// check is runtime-only: a destination object known smaller than
+/// PATH_MAX aborts; ours is the same test, then the plain body.
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn __realpath_chk(
+    path: *const c_char,
+    resolved: *mut c_char,
+    resolvedlen: usize,
+) -> *mut c_char {
+    if resolvedlen < libc::PATH_MAX as usize {
+        // glibc's __realpath_chk calls __chk_fail here; it never returns.
+        unsafe { plat::real___chk_fail()() }
+    }
+    unsafe { realpath_impl(path, resolved) }
+}
+
 /// Interposed `close` (fd-flag dispatch; a memfs fd never reaches the
 /// real close).
 #[cfg_attr(target_os = "linux", no_mangle)]
@@ -1621,6 +1758,10 @@ pub unsafe extern "C" fn posix_spawnp(
 /// not mount, is a named configuration error: a clear stderr message
 /// naming the variable and the offending token, then EX_CONFIG (78).
 pub fn init() {
+    // Record the initializing pid FIRST, before anything can fork/vfork:
+    // the pid gate (see `INIT_PID`) is the only guard that reaches vfork
+    // children — glibc runs no atfork handlers for vfork(2).
+    INIT_PID.store(unsafe { libc::getpid() }, Ordering::Relaxed);
     // Arm the fork-child guard FIRST, before any mount can happen: a
     // backend worker pool comes into existence at mount time, and the
     // guard must already be registered before any later fork.

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -173,12 +173,17 @@ pub(crate) fn register_fork_guard() {
 /// dead threads.
 ///
 /// pub(crate) for the TEST seam: a test that calls the route layer
-/// directly must enter through this guard exactly like the shims do.
-/// Unguarded direct entry leaves IN_ENGINE unset, so the engine's own
-/// host IO (the extraction writes under the context lock) re-enters the
-/// shims and deadlocks the context lock on glibc (the 2026-08-21
-/// route_matrix ubuntu hang; macOS test binaries do not interpose
-/// in-process, so only Linux CI saw it).
+/// directly must enter through this guard exactly like the shims do —
+/// and it must wrap its WHOLE body in ONE engine_call (route_matrix is
+/// the exemplar), not wrap each call. A nested engine_call returns
+/// `None` (IN_ENGINE is already armed), so per-call wraps inside the
+/// body would panic on unwrap; plain inner calls behave exactly like a
+/// production shim re-entry under the armed guard. Unguarded direct
+/// entry leaves IN_ENGINE unset, so the engine's own host IO (mount
+/// reads, extraction writes, the policy layer's realpath re-validation)
+/// re-enters the shims and self-deadlocks the context RwLock on glibc
+/// (the 2026-08-21 and 2026-09-02 route_matrix ubuntu hangs; macOS test
+/// binaries do not interpose in-process, so only Linux CI saw them).
 pub(crate) fn engine_call<T>(f: impl FnOnce() -> T) -> Option<T> {
     engine_call_inner(
         IN_FORK_CHILD.load(Ordering::Relaxed) || in_foreign_process(),
@@ -1020,30 +1025,13 @@ pub unsafe extern "C" fn mmap64(
 /// `resolved` must name a caller buffer of `PATH_MAX` bytes (the
 /// realpath(3) contract).
 unsafe fn realpath_impl(path: *const c_char, resolved: *mut c_char) -> *mut c_char {
-    // Temporary wedge forensics (2026-09-02, route_matrix ubuntu hang):
-    // the debug lines name the path, the IN_ENGINE state, and each stage
-    // boundary, so a wedge's last printed line IS the wedged stage.
-    let dbg = std::env::var_os("TEBAKO_DEBUG_TFS").is_some();
-    if dbg {
-        let p = if path.is_null() {
-            std::ffi::CString::default()
-        } else {
-            unsafe { CStr::from_ptr(path) }.to_owned()
-        };
-        eprintln!(
-            "[preload] realpath enter path={p:?} in_engine={} foreign={}",
-            IN_ENGINE.with(|c| c.get()),
-            in_foreign_process()
-        );
+    if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
+        eprintln!("[preload] realpath");
     }
     let Some(p) = (unsafe { c_path(path) }) else {
         return unsafe { plat::real_realpath()(path, resolved) };
     };
-    let routed = engine_call(|| route::vfs_realpath(p));
-    if dbg {
-        eprintln!("[preload] realpath routed={}", routed.is_some());
-    }
-    match routed {
+    match engine_call(|| route::vfs_realpath(p)) {
         Some(PathRoute::Vfs(c)) => {
             let bytes = c.as_bytes_with_nul();
             if bytes.len() > libc::PATH_MAX as usize {
@@ -1072,16 +1060,7 @@ unsafe fn realpath_impl(path: *const c_char, resolved: *mut c_char) -> *mut c_ch
             set_errno(e);
             std::ptr::null_mut()
         }
-        Some(PathRoute::Host) | None => {
-            if dbg {
-                eprintln!("[preload] realpath forwarding to host");
-            }
-            let out = unsafe { plat::real_realpath()(path, resolved) };
-            if dbg {
-                eprintln!("[preload] realpath host answered null={}", out.is_null());
-            }
-            out
-        }
+        Some(PathRoute::Host) | None => unsafe { plat::real_realpath()(path, resolved) },
     }
 }
 

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -21,6 +21,15 @@
 //!   __fxstatat64 — the LFS64/fortify/versioned twins of already-covered
 //!   names, incl. OpenSSL 3.6's `openssl_fopen` → `fopen64`): the jail
 //!   gates each alias exactly like its plain-name twin,
+//! - the realpath family (spec 07 §8): glibc's realpath walks the
+//!   path with libc-internal aliases no PLT interpose sees, so covered
+//!   paths must be answered by the shim with the MOUNT spelling — never
+//!   the host-canonicalized one (the dogfood linux-gnu jing
+//!   ClassNotFound: usrmerge /lib→usr/lib leaked into the JDK's
+//!   URLClassPath on a root-mounted payload),
+//! - the vfork arm of the fork guard: atfork handlers never run for
+//!   vfork(2), so the pid gate passes a vfork child's engine entries to
+//!   the host libc (the dash vfork+lazy-init deadlock),
 //! - named errors + EX_CONFIG (78) on misformatted env.
 //!
 //! Skip policy (documented in the crate README/spec): tests SKIP (pass
@@ -154,6 +163,8 @@ fn build_fixtures() -> Option<Fixtures> {
         "close-probe",
         "fork-exec",
         "alias-probe",
+        "realpath-probe",
+        "vfork-probe",
     ] {
         let src = src_dir.join(format!("{name}.c"));
         let out = dir.join("bin").join(name);
@@ -1088,6 +1099,109 @@ fn fork_child_exec_under_root_mount_completes() {
     assert_eq!(
         out.stdout, b"HOST-FILE\n",
         "the grandchild's host read under the root mount"
+    );
+}
+
+// ---------------------------------------------------------------------
+// The 2026-09-03 dogfood linux-gnu pair: realpath + vfork (spec 07 §8)
+// ---------------------------------------------------------------------
+
+/// glibc realpath(3) walks the path with libc-INTERNAL stat/readlink
+/// aliases that PLT interposition never sees — so before the shim
+/// interposed the realpath family, realpath under a VFS mount fell
+/// through to the host resolver. On a root-mounted payload whose
+/// spelling crosses a host symlink (usrmerge /lib → usr/lib on the
+/// ubuntu:24.04 dogfood container) the JDK's File.getCanonicalFile
+/// leaked the RESOLVED spelling into URLClassPath, the jar lookup then
+/// missed, and the user saw ClassNotFoundException on a byte-perfect
+/// jar. The shim now answers covered paths with the MOUNT spelling
+/// (lexically normalized — the VFS is already canonical; host symlink
+/// resolution must never rewrite a VFS path).
+///
+/// The red state is portable (macOS + linux): pre-fix there was no
+/// realpath interpose at all, so the probe below fell through to the
+/// host realpath — which resolved the symlinked mount point and then
+/// ENOENT'd on the in-image file.
+#[test]
+fn realpath_under_symlinked_mount_keeps_the_vfs_spelling() {
+    let Some(f) = fixtures() else { return };
+    // A symlinked mount spelling: vlink → vtarget. The image mounts at
+    // the LINK; realpath must answer with the link spelling, not the
+    // host-resolved target.
+    let target = f.dir.join("vtarget");
+    std::fs::create_dir_all(&target).unwrap();
+    let link = f.dir.join("vlink");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    let want = format!("{}/data/secret.txt", link.display());
+    let mounts = format!("{}:{}", f.zip.display(), link.display());
+
+    // Caller-buffer arm (the JDK's canonicalize_md.c shape).
+    let r = run_with_mounts(f, "realpath-probe", &[&want], &mounts, None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(
+        r.stdout,
+        format!("{want}\n"),
+        "the VFS spelling, not the host-canonicalized one"
+    );
+
+    // NULL-buffer arm (glibc canonicalize_file_name semantics).
+    let r = run_with_mounts(f, "realpath-probe", &[&want, "null"], &mounts, None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, format!("{want}\n"), "NULL-buffer arm");
+
+    // Host control: an uncovered host path still gets the HOST realpath
+    // (f.dir is canonicalized at fixture build, so the host canonical
+    // form is exactly this spelling).
+    let host = f.work.join("hostfile.txt").display().to_string();
+    let r = run_with_mounts(f, "realpath-probe", &[&host], &mounts, None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, format!("{host}\n"), "host passthrough");
+}
+
+/// The vfork arm of the fork guard: pthread_atfork handlers do NOT run
+/// for vfork(2), so the atfork guard alone never armed in a vfork child
+/// — and a vfork child shares the parent's whole address space with the
+/// parent's calling thread suspended in the kernel. dash's execvp PATH
+/// search hit exactly this in the dogfood repro (parent in kernel_clone,
+/// child in futex_wait). The pid gate (INIT_PID) catches what atfork
+/// cannot: the child's getpid differs from the init pid even though the
+/// address space is shared, so every engine entry in the child passes
+/// through to the host libc — the same semantics as the fork guard.
+///
+/// The fixture stats a path that exists IN THE IMAGE (root-mounted
+/// DWARFS — the zip backend has no worker pool, so it cannot
+/// distinguish the guard from the bug) but not on the host: the gated
+/// child must answer the HOST's ENOENT ('E'). Ungated, the child either
+/// wedges in the engine (the fixture's sibling watchdog SIGKILLs the
+/// probe's process group after a grace window — a wedged vfork child
+/// suspends the parent, so the parent cannot be its own watchdog) or
+/// answers the image's 'H'. Both fail here; a regression can never hang
+/// the suite.
+#[test]
+fn vfork_child_stat_answers_from_the_host() {
+    let Some(f) = fixtures() else { return };
+    let mut cmd = Command::new(f.dir.join("bin").join("vfork-probe"));
+    cmd.arg("/data/secret.txt")
+        .env(preload_var(), &f.shim)
+        .env("TEBAKO_TFS_MOUNTS", format!("{}:/", f.dwarfs.display()))
+        .env_remove("DYLD_PRINT_LIBRARIES")
+        .env_remove("TEBAKO_JAIL");
+    let out = cmd.output().unwrap();
+    #[cfg(unix)]
+    let signal = std::os::unix::process::ExitStatusExt::signal(&out.status);
+    #[cfg(not(unix))]
+    let signal = None;
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "vfork-probe failed (signal: {signal:?} — SIGKILL here means the \
+         watchdog fired: the vfork child wedged in the engine, the \
+         pid-gate regression), stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        out.stdout, b"E\n",
+        "the vfork child answered the HOST stat (ENOENT), not the image"
     );
 }
 

--- a/crates/libtfs-preload/tests/fixtures/realpath-probe.c
+++ b/crates/libtfs-preload/tests/fixtures/realpath-probe.c
@@ -1,0 +1,53 @@
+/* realpath-probe: print realpath(argv[1]) on stdout, or "ERR <errno>"
+ * (rc 1) when it fails. argv[2] == "null" selects the NULL-buffer arm
+ * (malloc'd result — glibc's canonicalize_file_name semantics; the JDK's
+ * canonicalize_md.c uses the caller-buffer arm).
+ *
+ * The 2026-09-03 dogfood linux-gnu regression pin: glibc realpath(3)
+ * walks the path with libc-INTERNAL stat/readlink aliases that PLT
+ * interposition never sees, so before the shim interposed the realpath
+ * family, a path under a VFS mount fell through to the host resolver —
+ * which canonicalized host symlinks in the mount spelling (usrmerge
+ * /lib -> usr/lib) and then ENOENT'd on the in-image file. The JDK's
+ * URLClassPath built the classpath URL from that leaked spelling and
+ * dropped the jar: ClassNotFoundException on a byte-perfect jar. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+int main(int argc, char **argv) {
+    if (argc < 2 || argc > 3) {
+        dprintf(2, "usage: realpath-probe <path> [null]\n");
+        return 64;
+    }
+    char *buf = NULL;
+    char *resolved;
+    errno = 0;
+    if (argc == 3 && strcmp(argv[2], "null") == 0) {
+        resolved = realpath(argv[1], NULL);
+    } else {
+        buf = malloc(PATH_MAX);
+        if (!buf) {
+            dprintf(2, "malloc: %s\n", strerror(errno));
+            return 70;
+        }
+        resolved = realpath(argv[1], buf);
+    }
+    if (!resolved) {
+        int e = errno;
+        printf("ERR %d\n", e);
+        free(buf);
+        return 1;
+    }
+    printf("%s\n", resolved);
+    if (resolved != buf) free(resolved);
+    free(buf);
+    return 0;
+}

--- a/crates/libtfs-preload/tests/fixtures/vfork-probe.c
+++ b/crates/libtfs-preload/tests/fixtures/vfork-probe.c
@@ -1,0 +1,110 @@
+/* vfork-probe: the vfork arm of the preload fork-guard regression pin
+ * (the 2026-09-03 dogfood-repro deadlock). glibc runs NO pthread_atfork
+ * handlers for vfork(2), so the atfork child guard alone never armed in
+ * a vfork child — and a vfork child shares the parent's whole address
+ * space with the parent's calling thread suspended in the kernel, so an
+ * engine entry there raced live backend state in memory the parent still
+ * owned (dash's execvp PATH search: parent in kernel_clone, child in
+ * futex_wait — deterministic under Rosetta, latent corruption natively).
+ * The shim's pid gate is the vfork backstop: every engine entry in a
+ * vfork child passes through to the host libc, exactly like the fork
+ * guard.
+ *
+ * Protocol: vfork; the CHILD stat()s argv[1] through the interposed
+ * shim and writes one answer byte down the pipe — 'H' stat hit, 'E'
+ * ENOENT, 'X' any other errno — then _exit(0). The parent prints the
+ * byte. The test stats a path that exists IN THE IMAGE but not on the
+ * host under a root mount: the gated child must answer the HOST's
+ * ENOENT ('E'); ungated it either wedges (deadlock) or answers the
+ * image's 'H' — both fail the test.
+ *
+ * Watchdog: a wedged vfork child leaves the PARENT suspended in the
+ * kernel, so the parent cannot be its own watchdog (the fork-exec
+ * fixture's pattern does not reach vfork). A forked SIBLING watchdog
+ * SIGKILLs the probe's own process group after a grace window — the
+ * probe setpgid's first so the kill can never reach the test harness's
+ * group. A regression reports a signal death, not a hung suite.
+ *
+ * The parent warms the pass-through slots the gated child will need
+ * (real_stat via a covered-but-MISSING path's host fallback, real_write
+ * via a zero-byte pipe write): the slots resolve lazily through dlsym,
+ * and a first-call dlsym inside the vfork child's shared address space
+ * would itself be undefined. */
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <signal.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#define GRACE_S 15
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        dprintf(2, "usage: vfork-probe <path>\n");
+        return 64;
+    }
+    /* Own process group: the watchdog's kill(0, …) reaches only this
+     * probe and its children, never the spawning test harness. */
+    (void)setpgid(0, 0);
+    int p[2];
+    if (pipe(p) != 0) {
+        dprintf(2, "pipe: %s\n", strerror(errno));
+        return 70;
+    }
+    pid_t wd = fork();
+    if (wd < 0) {
+        dprintf(2, "fork: %s\n", strerror(errno));
+        return 70;
+    }
+    if (wd == 0) {
+        /* Watchdog sibling. Only non-interposed calls here: a fork
+         * child's first dlsym on an interposed symbol could take a
+         * loader lock a dead sibling thread held. */
+        struct timespec ts = {GRACE_S, 0};
+        nanosleep(&ts, NULL);
+        kill(0, SIGKILL);
+        _exit(0);
+    }
+    /* Warm the gated child's pass-through slots (see the header). A
+     * covered-but-missing path routes to the host fallback, resolving
+     * real_stat; the zero-byte write resolves real_write. */
+    struct stat st;
+    (void)stat("/tebako-vfork-probe-warm-nonexistent", &st);
+    (void)write(p[1], "", 0);
+
+    pid_t pid = vfork();
+    if (pid < 0) {
+        dprintf(2, "vfork: %s\n", strerror(errno));
+        return 70;
+    }
+    if (pid == 0) {
+        /* vfork child: SHARED address space, parent thread suspended.
+         * Nothing here may allocate, lock, or return from this frame. */
+        char b;
+        if (stat(argv[1], &st) == 0) {
+            b = 'H';
+        } else if (errno == ENOENT) {
+            b = 'E';
+        } else {
+            b = 'X';
+        }
+        (void)write(p[1], &b, 1);
+        _exit(0);
+    }
+    close(p[1]);
+    char b = '?';
+    ssize_t n = read(p[0], &b, 1);
+    kill(wd, SIGKILL);
+    waitpid(wd, NULL, 0);
+    waitpid(pid, NULL, 0);
+    if (n != 1) {
+        dprintf(2, "vfork-probe: no answer from the child\n");
+        return 71;
+    }
+    printf("%c\n", b);
+    return 0;
+}

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -184,7 +184,18 @@ The locked model is three tiers — **interposition-first, never FUSE**:
    close(+the plain and $NOCANCEL spellings on x86_64 darwin — the libc
    crate maps `libc::close` to `close$NOCANCEL` there, C binaries
    (the JVM's libjava/libjli/libzip) import plain `close`; both route
-   to the shim)/mkdir/unlink/rename + dlopen + execve/posix_spawn/posix_spawnp;
+   to the shim)/mkdir/unlink/rename + dlopen + execve/posix_spawn/posix_spawnp
+   + the realpath family (realpath, plus macOS's realpath$DARWIN_EXTSN;
+   canonicalize_file_name and the fortified __realpath_chk on linux):
+   glibc's realpath(3) walks the path with libc-INTERNAL stat/readlink
+   aliases no PLT interpose sees, so a covered path MUST be answered by
+   the shim with the MOUNT spelling, lexically normalized — the host
+   resolver's canonicalization must never rewrite a VFS path (the
+   2026-09-03 dogfood linux-gnu jing ClassNotFound: usrmerge
+   /lib→usr/lib leaked into the JDK's URLClassPath on a root-mounted
+   payload, and the jar lookup silently dropped a byte-perfect jar);
+   covered-but-not-held paths still pass to the host realpath (the
+   /etc/localtime discipline);
    `TEBAKO_JAIL` carries the spec 08 §1 env form (`open|deny` +
    `host:mount:ro|rw` grants + `@` argument files); the ENTRYPOINT (when
    in-image) is materialized through `dlmap2file` (execve needs a host
@@ -207,7 +218,16 @@ The locked model is three tiers — **interposition-first, never FUSE**:
    fork-safe: dwarfs-t's block-cache worker pool dies at fork, so a
    backend-touching call in the child — e.g. the execve materialization
    probe under a `/` mount — would wait on threads that no longer exist;
-   the 2026-08-22 git-clone deadlock, runtime 0.16.4), and a fork child
+   the 2026-08-22 git-clone deadlock, runtime 0.16.4); glibc runs NO
+   atfork handlers for vfork(2), and a vfork child shares the parent's
+   whole address space with the parent thread suspended in the kernel,
+   so the guard carries a PID backstop — the constructor records the
+   initializing pid, and an engine entry under a different pid is a
+   fork/vfork child in its pre-exec window and passes through exactly
+   like the atfork flag's child (the 2026-09-03 dash vfork deadlock in
+   the dogfood repro; exec preserves the pid, so the exec'd image's
+   constructor re-stores the same value and the gate re-opens at exec);
+   and a fork child
    that execs re-enters a fresh shim through the inherited preload env,
    so the grandchild rule above is unaffected; not interposed: fork,
    `openat2` (glibc exposes no wrapper
@@ -217,7 +237,11 @@ The locked model is three tiers — **interposition-first, never FUSE**:
    32-bit-inode layout), `__fxstatat64` and the write-side
    pwrite64/ftruncate64/statvfs64 family plus
    readv/preadv/sendfile/copy_file_range on memfs fds on linux,
-   fdopendir (memfs directories are never fd-opened), and
+   fdopendir (memfs directories are never fd-opened), the
+   internal-walk family glob/nftw/ftw/wordexp (UNAUDITED — their path
+   walks ride libc-internal aliases, the same bypass class as realpath;
+   no importer observed on the JDK/ruby boot paths, so this is pinned
+   debt, never silently assumed covered), and
    syscall()-direct IO (raw syscalls bypass userland interposition by
    construction); `dirfd` of a memfs stream answers -1/ENOTSUP;
    `getdents64` on a memfs fd answers ENOTDIR (VFS directories enumerate

--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -646,6 +646,55 @@ The floor's promise is the end of the segfault class: every missing
 grant surfaces as the workload's own named error, pinned in the audit
 journal — never a crash in someone else's library.
 
+### 3.5 The exec'd child's libc process surface — internal walks and vfork (locked 2026-09-03)
+
+A class-E-delivered child runs the preload shim inside a binary tebako
+did not compile, so its guarantees must hold against libc behaviors that
+no path-prefix routing table reaches. Two surfaced in the 2026-09-03
+dogfood repro (the metanorma → jing java exec on linux-gnu); both are
+pinned in libtfs-preload's e2e suite.
+
+**The internal-walk hazard (realpath).** glibc's `realpath(3)` — the
+JDK's `File.getCanonicalFile` → `JDK_Canonicalize` path — walks the
+path with libc-INTERNAL stat/readlink aliases that PLT/symbol
+interposition never sees. A covered path answered by the host resolver
+therefore leaks the HOST-canonicalized spelling: on a usrmerge host
+(`/lib` → `usr/lib`, the ubuntu:24.04 dogfood container) the jar URL
+the JDK's `URLClassPath` built named `/usr/lib/ruby/…`, the lookup
+missed, and the user saw `ClassNotFoundException` on a byte-perfect
+jar. The shim therefore interposes the realpath family (spec 07 §8's
+surface) and answers a covered path with the MOUNT spelling, lexically
+normalized (`.`/`..` resolved textually — the VFS is already canonical;
+host symlinks in the mount spelling are the payload's own spelling and
+MUST survive). A covered-but-not-held path still passes to the host
+realpath (the §3.4 `/etc/localtime` discipline); a denied path answers
+the jail's errno. The same hazard class — libc functions whose path
+walks ride internal aliases — covers `glob`/`nftw`/`ftw`/`wordexp`:
+UNAUDITED today (no importer observed on the JDK/ruby boot paths),
+pinned as debt, never silently assumed covered.
+
+**The vfork gap.** The fork-child guard arms through `pthread_atfork`,
+but glibc runs NO atfork handlers for `vfork(2)` — and a vfork child
+shares the parent's whole address space with the parent's calling
+thread suspended in the kernel, so an engine entry there is not merely
+a wait on fork-dead threads: it races live backend state in memory the
+suspended parent owns (dash's `execvp` PATH search in the dogfood
+repro: parent in `kernel_clone`, child in `futex_wait` — deterministic
+under Rosetta, latent corruption natively). The guard's backstop is
+therefore a PID gate, not the atfork flag alone: the constructor
+records the initializing pid, and an engine entry whose `getpid`
+differs is a fork/vfork child in its pre-exec window and passes
+through to the host libc. `exec` preserves the pid, so the exec'd
+image's constructor re-stores the same value and the gate re-opens
+exactly at exec — the §3.1 grandchild rule is unaffected. The gated
+pass-through's own residual: the shim's real-symbol slots resolve
+lazily (dlsym on first use), and a FIRST call inside a vfork child's
+shared address space would be its own hazard — POSIX already bounds
+the vfork child to async-signal-safe work before exec, so a gated
+first-call dlsym is a corner the parent's own prior IO covers in
+practice; eagerly warming the pass-through slots at constructor is the
+tracked hardening, pinned as debt with the glob/nftw audit above.
+
 Amended 2026-08-30 (tebako#502): the acceptance shape above predates
 the wrapper-runtime pattern. A home-annotated runtime payload
 materializes the interpreter's home INTO the per-process dl tree (§3's


### PR DESCRIPTION
# preload: interpose the realpath family + the vfork pid gate

**Draft — merge only with the owner's go (the HARD RULE).** The
linux-gnu end-to-end proof below gates the merge.

## What broke (dogfood linux-gnu, run 33568568520)

`java -jar <payload-resident jing jar>` under the dogfood composition
died with `ClassNotFoundException: com.thaiopensource.relaxng.util.Driver`
on a byte-perfect jar (macOS legs green). Root-caused in the local
ubuntu:24.04 repro rig (both directions proven; PROGRESS/31):

1. **glibc `realpath(3)` bypasses PLT interposition** — it walks the path
   with libc-internal stat/readlink aliases. The JDK's
   `File.getCanonicalFile` → `JDK_Canonicalize` therefore fell through to
   the host resolver; on usrmerge hosts (`/lib` → `usr/lib`, the
   ubuntu:24.04 container) the RESOLVED spelling leaked into the JDK's
   `URLClassPath` for the root-mounted payload; `JarLoader`'s
   `FileURLMapper.exists()` missed and the IOException is swallowed →
   ClassNotFound. Bites only when the payload is root-mounted AND the
   path crosses a host symlink.
2. **`pthread_atfork` never runs for `vfork(2)`** — the fork-child guard
   never armed in dash's vfork child, which entered engine lazy-init in
   the SHARED address space (parent suspended in `kernel_clone`, child in
   `futex_wait` — the full-chain repro's hang; deterministic under
   Rosetta, latent corruption natively).

## The fixes

- `route::vfs_realpath`: lexical normalization + the route answer —
  Vfs-covered paths resolve to the **mount spelling** (the VFS is already
  canonical; the host's symlink resolution must never rewrite a VFS
  path); covered-but-missing stays Host (the `/etc/localtime`
  discipline); denied → the jail errno. Interposed: `realpath` (ELF +
  macOS `realpath$DARWIN_EXTSN`), `canonicalize_file_name` and
  `__realpath_chk` (linux).
- The **pid gate**: `INIT_PID` stored first in the constructor;
  `engine_call` passes through when `getpid` differs — covering vfork
  children, which the atfork flag cannot reach. `exec` preserves the pid,
  so the gate re-opens at exec.

## The pins

- `realpath_under_symlinked_mount_keeps_the_vfs_spelling` — image mounted
  at a host-symlink spelling; realpath must answer the link spelling
  (caller-buffer and NULL-buffer arms) while a host control path still
  gets the host realpath. Portable red: pre-fix there was no interpose
  at all, so the probe fell through to the host → ENOENT everywhere.
- `vfork_child_stat_answers_from_the_host` — vfork child stats an
  in-image/host-missing path under a DWARFS root mount; the gated child
  must answer the host's ENOENT. A wedged child suspends the parent
  (vfork), so the fixture forks a sibling watchdog that SIGKILLs the
  probe's own process group after 15 s — a regression fails, never hangs.

## Evidence

- Local (macOS host, debug): `cargo test -p libtfs-preload` — 16 unit +
  25 e2e green, both new pins included; `cargo fmt --all -- --check`
  clean; `cargo clippy -p libtfs-preload --all-targets -- -D warnings`
  clean.
- linux-gnu e2e runs in CI on this PR.

## Doc sync (same commit)

- `crates/libtfs-preload/src/lib.rs` — interposed-surface list gains the
  realpath family; the fork-guard bullet gains the vfork/pid-gate.
- `crates/libtfs-preload/src/sys/linux.rs` — coverage note + the
  `glob`/`nftw`/`ftw`/`wordexp` internal-walk hazard pinned as debt.
- `docs/spec/07-shims-and-dispatch.md` §8 item 1 — the covered surface
  gains the realpath family; the fork guard gains the pid backstop; the
  internal-walk hazard class is named in the not-interposed list.
- `docs/spec/22-runtime-native-interposition.md` §3.5 (new, locked
  2026-09-03) — the internal-walk hazard + the vfork gap, normative for
  class-E-delivered children; the lazy-dlsym-in-a-vfork-child residual is
  stated honestly (constructor warming of the pass-through slots is the
  tracked hardening).

## After merge (the release chain — owner go required at every step)

The shim ships INSIDE the env images, so: tebako v2.1.3 →
tebako-runtime-ruby tools bump + runtime re-cut → openjdk feedstock
re-cut → metanorma feedstock dogfood re-kick → packed-mn tail
(PROGRESS/30, java/05). Then the tebako#400 reply.
