### PR TITLE
spec 30 §2's dispatch half: the bootstrap resolves spawned runtime edges (+ tebako-pkg bundle --exact-mounts)

### DIFF
--- a/crates/tebako-bootstrap/src/bin/tebako-fake-runtime.rs
+++ b/crates/tebako-bootstrap/src/bin/tebako-fake-runtime.rs
@@ -21,6 +21,9 @@ fn main() {
     println!("JAIL={}", env_or_unset("TEBAKO_JAIL"));
     println!("JAIL-SOURCE={}", env_or_unset("TEBAKO_JAIL_SOURCE"));
     println!("JAIL-JOURNAL={}", env_or_unset("TEBAKO_JAIL_JOURNAL"));
+    // The spawned-edge probe's contract (tests/compose.rs): UNSET when
+    // the loader exported no spawn lock (spec 30 §3).
+    println!("SPAWN-LOCK={}", env_or_unset("TEBAKO_SPAWN_LOCK"));
     for (i, arg) in std::env::args().skip(1).enumerate() {
         println!("argv[{i}]={arg}");
     }

--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -2084,6 +2084,7 @@ fn resolve_runtime(
     }
 
     // The interpreter: cache hit / fat payload slot / download+verify.
+    let base_raw = releases_base();
     let exe = if file_exists(&layout.exe_path) {
         ux.cached(rr);
         layout.exe_path.clone()
@@ -2105,13 +2106,13 @@ fn resolve_runtime(
         }
         match payload_exe {
             Some(exe) => exe,
-            None => download_executable(runtime_ref, rr, &layout, &mut ux)?,
+            None => download_executable(runtime_ref, rr, &layout, &mut ux, &base_raw)?,
         }
     };
 
     // item 30b: the `;image` flag resolves the runtime image alongside.
     let image = if runtime_ref_wants_image(runtime_ref) {
-        Some(resolve_image(runtime_ref, rr, &layout, &mut ux)?)
+        Some(resolve_image(runtime_ref, rr, &layout, &mut ux, &base_raw)?)
     } else {
         None
     };
@@ -2121,7 +2122,7 @@ fn resolve_runtime(
     // declares no dll facet (every POSIX release, pre-#40 windows
     // releases). No handoff: the PE loader finds the DLL on its own.
     if runtime_ref_wants_image(runtime_ref) {
-        resolve_dll(runtime_ref, rr, &layout, &mut ux)?;
+        resolve_dll(runtime_ref, rr, &layout, &mut ux, &base_raw)?;
     }
     // The image value is a wire form, not necessarily a bare path: the
     // carried branch spells it `<package>:<slot>` (spec 17 §2.1).
@@ -2133,12 +2134,12 @@ fn download_executable(
     rr: &RuntimeRef,
     layout: &CacheLayout,
     ux: &mut BootUx,
+    base_raw: &str,
 ) -> Result<PathBuf, BootError> {
     let (root, entry_dir, entry) = (&layout.root, &layout.entry_dir, &layout.entry);
 
-    let base_raw = releases_base();
-    let base = skip_file_scheme(&base_raw).to_string();
-    let local = base_is_local(&base_raw);
+    let base = skip_file_scheme(base_raw).to_string();
+    let local = base_is_local(base_raw);
     let manifest_url = format!("{base}/v{}/manifest.json", rr.abi);
     let sums_url = format!("{base}/v{}/SHA256SUMS.txt", rr.abi);
 
@@ -2318,6 +2319,7 @@ fn resolve_image(
     rr: &RuntimeRef,
     layout: &CacheLayout,
     ux: &mut BootUx,
+    base_raw: &str,
 ) -> Result<PathBuf, BootError> {
     let (root, entry_dir, entry) = (&layout.root, &layout.entry_dir, &layout.entry);
     let id = ReleaseIdentity::of(rr, platform_string());
@@ -2334,9 +2336,8 @@ fn resolve_image(
         return Ok(image_path);
     }
 
-    let base_raw = releases_base();
-    let base = skip_file_scheme(&base_raw).to_string();
-    let local = base_is_local(&base_raw);
+    let base = skip_file_scheme(base_raw).to_string();
+    let local = base_is_local(base_raw);
     let manifest_url = format!("{base}/v{}/manifest.json", rr.abi);
     let sums_url = format!("{base}/v{}/SHA256SUMS.txt", rr.abi);
 
@@ -2605,6 +2606,7 @@ fn resolve_dll(
     rr: &RuntimeRef,
     layout: &CacheLayout,
     ux: &mut BootUx,
+    base_raw: &str,
 ) -> Result<Option<PathBuf>, BootError> {
     let (root, entry_dir, entry) = (&layout.root, &layout.entry_dir, &layout.entry);
 
@@ -2640,9 +2642,8 @@ fn resolve_dll(
         );
     }
 
-    let base_raw = releases_base();
-    let base = skip_file_scheme(&base_raw).to_string();
-    let local = base_is_local(&base_raw);
+    let base = skip_file_scheme(base_raw).to_string();
+    let local = base_is_local(base_raw);
     let dll_url = format!("{base}/v{}/{dll_asset}", rr.abi);
 
     if offline_mode() {
@@ -3141,6 +3142,473 @@ fn resolve_shared_slices(
     Ok(out)
 }
 
+// ---------------------------------------------------------------------
+// spawned runtime edges (spec 30 §2's dispatch half, spec 23 §13.6)
+// ---------------------------------------------------------------------
+
+/// The recorded digest of an installed artifact: the first whitespace
+/// token of its marker file, lowercased. `None` when the marker is
+/// missing or empty — the caller's incomplete-entry signal.
+fn recorded_digest(marker: &Path) -> Option<String> {
+    std::fs::read_to_string(marker)
+        .ok()?
+        .split_whitespace()
+        .next()
+        .map(str::to_lowercase)
+}
+
+/// One spawned artifact's cache state against its lock pin.
+enum SpawnedArtifactState {
+    /// The bytes are absent — the caller installs.
+    Missing,
+    /// Bytes + recorded digest present and agreeing with the pin.
+    Present,
+}
+
+/// The fail-closed pin discipline of a spawned row (spec 23 §13.4): an
+/// artifact present WITHOUT its digest marker is an incomplete cache
+/// entry (named — publish_entry's stance: never delete user state
+/// behind its back); a recorded digest DISAGREEING with the lock pin
+/// means the entry was installed from different bytes (a release re-cut
+/// under the same version) — named, never a silent re-fetch.
+fn spawned_artifact_state(
+    path: &Path,
+    marker: &Path,
+    pin: &str,
+    entry_dir: &Path,
+    what: &str,
+) -> Result<SpawnedArtifactState, BootError> {
+    if !file_exists(path) {
+        return Ok(SpawnedArtifactState::Missing);
+    }
+    let Some(recorded) = recorded_digest(marker) else {
+        return fail(
+            EX_TEBAKO_IO,
+            format!(
+                "cache entry {} exists but is incomplete (the {what} is present but its digest marker is missing)\n  remove that directory and run again",
+                entry_dir.display()
+            ),
+        );
+    };
+    if recorded != pin {
+        return fail(
+            EX_TEBAKO_SHA,
+            format!(
+                "SHA256 mismatch for the {what} — refusing to execute\n  expected: {pin} (the press-time lock pin, spec 23 §13.4)\n  recorded: {recorded} ({})\n  the cache entry {} holds bytes a different press pinned — remove that directory and run again",
+                marker.display(),
+                entry_dir.display()
+            ),
+        );
+    }
+    Ok(SpawnedArtifactState::Present)
+}
+
+/// The spawned entry's env-image spelling: the cached release index's
+/// verbatim `image.filename` when it names this identity, else the
+/// synthesized fallback — the same derivation resolve_image applies, so
+/// the completeness check and the carried staging agree on the name.
+fn spawned_image_asset(rr: &RuntimeRef, layout: &CacheLayout) -> String {
+    let id = ReleaseIdentity::of(rr, platform_string());
+    let cached_index = std::fs::read_to_string(layout.entry_dir.join("manifest.json")).ok();
+    cached_index
+        .as_deref()
+        .and_then(|text| id.entry(text))
+        .and_then(|e| manifest_entry_facet_filename(&e, "image"))
+        .unwrap_or_else(|| format!("{}.tfs", layout.asset_base))
+}
+
+/// The dispatch cache hit (spec 30 §2): the row's exe + image (+
+/// host-covered dll facet) all present with recorded digests agreeing
+/// with the lock pins. Any missing byte is simply `false` (the caller
+/// installs); a present-but-unmarked or disagreeing artifact is the
+/// named fail-closed error, never a guess.
+fn spawned_entry_complete(
+    rr: &RuntimeRef,
+    layout: &CacheLayout,
+    row: &tpkg::LockedSpawned,
+    self_path: &Path,
+) -> Result<bool, BootError> {
+    let what = format!("spawned runtime \"{}\" executable", row.engine);
+    let exe_pin = pin_for_host(&row.exe.sha256, &what, self_path)?;
+    match spawned_artifact_state(
+        &layout.exe_path,
+        &layout.entry_dir.join("sha256"),
+        exe_pin,
+        &layout.entry_dir,
+        &what,
+    )? {
+        SpawnedArtifactState::Missing => return Ok(false),
+        SpawnedArtifactState::Present => {}
+    }
+
+    let what = format!("spawned runtime \"{}\" image", row.engine);
+    let image_pin = pin_for_host(&row.image.sha256, &what, self_path)?;
+    let image_asset = spawned_image_asset(rr, layout);
+    match spawned_artifact_state(
+        &layout.entry_dir.join(&image_asset),
+        &layout.entry_dir.join(format!("{image_asset}.sha256")),
+        image_pin,
+        &layout.entry_dir,
+        &what,
+    )? {
+        SpawnedArtifactState::Missing => return Ok(false),
+        SpawnedArtifactState::Present => {}
+    }
+
+    // The dll facet is the windows PE era's (tebako-runtime-ruby#40): a
+    // row whose pin map does not cover this host carries no facet here.
+    if let Some(dll) = &row.dll {
+        if dll.sha256.for_host(tpkg::Platform::host()).is_some() {
+            let what = format!("spawned runtime \"{}\" dll", row.engine);
+            let Some(install_as) = dll.install_as.as_deref() else {
+                return fail(
+                    EX_TEBAKO_MANIFEST,
+                    format!(
+                        "the lock's spawned runtime \"{}\" carries a dll pin without its install_as (the PE import name) — re-press with a current tebako",
+                        row.engine
+                    ),
+                );
+            };
+            let dll_pin = pin_for_host(&dll.sha256, &what, self_path)?;
+            match spawned_artifact_state(
+                &layout.entry_dir.join(install_as),
+                &layout.entry_dir.join(format!("{install_as}.sha256")),
+                dll_pin,
+                &layout.entry_dir,
+                &what,
+            )? {
+                SpawnedArtifactState::Missing => return Ok(false),
+                SpawnedArtifactState::Present => {}
+            }
+        }
+    }
+    Ok(true)
+}
+
+/// Stage one carried spawned-runtime file (the env image; the windows
+/// dll facet) into the existing cache entry dir — the stage_carried_dll
+/// pattern: entry lock, re-check, tmp staging, the lock's digest pin,
+/// trust markers, atomic rename. Present bytes with their marker are
+/// never overwritten (the caller's completeness check owns the pin
+/// comparison).
+#[allow(clippy::too_many_arguments)]
+fn stage_carried_spawned_file(
+    self_path: &Path,
+    slot_index: u32,
+    slot: &tpkg::Slot,
+    pin: &tpkg::DigestPin,
+    install_name: &str,
+    layout: &CacheLayout,
+    what: &str,
+) -> Result<(), BootError> {
+    let dst = layout.entry_dir.join(install_name);
+    let marker = layout.entry_dir.join(format!("{install_name}.sha256"));
+    if file_exists(&dst) && file_exists(&marker) {
+        return Ok(());
+    }
+    let expected = pin_for_host(pin, what, self_path)?;
+
+    // Serialize against other bootstraps installing this entry (the
+    // same lock file the exe/image/dll installs use).
+    let locks = layout.root.join("locks");
+    mkdir_p(&locks).map_err(|e| {
+        BootError::new(
+            EX_TEBAKO_IO,
+            format!(
+                "cannot create tebako cache directories under {}: {e}",
+                layout.root.display()
+            ),
+        )
+    })?;
+    let lock_path = locks.join(format!("{}.lock", layout.entry));
+    let lock = flock_acquire(&lock_path, LOCK_TIMEOUT_MS).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::TimedOut {
+            BootError::new(
+                EX_TEBAKO_UNAVAILABLE,
+                format!(
+                    "timed out after {}s waiting for another tebako bootstrap to finish installing \"{}\"\n  lock: {}\n  if no other tebako process is running, remove the stale lock file",
+                    LOCK_TIMEOUT_MS / 1000,
+                    layout.entry,
+                    lock_path.display()
+                ),
+            )
+        } else {
+            BootError::new(
+                EX_TEBAKO_IO,
+                format!("cannot acquire install lock {}: {e}", lock_path.display()),
+            )
+        }
+    })?;
+    if file_exists(&dst) && file_exists(&marker) {
+        lock_release(lock);
+        return Ok(());
+    }
+    let tmp_dir =
+        layout
+            .root
+            .join("tmp")
+            .join(format!("{}.{}.spawned", layout.entry, std::process::id()));
+    cleanup_tmp_entry(&tmp_dir, install_name);
+    let result = (|| -> Result<(), BootError> {
+        std::fs::create_dir(&tmp_dir).map_err(|e| {
+            BootError::new(
+                EX_TEBAKO_IO,
+                format!("cannot create {}: {e}", tmp_dir.display()),
+            )
+        })?;
+        let tmp = tmp_dir.join(install_name);
+        let actual = stage_locked_slot(self_path, slot, expected, &tmp, what)?;
+        make_readonly(&tmp);
+        os_rename(&tmp, &dst).map_err(|e| {
+            BootError::new(
+                EX_TEBAKO_IO,
+                format!(
+                    "cannot install the {what} into the cache ({} -> {}): {e}",
+                    tmp.display(),
+                    dst.display()
+                ),
+            )
+        })?;
+        let _ = write_small_file(&marker, &format!("{actual}  {install_name}\n"));
+        let _ = write_small_file(
+            &layout.entry_dir.join(format!("{install_name}.origin")),
+            &format!(
+                "carried={} slot {slot_index}\nsha256={actual}\n",
+                self_path.display()
+            ),
+        );
+        Ok(())
+    })();
+    cleanup_tmp_entry(&tmp_dir, install_name);
+    lock_release(lock);
+    result
+}
+
+/// The carried spawned row's image (+ host-covered dll) facets — the
+/// single-file staging shared by the fresh-publish and the
+/// concurrent-winner paths.
+fn stage_carried_spawned_facets(
+    rr: &RuntimeRef,
+    self_path: &Path,
+    m: &tpkg::Manifest,
+    layout: &CacheLayout,
+    row: &tpkg::LockedSpawned,
+) -> Result<(), BootError> {
+    // carry: true without the exe/image slots fails the lock's own
+    // validation at manifest parse; guard anyway — never an unwrap on
+    // this path (spec 14).
+    let Some(image_slot) = row.image.slot else {
+        return fail(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "the lock of {} declares a carried spawned runtime \"{}\" without its image slot — re-press the package",
+                self_path.display(),
+                row.engine
+            ),
+        );
+    };
+    let image_asset = spawned_image_asset(rr, layout);
+    stage_carried_spawned_file(
+        self_path,
+        image_slot,
+        slot_at(m, image_slot, self_path)?,
+        &row.image.sha256,
+        &image_asset,
+        layout,
+        &format!("spawned runtime \"{}\" image", row.engine),
+    )?;
+    if let Some(dll) = &row.dll {
+        if dll.sha256.for_host(tpkg::Platform::host()).is_some() {
+            let Some(dll_slot) = dll.slot else {
+                return fail(
+                    EX_TEBAKO_MANIFEST,
+                    format!(
+                        "the lock of {} declares a carried spawned runtime \"{}\" dll without its slot — re-press the package",
+                        self_path.display(),
+                        row.engine
+                    ),
+                );
+            };
+            let Some(install_as) = dll.install_as.as_deref() else {
+                return fail(
+                    EX_TEBAKO_MANIFEST,
+                    format!(
+                        "the lock's spawned runtime \"{}\" carries a dll slot without its install_as (the PE import name) — re-press with a current tebako",
+                        row.engine
+                    ),
+                );
+            };
+            stage_carried_spawned_file(
+                self_path,
+                dll_slot,
+                slot_at(m, dll_slot, self_path)?,
+                &dll.sha256,
+                install_as,
+                layout,
+                &format!("spawned runtime \"{}\" dll", row.engine),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// The carried spawned-runtime row (spec 30 §2, spec 23 §13.6): exe +
+/// image (+ host-covered dll) stage from their trailer slots into the
+/// machine runtime cache under the entry lock, digest-pinned by the
+/// lock. UNLIKE the primary carried runtime — whose env image mounts
+/// from the package as `<package>:<slot>` (spec 17 §2.1) — the spawned
+/// image lands as a real cache file: the driver's spawn planner
+/// resolves the entry from the store, never from this package.
+fn stage_carried_spawned(
+    runtime_ref: &str,
+    rr: &RuntimeRef,
+    self_path: &Path,
+    m: &tpkg::Manifest,
+    layout: &CacheLayout,
+    row: &tpkg::LockedSpawned,
+    ux: &mut BootUx,
+) -> Result<(), BootError> {
+    // The exe stages as a whole-entry publish — the primary carried
+    // runtime's staging (stage_carried_runtime's exe branch).
+    if !file_exists(&layout.exe_path) {
+        let Some(exe_slot) = row.exe.slot else {
+            return fail(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "the lock of {} declares a carried spawned runtime \"{}\" without its exe slot — re-press the package",
+                    self_path.display(),
+                    row.engine
+                ),
+            );
+        };
+        let what = format!("spawned runtime \"{}\" executable", row.engine);
+        let expected = pin_for_host(&row.exe.sha256, &what, self_path)?;
+        let slot = slot_at(m, exe_slot, self_path)?;
+        let Some(ins) = begin_entry_install(
+            &layout.root,
+            &layout.entry,
+            &layout.exe_path,
+            &layout.asset,
+            runtime_ref,
+        )?
+        else {
+            // A concurrent install won the race; the facets still run.
+            ux.cached(rr);
+            return stage_carried_spawned_facets(rr, self_path, m, layout, row);
+        };
+        match stage_locked_slot(self_path, slot, expected, &ins.tmp_asset, &what) {
+            Ok(actual) => {
+                let origin = format!(
+                    "runtime_ref={runtime_ref}\ncarried={} slot {}\nsha256={actual}\n",
+                    self_path.display(),
+                    exe_slot
+                );
+                publish_entry(
+                    ins,
+                    &layout.entry_dir,
+                    &layout.exe_path,
+                    &layout.asset,
+                    &actual,
+                    &origin,
+                )?;
+            }
+            Err(e) => {
+                cleanup_tmp_entry(&ins.tmp_dir, &layout.asset);
+                lock_release(ins.lock);
+                return Err(e);
+            }
+        }
+    }
+    stage_carried_spawned_facets(rr, self_path, m, layout, row)
+}
+
+/// The shared spawned-runtime row (carry: false): the pair lands from
+/// the lock's recorded fetch coordinates — `source` is the
+/// press-resolved release download base, replayed verbatim through the
+/// same shard/manifest.json machinery the primary runtime uses (spec 05
+/// §2) — then the caller's completeness re-assert fails closed if the
+/// release moved under the lock pins (spec 23 §13.4), never a silent
+/// drift.
+fn download_spawned(
+    runtime_ref: &str,
+    rr: &RuntimeRef,
+    layout: &CacheLayout,
+    row: &tpkg::LockedSpawned,
+    ux: &mut BootUx,
+) -> Result<(), BootError> {
+    // validate() already rejects a shared row without fetch
+    // coordinates; guard anyway — never an unwrap on this path.
+    let Some(base_raw) = row.source.as_deref().filter(|s| !s.is_empty()) else {
+        return fail(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "the lock's spawned runtime \"{}\" rides the machine cache but carries no fetch coordinates (source:) — re-press the package with a current tebako",
+                row.engine
+            ),
+        );
+    };
+    download_executable(runtime_ref, rr, layout, ux, base_raw)?;
+    resolve_image(runtime_ref, rr, layout, ux, base_raw)?;
+    resolve_dll(runtime_ref, rr, layout, ux, base_raw)?;
+    Ok(())
+}
+
+/// spec 30 §2's dispatch half for a self-contained package: every
+/// `lock.spawned[]` edge resolves into the machine runtime cache BEFORE
+/// handoff — a cache hit by recorded digest, the carried pair staged
+/// from its trailer slots, or the shared pair fetched from the lock's
+/// recorded coordinates — and the pins reach the driver as
+/// `TEBAKO_SPAWN_LOCK` (`;`-joined `engine=lang_version:tebako_version`
+/// entries, manifest order). The driver's spawn planner then resolves
+/// cache-only: a spawn NEVER downloads. `TEBAKO_OFFLINE=1` blocks only
+/// the fetch path (cache hits and carried staging move no network
+/// bytes).
+fn resolve_spawned_edges(
+    self_path: &Path,
+    m: &tpkg::Manifest,
+    lock: &tpkg::PackageLock,
+) -> Result<Vec<String>, BootError> {
+    let mut out = Vec::new();
+    for row in &lock.spawned {
+        // The synthesized ref reuses the whole runtime-resolution
+        // grammar (store layout, index identity, contract gate):
+        // `engine@lang_version;tebako=<line>;image`.
+        let runtime_ref = format!("{}@{};tebako={};image", row.engine, row.version, row.tebako);
+        let rr = parse_runtime_ref(&runtime_ref)?;
+        let layout = cache_layout(&rr)?;
+        let mut ux = BootUx::new();
+        ux.prog.set_quiet(m.is_quiet_notices());
+        if spawned_entry_complete(&rr, &layout, row, self_path)? {
+            ux.cached(&rr);
+        } else {
+            if row.carry {
+                stage_carried_spawned(&runtime_ref, &rr, self_path, m, &layout, row, &mut ux)?;
+            } else {
+                download_spawned(&runtime_ref, &rr, &layout, row, &mut ux)?;
+            }
+            // Fail closed when the install left the entry short of the
+            // lock's pins (a moved release, a partial publish) — never
+            // hand the driver a spawn lock the store cannot honor.
+            if !spawned_entry_complete(&rr, &layout, row, self_path)? {
+                return fail(
+                    EX_TEBAKO_IO,
+                    format!(
+                        "the spawned runtime \"{}\" installed into {} but the entry is still incomplete against the lock's pins — remove that directory and run again; if it persists, the release moved under the press-time pins (re-press the package)",
+                        row.engine,
+                        layout.entry_dir.display()
+                    ),
+                );
+            }
+        }
+        out.push(tpkg::runtime_store::spawn_lock_entry(
+            &row.engine,
+            &row.version,
+            &row.tebako,
+        ));
+    }
+    Ok(out)
+}
+
 /// spec 05 §4's scoped lazy-seed exception (locked 2026-08-25,
 /// tebako#460): a package that CARRIES artifacts seeds the machine cache
 /// with them at run time, so later packages share them. Best-effort — a
@@ -3510,6 +3978,7 @@ fn exec_runtime(
     jail: Option<&JailEnv>,
     lock: Option<&tpkg::PackageLock>,
     shared: &[(String, PathBuf)],
+    spawn_lock: Option<&str>,
 ) -> BootError {
     use std::os::unix::process::CommandExt;
 
@@ -3531,6 +4000,11 @@ fn exec_runtime(
         cmd.env("TEBAKO_JAIL", &jail.spec);
         cmd.env("TEBAKO_JAIL_SOURCE", jail.source);
         cmd.env("TEBAKO_JAIL_JOURNAL", &jail.journal);
+    }
+    if let Some(lock) = spawn_lock {
+        // spec 30 §3: the dispatch-time spawn pin — the driver's spawn
+        // planner resolves exactly these version pairs, cache-only.
+        cmd.env(tpkg::runtime_store::SPAWN_LOCK_VAR, lock);
     }
     let err = cmd.exec();
     BootError::new(
@@ -3558,9 +4032,10 @@ fn exec_runtime(
     jail: Option<&JailEnv>,
     lock: Option<&tpkg::PackageLock>,
     shared: &[(String, PathBuf)],
+    spawn_lock: Option<&str>,
 ) -> BootError {
     let nargv = handoff_argv(runtime, self_path, m, selection, argv, lock, shared);
-    let err = platform::spawn_handoff(runtime, &nargv[1..], image, jail);
+    let err = platform::spawn_handoff(runtime, &nargv[1..], image, jail, spawn_lock);
     BootError::new(
         EX_TEBAKO_IO,
         format!("cannot execute runtime {}: {err}", runtime.display()),
@@ -3690,11 +4165,21 @@ pub fn run(argv: &[String]) -> Result<std::convert::Infallible, BootError> {
         Some(lock) => resolve_shared_slices(lock, &self_path)?,
         None => Vec::new(),
     };
+    // spec 30 §2's dispatch half: the app payload's spawned-runtime
+    // edges resolve into the machine cache BEFORE handoff (cache hit by
+    // recorded digest / carried staging / locked-coordinate fetch), and
+    // the pins ride to the driver as TEBAKO_SPAWN_LOCK — a spawn NEVER
+    // downloads.
+    let spawn_lock = match pm_lock {
+        Some(lock) => resolve_spawned_edges(&self_path, &m, lock)?,
+        None => Vec::new(),
+    };
     // spec 05 §4's scoped exception: carried artifacts seed the machine
     // cache — best-effort, journaled, never blocking the run.
     if let Some(lock) = pm_lock {
         lazy_seed(&self_path, &m, lock, &runtime_ref, &rr);
     }
+    let spawn_lock_value = (!spawn_lock.is_empty()).then(|| spawn_lock.join(";"));
     Err(exec_runtime(
         &runtime,
         image.as_deref(),
@@ -3705,6 +4190,7 @@ pub fn run(argv: &[String]) -> Result<std::convert::Infallible, BootError> {
         jail.as_ref(),
         pm_lock,
         &shared,
+        spawn_lock_value.as_deref(),
     ))
 }
 
@@ -3873,8 +4359,11 @@ mod dll_tests {
         assert_eq!(dll_install_as_from_manifest(&text, DLL), Err(()));
     }
 
-    /// The env-using flow (TEBAKO_RUNTIME_MIRROR / TEBAKO_OFFLINE) lives
-    /// in ONE test so the process-wide variables never race a sibling.
+    /// The env-using flow (TEBAKO_OFFLINE) lives in ONE test so the
+    /// process-wide variable never races a sibling; the mirror base is
+    /// the explicit parameter every caller resolves (resolve_runtime's
+    /// TEBAKO_RUNTIME_MIRROR consultation; the spawned-edge replay of
+    /// the lock row's `source`).
     #[test]
     fn resolve_dll_flow() {
         let home = dir("flow");
@@ -3884,14 +4373,11 @@ mod dll_tests {
         let dll_sha = sha256_file_hex(&mirror.join(DLL)).unwrap();
         let text = manifest(&dll_key(INSTALL_AS, &dll_sha));
         let (layout, rr) = dll_layout(&home, Some(&text));
-        std::env::set_var(
-            "TEBAKO_RUNTIME_MIRROR",
-            format!("file://{}", home.join("mirror").display()),
-        );
+        let base = format!("file://{}", home.join("mirror").display());
 
         // fresh install: the dll lands AS install_as with trusted markers
         let mut ux = BootUx::new();
-        let got = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux).unwrap();
+        let got = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux, &base).unwrap();
         let dll_path = layout.entry_dir.join(INSTALL_AS);
         assert_eq!(got, Some(dll_path.clone()));
         assert!(dll_path.is_file());
@@ -3917,7 +4403,7 @@ mod dll_tests {
         // a cached run needs no mirror at all (offline-safe re-resolution)
         std::fs::remove_dir_all(home.join("mirror")).unwrap();
         let mut ux = BootUx::new();
-        let got = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux).unwrap();
+        let got = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux, &base).unwrap();
         assert_eq!(got, Some(dll_path.clone()));
 
         // a declared-but-missing dll under TEBAKO_OFFLINE is the named error
@@ -3925,7 +4411,7 @@ mod dll_tests {
         std::fs::remove_file(layout.entry_dir.join(format!("{INSTALL_AS}.sha256"))).unwrap();
         std::env::set_var("TEBAKO_OFFLINE", "1");
         let mut ux = BootUx::new();
-        let err = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux).unwrap_err();
+        let err = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux, &base).unwrap_err();
         assert_eq!(err.code, EX_TEBAKO_UNAVAILABLE);
         assert!(err.message.contains("TEBAKO_OFFLINE"), "{}", err.message);
         std::env::remove_var("TEBAKO_OFFLINE");
@@ -3939,7 +4425,7 @@ mod dll_tests {
         )
         .unwrap();
         let mut ux = BootUx::new();
-        let err = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux).unwrap_err();
+        let err = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux, &base).unwrap_err();
         assert_eq!(err.code, EX_TEBAKO_SHA);
         assert!(!dll_path.exists());
         assert!(
@@ -3957,7 +4443,7 @@ mod dll_tests {
         )
         .unwrap();
         let mut ux = BootUx::new();
-        let err = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux).unwrap_err();
+        let err = resolve_dll(RUNTIME_REF, &rr, &layout, &mut ux, &base).unwrap_err();
         assert_eq!(err.code, EX_TEBAKO_UNAVAILABLE);
         assert!(err.message.contains("bare file name"), "{}", err.message);
         assert!(!home.join("runtimes").join("evil.dll").exists());
@@ -3966,18 +4452,17 @@ mod dll_tests {
         let home2 = dir("nofacet");
         let (layout2, rr2) = dll_layout(&home2, Some(&manifest("")));
         let mut ux = BootUx::new();
-        assert!(resolve_dll(RUNTIME_REF, &rr2, &layout2, &mut ux)
+        assert!(resolve_dll(RUNTIME_REF, &rr2, &layout2, &mut ux, &base)
             .unwrap()
             .is_none());
         // no cached release index at all (the fat-payload path): a no-op
         let home3 = dir("nomanifest");
         let (layout3, rr3) = dll_layout(&home3, None);
         let mut ux = BootUx::new();
-        assert!(resolve_dll(RUNTIME_REF, &rr3, &layout3, &mut ux)
+        assert!(resolve_dll(RUNTIME_REF, &rr3, &layout3, &mut ux, &base)
             .unwrap()
             .is_none());
 
-        std::env::remove_var("TEBAKO_RUNTIME_MIRROR");
         let _ = std::fs::remove_dir_all(&home);
         let _ = std::fs::remove_dir_all(&home2);
         let _ = std::fs::remove_dir_all(&home3);
@@ -4088,5 +4573,313 @@ mod manifest_identity_tests {
                 "{text:?} must be no match"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod spawned_tests {
+    use super::*;
+
+    const EXE_BYTES: &[u8] = b"fake spawned java exe\n";
+    const IMAGE_BYTES: &[u8] = b"fake spawned java image\n";
+
+    fn dir(tag: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("tebako-boot-spawned-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    fn sha_of(home: &Path, name: &str, bytes: &[u8]) -> String {
+        let path = home.join(name);
+        std::fs::write(&path, bytes).unwrap();
+        sha256_file_hex(&path).unwrap()
+    }
+
+    /// The row under test: a carried java edge, pins covering every host
+    /// (DigestPin::One) — the triplet-map coverage rule itself is pinned
+    /// by tpkg's package tests.
+    fn java_row(exe_sha: &str, image_sha: &str) -> tpkg::LockedSpawned {
+        tpkg::LockedSpawned {
+            engine: "java".to_string(),
+            implementation: None,
+            constraint: tpkg::Constraint::new(">= 21, < 26").unwrap(),
+            expose: vec!["java".to_string()],
+            version: "21.0.12".to_string(),
+            tebako: "2.1.5".to_string(),
+            carry: true,
+            exe: tpkg::LockedSpawnedArtifact {
+                slot: Some(1),
+                sha256: tpkg::DigestPin::One(exe_sha.to_string()),
+                install_as: None,
+            },
+            image: tpkg::LockedSpawnedArtifact {
+                slot: Some(2),
+                sha256: tpkg::DigestPin::One(image_sha.to_string()),
+                install_as: None,
+            },
+            dll: None,
+            source: None,
+        }
+    }
+
+    /// A hand-built cache layout for the java row (the dll_tests
+    /// pattern) — no env, no cache_root consultation.
+    fn java_layout(home: &Path) -> (CacheLayout, RuntimeRef) {
+        let platform = platform_string();
+        let entry = format!("java-21.0.12-2.1.5-{platform}");
+        let asset_base = format!("tebako-runtime-2.1.5-21.0.12-{platform}");
+        let asset = format!("{asset_base}{}", exe_suffix());
+        let entry_dir = home.join("runtimes").join(&entry);
+        let exe_path = entry_dir.join(&asset);
+        (
+            CacheLayout {
+                root: home.to_path_buf(),
+                entry_dir,
+                exe_path,
+                asset,
+                asset_base,
+                entry,
+            },
+            RuntimeRef {
+                r#type: "java".to_string(),
+                version: "21.0.12".to_string(),
+                abi: "2.1.5".to_string(),
+            },
+        )
+    }
+
+    /// The fake package: padding + the exe bytes + the image bytes, with
+    /// the manifest's slots 1/2 naming those regions (slot 0 is the app
+    /// payload, never touched by the spawned path).
+    fn fake_package(home: &Path) -> (PathBuf, tpkg::Manifest) {
+        let pkg_path = home.join("fake-package");
+        let mut bytes = vec![0u8; 64];
+        bytes.extend_from_slice(EXE_BYTES);
+        let exe_offset = 64u64;
+        let image_offset = exe_offset + EXE_BYTES.len() as u64;
+        bytes.extend_from_slice(IMAGE_BYTES);
+        std::fs::write(&pkg_path, &bytes).unwrap();
+        let m = tpkg::Manifest {
+            slots: vec![
+                tpkg::Slot::default(),
+                tpkg::Slot {
+                    offset: exe_offset,
+                    size: EXE_BYTES.len() as u64,
+                    ..Default::default()
+                },
+                tpkg::Slot {
+                    offset: image_offset,
+                    size: IMAGE_BYTES.len() as u64,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        (pkg_path, m)
+    }
+
+    #[test]
+    fn recorded_digest_reads_the_first_token() {
+        let home = dir("recorded");
+        std::fs::create_dir_all(&home).unwrap();
+        let marker = home.join("x.sha256");
+        assert_eq!(recorded_digest(&marker), None);
+        std::fs::write(&marker, b"").unwrap();
+        assert_eq!(recorded_digest(&marker), None);
+        std::fs::write(&marker, b"AABBcc00  x.exe\n").unwrap();
+        assert_eq!(recorded_digest(&marker), Some("aabbcc00".to_string()));
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn completeness_is_fail_closed() {
+        let home = dir("complete");
+        std::fs::create_dir_all(&home).unwrap();
+        let exe_sha = sha_of(&home, "exe-bytes", EXE_BYTES);
+        let image_sha = sha_of(&home, "image-bytes", IMAGE_BYTES);
+        let (layout, rr) = java_layout(&home);
+        std::fs::create_dir_all(&layout.entry_dir).unwrap();
+        let row = java_row(&exe_sha, &image_sha);
+        let self_path = home.join("fake-package");
+
+        // nothing there: simply incomplete (the caller installs)
+        assert!(!spawned_entry_complete(&rr, &layout, &row, &self_path).unwrap());
+
+        // exe present without its digest marker: the named
+        // incomplete-entry error, never a silent re-fetch
+        std::fs::write(&layout.exe_path, EXE_BYTES).unwrap();
+        let err = spawned_entry_complete(&rr, &layout, &row, &self_path).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_IO);
+        assert!(err.message.contains("incomplete"), "{}", err.message);
+
+        // marked but disagreeing with the lock pin: exit 70
+        std::fs::write(
+            layout.entry_dir.join("sha256"),
+            format!("{}  {}\n", "f".repeat(64), layout.asset),
+        )
+        .unwrap();
+        let err = spawned_entry_complete(&rr, &layout, &row, &self_path).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_SHA);
+        assert!(err.message.contains(&exe_sha), "{}", err.message);
+
+        // exe agreeing, image still missing: incomplete again
+        std::fs::write(
+            layout.entry_dir.join("sha256"),
+            format!("{exe_sha}  {}\n", layout.asset),
+        )
+        .unwrap();
+        assert!(!spawned_entry_complete(&rr, &layout, &row, &self_path).unwrap());
+
+        // the image lands with its marker: complete
+        let image_asset = format!("{}.tfs", layout.asset_base);
+        std::fs::write(layout.entry_dir.join(&image_asset), IMAGE_BYTES).unwrap();
+        std::fs::write(
+            layout.entry_dir.join(format!("{image_asset}.sha256")),
+            format!("{image_sha}  {image_asset}\n"),
+        )
+        .unwrap();
+        assert!(spawned_entry_complete(&rr, &layout, &row, &self_path).unwrap());
+
+        // a dll pin that does not cover this host carries no facet here
+        let mut row = row;
+        row.dll = Some(tpkg::LockedSpawnedArtifact {
+            slot: Some(3),
+            sha256: tpkg::DigestPin::PerTriplet(std::collections::BTreeMap::from([(
+                "a-triplet-that-is-never-the-host".to_string(),
+                "c".repeat(64),
+            )])),
+            install_as: Some("jvm.dll".to_string()),
+        });
+        assert!(spawned_entry_complete(&rr, &layout, &row, &self_path).unwrap());
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// The carried row stages exe + image into the runtime cache — and
+    /// the staged entry is EXACTLY what the driver's spawn planner picks
+    /// (tpkg::runtime_store::resolve_locked, the spec 30 §3 consumer).
+    #[test]
+    fn carried_row_stages_into_a_driver_resolvable_entry() {
+        let home = dir("carried");
+        std::fs::create_dir_all(&home).unwrap();
+        let exe_sha = sha_of(&home, "exe-bytes", EXE_BYTES);
+        let image_sha = sha_of(&home, "image-bytes", IMAGE_BYTES);
+        let (layout, rr) = java_layout(&home);
+        let (pkg, m) = fake_package(&home);
+        let row = java_row(&exe_sha, &image_sha);
+
+        let mut ux = BootUx::new();
+        stage_carried_spawned(
+            "java@21.0.12;tebako=2.1.5;image",
+            &rr,
+            &pkg,
+            &m,
+            &layout,
+            &row,
+            &mut ux,
+        )
+        .unwrap();
+
+        assert!(layout.exe_path.is_file());
+        let image_asset = format!("{}.tfs", layout.asset_base);
+        let image_path = layout.entry_dir.join(&image_asset);
+        assert!(image_path.is_file());
+        assert_eq!(
+            std::fs::read_to_string(layout.entry_dir.join("sha256")).unwrap(),
+            format!("{exe_sha}  {}\n", layout.asset)
+        );
+        assert_eq!(
+            std::fs::read_to_string(layout.entry_dir.join(format!("{image_asset}.sha256")))
+                .unwrap(),
+            format!("{image_sha}  {image_asset}\n")
+        );
+        let origin = std::fs::read_to_string(layout.entry_dir.join("origin")).unwrap();
+        assert!(origin.contains("carried="), "{origin}");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                layout.exe_path.metadata().unwrap().permissions().mode() & 0o777,
+                0o755
+            );
+            assert_eq!(
+                image_path.metadata().unwrap().permissions().mode() & 0o777,
+                0o444
+            );
+        }
+
+        // the completeness check agrees, and the driver's locked pick
+        // finds exe + verified image (spec 30 §3's contract)
+        assert!(spawned_entry_complete(&rr, &layout, &row, &pkg).unwrap());
+        let picked = tpkg::runtime_store::resolve_locked(&home, "java", None, "21.0.12", "2.1.5")
+            .expect("the staged entry is the driver's spawn pick");
+        assert_eq!(picked.exe, layout.exe_path);
+        assert_eq!(picked.image.as_deref(), Some(image_path.as_path()));
+
+        // idempotent: a second staging over present bytes is a quiet hit
+        let mut ux = BootUx::new();
+        stage_carried_spawned(
+            "java@21.0.12;tebako=2.1.5;image",
+            &rr,
+            &pkg,
+            &m,
+            &layout,
+            &row,
+            &mut ux,
+        )
+        .unwrap();
+
+        // a tampered slot region under the same pin fails closed
+        // (nothing installed, exit 70)
+        let home2 = dir("carried-sha");
+        std::fs::create_dir_all(&home2).unwrap();
+        let (layout2, rr2) = java_layout(&home2);
+        let row2 = java_row(&"f".repeat(64), &image_sha);
+        let mut ux = BootUx::new();
+        let err = stage_carried_spawned(
+            "java@21.0.12;tebako=2.1.5;image",
+            &rr2,
+            &pkg,
+            &m,
+            &layout2,
+            &row2,
+            &mut ux,
+        )
+        .unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_SHA);
+        assert!(!layout2.exe_path.exists());
+
+        let _ = std::fs::remove_dir_all(&home);
+        let _ = std::fs::remove_dir_all(&home2);
+    }
+
+    /// The env user (TEBAKO_HOME) is ONE test so the process-wide
+    /// variable never races a sibling: the full dispatch loop — carried
+    /// staging through resolve_spawned_edges — exports the spec 30 §3
+    /// wire form in manifest order.
+    #[test]
+    fn resolve_spawned_edges_exports_the_spawn_lock() {
+        let home = dir("lock-export");
+        std::fs::create_dir_all(&home).unwrap();
+        std::env::set_var("TEBAKO_HOME", &home);
+        let exe_sha = sha_of(&home, "exe-bytes", EXE_BYTES);
+        let image_sha = sha_of(&home, "image-bytes", IMAGE_BYTES);
+        let (pkg, m) = fake_package(&home);
+        let lock = tpkg::PackageLock {
+            runtime: None,
+            slices: vec![],
+            spawned: vec![java_row(&exe_sha, &image_sha)],
+        };
+
+        let entries = resolve_spawned_edges(&pkg, &m, &lock).unwrap();
+        assert_eq!(entries, vec!["java=21.0.12:2.1.5".to_string()]);
+
+        // a cache-hit run re-exports the same pin without touching bytes
+        let entries = resolve_spawned_edges(&pkg, &m, &lock).unwrap();
+        assert_eq!(entries, vec!["java=21.0.12:2.1.5".to_string()]);
+
+        std::env::remove_var("TEBAKO_HOME");
+        let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/crates/tebako-bootstrap/src/platform.rs
+++ b/crates/tebako-bootstrap/src/platform.rs
@@ -322,6 +322,7 @@ pub fn spawn_handoff(
     args: &[String],
     image: Option<&str>,
     jail: Option<&crate::JailEnv>,
+    spawn_lock: Option<&str>,
 ) -> io::Error {
     install_ctrl_swallow();
     let mut cmd = std::process::Command::new(runtime);
@@ -340,6 +341,12 @@ pub fn spawn_handoff(
         cmd.env("TEBAKO_JAIL", &jail.spec);
         cmd.env("TEBAKO_JAIL_SOURCE", jail.source);
         cmd.env("TEBAKO_JAIL_JOURNAL", &jail.journal);
+    }
+    if let Some(lock) = spawn_lock {
+        // spec 30 §3: the dispatch-time spawn pin (the unix exec path
+        // exports the same variable) — the driver's spawn planner
+        // resolves exactly these version pairs, cache-only.
+        cmd.env(tpkg::runtime_store::SPAWN_LOCK_VAR, lock);
     }
     let status = match cmd.spawn().and_then(|mut child| child.wait()) {
         Ok(status) => status,

--- a/crates/tebako-bootstrap/tests/compose.rs
+++ b/crates/tebako-bootstrap/tests/compose.rs
@@ -127,6 +127,7 @@ fn self_contained_pkg(h: &Harness, name: &str, package_flags: u32) -> (PathBuf, 
             sha256: pin(&app),
             source: None,
         }],
+        spawned: vec![],
     };
     let pm = composed_pm(&runtime_ref, lock);
     let pkg = stitch_composed(
@@ -255,6 +256,7 @@ fn the_shared_slice_resolves_mid_run_by_its_locked_digest() {
                 source: Some(tebako_http::file_url(&shared_file)),
             },
         ],
+        spawned: vec![],
     };
     let pm = composed_pm(&runtime_ref, lock);
     let pkg = stitch_composed(
@@ -356,6 +358,7 @@ fn a_tampered_carried_exe_fails_closed_with_70() {
             dll: None,
         }),
         slices: vec![],
+        spawned: vec![],
     };
     let pm = composed_pm(&runtime_ref, lock);
     let pkg = stitch_composed(
@@ -416,6 +419,7 @@ fn a_shared_slice_mismatching_its_lock_pin_fails_closed_with_70() {
                 source: Some(tebako_http::file_url(&shared_file)),
             },
         ],
+        spawned: vec![],
     };
     let pm = composed_pm(&runtime_ref, lock);
     let pkg = stitch_composed(
@@ -477,6 +481,7 @@ fn a_lock_without_host_coverage_is_a_named_65() {
                 source: Some("file:///nonexistent.tfs".to_string()),
             },
         ],
+        spawned: vec![],
     };
     let pm = composed_pm(&runtime_ref, lock);
     let pkg = stitch_composed(
@@ -574,6 +579,7 @@ fn the_pointer_entrys_shared_slice_leads_the_image_list() {
                 source: Some("tfs:github:tebako-packages/mn2pdf-feedstock:2.0.0".to_string()),
             },
         ],
+        spawned: vec![],
     };
     let pm = tpkg::PackageManifest {
         schema_version: tpkg::PACKAGE_SCHEMA_VERSION,
@@ -658,5 +664,135 @@ fn the_pointer_entrys_shared_slice_leads_the_image_list() {
             "--tebako-entry".to_string(),
             "mnconvert".to_string(),
         ]
+    );
+}
+
+/// spec 30 §2's dispatch half (spec 23 §13.6): a self-contained package
+/// whose lock carries a spawned-runtime edge stages the carried pair
+/// into the machine runtime cache and hands the driver the spawn lock —
+/// `TEBAKO_SPAWN_LOCK=java=21.0.12:2.1.5` — echoed here by the fake
+/// runtime. The second run is the cache hit; both run under
+/// TEBAKO_OFFLINE (carried staging moves no network bytes). The staged
+/// entry is EXACTLY what the driver's spawn planner picks
+/// (tpkg::runtime_store::resolve_locked, the spec 30 §3 consumer).
+#[test]
+fn a_carried_spawned_runtime_dispatches_and_exports_the_lock() {
+    let h = Harness::new(rust_bootstrap());
+    let app = h.fake_image();
+    let env_image = h.tmp.0.join("java-edge-env.tfs");
+    std::fs::write(&env_image, b"FAKE RUNTIME ENV IMAGE").unwrap();
+    let java_exe = h.tmp.0.join("java-exe");
+    std::fs::write(&java_exe, b"FAKE SPAWNED JAVA EXE").unwrap();
+    let java_image = h.tmp.0.join("java-image.tfs");
+    std::fs::write(&java_image, b"FAKE SPAWNED JAVA IMAGE").unwrap();
+    let runtime_ref = format!("{};image", h.runtime_ref);
+    let lock = tpkg::PackageLock {
+        runtime: Some(tpkg::LockedRuntime {
+            version: harness::RUBY_VER.to_string(),
+            carry: true,
+            exe: Some(tpkg::LockedArtifact {
+                slot: 1,
+                sha256: pin(&h.fake_runtime),
+                install_as: None,
+            }),
+            image: Some(tpkg::LockedArtifact {
+                slot: 2,
+                sha256: pin(&env_image),
+                install_as: None,
+            }),
+            dll: None,
+        }),
+        slices: vec![tpkg::LockedSlice {
+            name: "mnconvert".to_string(),
+            version: APP_VER.to_string(),
+            carry: true,
+            slot: Some(0),
+            mount: Some("/__tfs__".to_string()),
+            sha256: pin(&app),
+            source: None,
+        }],
+        spawned: vec![tpkg::LockedSpawned {
+            engine: "java".to_string(),
+            implementation: None,
+            constraint: tpkg::Constraint::new(">= 21, < 26").unwrap(),
+            expose: vec!["java".to_string()],
+            version: "21.0.12".to_string(),
+            tebako: "2.1.5".to_string(),
+            carry: true,
+            exe: tpkg::LockedSpawnedArtifact {
+                slot: Some(3),
+                sha256: pin(&java_exe),
+                install_as: None,
+            },
+            image: tpkg::LockedSpawnedArtifact {
+                slot: Some(4),
+                sha256: pin(&java_image),
+                install_as: None,
+            },
+            dll: None,
+            source: None,
+        }],
+    };
+    let pm = composed_pm(&runtime_ref, lock);
+    let pkg = stitch_composed(
+        &h,
+        "mnconvert-java",
+        &[
+            (app.clone(), tpkg::TPKG_FORMAT_DWARFS, "/__tfs__"),
+            (h.fake_runtime.clone(), tpkg::TPKG_FORMAT_AUTO, ""),
+            (env_image.clone(), tpkg::TPKG_FORMAT_DWARFS, ""),
+            (java_exe.clone(), tpkg::TPKG_FORMAT_AUTO, ""),
+            (java_image.clone(), tpkg::TPKG_FORMAT_DWARFS, ""),
+        ],
+        &runtime_ref,
+        &pm,
+        0,
+    );
+    let home = h.home("home");
+
+    for attempt in 0..2 {
+        let (rc, out, err) = h.run(
+            &pkg,
+            &home,
+            &[("TEBAKO_OFFLINE", "1")],
+            &["mnconvert", "doc.xml"],
+        );
+        assert_eq!(rc, 0, "run {attempt} stdout:\n{out}\nstderr:\n{err}");
+        assert!(
+            out.contains("SPAWN-LOCK=java=21.0.12:2.1.5\n"),
+            "run {attempt} stdout:\n{out}"
+        );
+    }
+
+    // The carried pair landed in the runtime cache, in the store
+    // grammar the driver's resolve_locked scans — and the driver's
+    // locked pick finds exe + verified image.
+    let plat = harness::platform();
+    let exe = tebako_bootstrap::platform::exe_suffix();
+    let entry = home
+        .join("runtimes")
+        .join(format!("java-21.0.12-2.1.5-{plat}"));
+    assert!(
+        entry
+            .join(format!("tebako-runtime-2.1.5-21.0.12-{plat}{exe}"))
+            .is_file(),
+        "the staged exe: {}",
+        entry.display()
+    );
+    let image = entry.join(format!("tebako-runtime-2.1.5-21.0.12-{plat}.tfs"));
+    assert!(image.is_file(), "the staged image: {}", entry.display());
+    assert!(
+        entry
+            .join(format!("tebako-runtime-2.1.5-21.0.12-{plat}.tfs.sha256"))
+            .is_file(),
+        "the image trust marker: {}",
+        entry.display()
+    );
+    let picked = tpkg::runtime_store::resolve_locked(&home, "java", None, "21.0.12", "2.1.5")
+        .expect("the staged entry is the driver's spawn pick");
+    assert_eq!(
+        picked.image.as_deref(),
+        Some(image.as_path()),
+        "the driver's pick carries the verified image"
     );
 }

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -425,6 +425,13 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     let lock = tpkg::PackageLock {
         runtime: Some(lock_runtime),
         slices: lock_slices,
+        // The D2 press does not yet mirror the app payload's L1
+        // `requires[].kind: runtime` edges (spec 30 §1) into lock rows —
+        // packages declaring spawned edges hand-author the lock's
+        // `spawned[]` block (packed-mn) and `tebako-pkg validate`
+        // cross-checks the mirror. Auto-mirroring (press-time runtime
+        // resolution for the pick + pins) is the follow-up.
+        spawned: Vec::new(),
     };
 
     let mut runtime_ref = format!("ruby@{ruby_ver};tebako={}", opts.tebako_version);
@@ -1635,6 +1642,7 @@ mod tests {
                     source: Some("tfs:github:acme/templates:3.2".to_string()),
                 },
             ],
+            spawned: vec![],
         };
         let m = press_package_manifest(
             "/tmp/out/hello",

--- a/crates/tebako-info/src/verify.rs
+++ b/crates/tebako-info/src/verify.rs
@@ -406,7 +406,10 @@ pub fn verify_package(
             exit_code::MALFORMED,
         )),
         Ok(None) => {}
-        Ok(Some(pm)) => entry_checks(binary, &pm, &inspection, &mut checks)?,
+        Ok(Some(pm)) => {
+            entry_checks(binary, &pm, &inspection, &mut checks)?;
+            spawned_checks(&pm, &inspection, &mut checks);
+        }
     }
 
     Ok((checks, Some(inspection)))
@@ -548,6 +551,147 @@ fn entry_checks(
         }
     }
     Ok(())
+}
+
+/// The spawned-edge cross-check of [`verify_package`] (spec 30 §2, spec
+/// 23 §13.6; one check per L2 lock row plus one per unmirrored L1 edge,
+/// named `spawned[<engine>]`). The lock's `spawned[]` rows are the
+/// bootstrap's ONLY edge source (the size gate bars in-image reads), so
+/// press mirrors the app payload's L1 `requires[].kind: runtime` edges
+/// into them and this check pins the mirror both ways: every row mirrors
+/// an L1 edge (engine + implementation parity, the constraint verbatim,
+/// the locked version satisfying it, the expose set verbatim) and every
+/// L1 edge has its row. The mirror source is the PRIMARY entry's slot
+/// image; a package whose app slot carries no usable L1 manifest skips —
+/// pre-manifest packages stay valid (the entry cross-check's rule).
+fn spawned_checks(
+    pm: &tpkg::PackageManifest,
+    inspection: &PackageInspection,
+    checks: &mut Vec<Check>,
+) {
+    let rows: &[tpkg::LockedSpawned] = match pm.lock.as_ref() {
+        Some(lock) => &lock.spawned,
+        None => &[],
+    };
+    let app_l1 = pm
+        .entries
+        .first()
+        .and_then(|e| e.slot)
+        .and_then(|slot| inspection.slots.get(slot as usize))
+        .and_then(|s| s.payload.as_ref())
+        .filter(|p| p.mount_error.is_none());
+    let usable = match app_l1 {
+        Some(p) => match (&p.manifest, &p.manifest_validation) {
+            (Some(m), None) => Some(m),
+            _ => None,
+        },
+        None => None,
+    };
+    let Some(l1) = usable else {
+        for row in rows {
+            checks.push(Check::skip(
+                format!("spawned[{}]", row.engine),
+                "the app payload carries no usable L1 manifest — the spawned-edge mirror is unchecked"
+                    .to_string(),
+            ));
+        }
+        return;
+    };
+
+    let edges: Vec<(&str, Option<&str>, &tpkg::Constraint, &[String])> = l1
+        .requires
+        .iter()
+        .filter_map(|r| match r {
+            tpkg::Requirement::Runtime {
+                engine,
+                implementation,
+                constraint,
+                expose,
+            } => Some((
+                engine.as_str(),
+                implementation.as_deref(),
+                constraint,
+                expose.as_slice(),
+            )),
+            _ => None,
+        })
+        .collect();
+
+    for row in rows {
+        let name = format!("spawned[{}]", row.engine);
+        let edge = edges.iter().find(|(engine, implementation, ..)| {
+            *engine == row.engine.as_str() && *implementation == row.implementation.as_deref()
+        });
+        let Some((_, _, constraint, expose)) = edge else {
+            checks.push(Check::fail(
+                name,
+                "the lock's spawned row mirrors no `kind: runtime` edge of the app payload's L1 manifest — re-press with a current tebako".to_string(),
+                exit_code::MALFORMED,
+            ));
+            continue;
+        };
+        if constraint.as_str() != row.constraint.as_str() {
+            checks.push(Check::fail(
+                name,
+                format!(
+                    "the constraint mirror differs — L1 declares \"{}\", the lock carries \"{}\" — re-press with a current tebako",
+                    constraint.as_str(),
+                    row.constraint.as_str()
+                ),
+                exit_code::MALFORMED,
+            ));
+            continue;
+        }
+        if !tpkg::versions::from_validated(&row.constraint).matches(&row.version) {
+            checks.push(Check::fail(
+                name,
+                format!(
+                    "the locked version {} does not satisfy the mirrored constraint \"{}\" — re-press with a current tebako",
+                    row.version,
+                    row.constraint.as_str()
+                ),
+                exit_code::MALFORMED,
+            ));
+            continue;
+        }
+        let declared: std::collections::BTreeSet<&str> =
+            expose.iter().map(String::as_str).collect();
+        let mirrored: std::collections::BTreeSet<&str> =
+            row.expose.iter().map(String::as_str).collect();
+        if declared != mirrored {
+            checks.push(Check::fail(
+                name,
+                format!(
+                    "the expose mirror differs — L1 declares [{}], the lock carries [{}] — re-press with a current tebako",
+                    declared.into_iter().collect::<Vec<_>>().join(", "),
+                    mirrored.into_iter().collect::<Vec<_>>().join(", ")
+                ),
+                exit_code::MALFORMED,
+            ));
+            continue;
+        }
+        checks.push(Check::pass(
+            name,
+            format!(
+                "mirrors the L1 edge; the locked version {} satisfies \"{}\"",
+                row.version,
+                row.constraint.as_str()
+            ),
+        ));
+    }
+
+    for (engine, implementation, ..) in &edges {
+        let mirrored = rows.iter().any(|row| {
+            row.engine.as_str() == *engine && row.implementation.as_deref() == *implementation
+        });
+        if !mirrored {
+            checks.push(Check::fail(
+                format!("spawned[{engine}]"),
+                "the app payload's L1 manifest declares this spawned-runtime edge but the lock carries no row — a standalone package would never resolve it; re-press with a current tebako".to_string(),
+                exit_code::MALFORMED,
+            ));
+        }
+    }
 }
 
 /// Re-read the raw trailer bytes (the v2 signed region is computed over

