### PR TITLE
validate: skip the manifest check for lock-claimed raw slots (spec 30 §2)

### DIFF
--- a/crates/tebako-info/src/verify.rs
+++ b/crates/tebako-info/src/verify.rs
@@ -337,11 +337,41 @@ pub fn verify_package(
     // 4 + 5. Per-slot manifest schema validation and digest agreement.
     // Runtime payload slots (the v1 legacy role) are launchers, not image
     // payloads: never mounted, no manifest checks (spec 15 §3).
+    //
+    // The L2 package manifest parses once — the raw-slot set below and
+    // the section-6 cross-checks share it. Slots a lock.spawned[] row
+    // claims as `exe`/`dll` carry RAW BYTES (a wrapper exe / a PE dll —
+    // never an image): no mount, no manifest check (spec 23 §13.6,
+    // spec 30 §2). The byte identity rides the trailer slot digest
+    // (check 2) and the lock's digest pin.
+    let pm_result = trailer.package_manifest();
+    let raw_slots: std::collections::BTreeSet<usize> = match &pm_result {
+        Ok(Some(pm)) => pm
+            .lock
+            .iter()
+            .flat_map(|lock| lock.spawned.iter())
+            .flat_map(|row| {
+                row.exe
+                    .slot
+                    .into_iter()
+                    .chain(row.dll.as_ref().and_then(|d| d.slot))
+            })
+            .map(|s| s as usize)
+            .collect(),
+        _ => Default::default(),
+    };
     let inspection = package::inspect_package(binary, package::Depth::Manifests, None)?;
     for slot in &inspection.slots {
         let name = format!("slot[{}] manifest", slot.index);
         if slot.format_hint == tpkg::TPKG_FORMAT_RUNTIME {
             checks.push(Check::skip(name, "runtime (legacy role) — never mounted"));
+            continue;
+        }
+        if raw_slots.contains(&slot.index) {
+            checks.push(Check::skip(
+                name,
+                "spawned runtime artifact (raw bytes — never mounted; the trailer digest and the lock pin carry its identity)",
+            ));
             continue;
         }
         let p = slot
@@ -399,7 +429,7 @@ pub fn verify_package(
     //    entrypoint of that payload (the name facet is unchecked, never
     //    failing, when the slot carries no usable L1 manifest —
     //    pre-manifest packages stay valid).
-    match trailer.package_manifest() {
+    match pm_result {
         Err(e) => checks.push(Check::fail(
             "package manifest",
             format!("extension block: {e}"),

--- a/crates/tebako-pkg/tests/info.rs
+++ b/crates/tebako-pkg/tests/info.rs
@@ -1241,3 +1241,58 @@ fn validate_spawned_mirror_mismatches_are_65() {
         "{out}"
     );
 }
+
+/// The CARRIED spawned-runtime layout (packed-mn's 4-slot shape, spec 30
+/// §1/§2): slot 1 is the RAW wrapper exe — never an image. validate must
+/// skip its manifest check (the packed-mn#254 gate failure: slot[1]
+/// manifest FAILED with "cannot mount the image (errno 22)").
+#[test]
+fn validate_spawned_carried_raw_exe_slot_skips_the_manifest_check() {
+    use sha2::{Digest, Sha256};
+    let sha256_hex = |p: &Path| format!("{:x}", Sha256::digest(std::fs::read(p).unwrap()));
+
+    let w = TempDir::new("psp-raw");
+    let home = test_home("psp-raw");
+    let app = mk_image_files(
+        &w,
+        "spawned.tfs",
+        Some(SPAWNED_APP_MANIFEST),
+        &[("probe", b"#!/bin/sh\n")],
+    );
+    let exe = w.0.join("java-exe");
+    std::fs::write(&exe, b"\x7fELF raw wrapper bytes - never an image").unwrap();
+    let env = mk_image(&w, "java-env.tfs", None);
+
+    let pm_yaml = spawned_pm(&format!(
+        "lock:\n  spawned:\n   - engine: java\n     constraint: \">= 21, < 26\"\n     expose: [java]\n     version: \"21.0.12\"\n     tebako: \"2.1.6\"\n     carry: true\n     exe: {{slot: 1, sha256: \"{}\"}}\n     image: {{slot: 2, sha256: \"{}\"}}\n",
+        sha256_hex(&exe),
+        sha256_hex(&env)
+    ));
+    let pm = pm_file(&w, &pm_yaml);
+    let pkg =
+        w.0.join(format!("pkg-{}", COUNTER.fetch_add(1, Ordering::Relaxed)));
+    bundle(
+        &home,
+        &w,
+        &["--package-manifest", pm.to_str().unwrap(), "--exact-mounts"],
+        &[&app, &exe, &env],
+        &pkg,
+    );
+
+    let (rc, out, _) = run(&["validate", pkg.to_str().unwrap()], &w.0, &home);
+    assert_eq!(rc, 70, "{out}"); // slot 0 digest agreement, see above
+    assert!(
+        out.contains(
+            "  slot[1] manifest: skip — spawned runtime artifact (raw bytes — never mounted; the trailer digest and the lock pin carry its identity)\n"
+        ),
+        "{out}"
+    );
+    assert!(!out.contains("slot[1] manifest: FAILED"), "{out}");
+    // The lock row still mirrors the L1 edge — the cross-check stands.
+    assert!(
+        out.contains(
+            "  spawned[java]: ok — mirrors the L1 edge; the locked version 21.0.12 satisfies \">= 21, < 26\"\n"
+        ),
+        "{out}"
+    );
+}


### PR DESCRIPTION
# validate: skip the manifest check for lock-claimed raw slots (spec 30 §2)

## The bug (caught by packed-mn's structural gate)

packed-mn#254's press legs failed validate with:

```
slot[1] manifest: FAILED — cannot mount the image (errno 22): Invalid argument
```

Slot 1 in the spec-30 4-slot layout is the carried java **exe** — raw bytes, never an image. `verify_package`'s per-slot manifest check (section 4) mounted every slot that isn't the v1 legacy runtime role, so the raw exe slot died at mount. Spec 30's raw-slot rule was implemented for dispatch (#519: the bootstrap never mounts claimed slots) but not for validate.

## The fix

`crates/tebako-info/src/verify.rs`:

- `verify_package` now parses the L2 package manifest ONCE (the raw-slot set and the section-6 cross-checks share the parse — previously section 6 re-parsed).
- `raw_slots` = the set of slots claimed by `lock.spawned[].exe.slot` ∪ `.dll.slot` (carried rows only; shared rows carry no slots).
- The per-slot loop skips those slots with a named skip: `spawned runtime artifact (raw bytes — never mounted; the trailer digest and the lock pin carry its identity)`.

Byte identity of the raw slots stays covered: the trailer's per-slot sha256 (check 2, unchanged) plus the lock's digest pin (asserted at staging by the bootstrap; press-side byte verification is the tracked follow-up).

The spawned **image** slot is untouched — it mounts and manifest-checks as before.

## Tests

New regression test in `crates/tebako-pkg/tests/info.rs`
(`validate_spawned_carried_raw_exe_slot_skips_the_manifest_check`):
builds the packed-mn shape in-test — slot 0 app image, slot 1 raw exe
bytes (`\x7fELF…`), slot 2 plain env image, carried `lock.spawned[]`
row with real digest pins, pressed with `--exact-mounts`. Asserts:

- exit 70 (only the fixture's known blob_sha256 placeholder failure)
- the slot[1] manifest **skip** line
- no `slot[1] manifest: FAILED`
- the `spawned[java]` mirror cross-check still passes

Local evidence: all 4 spawned validate tests + the full tebako-info
suite green; `cargo fmt --check` + `clippy -p tebako-info -p tebako-pkg
--all-targets -D warnings` clean.

## After merge

Release v2.1.7 (packed-mn#254 is pinned to 2.1.6 and needs this fix to
go green — its gate accepts exactly the three placeholder lines and
nothing else).
