### PR TITLE
ci: drop the feat/* push trigger (push+PR double-fire poisons the merge rollup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,17 @@
 name: CI
 
 on:
+  # Push runs on main only. A feat/* push with an open PR double-fires
+  # (push + pull_request share one concurrency group via head_ref), the
+  # PR run cancels the push run, and branch protection's rollup then
+  # keeps the CANCELLED check runs beside the SUCCESS ones on the same
+  # SHA — mergeStateStatus BLOCKED (the rerun-the-cancelled-run dance on
+  # #519/#520/#521). PR branches get CI from the pull_request event.
   push:
-    branches: [main, feat/*]
+    branches: [main]
   pull_request:
 
-# One run per branch/PR-head at a time: pushing to a branch with an open
-# PR would otherwise run every job twice (push + pull_request events);
-# a new run cancels the stale one.
+# One run per branch/PR-head at a time: a new push cancels the stale run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/trace-dogfood.yml
+++ b/.github/workflows/trace-dogfood.yml
@@ -9,8 +9,10 @@ name: Trace dogfood (spec 25)
 # ci/trace-dogfood/ — never inline run-blocks.
 
 on:
+  # Push runs on main only — see ci.yml's trigger note (the feat/* double-
+  # fire poisoned the merge rollup with cancelled check runs).
   push:
-    branches: [main, feat/*]
+    branches: [main]
   pull_request:
 
 # One run per branch/PR-head at a time (ci.yml's rule).


### PR DESCRIPTION
## What

Drops `feat/*` from the `push` triggers of `ci.yml` and `trace-dogfood.yml`; push runs now fire on `main` only.

## Why

A `feat/*` push with an open PR double-fires every job: the push and pull_request events share one concurrency group (`github.head_ref || github.ref_name` is the branch name in both), so the PR run cancels the push run. Branch protection's statusCheckRollup then keeps the CANCELLED check runs beside the SUCCESS ones on the same head SHA → `mergeStateStatus: BLOCKED` → someone must `gh run rerun` the cancelled runs before the merge unblocks. #519, #520 and #521 each paid that dance.

PR branches still get full CI from the `pull_request` event; `main` keeps its push runs. No coverage lost.

## Evidence

YAML parses clean (`python3 -c yaml.safe_load` on both files). This PR's own checks are the pull_request event working as intended.