--- a/crates/tebako-pkg/src/main.rs
+++ b/crates/tebako-pkg/src/main.rs
@@ -8,7 +8,7 @@
 //! tebako-pkg info [--full|--slot N|--json|--verify|--depth N|--require-signed] <archive>
 //! tebako-pkg validate [--require-signed] <binary>
 //! tebako-pkg bundle --bootstrap <exe> --image <img[:mountpoint]>... -o <file>
-//!                    [--runtime-ref <ref>] [--lean] [--launcher-abi <n>]
+//!                    [--runtime-ref <ref>] [--lean] [--exact-mounts] [--launcher-abi <n>]
 //!                    [--package-manifest <file.yaml>]
 //! tebako-pkg unbundle <binary> -o <dir>
 //! tebako-pkg reassemble <dir> -o <file>
@@ -27,9 +27,9 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use tebako_pkg::{
-    bundle, default_mount, info, info_rich, insert_image, parse_image_spec, reassemble,
-    remove_image, set_runtime, unbundle, validate, InfoOptions, PackageImage, PackageOptions,
-    SignRequest,
+    bundle, bundle_exact, default_mount, info, info_rich, insert_image, parse_image_spec,
+    reassemble, remove_image, set_runtime, unbundle, validate, InfoOptions, PackageImage,
+    PackageOptions, SignRequest,
 };
 
 fn main() -> ExitCode {
@@ -78,6 +78,7 @@ struct Args {
     runtime_ref: Option<String>,
     package_manifest: Option<String>,
     lean: bool,
+    exact_mounts: bool,
     launcher_abi: Option<i64>,
     verbose: bool,
     sign: Option<SignRequest>,
@@ -113,6 +114,7 @@ impl Args {
             match name {
                 "-v" | "--verbose" => a.verbose = true,
                 "--lean" => a.lean = true,
+                "--exact-mounts" => a.exact_mounts = true,
                 "--full" => a.full = true,
                 "--json" => a.json = true,
                 "--verify" => a.verify = true,
@@ -339,7 +341,18 @@ fn cmd_bundle(rest: &[String]) -> ExitCode {
         sign: a.sign.unwrap_or_default(),
         package_manifest,
     };
-    match bundle(Path::new(&bootstrap), &images, Path::new(&output), &opts) {
+    // --exact-mounts (spec 30 §1 / spec 23 §13.6): mount points are used
+    // exactly as given — an <img> with no `:mount` carries an EMPTY mount
+    // point. Required when the press carries lock-claimed slots (a carried
+    // runtime pair, a carried spawned-runtime pair): those slots are never
+    // mounted, and recording the default `/__tfs_N__` spelling would lie in
+    // the trailer.
+    let result = if a.exact_mounts {
+        bundle_exact(Path::new(&bootstrap), &images, Path::new(&output), &opts)
+    } else {
+        bundle(Path::new(&bootstrap), &images, Path::new(&output), &opts)
+    };
+    match result {
         Ok(()) => {
             if a.verbose {
                 println!("Wrote package: {output} ({} image slot(s))", images.len());

--- a/crates/tebako-pkg/tests/cli.rs
+++ b/crates/tebako-pkg/tests/cli.rs
@@ -333,3 +333,59 @@ fn flag_forms() {
     assert!(out.contains("Flags: 0x3 (LEAN|SIGNED_V2)"), "{out}");
     assert!(out.contains("Signature: OpenPGP v2"), "{out}");
 }
+
+/// spec 30 §1 / spec 23 §13.6: `--exact-mounts` keeps an `<img>` with no
+/// `:mount` at an EMPTY mount point (the lock-claimed slot shape — a
+/// carried runtime/spawned-runtime slot is never mounted, so the trailer
+/// must not record a fabricated `/__tfs_N__`); without the flag the
+/// default-mount behavior is untouched (the C++ contract).
+#[test]
+fn exact_mounts_flag_keeps_bare_image_mounts_empty() {
+    let w = TempDir::new("cli-exact");
+    let boot = w.0.join("boot.bin");
+    std::fs::write(&boot, patterned_bytes(512, 0x5a)).unwrap();
+
+    // Default: the bare second image takes default_mount(1).
+    let pkg = w.0.join("pkg-default");
+    let (rc, _, err) = run(
+        &[
+            "bundle",
+            "--bootstrap",
+            boot.to_str().unwrap(),
+            "--image",
+            fixture("simple.dwarfs").to_str().unwrap(),
+            "--image",
+            fixture("simple.sqfs").to_str().unwrap(),
+            "-o",
+            pkg.to_str().unwrap(),
+        ],
+        &w.0,
+    );
+    assert_eq!((rc, err.as_str()), (0, ""), "default bundle");
+    let mut f = std::fs::File::open(&pkg).unwrap();
+    let m = tpkg::read_from(&mut f).unwrap();
+    assert_eq!(m.slots[1].mount_point_str().unwrap(), "/__tfs_1__");
+
+    // --exact-mounts: the bare second image stays mount-less.
+    let pkg = w.0.join("pkg-exact");
+    let (rc, _, err) = run(
+        &[
+            "bundle",
+            "--exact-mounts",
+            "--bootstrap",
+            boot.to_str().unwrap(),
+            "--image",
+            &format!("{}:/__tfs__", fixture("simple.dwarfs").display()),
+            "--image",
+            fixture("simple.sqfs").to_str().unwrap(),
+            "-o",
+            pkg.to_str().unwrap(),
+        ],
+        &w.0,
+    );
+    assert_eq!((rc, err.as_str()), (0, ""), "bundle --exact-mounts");
+    let mut f = std::fs::File::open(&pkg).unwrap();
+    let m = tpkg::read_from(&mut f).unwrap();
+    assert_eq!(m.slots[0].mount_point_str().unwrap(), "/__tfs__");
+    assert_eq!(m.slots[1].mount_point_str().unwrap(), "");
+}

--- a/crates/tebako-pkg/tests/info.rs
+++ b/crates/tebako-pkg/tests/info.rs
@@ -1101,3 +1101,143 @@ fn default_output_is_the_legacy_trailer_dump() {
     assert!(out.contains("Trailer: valid (magic and crc32 ok)"), "{out}");
     assert!(!out.contains("kind: app"), "{out}");
 }
+
+// ---------------------------------------------------------------------
+// validate: the L2 lock.spawned[] ↔ L1 requires[].kind: runtime
+// cross-check (spec 30 §2, spec 23 §13.6)
+// ---------------------------------------------------------------------
+
+/// The L1 shape shared by the spawned cross-check tests: the java edge
+/// plus the `probe` entrypoint the L2 entries mirror. Its digest block
+/// can never name the image that embeds it (the check-5 note in
+/// verify.rs), so these packages exit 70 on digest agreement — the
+/// spawned checks are asserted by their report lines (the suite tests'
+/// rule).
+const SPAWNED_APP_MANIFEST: &str = "identity:\n\
+     \x20 schema_version: 1\n\
+     \x20 kind: app\n\
+     \x20 name: mn\n\
+     \x20 version: 1.0.0\n\
+     \x20 producer: {tool: tebako-pkg, tool_version: 0.1.0}\n\
+     \x20 created: \"2026-08-01T00:00:00Z\"\n\
+     \x20 source:\n\
+     \x20   commit: 4f3c2b1a9d8e7f605a4b3c2d1e0f9a8b7c6d5e4f\n\
+     \x20   builder: gha:run:20260721-1042\n\
+     \x20 sbom: {ref: sbom/mn-1.0.0.spdx.json}\n\
+     \x20 digest:\n\
+     \x20   tree_hash: sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\n\
+     \x20   blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1\n\
+     \x20 signing: {state: unsigned}\n\
+     \x20 encryption: {state: none}\n\
+     provides:\n\
+     \x20 entrypoints:\n\
+     \x20   - name: probe\n\
+     \x20     path: /probe\n\
+     \x20     runtime_requirement: {engine: ruby, constraint: \">= 3.3, < 5.0\"}\n\
+     \x20 platforms: [aarch64-macos, x86_64-linux-gnu]\n\
+     \x20 capabilities: {exec: true, read: true}\n\
+     requires:\n\
+     \x20 - kind: runtime\n\
+     \x20   engine: java\n\
+     \x20   constraint: \">= 21, < 26\"\n\
+     \x20   expose: [java]\n";
+
+/// The L2 shape shared by the spawned cross-check tests: the entries
+/// row plus whatever lock the test names.
+fn spawned_pm(lock_yaml: &str) -> String {
+    format!(
+        "schema_version: 1\n\
+         package: {{name: mn, version: 1.0.0, producer: {{tool: tebako-pkg, tool_version: 0.1.0}}, created: 2026-08-01T00:00:00Z}}\n\
+         entries:\n  - {{name: probe, slot: 0, entrypoint: probe, runtime_ref: ruby@3.4.2;tebako=0.15.9}}\n\
+         {lock_yaml}"
+    )
+}
+
+/// The lock block mirroring the L1 java edge (a shared row: no slots,
+/// the press-resolved coordinates + pins).
+const SPAWNED_LOCK_YAML: &str = "lock:\n\
+     \x20 spawned:\n\
+     \x20   - engine: java\n\
+     \x20     constraint: \">= 21, < 26\"\n\
+     \x20     expose: [java]\n\
+     \x20     version: \"21.0.12\"\n\
+     \x20     tebako: \"2.1.5\"\n\
+     \x20     carry: false\n\
+     \x20     exe: {sha256: \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}\n\
+     \x20     image: {sha256: \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}\n\
+     \x20     source: \"https://github.com/tebako-packages/openjdk/releases/download\"\n";
+
+fn bundle_spawned_app(w: &TempDir, home: &Path, pm_yaml: &str) -> PathBuf {
+    let app = mk_image_files(
+        w,
+        "spawned.tfs",
+        Some(SPAWNED_APP_MANIFEST),
+        &[("probe", b"#!/bin/sh\n")],
+    );
+    let pm = pm_file(w, pm_yaml);
+    let pkg =
+        w.0.join(format!("pkg-{}", COUNTER.fetch_add(1, Ordering::Relaxed)));
+    bundle(
+        home,
+        w,
+        &["--package-manifest", pm.to_str().unwrap()],
+        &[&app],
+        &pkg,
+    );
+    pkg
+}
+
+#[test]
+fn validate_spawned_mirror_passes_when_the_lock_mirrors_the_edge() {
+    let w = TempDir::new("psp-ok");
+    let home = test_home("psp-ok");
+    let pkg = bundle_spawned_app(&w, &home, &spawned_pm(SPAWNED_LOCK_YAML));
+
+    let (rc, out, _) = run(&["validate", pkg.to_str().unwrap()], &w.0, &home);
+    assert_eq!(rc, 70, "{out}"); // digest agreement (check 5), see above
+    assert!(
+        out.contains(
+            "  spawned[java]: ok — mirrors the L1 edge; the locked version 21.0.12 satisfies \">= 21, < 26\"\n"
+        ),
+        "{out}"
+    );
+}
+
+#[test]
+fn validate_spawned_unmirrored_edge_is_65() {
+    let w = TempDir::new("psp-miss");
+    let home = test_home("psp-miss");
+    // The lock without the spawned row: the L1 java edge would never
+    // resolve on the standalone path — named, fail-closed.
+    let pkg = bundle_spawned_app(&w, &home, &spawned_pm(""));
+
+    let (rc, out, _) = run(&["validate", pkg.to_str().unwrap()], &w.0, &home);
+    assert_eq!(rc, 70, "{out}"); // digest agreement masks the 65, see above
+    assert!(
+        out.contains(
+            "  spawned[java]: FAILED — the app payload's L1 manifest declares this spawned-runtime edge but the lock carries no row"
+        ),
+        "{out}"
+    );
+}
+
+#[test]
+fn validate_spawned_mirror_mismatches_are_65() {
+    let w = TempDir::new("psp-bad");
+    let home = test_home("psp-bad");
+    // The row's locked version does not satisfy the mirrored constraint.
+    let pkg = bundle_spawned_app(
+        &w,
+        &home,
+        &spawned_pm(&SPAWNED_LOCK_YAML.replace("version: \"21.0.12\"", "version: \"20.0.2\"")),
+    );
+
+    let (rc, out, _) = run(&["validate", pkg.to_str().unwrap()], &w.0, &home);
+    assert_eq!(rc, 70, "{out}"); // digest agreement masks the 65, see above
+    assert!(
+        out.contains(
+            "  spawned[java]: FAILED — the locked version 20.0.2 does not satisfy the mirrored constraint \">= 21, < 26\""
+        ),
+        "{out}"
+    );
+}

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -191,9 +191,9 @@ pub use merkle::{
 };
 pub use model::{Manifest, Slot, V2Extension};
 pub use package::{
-    DigestPin, LockedArtifact, LockedRuntime, LockedSlice, MountMode, PackageEntry,
-    PackageIdentity, PackageLock, PackageManifest, PackageManifestError, PackageMount, Precedence,
-    PACKAGE_SCHEMA_VERSION,
+    DigestPin, LockedArtifact, LockedRuntime, LockedSlice, LockedSpawned, LockedSpawnedArtifact,
+    MountMode, PackageEntry, PackageIdentity, PackageLock, PackageManifest, PackageManifestError,
+    PackageMount, Precedence, PACKAGE_SCHEMA_VERSION,
 };
 pub use region::{resolve_slot_region, SlotRegion, SlotRegionError};
 

--- a/crates/tpkg/src/package.rs
+++ b/crates/tpkg/src/package.rs
@@ -353,6 +353,65 @@ pub struct LockedSlice {
     pub source: Option<String>,
 }
 
+/// One artifact of a locked spawned-runtime pair (spec 23 §13.6): the
+/// digest pin ALWAYS (spec 23 §13.4 records the digest carried or
+/// shared), the trailer slot when carried, and — the windows dll-era
+/// facet only — the PE install name (tebako-runtime-ruby#40, the same
+/// rule as [`LockedArtifact`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockedSpawnedArtifact {
+    /// The trailer slot carrying the bytes (carried rows only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slot: Option<u32>,
+    pub sha256: DigestPin,
+    /// The PE install name (the windows dll facet only): a bare file
+    /// name, never the release-asset spelling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_as: Option<String>,
+}
+
+/// One locked spawned-runtime edge (spec 23 §13.6, spec 30 §2): the app
+/// payload's L1 `requires[].kind: runtime` edge mirrored (engine /
+/// implementation / constraint / expose), the press-time pick's version
+/// pair (`version` = the runtime's language version, `tebako` = its own
+/// tebako line), the carry verdict, and the pair's digest pins. The
+/// loader (the bootstrap for a self-contained package) resolves each row
+/// into the store's `runtimes/` area at dispatch and exports the pin via
+/// `TEBAKO_SPAWN_LOCK`; the edge is NEVER co-mounted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockedSpawned {
+    /// The L1 edge's engine (`java`, …).
+    pub engine: String,
+    /// The L1 edge's implementation axis (spec 28 §8), when named.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub implementation: Option<String>,
+    /// The L1 edge's constraint, mirrored verbatim (the validate
+    /// cross-check asserts the mirror and that `version` satisfies it).
+    pub constraint: crate::manifest::Constraint,
+    /// The L1 edge's exposed command names (bare names), mirrored.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expose: Vec<String>,
+    /// The press-time pick: the runtime's language version.
+    pub version: String,
+    /// The press-time pick: the runtime's own tebako line.
+    pub tebako: String,
+    pub carry: bool,
+    /// The wrapper exe — always present (the digest pin stands either
+    /// way); `slot` exactly when carried.
+    pub exe: LockedSpawnedArtifact,
+    /// The env image — always present; `slot` exactly when carried.
+    pub image: LockedSpawnedArtifact,
+    /// The windows dll-era facet, when the resolved release declares it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dll: Option<LockedSpawnedArtifact>,
+    /// The fetch coordinates (shared rows only — required there): the
+    /// press-resolved release download base (the `{base}/v<tebako>/…`
+    /// root the loader replays verbatim, spec 23 §13.6). On a carried
+    /// row it is provenance, never a fallback fetch path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
 /// The `lock:` block of the L2 package manifest (spec 23 §4/§13): what
 /// press resolved is what runs — the full composition closure locked per
 /// slice. Run-time resolution follows the lock by locked digest, never
@@ -368,6 +427,12 @@ pub struct PackageLock {
     /// first, then its dependency closure.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub slices: Vec<LockedSlice>,
+    /// Every spawned-runtime edge (spec 30) of the app payload, in
+    /// manifest order, press-locked (spec 23 §13.6): the L1 edge mirror
+    /// (engine/implementation/constraint/expose), the pick's version
+    /// pair, the carry verdict, and the pair's digest pins.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub spawned: Vec<LockedSpawned>,
 }
 
 impl PackageLock {
@@ -377,8 +442,8 @@ impl PackageLock {
     }
 
     /// The trailer slots the lock claims (the carried runtime pair plus
-    /// every carried slice) — the set the bootstrap must never hand to
-    /// the driver as payload mounts.
+    /// every carried slice plus every carried spawned pair) — the set the
+    /// bootstrap must never hand to the driver as payload mounts.
     pub fn claimed_slots(&self) -> Vec<u32> {
         let mut out = Vec::new();
         if let Some(runtime) = &self.runtime {
@@ -392,6 +457,17 @@ impl PackageLock {
         for slice in &self.slices {
             if let Some(slot) = slice.slot {
                 out.push(slot);
+            }
+        }
+        for spawned in &self.spawned {
+            let mut artifacts = vec![&spawned.exe, &spawned.image];
+            if let Some(dll) = &spawned.dll {
+                artifacts.push(dll);
+            }
+            for artifact in artifacts {
+                if let Some(slot) = artifact.slot {
+                    out.push(slot);
+                }
             }
         }
         out
@@ -492,6 +568,83 @@ impl PackageLock {
             return Err(PackageManifestError::Invalid(
                 "duplicate lock.slices[].name (one lock row per slice)",
             ));
+        }
+        let mut edges: Vec<(&str, Option<&str>)> = Vec::new();
+        for spawned in &self.spawned {
+            check_non_empty(&spawned.engine, "lock.spawned[].engine must not be empty")?;
+            check_non_empty(&spawned.version, "lock.spawned[].version must not be empty")?;
+            check_non_empty(&spawned.tebako, "lock.spawned[].tebako must not be empty")?;
+            if let Some(implementation) = &spawned.implementation {
+                check_non_empty(
+                    implementation,
+                    "lock.spawned[].implementation, when present, must not be empty",
+                )?;
+            }
+            for name in &spawned.expose {
+                if name.is_empty()
+                    || name.contains('/')
+                    || name.contains('\\')
+                    || name.contains(':')
+                {
+                    return Err(PackageManifestError::Invalid(
+                        "lock.spawned[].expose names must be bare command names",
+                    ));
+                }
+            }
+            let mut artifacts = vec![(&spawned.exe, "exe"), (&spawned.image, "image")];
+            if let Some(dll) = &spawned.dll {
+                artifacts.push((dll, "dll"));
+            }
+            for (artifact, which) in artifacts {
+                artifact
+                    .sha256
+                    .validate("lock.spawned[] sha256 pins must be 64 lowercase hex")?;
+                match (spawned.carry, artifact.slot) {
+                    (true, Some(slot)) => {
+                        if slot >= TPKG_MAX_SLOTS {
+                            return Err(PackageManifestError::Invalid(
+                                "lock.spawned[] slot is outside the container's slot capacity (0..TPKG_MAX_SLOTS-1)",
+                            ));
+                        }
+                    }
+                    (true, None) => {
+                        return Err(PackageManifestError::Invalid(
+                            match which {
+                                "dll" => "lock.spawned[].dll with carry: true requires its trailer slot",
+                                _ => "lock.spawned[] with carry: true requires the exe and image slots (the carried pair)",
+                            },
+                        ));
+                    }
+                    (false, Some(_)) => {
+                        return Err(PackageManifestError::Invalid(
+                            "lock.spawned[] with carry: false declares no slots — a shared spawned runtime rides the machine cache",
+                        ));
+                    }
+                    (false, None) => {}
+                }
+                if let Some(install_as) = &artifact.install_as {
+                    if install_as.is_empty()
+                        || install_as.contains('/')
+                        || install_as.contains('\\')
+                    {
+                        return Err(PackageManifestError::Invalid(
+                            "lock.spawned[] install_as must be a bare file name (the PE import name)",
+                        ));
+                    }
+                }
+            }
+            if !spawned.carry && spawned.source.as_deref().map_or(true, |s| s.is_empty()) {
+                return Err(PackageManifestError::Invalid(
+                    "lock.spawned[] with carry: false requires its fetch coordinates (source:)",
+                ));
+            }
+            let edge = (spawned.engine.as_str(), spawned.implementation.as_deref());
+            if edges.contains(&edge) {
+                return Err(PackageManifestError::Invalid(
+                    "duplicate lock.spawned[] edge (one lock row per engine+implementation)",
+                ));
+            }
+            edges.push(edge);
         }
         let mut slots = self.claimed_slots();
         slots.sort_unstable();
@@ -1004,6 +1157,7 @@ mod tests {
                 dll: None,
             }),
             slices: vec![carried_slice(), shared_slice()],
+            spawned: vec![],
         }
     }
 
@@ -1019,6 +1173,118 @@ mod tests {
         let text = m.to_yaml().unwrap();
         let back = PackageManifest::from_yaml(&text).unwrap();
         assert_eq!(back, m);
+    }
+
+    /// A carried spawned-runtime row (spec 23 §13.6): the java pair.
+    fn spawned_java() -> LockedSpawned {
+        LockedSpawned {
+            engine: "java".to_string(),
+            implementation: None,
+            constraint: crate::manifest::Constraint::new(">= 21, < 26").unwrap(),
+            expose: vec!["java".to_string()],
+            version: "21.0.12".to_string(),
+            tebako: "2.1.5".to_string(),
+            carry: true,
+            exe: LockedSpawnedArtifact {
+                slot: Some(3),
+                sha256: DigestPin::PerTriplet(BTreeMap::from([(
+                    "macos-arm64".to_string(),
+                    sha('e'),
+                )])),
+                install_as: None,
+            },
+            image: LockedSpawnedArtifact {
+                slot: Some(4),
+                sha256: DigestPin::PerTriplet(BTreeMap::from([(
+                    "macos-arm64".to_string(),
+                    sha('f'),
+                )])),
+                install_as: None,
+            },
+            dll: None,
+            source: Some(
+                "tfs:github:tebako-packages/openjdk:2.1.5#tebako-runtime-2.1.5-21.0.12-macos-arm64.tfs"
+                    .to_string(),
+            ),
+        }
+    }
+
+    #[test]
+    fn spawned_rows_round_trip_and_claim_their_slots() {
+        let mut lock = carried_lock();
+        lock.spawned.push(spawned_java());
+        let mut m = minimal();
+        m.lock = Some(lock);
+        let text = m.to_yaml().unwrap();
+        let back = PackageManifest::from_yaml(&text).unwrap();
+        assert_eq!(back, m);
+
+        // the carried pair's slots join the claimed set (never mounted)
+        let claimed = m.lock.as_ref().unwrap().claimed_slots();
+        assert!(claimed.contains(&3) && claimed.contains(&4), "{claimed:?}");
+    }
+
+    #[test]
+    fn spawned_row_validation_is_fail_closed() {
+        let bad = |lock: PackageLock| {
+            let mut m = minimal();
+            m.lock = Some(lock);
+            m.validate().is_err()
+        };
+
+        // carried row without the pair slots
+        let mut lock = carried_lock();
+        lock.spawned.push(spawned_java());
+        lock.spawned[0].image.slot = None;
+        assert!(bad(lock));
+
+        // shared row declaring a slot
+        let mut lock = carried_lock();
+        let mut row = spawned_java();
+        row.carry = false;
+        row.exe.slot = None;
+        row.image.slot = None;
+        row.dll = None;
+        lock.spawned.push(row);
+        lock.spawned[0].exe.slot = Some(5);
+        assert!(bad(lock));
+
+        // shared row without fetch coordinates
+        let mut lock = carried_lock();
+        let mut row = spawned_java();
+        row.carry = false;
+        row.exe.slot = None;
+        row.image.slot = None;
+        row.source = None;
+        lock.spawned.push(row);
+        assert!(bad(lock));
+
+        // duplicate engine edge
+        let mut lock = carried_lock();
+        lock.spawned.push(spawned_java());
+        lock.spawned.push(spawned_java());
+        assert!(bad(lock));
+
+        // a non-bare expose name
+        let mut lock = carried_lock();
+        let mut row = spawned_java();
+        row.expose = vec!["/usr/bin/java".to_string()];
+        lock.spawned.push(row);
+        assert!(bad(lock));
+
+        // a carried pair slot colliding with a carried slice slot
+        let mut lock = carried_lock();
+        let mut row = spawned_java();
+        row.exe.slot = Some(0);
+        lock.spawned.push(row);
+        assert!(bad(lock));
+
+        // an empty engine
+        let mut lock = carried_lock();
+        let mut row = spawned_java();
+        row.engine = String::new();
+        lock.spawned.push(row);
+        assert!(bad(lock));
     }
 
     #[test]
@@ -1102,6 +1368,7 @@ mod tests {
         m.lock = Some(PackageLock {
             runtime: None,
             slices: vec![shared_slice()],
+            spawned: vec![],
         });
         m.validate().unwrap();
 
@@ -1111,6 +1378,7 @@ mod tests {
         m.lock = Some(PackageLock {
             runtime: None,
             slices: vec![carried_slice()],
+            spawned: vec![],
         });
         assert!(m.validate().is_err());
     }

--- a/docs/spec/03-payload-manifest.md
+++ b/docs/spec/03-payload-manifest.md
@@ -328,6 +328,18 @@ mounts:                           # per-slot mount semantics (locked 2026-08-04)
     point: /__tfs__
     mode: union                   # exclusive (default) | union; cow/enc reserved
     precedence: after-env         # union only: this image shadows the env image
+lock:                             # the press-time composition lock (spec 23 §4/§13)
+  runtime: {version: 0.16.19, carry: false}
+  slices: [{name: metanorma, version: 1.2.3, carry: true, slot: 0, sha256: …}]
+  spawned:                        # spec 30 edges, press-locked (spec 23 §13.6)
+    - engine: java
+      constraint: ">= 21, < 26"   # mirrored from slot 0's L1 requires
+      expose: [java]              # mirrored from slot 0's L1 requires
+      version: "21.0.12"          # the press-time pick
+      tebako: "2.1.5"
+      carry: true
+      exe:   {slot: 1, sha256: …} # carried pair — never mounted
+      image: {slot: 2, sha256: …}
 ```
 
 - `runtime_ref` per entry kills the 128-byte single-field limit (suites,
@@ -351,6 +363,14 @@ mounts:                           # per-slot mount semantics (locked 2026-08-04)
   (spec 17 §1). `cow`/`enc` are RESERVED mode spellings on the same
   axis (the transforms law: overlays exist only in the Rust TFS) and
   are named errors until their specs land.
+- `lock` is optional (absent on pre-spectrum packages — they resolve
+  exactly as before). `lock.spawned[]` mirrors the app payload's L1
+  `requires[].kind: runtime` edges (engine/implementation/constraint/
+  expose) plus the press-time pick and carry verdict (spec 23 §13.6);
+  `tebako-pkg validate` cross-checks the mirror against slot 0's L1
+  (the tebako#494 class), and the bootstrap resolves the rows at
+  dispatch into the store's `runtimes/` area + `TEBAKO_SPAWN_LOCK`
+  (spec 30 §2).
 
 **toolkit** (native layer, e.g. inkscape/gtk — the distro-ports model,
 spec 13 §9):

--- a/docs/spec/23-declarative-composition.md
+++ b/docs/spec/23-declarative-composition.md
@@ -9,8 +9,10 @@ is Phase-R. Dogfooded 2026-08-14: a JVM boot recorded, drafted, and
 replayed under deny with zero hand edits and zero unexpected denials.
 **Amended 2026-08-25 (owner-locked, tebako#460): §13 — the composition
 spectrum: per-slice `carry`, the `self-contained`/`shared-runtime`
-presets, and the `platforms:` coverage assertion. PLANNED; lands with
-the implementation PR (spec 14 order).**
+presets, and the `platforms:` coverage assertion. The lock substrate
+(§4's rows, §13.1's carry verdicts, `claimed_slots`, shared-slice
+resolution, lazy-seed) is IMPLEMENTED; §13.6's spawned-runtime rows land
+with the standalone-dispatch PR (spec 30 §2's bootstrap half).**
 
 A tebako run is a composition of one runtime (exe + env image) and N
 payload slices, executed under one host-access policy. This spec makes
@@ -184,7 +186,9 @@ and locks, per slice, into the L2 manifest: the concrete version, the
 the per-target-triplet digest map (§13.3). What press tested is what
 runs, always: a shared slice resolves at run time BY THE LOCKED DIGEST,
 never by fresh semver (fail-closed on mismatch). Carry changes where
-the bytes come from, never WHAT runs.
+the bytes come from, never WHAT runs. Spawned-runtime edges (spec 30)
+lock the same way, as `lock.spawned[]` rows (§13.6) — the press-time
+pick's version pair and digest pins, exactly like any DEPENDS.
 
 ## 5. The default policy — jail-safe by default
 
@@ -430,7 +434,10 @@ stands unchanged.)
 
 ## 13. The composition spectrum — carried and shared (owner-locked 2026-08-25, tebako#460)
 
-**Status: PLANNED** — lands with the implementation PR (spec 14 order).
+**Status: the lock substrate is IMPLEMENTED** (the `lock:` L2 block,
+`carry` verdicts, `claimed_slots`, shared-slice resolution, lazy-seed —
+and, with §13.6, the spawned-runtime rows). The compose-document presets
+(§13.2's D2 surface) land with their own PR.
 Fat and lean are the same architecture: ONE composition pipeline whose
 only dial is which resolved slices are physically embedded as trailer
 slots. "Fat" meant *fully resolved with no hanging dependencies*;
@@ -526,11 +533,53 @@ native bytes in a "universal" image fail there, before publication.
 |---|---|
 | `carry` / preset / `platforms:` assertion grammar | THIS section (D2 §3 mirrors it) |
 | The lock's digest-map shape | the L2 package-manifest schema (spec 02 §5b type-2 block; `schema/tebako-compose-v1.schema.json` stays the D2 document's) |
+| The lock's spawned-row shape (`lock.spawned[]`) | §13.6 (the L2 schema mirrors it; spec 30 §2 consumes it) |
 | Coverage declaration | spec 03 §3 (unchanged — the assertion references it) |
 | Registry row shape (concrete only) | spec 04 (amended: one sentence) |
 | Lazy-seed mechanics | spec 05 §4 (amended: the scoped exception) |
 | Two-slot carried runtime | spec 19 (amended) + tebako#458 |
 | Lean/fat alias warning | the named-warning vocabulary (invariant 9); exit codes unchanged — carry choices never gate a run |
+
+### 13.6 The spawned-runtime rows (`lock.spawned[]`)
+
+A payload's `kind: runtime` edge (spec 30) joins the lock like any
+resolved slice — press version-locks the edge (spec 30 §1) and records
+the dispatch channel. One row per edge:
+
+```yaml
+lock:
+  spawned:
+    - engine: java                  # the L1 edge's engine (+ `implementation:` when the edge names one)
+      constraint: ">= 21, < 26"     # mirrored from the L1 edge (press validate cross-checks)
+      expose: [java]                # mirrored from the L1 edge
+      version: "21.0.12"            # the press-time pick (the runtime's language version)
+      tebako: "2.1.5"               # the pick's own tebako line
+      carry: true                   # the same two words as §13.1
+      exe:   {slot: 1, sha256: …}   # carried: the pair's trailer slots + digest pins
+      image: {slot: 2, sha256: …}   # (`dll:` rides too on the windows dll facet)
+      # carry: false instead: no slots — `source:` records the
+      # press-resolved release download base (the `{base}/v<tebako>/…`
+      # root, replayed verbatim like TEBAKO_RUNTIME_MIRROR's value);
+      # the digest pins stand, per §13.3's universal-or-triplet-map
+      # shape.
+```
+
+Run time reads ONE block: the loader resolves each row into the store's
+`runtimes/` area — carried → slot extract + digest-verify + install;
+shared → cache hit on the locked identity + digest, else fetch the pair
+from the row's `source` + verify + install — and exports the dispatch
+lock (`TEBAKO_SPAWN_LOCK`, spec 30 §2). A carried spawned pair is never
+mounted: its slots ride the lock's claimed-slot set, invisible to the
+driver's mount composition. Offline discipline is spec 05's: carried
+installs and cache hits never touch the network; a shared miss offline
+is the named error. A locked spawn row whose pinned runtime later
+vanishes from the store is the driver's named error, never a silent
+re-pick (spec 30 §2).
+
+The per-engine download base chain (spec 05 §2) is not a prerequisite:
+the shared row's `source:` is the press-resolved release download base,
+replayed verbatim — the same dodge shared slices already use, and the
+answer until the per-engine chain lands.
 
 ## 14. The settings registry — one setting, three channels, one SSOT (owner-directed 2026-08-26, tebako#400)
 

--- a/docs/spec/30-runtime-spawned-dependency.md
+++ b/docs/spec/30-runtime-spawned-dependency.md
@@ -94,7 +94,13 @@ the bootstrap for a self-contained package) resolves every
 `kind: runtime` edge of the payload being dispatched — cache hit or
 download per spec 05 §5 — and exports the pins as `TEBAKO_SPAWN_LOCK`
 = `engine=language_version:tebako_version`, `;`-joined in manifest
-order (spec 17 §2). At SPAWN the driver resolves CACHE-ONLY and never
+order (spec 17 §2). The edge SOURCE differs per loader, one spelling
+each: the shim reads the installed payload's L1 manifest mirror; the
+bootstrap reads the L2 lock's `spawned[]` rows (spec 23 §13.6) — the
+payload's L1 manifest is in-image, and the bootstrap's size class
+carries no image reader, so press mirrors the edges into the lock and
+`tebako-pkg validate` cross-checks the mirror against slot 0's L1
+(the tebako#494 class). At SPAWN the driver resolves CACHE-ONLY and never
 downloads: a locked edge resolves to exactly the pinned pair (a pinned
 runtime gone from the store is a named error, never a silent re-pick);
 an UNLOCKED edge (a hand-rolled dispatch, a test harness) resolves the

--- a/schema/tpkg-package-manifest-v1.schema.json
+++ b/schema/tpkg-package-manifest-v1.schema.json
@@ -188,6 +188,54 @@
       },
       "description": "One locked payload slice (spec 23 §4/§13)."
     },
+    "lockedSpawnedArtifact": {
+      "type": "object",
+      "required": ["sha256"],
+      "properties": {
+        "slot": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 7,
+          "description": "The trailer slot carrying the bytes (carried rows only — the carry⇔slot agreement is semantic: carry: true requires it, carry: false forbids it)."
+        },
+        "sha256": { "$ref": "#/$defs/digestPin" },
+        "install_as": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[^/\\\\]+$",
+          "description": "The PE install name (the windows dll-era facet only): a bare file name, flowed from the release manifest's dll.install_as at press."
+        }
+      },
+      "description": "One artifact of a locked spawned-runtime pair (spec 23 §13.6): the digest pin always (§13.4 records the digest carried or shared), the trailer slot when carried."
+    },
+    "lockedSpawned": {
+      "type": "object",
+      "required": ["engine", "constraint", "version", "tebako", "carry", "exe", "image"],
+      "properties": {
+        "engine": { "type": "string", "minLength": 1 },
+        "implementation": { "type": "string", "minLength": 1 },
+        "constraint": { "type": "string", "minLength": 1 },
+        "expose": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "pattern": "^[^/\\\\:]+$" }
+        },
+        "version": { "type": "string", "minLength": 1 },
+        "tebako": { "type": "string", "minLength": 1 },
+        "carry": { "type": "boolean" },
+        "exe": { "$ref": "#/$defs/lockedSpawnedArtifact" },
+        "image": { "$ref": "#/$defs/lockedSpawnedArtifact" },
+        "dll": {
+          "$ref": "#/$defs/lockedSpawnedArtifact",
+          "description": "The windows dll-era facet, when the resolved release declares it."
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The fetch coordinates (a spec 04 reference) the press resolved from — required on a shared row; on a carried row it is provenance, never a fallback fetch path."
+        }
+      },
+      "description": "One locked spawned-runtime edge (spec 23 §13.6, spec 30 §2): the app payload's L1 requires[].kind: runtime edge mirrored (engine/implementation/constraint/expose), the press-time pick's version pair, the carry verdict, and the pair's digest pins. The L1-mirror parity, the locked-version-satisfies-constraint rule, and the one-row-per-edge uniqueness are semantic (the crate's validate() and the tebako-pkg validate cross-check)."
+    },
     "packageLock": {
       "type": "object",
       "properties": {
@@ -196,6 +244,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/lockedSlice" },
           "description": "Every resolved payload slice, in mount order: the app payload first, then its dependency closure. Slice-name uniqueness and the no-two-artifacts-per-slot rule are semantic (the crate's validate())."
+        },
+        "spawned": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/lockedSpawned" },
+          "description": "Every spawned-runtime edge (spec 30) of the app payload, in manifest order, press-locked (spec 23 §13.6). The bootstrap resolves each row into the store's runtimes/ area at dispatch and exports TEBAKO_SPAWN_LOCK; carried pairs are never mounted."
         }
       },
       "description": "The press-time lock (spec 23 §4/§13): what press resolved is what runs — the full composition closure locked per slice."


### PR DESCRIPTION
# Standalone spawned-runtime dispatch (spec 30 §2's missing half)

## Root cause

packed-mn #254 (run 33689243863) went red on all three press legs at `Compile xml+html (OIML)`:

```
Jing failed with error: tebako: spawn launcher cannot plan: spawn 'java':
no cached runtime satisfies engine 'java' — a spawn never downloads:
`tebako install` the runtime ahead, or dispatch through the shim (spec 30 §2)
```

The metanorma payload's java edge became `kind: runtime` (spec 30) in payload 1.16.9-7, so this is the first acceptance run that routes `java` through spec 30. The spec's dispatch half — the loader resolves every `requires[].kind: runtime` edge and exports `TEBAKO_SPAWN_LOCK`; the driver then resolves cache-only, never downloads — was implemented for the **shim** (`tebako-shim/src/dispatch.rs`) and the **driver** (`crates/tebako-driver/src/spawn.rs`), but never for the **bootstrap**. A standalone package therefore never installed the depended runtime and never exported the lock; the driver's spawn planner died with the named error (spawn.rs:356).

## The fix

Spec 30 §2's dispatch half, implemented in the bootstrap, locked by spec deltas riding the same PR (spec 14 order):

**Spec deltas**

- spec 23 §13.6 (new) + §4 + §13.5 SSOT table: `lock.spawned[]` — the L2 lock row for a spawned-runtime edge: engine / implementation / constraint / expose mirrored from the app payload's L1 edge, the press-time pick's version pair (`version` = lang version, `tebako` = the runtime's own tebako line), the carry verdict, per-artifact digest pins, and `source:` — the press-resolved **release download base** (the `{base}/v<tebako>/…` root the bootstrap's existing runtime download machinery replays verbatim; not a spec-04 slice reference — the machinery is base-shaped).
- spec 30 §2: names the L2 lock as the bootstrap's edge source (the L1 manifest is in-image and the bootstrap has no TFS reader by size-gate construction).
- spec 03 §6: lock sketch carries the new block.

**`tpkg` model** (`crates/tpkg/src/package.rs`)

- `LockedSpawnedArtifact {slot, sha256, install_as}` and `LockedSpawned {engine, implementation, constraint, expose, version, tebako, carry, exe, image, dll, source}`; `PackageLock.spawned: Vec<LockedSpawned>`.
- `claimed_slots()` extends to spawned slots — they are never handed to the driver as mounts (spec 30 §1: the edge is NEVER co-mounted).
- `validate()` fail-closed: carried rows pin slots within the slot table and claim each slot at most once; shared rows require `source:` and forbid slots.
- JSON schema `tpkg-package-manifest-v1.schema.json` gains `lockedSpawnedArtifact` / `lockedSpawned` and `packageLock.spawned`.

**Bootstrap dispatch** (`crates/tebako-bootstrap/src/lib.rs`)

New `resolve_spawned_edges`, run after the primary runtime resolves and before handoff. Per `lock.spawned` row, by engine + locked version pair + host triplet:

- store entry present with the recorded digests → cache-hit line, done (no freshness re-checks — the `.sha256` marker is the trust anchor);
- present-but-incomplete (missing markers) or digest drift → the named store errors (`EX_TEBAKO_IO` / `EX_TEBAKO_SHA`), never a silent reinstall;
- `carry: true` → the exe/image(/dll) slots stage into the machine runtime cache under the entry flock, digest-verified, tmp+rename published — the image lands as a **real cache file** (unlike the primary carried runtime's `<package>:<slot>` image form) because the driver's spawn planner resolves from the store;
- `carry: false` → the pair downloads from the row's `source` base through the existing shard/manifest.json machinery, digest-verified against the lock pins, installed;
- `TEBAKO_OFFLINE=1`: cache hits and carried staging proceed (no network); a shared miss is the named spec 05 error.

`TEBAKO_SPAWN_LOCK` (`tpkg::runtime_store::spawn_lock_entry`, `;`-joined, manifest order) is exported on both exec paths (unix `exec_runtime`, windows via `platform::spawn_handoff`). The driver consumes it unchanged.

**`tebako-info validate` cross-check** (`crates/tebako-info/src/verify.rs`)

Per lock row, against slot-0's L1 manifest: the `requires[].kind: runtime` edge must exist (engine + implementation exact parity), the constraint must mirror verbatim, the locked `version` must satisfy the constraint, `expose` must match as a set — **both directions** (an L1 runtime edge without a lock row fails 65). No usable L1 → skip (the check class of tebako#494).

**`tebako-pkg bundle --exact-mounts`** (new CLI flag, maps to the existing lib `bundle_exact`): mount points are used exactly as given, so a lock-claimed carried slot (the runtime pair, a spawned pair) records an EMPTY mount point instead of a fabricated `/__tfs_N__`. Required by the spec 30 §1 never-co-mounted rule at press time; packed-mn's 4-slot layout uses it. Default behavior unchanged.

**`tebako-cli` D2 auto-press**: deliberately does NOT auto-mirror L1 runtime edges yet (`spawned: Vec::new()` + comment). Hand-authored locks (packed-mn) plus the validate cross-check carry the load; the auto-mirror is a follow-up.

## Tests

- tpkg unit: `LockedSpawned` round-trip, validate fail-closed matrix (slot claims, shared-row source required, dll host gating).
- bootstrap unit (`spawned_tests`): digest recording, fail-closed completeness (missing/incomplete/drift, dll-coverage gating), carried staging lands a driver-pickable entry (`tpkg::runtime_store::resolve_locked` picks the staged entry), lock export value.
- bootstrap e2e (`compose.rs`): a 5-slot package (app + primary runtime pair + carried java pair) boots twice under `TEBAKO_OFFLINE=1` — `SPAWN-LOCK=java=21.0.12:2.1.5` echoed by the fake runtime both runs; the staged cache entry carries exe + image + image marker; the driver's locked pick resolves it.
- tebako-pkg e2e (`info.rs`): `validate` passes a mirrored lock, fails 65 on an unmirrored L1 edge, fails 65 on mirror drift (constraint / version-out-of-constraint / expose). CLI (`cli.rs`): `--exact-mounts` keeps bare-slot mounts empty; the default-mount behavior is untouched without it.

Local evidence: full `cargo test --workspace` — 114 suites green, 0 failures (one tebako-cli doctest compile casualty caused by an edit landing mid-sweep; re-verified on the stable tree: tebako-pkg 12 suites + tebako-cli lib 152 + doc all green).

## Chain

This unblocks packed-mn #254: the package manifest gains the `lock:` block (lean runtime row, carried metanorma slice, carried spawned java pair), the `/opt/openjdk` co-mount drops (spec 30 §1), and the bundle gains the openjdk exe slot.

Refs: spec 23 §13.6, spec 30 §2, spec 03 §6, tebako#494.
