### PR TITLE
fix(preload): route the realpath NULL-buffer arm to canonicalize_file_name (glibc ≤ 2.31 compat-twin EINVAL)

### DIFF
--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -303,6 +303,22 @@ real_fn!(
     c"realpath",
     unsafe extern "C" fn(*const c_char, *mut c_char) -> *mut c_char
 );
+// The always-allocating realpath spelling — the NULL-buffer pass-through
+// arm's target. A plain `dlsym(RTLD_NEXT, "realpath")` is NOT safe for
+// that arm: glibc carries a versioned compat twin `realpath@GLIBC_2.0`
+// (`__old_realpath`, stdlib/canonicalize.c) that EINVALs a NULL buffer,
+// and the default-version lookup lands on it at least on glibc 2.31
+// (ubuntu-20.04 — the 0.16.19 factory re-cut's linux-gnu x86_64 boot
+// smoke died there: Rust std's canonicalize always rides the NULL arm,
+// so the jail bind's canonicalize of every grant path returned EINVAL,
+// 2026-09-02). `canonicalize_file_name` entered glibc at 2.3 with no
+// versioned history, so the resolution is unambiguous; musl ships it
+// too (≥ 1.1.9), so one code path serves both libcs.
+real_fn!(
+    real_canonicalize_file_name,
+    c"canonicalize_file_name",
+    unsafe extern "C" fn(*const c_char) -> *mut c_char
+);
 real_fn!(
     real_rewinddir,
     c"rewinddir",

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -1060,7 +1060,21 @@ unsafe fn realpath_impl(path: *const c_char, resolved: *mut c_char) -> *mut c_ch
             set_errno(e);
             std::ptr::null_mut()
         }
-        Some(PathRoute::Host) | None => unsafe { plat::real_realpath()(path, resolved) },
+        Some(PathRoute::Host) | None => {
+            // The NULL-buffer arm must NOT ride the plain-dlsym realpath
+            // on glibc: the default-version lookup can land on the
+            // GLIBC_2.0 compat twin (`__old_realpath`), which EINVALs a
+            // NULL buffer — Rust std's canonicalize only ever uses the
+            // NULL arm, so every host canonicalize died there on
+            // glibc 2.31 (the 0.16.19 boot-smoke legs, 2026-09-02).
+            // canonicalize_file_name has no versioned twin and is exactly
+            // the always-allocating spelling (see sys/linux.rs).
+            #[cfg(target_os = "linux")]
+            if resolved.is_null() {
+                return unsafe { plat::real_canonicalize_file_name()(path) };
+            }
+            unsafe { plat::real_realpath()(path, resolved) }
+        }
     }
 }
 

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -1156,6 +1156,18 @@ fn realpath_under_symlinked_mount_keeps_the_vfs_spelling() {
     let r = run_with_mounts(f, "realpath-probe", &[&host], &mounts, None);
     assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
     assert_eq!(r.stdout, format!("{host}\n"), "host passthrough");
+
+    // The NULL-arm host pass-through — Rust std::fs::canonicalize's only
+    // shape, and the jail bind's canonicalize rides it. A plain-dlsym
+    // realpath on glibc ≤ 2.31 lands on the GLIBC_2.0 compat twin
+    // (__old_realpath), which EINVALs a NULL buffer: the 0.16.19 factory
+    // re-cut's linux-gnu x86_64 legs (ubuntu-20.04) died at the child
+    // constructor's policy bind with exactly that (2026-09-02). The
+    // pass-through reroutes the arm to canonicalize_file_name; this pin
+    // keeps the arm exercised on every CI host glibc.
+    let r = run_with_mounts(f, "realpath-probe", &[&host, "null"], &mounts, None);
+    assert_eq!(r.rc, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, format!("{host}\n"), "NULL-arm host passthrough");
 }
 
 /// The vfork arm of the fork guard: pthread_atfork handlers do NOT run

--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -673,6 +673,21 @@ walks ride internal aliases — covers `glob`/`nftw`/`ftw`/`wordexp`:
 UNAUDITED today (no importer observed on the JDK/ruby boot paths),
 pinned as debt, never silently assumed covered.
 
