### PR TITLE
fix(preload): scope the realpath NULL-arm reroute to glibc — musl has no canonicalize_file_name

### DIFF
--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -304,16 +304,22 @@ real_fn!(
     unsafe extern "C" fn(*const c_char, *mut c_char) -> *mut c_char
 );
 // The always-allocating realpath spelling — the NULL-buffer pass-through
-// arm's target. A plain `dlsym(RTLD_NEXT, "realpath")` is NOT safe for
-// that arm: glibc carries a versioned compat twin `realpath@GLIBC_2.0`
+// arm's target on glibc. A plain `dlsym(RTLD_NEXT, "realpath")` is NOT safe
+// for that arm: glibc carries a versioned compat twin `realpath@GLIBC_2.0`
 // (`__old_realpath`, stdlib/canonicalize.c) that EINVALs a NULL buffer,
 // and the default-version lookup lands on it at least on glibc 2.31
 // (ubuntu-20.04 — the 0.16.19 factory re-cut's linux-gnu x86_64 boot
 // smoke died there: Rust std's canonicalize always rides the NULL arm,
 // so the jail bind's canonicalize of every grant path returned EINVAL,
 // 2026-09-02). `canonicalize_file_name` entered glibc at 2.3 with no
-// versioned history, so the resolution is unambiguous; musl ships it
-// too (≥ 1.1.9), so one code path serves both libcs.
+// versioned history, so the resolution is unambiguous. glibc-ONLY:
+// musl has no `canonicalize_file_name` at all (verified: zero symbols
+// matching 'canonicalize' in musl 1.2.5's dynamic table, alpine
+// 3.21.7 — the 0.16.19 musl boot smoke aborted on this very lookup,
+// 2026-09-02) and needs no reroute anyway: with no symbol versioning
+// there is no compat twin, so musl's plain realpath dlsym is already
+// unambiguous.
+#[cfg(target_env = "gnu")]
 real_fn!(
     real_canonicalize_file_name,
     c"canonicalize_file_name",

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -1068,8 +1068,13 @@ unsafe fn realpath_impl(path: *const c_char, resolved: *mut c_char) -> *mut c_ch
             // NULL arm, so every host canonicalize died there on
             // glibc 2.31 (the 0.16.19 boot-smoke legs, 2026-09-02).
             // canonicalize_file_name has no versioned twin and is exactly
-            // the always-allocating spelling (see sys/linux.rs).
-            #[cfg(target_os = "linux")]
+            // the always-allocating spelling (see sys/linux.rs). The
+            // reroute is glibc-SCOPED: musl has no canonicalize_file_name
+            // at all (the RTLD_NEXT lookup panics — the 0.16.19 musl
+            // smoke legs, same day) and no versioned-twin hazard to dodge
+            // (no symbol versioning), so musl's NULL arm stays on the
+            // plain realpath dlsym.
+            #[cfg(all(target_os = "linux", target_env = "gnu"))]
             if resolved.is_null() {
                 return unsafe { plat::real_canonicalize_file_name()(path) };
             }

--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -682,11 +682,20 @@ EINVALs a NULL buffer, and the default-version dlsym lookup lands on it
 at least on glibc 2.31 (ubuntu-20.04 — the factory build container;
 the 0.16.19 re-cut's linux-gnu x86_64 legs died at the child
 constructor's policy bind, 2026-09-02). The arm therefore reroutes to
-`canonicalize_file_name` — a single-versioned symbol since glibc 2.3,
-present in musl — which IS the always-allocating spelling. The
-caller-buffer arm keeps the plain realpath resolution (the compat twin
-forwards non-NULL buffers correctly), so the reroute costs nothing on
-the JDK's own canonicalization shape.
+`canonicalize_file_name` — a single-versioned symbol since glibc 2.3 —
+which IS the always-allocating spelling. The caller-buffer arm keeps
+the plain realpath resolution (the compat twin forwards non-NULL
+buffers correctly), so the reroute costs nothing on the JDK's own
+canonicalization shape.
+
+**The reroute is glibc-scoped.** `canonicalize_file_name` is a
+glibc-only spelling: musl has no such symbol at all (verified against
+musl 1.2.5's dynamic table, alpine 3.21.7 — the 0.16.19 musl boot-smoke
+legs aborted on the RTLD_NEXT lookup, same day), and musl needs no
+reroute: without symbol versioning there is no compat twin, so its
+plain-`dlsym` realpath is unambiguous and NULL-safe (the v2.1.3 musl
+shim binds jails correctly). The NULL-arm reroute compiles only for
+`target_env = "gnu"`; musl's NULL arm stays on plain realpath.
 
 **The vfork gap.** The fork-child guard arms through `pthread_atfork`,
 but glibc runs NO atfork handlers for `vfork(2)` — and a vfork child


### PR DESCRIPTION
## What

Scope the #516 realpath NULL-arm reroute to glibc (`target_env = "gnu"`): musl has **no** `canonicalize_file_name` at all, so the reroute's `dlsym(RTLD_NEXT, …)` panicked in the preload constructor under `TEBAKO_JAIL` and every jailed child aborted (rc=134) — the 0.16.19 re-cut's musl boot-smoke legs (7, both arches, deterministic) all died with an empty backtick at `host_shell_string` (spec 22 class E).

musl needs no reroute: the hazard #516 dodges is glibc's symbol-versioned compat twin (`realpath@GLIBC_2.0` EINVALs the NULL arm on ≤ 2.31); musl has no symbol versioning, so its plain-dlsym `realpath` is the only one and is NULL-safe. The fix gates both the `real_fn!` declaration and the call site; musl keeps exactly the v2.1.3 behavior.

## Evidence

- **musl symbol absence**: `nm -D /lib/ld-musl-x86_64.so.1` on alpine:3.21.7 — zero matches for `canonicalize`.
- **A/B in alpine (the factory's musl shim artifacts)**:
  - v2.1.3 musl shim: bare `LD_PRELOAD` AND probe-shaped `TEBAKO_JAIL` both pass (`TEBAKO-SH-OK`, rc=0).
  - v2.1.4 musl shim: bare passes; jail leg `Aborted` rc=134 with `cannot resolve libc symbol "canonicalize_file_name" via RTLD_NEXT` at `sys/linux.rs:317` — this PR's exact site.
- **glibc side unchanged**: the gnu call site is byte-identical to #516's (CI's ubuntu-24.04 e2e NULL-arm pin covers it; the 20.04/24.04 container proofs stand).
- Spec 22 gains the glibc-scoped corollary; the #516 comment that claimed "musl ships it too" is corrected (that claim was never verified — now it is, in both directions).

## Chain

Follow-up in the owner-approved v2.1.4 → 0.16.19 re-cut chain: on green CI this becomes **v2.1.5**, the factory re-pins, and 0.16.19 re-dispatches. The in-flight 0.16.19 run (v2.1.4-based) stays live as the gnu/macos/windows evidence run; its musl legs are explained-doomed by this finding.

Refs: tebako#516, PROGRESS/31.
