### PR TITLE
spec 22 §3.1 / spec 30 §3: shell-form argument bridging + windows inline plan (ruby#107)

### DIFF
--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -456,6 +456,29 @@ strictest one.) A shell string whose operands are all host paths
 behaves exactly as on any host — the boundary is the VFS-operand case
 only.
 
+**Shell-form argument bridging (locked 2026-09-03; ruby#107, the
+packed-mn#254 jing failure is its tripwire).** A shell string's
+OPERANDS bridge parent-side on every platform, by the interpreter's
+spawn hook: the command line is tokenized on unquoted blanks (both
+quote characters honored), one wrapping quote layer is stripped for
+the probe, and any token naming an embedded path
+(`tebako_path_is_embedded`) is materialized through
+`tebako_fs_exec_materialize` and the token rewritten to the host twin
+— the windows argv bridge's own primitive and pass-through discipline
+(byte-identical when nothing bridges; a covered path the mounts do not
+hold keeps its spelling and the child answers honestly). The COMMAND
+token is never planned on POSIX: the shell stays the exec target so a
+composite string (redirections, pipes, `&&`) keeps its semantics, and
+the command's own PATH resolution rides spec 30 §3's launcher tier.
+On windows the first-token command IS offered to the §3.2/spec-30 plan
+FFI; when planned, the string is rebuilt as the quoted store exe plus
+the plan argv plus the span-bridged remainder, cmd.exe's separators
+and redirections preserved. (Before this lock the matrix's shell
+columns covered the COMMAND's resolution only; an embedded OPERAND —
+jing's `/__tfs__/…/jing-….jar` — passed through verbatim and the child
+answered `Unable to access jarfile`, and on windows the bare command
+itself was never planned.)
+
 **Rule E2.** Exec of a VFS-resident binary materializes the binary plus
 its loader closure (the same exec cache as Class L —
 `TEBAKO_EXEC_CACHE`, §6) and execs the real path with the original

--- a/docs/spec/30-runtime-spawned-dependency.md
+++ b/docs/spec/30-runtime-spawned-dependency.md
@@ -164,7 +164,14 @@ exit 69 — never a host-PATH fallback. The launchers append AFTER the
 preload shim's dependency wrappers (a dep wrapper wins a basename tie)
 and exist whether or not the preload shim armed: the launcher execs
 the child wrapper exe fresh and needs no interposition. Windows has no
-launcher tier — the §2 argv bridge is the whole surface there.
+launcher tier — the §2 argv bridge is the whole surface there, and a
+SHELL-form spawn plans its first-token command inline through the §2
+plan FFI (the string is rebuilt as the quoted store exe plus the plan
+argv plus the span-bridged remainder, cmd.exe's separators and
+redirections preserved). POSIX shell form is the mirror image: the
+command token is never planned — the shell stays the exec target, the
+launcher tier resolves it, and only the operand tokens bridge
+(spec 22 §3.1's shell-form argument-bridging paragraph).
 
 ## 4. Jail interaction (union-of-needs, never inheritance)
 


### PR DESCRIPTION
## What

Docs-only spec delta recording the shell-form spawn semantics shipped in tamatebako/ruby#107 (source release v0.2.33) — the packed-mn#254 jing failure (`Unable to access jarfile /__tfs__/…` on POSIX, `'"java"' is not recognized` on windows) is its tripwire.

- **spec 22 §3.1** gains the "Shell-form argument bridging" paragraph: a shell string's OPERANDS bridge parent-side on every platform (tokenize on unquoted blanks honoring both quote chars, strip one quote layer, `tebako_path_is_embedded` probe, `tebako_fs_exec_materialize` rewrite — the windows argv bridge's own primitive and pass-through discipline). The COMMAND token is never planned on POSIX (the shell stays the exec target; composite strings keep their semantics; the launcher tier resolves the command). On windows the first-token command IS offered to the plan FFI.
- **spec 30 §3**'s launcher-tier paragraph amended: the windows "no launcher tier" sentence now records the inline first-token plan for shell-form spawns, and the POSIX mirror (never plan the command token, operands bridge).

No code, no behavior change beyond what ruby#107 already ships; this keeps the spec set the normative record (spec 14 order: the implementation rode the ruby source-factory patch set, which carries no spec files).