+**The versioned-twin hazard (realpath NULL arm).** The pass-through's
+NULL-buffer arm (the only shape Rust std's `std::fs::canonicalize`
+uses — so the jail bind's own grant canonicalization rides it) must not
+target a plain `dlsym(RTLD_NEXT, "realpath")`: glibc carries a
+versioned compat twin `realpath@GLIBC_2.0` whose `__old_realpath`
+EINVALs a NULL buffer, and the default-version dlsym lookup lands on it
+at least on glibc 2.31 (ubuntu-20.04 — the factory build container;
+the 0.16.19 re-cut's linux-gnu x86_64 legs died at the child
+constructor's policy bind, 2026-09-02). The arm therefore reroutes to
+`canonicalize_file_name` — a single-versioned symbol since glibc 2.3,
+present in musl — which IS the always-allocating spelling. The
+caller-buffer arm keeps the plain realpath resolution (the compat twin
+forwards non-NULL buffers correctly), so the reroute costs nothing on
+the JDK's own canonicalization shape.
+
 **The vfork gap.** The fork-child guard arms through `pthread_atfork`,
 but glibc runs NO atfork handlers for `vfork(2)` — and a vfork child
 shares the parent's whole address space with the parent's calling


### PR DESCRIPTION
## The regression

The 0.16.19 runtime re-cut (tebako-runtime-ruby run 33614796101, the first build on the v2.1.3 link unit) failed **deterministically on every linux-gnu x86_64 leg** (16/16 red; macOS, linux-musl, linux-gnu arm64 all green) at the boot smoke's jailed java spawn:

```
libtfs-preload: TEBAKO_JAIL: cannot bind policy: Invalid argument
```

The factory's linux-gnu legs run in `tebako-ubuntu-20.04` — **glibc 2.31**. The probe authors a well-formed `deny;…:rw;…:ro` spec; `HostPolicy::bind` EINVAL'd anyway, the child constructor exited 78, java never ran.

## Root cause (container-pinned, glibc-source-pinned)

#515 interposed the realpath family. The pass-through for the **NULL-buffer arm** rode `dlsym(RTLD_NEXT, "realpath")` — and glibc carries a versioned compat twin:

- `realpath@@GLIBC_2.3` → `__realpath` (NULL arm mallocs — POSIX.1-2008),
- `realpath@GLIBC_2.0` → `__old_realpath`, which **EINVALs `resolved == NULL`** (compat shim, still present in glibc 2.39).

Plain `dlsym` without a version does not guarantee the default version on older glibc — on 2.31 it lands on the GLIBC_2.0 twin. Rust std's `std::fs::canonicalize` **only ever uses the NULL arm**, so the constructor's policy bind canonicalize of every grant path EINVAL'd before touching the filesystem (even a nonexistent grant path returned EINVAL, not ENOENT — the tell). Newer glibc (2.39, ubuntu-24.04 CI) resolves the default version correctly, which is why CI stayed green.

Evidence chain (tebako-ubuntu-20.04:0.16.2-amd64 container):

- v2.1.3 preload + probe-shaped jail → `bind EINVAL`, exit 78 (any grant; nonexistent path gives EINVAL, not ENOENT).
- `realpath-probe` fixture under the preload: buffer arm OK, NULL arm `ERR 22`; without the preload both arms OK.
- `dlvsym` probe: `realpath@GLIBC_2.3` NULL-arm OK; plain `dlsym` NULL-arm `errno=22`; `canonicalize_file_name` OK.

## The fix

The NULL-buffer pass-through arm reroutes to **`canonicalize_file_name`** — glibc's own always-allocating realpath spelling, single-versioned since glibc 2.3 (no compat twin), present in musl (one code path for linux). The caller-buffer arm keeps the plain realpath resolution (the compat twin forwards non-NULL buffers correctly), so the JDK's own canonicalization shape is byte-identical. macOS unchanged (its realpath NULL arm is unversioned).

- `crates/libtfs-preload/src/sys/linux.rs` — `real_canonicalize_file_name` resolver + the rationale comment.
- `crates/libtfs-preload/src/sys/mod.rs` — the `realpath_impl` Host/None arm reroute.
- `crates/libtfs-preload/tests/e2e.rs` — the NULL-arm **host pass-through** joins `realpath_under_symlinked_mount_keeps_the_vfs_spelling` (the arm is now exercised on every CI host glibc; the environment-sensitive proof is the factory's 20.04 legs).
- `docs/spec/22-runtime-native-interposition.md` — the versioned-twin hazard, recorded next to the internal-walk one.

## Verification

- [ ] CI green (fmt/clippy/unit/e2e incl. the new pin on 24.04's glibc 2.39).
- [ ] Container proof with the CI-built `libtfs_preload-linux-gnu-x86_64-debug` artifact: the probe-shaped jail + mounts green on **ubuntu-20.04 (glibc 2.31)** AND **ubuntu-24.04 (glibc 2.39)** before merge.

## After merge

The v2.1.4 tag → factory `contract.yml` re-pin → 0.16.19 re-dispatch (the cancelled run 33614796101 was burning runners on the deterministic failure) → the staged metanorma dogfood re-kick.
