### PR TITLE
libtfs-preload: interpose fcntl (the CPython FileIO boot blocker)

### DIFF
--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -188,6 +188,11 @@ real_fn!(
 );
 real_fn!(real_close, c"close", unsafe extern "C" fn(c_int) -> c_int);
 real_fn!(
+    real_fcntl,
+    c"fcntl",
+    unsafe extern "C" fn(c_int, c_int, ...) -> c_int
+);
+real_fn!(
     real_mkdir,
     c"mkdir",
     unsafe extern "C" fn(*const c_char, libc::mode_t) -> c_int

--- a/crates/libtfs-preload/src/sys/macos.rs
+++ b/crates/libtfs-preload/src/sys/macos.rs
@@ -82,18 +82,23 @@ core::arch::global_asm!(
     "_tebako_tramp_openat:",
     "    ldr w3, [sp]",
     "    b _openat_impl",
+    ".globl _tebako_tramp_fcntl",
+    "_tebako_tramp_fcntl:",
+    "    ldr w2, [sp]",
+    "    b _fcntl_impl",
 );
 
 #[cfg(target_arch = "aarch64")]
 unsafe extern "C" {
     fn tebako_tramp_open(path: *const c_char, flags: c_int, mode: c_int) -> c_int;
     fn tebako_tramp_openat(dirfd: c_int, path: *const c_char, flags: c_int, mode: c_int) -> c_int;
+    fn tebako_tramp_fcntl(fd: c_int, cmd: c_int, arg: c_int) -> c_int;
 }
 
 #[cfg(not(target_arch = "aarch64"))]
-use {super::open as shim_open, super::openat as shim_openat};
+use {super::fcntl as shim_fcntl, super::open as shim_open, super::openat as shim_openat};
 #[cfg(target_arch = "aarch64")]
-use {tebako_tramp_open as shim_open, tebako_tramp_openat as shim_openat};
+use {tebako_tramp_fcntl as shim_fcntl, tebako_tramp_open as shim_open, tebako_tramp_openat as shim_openat};
 
 interpose!(
     INTERPOSE_OPEN,
@@ -214,6 +219,15 @@ interpose!(
     super::close,
     close_plain,
     unsafe extern "C" fn(c_int) -> c_int
+);
+// fcntl is variadic (a cmd-dependent third argument) — the open/openat
+// trampoline note applies verbatim on arm64. No $NOCANCEL twin exists.
+interpose!(
+    INTERPOSE_FCNTL,
+    real_fcntl,
+    shim_fcntl,
+    libc::fcntl,
+    unsafe extern "C" fn(c_int, c_int, ...) -> c_int
 );
 interpose!(
     INTERPOSE_MKDIR,

--- a/crates/libtfs-preload/src/sys/macos.rs
+++ b/crates/libtfs-preload/src/sys/macos.rs
@@ -98,7 +98,10 @@ unsafe extern "C" {
 #[cfg(not(target_arch = "aarch64"))]
 use {super::fcntl as shim_fcntl, super::open as shim_open, super::openat as shim_openat};
 #[cfg(target_arch = "aarch64")]
-use {tebako_tramp_fcntl as shim_fcntl, tebako_tramp_open as shim_open, tebako_tramp_openat as shim_openat};
+use {
+    tebako_tramp_fcntl as shim_fcntl, tebako_tramp_open as shim_open,
+    tebako_tramp_openat as shim_openat,
+};
 
 interpose!(
     INTERPOSE_OPEN,

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -304,6 +304,36 @@ unsafe fn fill_stat(raw: &tfs::backend::RawStat) -> Result<libc::stat, i32> {
 /// until the next readdir/closedir on the same stream).
 static DIRENT_CACHE: Mutex<Option<HashMap<usize, Box<libc::dirent>>>> = Mutex::new(None);
 
+/// The memfs-fd descriptor table: presence = the fd is OPEN (the shim's
+/// liveness truth for the fd-verb commands), value = its close-on-exec
+/// bit. A memfs fd is a shim-side flag-bit integer with NO kernel state,
+/// so FD_CLOEXEC — set with O_CLOEXEC at open or with fcntl(F_SETFD) —
+/// must live here: the real fcntl would EBADF on the fake fd. That is
+/// the CPython io.FileIO boot blocker (the python runtime factory
+/// dogfood, TODO.python/02): FileIO.__init__ runs _Py_set_inheritable →
+/// fcntl(F_GETFD) on the freshly opened fd with raise=1
+/// (Modules/_io/fileio.c:451 → Python/fileutils.c get_inheritable), so
+/// EVERY source open of the unpatched interpreter died before user code.
+/// open/openat insert, close purges; fcntl reads/writes.
+static FD_TABLE: Mutex<Option<HashMap<c_int, bool>>> = Mutex::new(None);
+
+/// Record a freshly opened memfs fd with its close-on-exec state.
+fn fd_table_note(fd: c_int, cloexec: bool) {
+    FD_TABLE
+        .lock()
+        .unwrap()
+        .get_or_insert_with(HashMap::new)
+        .insert(fd, cloexec);
+}
+
+/// Drop a closed memfs fd: a flagged fd the table lacks is DEAD, and a
+/// later fcntl on it is EBADF — exactly the kernel's answer.
+fn fd_table_purge(fd: c_int) {
+    if let Some(m) = FD_TABLE.lock().unwrap().as_mut() {
+        m.remove(&fd);
+    }
+}
+
 /// Translate a TebakoCDirent into the native `struct dirent` (name
 /// NUL-terminated, d_type, d_namlen/d_reclen per platform, nonzero d_ino —
 /// some consumers skip zero-inode entries).
@@ -399,7 +429,10 @@ pub unsafe extern "C" fn open_impl(path: *const c_char, flags: c_int, mode: c_in
         return unsafe { plat::real_open()(path, flags, mode) };
     };
     match engine_call(|| route::vfs_open(p, flags)) {
-        Some(PathRoute::Vfs(fd)) => fd,
+        Some(PathRoute::Vfs(fd)) => {
+            fd_table_note(fd, flags & libc::O_CLOEXEC != 0);
+            fd
+        }
         Some(PathRoute::Denied(e)) => {
             set_errno(e);
             -1
@@ -448,7 +481,10 @@ pub unsafe extern "C" fn openat_impl(
         }
     };
     match engine_call(|| route::vfs_open(&routed, flags)) {
-        Some(PathRoute::Vfs(fd)) => fd,
+        Some(PathRoute::Vfs(fd)) => {
+            fd_table_note(fd, flags & libc::O_CLOEXEC != 0);
+            fd
+        }
         Some(PathRoute::Denied(e)) => {
             set_errno(e);
             -1
@@ -1132,6 +1168,7 @@ pub unsafe extern "C" fn __realpath_chk(
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn close(fd: c_int) -> c_int {
     if route::is_memfs_fd(fd) {
+        fd_table_purge(fd);
         return match engine_call(|| route::vfs_close(fd)) {
             Some(Ok(())) => 0,
             Some(Err(e)) => {
@@ -1145,6 +1182,67 @@ pub unsafe extern "C" fn close(fd: c_int) -> c_int {
         };
     }
     unsafe { plat::real_close()(fd) }
+}
+
+/// Interposed `fcntl` (fd-flag dispatch). Only the descriptor commands
+/// are meaningful on a memfs fd: F_GETFD/F_SETFD read/write the shim's
+/// fd table; F_GETFL answers the truthful read-only status word (payload
+/// images are always ro, spec 11 — O_RDONLY, never O_APPEND/O_NONBLOCK);
+/// F_SETFL is an accepted no-op (a memfs read never blocks and there is
+/// no kernel status word to mutate). The dup class (F_DUPFD and kin) is
+/// NOT modeled — duplicating a memfs fd is the engine's to own, and no
+/// tier-1 consumer (the CPython/JDK boot paths) calls it: EINVAL, like
+/// every other unrecognized command on a LIVE memfs fd ("cmd is not
+/// valid" — the fd is open, so EBADF would lie). A flagged-but-closed fd
+/// is EBADF. Host fds pass through untouched.
+///
+/// ABI note: fcntl is variadic like open — on Darwin arm64 the third
+/// argument rides the STACK (the first variadic slot at [sp, 0]), so the
+/// macOS tuple binds the trampoline (sys/macos.rs), which hoists it into
+/// the fixed-parameter register before the Rust body runs. x86_64 Darwin
+/// and linux pass it in the register, so the fixed declaration is
+/// correct there.
+#[cfg_attr(target_os = "linux", no_mangle)]
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+pub unsafe extern "C" fn fcntl(fd: c_int, cmd: c_int, arg: c_int) -> c_int {
+    fcntl_impl(fd, cmd, arg)
+}
+
+/// The Rust body of the fcntl shim (entry point per ABI, see above).
+#[no_mangle]
+pub unsafe extern "C" fn fcntl_impl(fd: c_int, cmd: c_int, arg: c_int) -> c_int {
+    if !route::is_memfs_fd(fd) {
+        // SAFETY: forwarding the original arguments to the real fcntl.
+        return unsafe { plat::real_fcntl()(fd, cmd, arg) };
+    }
+    let live = FD_TABLE
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|m| m.get(&fd).copied());
+    let Some(cloexec) = live else {
+        set_errno(libc::EBADF);
+        return -1;
+    };
+    match cmd {
+        libc::F_GETFD => {
+            if cloexec {
+                libc::FD_CLOEXEC
+            } else {
+                0
+            }
+        }
+        libc::F_SETFD => {
+            fd_table_note(fd, arg & libc::FD_CLOEXEC != 0);
+            0
+        }
+        libc::F_GETFL => libc::O_RDONLY,
+        libc::F_SETFL => 0,
+        _ => {
+            set_errno(libc::EINVAL);
+            -1
+        }
+    }
 }
 
 /// Interposed `mkdir` (write-class: memfs → EROFS, host → policy-gated).

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -161,6 +161,7 @@ fn build_fixtures() -> Option<Fixtures> {
         "dir-stream",
         "mmap-probe",
         "close-probe",
+        "fcntl-probe",
         "fork-exec",
         "alias-probe",
         "realpath-probe",
@@ -1054,6 +1055,25 @@ fn macos_plain_close_on_a_memfs_fd() {
     let r = run(f, "close-probe", &[path.as_str()], None);
     assert_eq!(r.rc, 0, "close-probe failed, stderr: {}", r.stderr);
     assert!(r.stdout.contains("close-probe:ok"), "stdout: {}", r.stdout);
+}
+
+/// CPython's FileIO boot path (the python runtime factory dogfood,
+/// TODO.python/02): `FileIO.__init__` runs `_Py_set_inheritable` →
+/// `get_inheritable` → `fcntl(F_GETFD)` on the freshly opened flagged
+/// memfs fd with raise=1 (Modules/_io/fileio.c:451) — unpatched, the
+/// real fcntl answered EBADF and every source open died importing
+/// `encodings`, before any user code. The probe replays the exact
+/// sequence: O_CLOEXEC open → F_GETFD (bit set) → F_SETFD clear/set →
+/// F_GETFL (truthful read-only) → F_SETFL accepted no-op → read →
+/// close → EBADF on the dead fd → host-fd passthrough. Cross-platform:
+/// fcntl's descriptor commands are plain POSIX.
+#[test]
+fn fcntl_on_a_memfs_fd() {
+    let Some(f) = fixtures() else { return };
+    let path = format!("{MOUNT}/data/secret.txt");
+    let r = run(f, "fcntl-probe", &[path.as_str()], None);
+    assert_eq!(r.rc, 0, "fcntl-probe failed, stderr: {}", r.stderr);
+    assert!(r.stdout.contains("fcntl-probe:ok"), "stdout: {}", r.stdout);
 }
 
 /// The 2026-08-22 fork/exec deadlock regression pin (runtime 0.16.4: a

--- a/crates/libtfs-preload/tests/fixtures/fcntl-probe.c
+++ b/crates/libtfs-preload/tests/fixtures/fcntl-probe.c
@@ -1,0 +1,61 @@
+/* CPython boot-path oracle (the python runtime factory dogfood,
+ * TODO.python/02): io.FileIO.__init__ runs _Py_set_inheritable →
+ * get_inheritable → fcntl(F_GETFD) on the freshly opened fd with
+ * raise=1 (Modules/_io/fileio.c:451 → Python/fileutils.c). The shim's
+ * memfs fds are flag-bit integers with no kernel state, so the real
+ * fcntl answered EBADF and EVERY source open of the unpatched
+ * interpreter died importing `encodings`, before any user code. The
+ * shim now serves the descriptor commands from its own fd table:
+ * F_GETFD/F_SETFD track the close-on-exec bit (O_CLOEXEC at open is
+ * the seed), F_GETFL answers the truthful read-only status word,
+ * F_SETFL is an accepted no-op, and a flagged-but-closed fd is EBADF —
+ * the kernel's own answer. A host fd must pass through untouched.
+ * The dup class (F_DUPFD and kin) is EINVAL by design (duplicating a
+ * memfs fd is the engine's to own) and is deliberately not pinned
+ * here. Cross-platform: fcntl's fd commands are plain POSIX. */
+#include <errno.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    char buf[16];
+    int fd, fl, hfd;
+    if (argc < 2) return 64;
+    /* CPython opens sources with O_CLOEXEC (PEP 446: non-inheritable
+     * by default) — the open seeds the shim's fd-table bit. */
+    fd = open(argv[1], O_RDONLY | O_CLOEXEC);
+    if (fd < 0) { perror("open"); return 65; }
+    /* THE PIN: F_GETFD on the flagged fd must be served by the shim
+     * (FD_CLOEXEC set), never reach the kernel (EBADF). */
+    fl = fcntl(fd, F_GETFD);
+    if (fl < 0 || !(fl & FD_CLOEXEC)) { perror("fcntl(F_GETFD)"); return 66; }
+    /* F_SETFD clears, F_GETFD reads back clear… */
+    if (fcntl(fd, F_SETFD, 0) != 0) { perror("fcntl(F_SETFD,0)"); return 67; }
+    fl = fcntl(fd, F_GETFD);
+    if (fl != 0) { fprintf(stderr, "F_GETFD after clear: %#x\n", fl); return 68; }
+    /* …F_SETFD sets again. */
+    if (fcntl(fd, F_SETFD, FD_CLOEXEC) != 0) { perror("fcntl(F_SETFD,CLOEXEC)"); return 69; }
+    /* F_GETFL: the truthful read-only status word (payloads are ro). */
+    fl = fcntl(fd, F_GETFL);
+    if (fl < 0) { perror("fcntl(F_GETFL)"); return 70; }
+    if ((fl & O_ACCMODE) != O_RDONLY) { fprintf(stderr, "F_GETFL accmode: %#x\n", fl); return 71; }
+    /* F_SETFL is an accepted no-op (a memfs read never blocks). */
+    if (fcntl(fd, F_SETFL, O_NONBLOCK) != 0) { perror("fcntl(F_SETFL)"); return 72; }
+    /* The fd still reads after the flag dances. */
+    if (read(fd, buf, sizeof(buf)) <= 0) { perror("read"); return 73; }
+    if (close(fd) != 0) { perror("close"); return 74; }
+    /* A flagged-but-closed fd: EBADF, exactly the kernel's answer. */
+    errno = 0;
+    if (fcntl(fd, F_GETFD) != -1 || errno != EBADF) {
+        fprintf(stderr, "fcntl on closed fd: rc/errno wrong\n");
+        return 75;
+    }
+    /* Host fds pass through to the real fcntl untouched. */
+    hfd = open("/dev/null", O_RDONLY);
+    if (hfd < 0) { perror("open /dev/null"); return 76; }
+    if (fcntl(hfd, F_GETFD) < 0) { perror("fcntl host F_GETFD"); return 77; }
+    if (close(hfd) != 0) { perror("close /dev/null"); return 78; }
+    puts("fcntl-probe:ok");
+    return 0;
+}

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -184,7 +184,14 @@ The locked model is three tiers — **interposition-first, never FUSE**:
    close(+the plain and $NOCANCEL spellings on x86_64 darwin — the libc
    crate maps `libc::close` to `close$NOCANCEL` there, C binaries
    (the JVM's libjava/libjli/libzip) import plain `close`; both route
-   to the shim)/mkdir/unlink/rename + dlopen + execve/posix_spawn/posix_spawnp
+   to the shim)/fcntl(the descriptor commands on a memfs fd are served
+   from the shim's own fd table — open/openat seed the close-on-exec
+   bit from O_CLOEXEC, F_GETFD/F_SETFD read/write it, F_GETFL answers
+   the truthful read-only status word, F_SETFL is an accepted no-op, a
+   flagged-but-closed fd is EBADF, the dup class (F_DUPFD and kin) is
+   EINVAL, host fds pass through untouched — CPython's io.FileIO boot
+   path fcntls every fresh source fd with raise=1, so unshimmed the
+   interpreter died importing `encodings` before any user code)/mkdir/unlink/rename + dlopen + execve/posix_spawn/posix_spawnp
    + the realpath family (realpath, plus macOS's realpath$DARWIN_EXTSN;
    canonicalize_file_name and the fortified __realpath_chk on linux):
    glibc's realpath(3) walks the path with libc-INTERNAL stat/readlink


### PR DESCRIPTION
# libtfs-preload: interpose fcntl (the CPython FileIO boot blocker)

**Draft — owner decides merge/release per the ecosystem rule.** This is the upstream half of the TODO.python/02 (python runtime factory) dogfood unblocker; the factory PR links back here.

## The gap

The python runtime factory (tebako-runtime-python) builds an **unpatched** CPython against the v2 driver contract: the env image mounts at the runtime root and `libtfs-preload` is the only way the interpreter reads its own stdlib. The macos-arm64 dogfood died before any user code:

```
Fatal Python error: init_import_site: Failed to import the site module
...
OSError: [Errno 9] Bad file descriptor   # importing encodings, in importlib get_data
```

lldb (conditioned breakpoints on the fd verbs) pinned it precisely: `_io_FileIO___init__` (Modules/_io/fileio.c:451) → `_Py_set_inheritable` → `get_inheritable` → **`fcntl(fd, F_GETFD)`** with raise=1 — on the shim's fake fd (bit-30 flagged). The shim never interposed `fcntl` (~40 symbols in both the macOS tuples and the linux no_mangle surface, none of them fcntl), so the real fcntl got the fake fd, the kernel answered EBADF, and CPython raises on it. Every source open died the same way.

Ruby never hit this: the ruby exe's visibility is the patch, not the shim. The shim's POSIX consumers so far were JDKs, and Temurin doesn't fcntl post-open. CPython does — on **every** source open.

A plain C probe under the same shim (stat/open/fstat/lseek/read, O_CLOEXEC) reads VFS files perfectly — the limnifs backend and the shim core were healthy; fcntl was the missing verb.

## The fix

A memfs fd is a shim-side flag-bit integer with **no kernel state**, so the descriptor flags must live in the shim:

- `FD_TABLE` (`crates/libtfs-preload/src/sys/mod.rs`): presence = the fd is open, value = its close-on-exec bit. `open`/`openat` seed it from `O_CLOEXEC`; `close` purges — so fcntl on a flagged-but-closed fd is EBADF, exactly the kernel's answer.
- Interposed `fcntl`: host fds pass through untouched (`real_fcntl` via the tuple on macOS, `RTLD_NEXT` on linux). On a live memfs fd: `F_GETFD`/`F_SETFD` read/write the table; `F_GETFL` answers the truthful read-only status word (payload images are always ro); `F_SETFL` is an accepted no-op (a memfs read never blocks, no kernel status word to mutate). The dup class (`F_DUPFD` and kin) is **EINVAL by design** — duplicating a memfs fd is the engine's to own, and no tier-1 consumer calls it.
- Darwin arm64 ABI: fcntl is variadic like open — the third argument rides the **stack** there, so the tuple binds a `global_asm!` trampoline (`_tebako_tramp_fcntl`) that hoists it into the register before the Rust body runs (the open/openat precedent, verbatim). x86_64 Darwin and linux bind the fixed-parameter body directly.
- Spec 07's interposed-surface paragraph names fcntl (doc sync in the same change).

## Evidence

- `cargo test -p libtfs-preload` (debug, macos-arm64): **16 unit + 26 e2e, all green** — including the new `fcntl_on_a_memfs_fd`, whose fixture (`tests/fixtures/fcntl-probe.c`) replays CPython's exact sequence: `O_CLOEXEC` open → `F_GETFD` (bit set) → `F_SETFD` clear/set → `F_GETFL` (truthful ro) → `F_SETFL` no-op → read → close → `F_GETFD` on the dead fd is EBADF → host-fd passthrough. Distinct exit codes per step, so a regression names its verb.
- Downstream dogfood (tebako-runtime-python, macos-arm64, env image repacked with this branch's debug dylib): **boot smoke all green — 7/7 scenarios** (`bare` driver's bare-boot warning + interpreter's own encodings failure; `boot` json/zlib/ssl imports off the mounted image with `sys.prefix` at the mount root; `payload` script runs from a `--tebako-image` mount with `__file__` at the VFS spelling; `mount-root-override` follows `TEBAKO_MOUNT_ROOT`; named errors 69/65/78 intact). No further fd-verb gap surfaced through interpreter boot + ssl/zlib dlopen. The factory PR links back here.

## Downstream note

The python factory's **CI** legs keep fetching the published v2.1.x link unit, so its POSIX boot-smoke legs stay red until a tebako **release** carries this fix (its `check_contract` pins the link-unit release explicitly — no silent source builds). That sequencing is the owner's call per the ecosystem rule; locally the factory dogfoods against this branch's build.
