### PR TITLE
limnifs: 0.3.6 -> 0.3.33 floor — the 0.3.7..0.3.33 line

### DIFF
--- a/crates/tebako-cli/Cargo.toml
+++ b/crates/tebako-cli/Cargo.toml
@@ -42,7 +42,7 @@ dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `press --format limnifs` (spec 20 §6)
 # — pure Rust, no `limni` binary anywhere. Floor: post-flip line rides
 # 0.2.65's format (see crates/tfs).
-limnifs-write = "0.3.6"
+limnifs-write = "0.3.33"
 libc = "0.2"
 sha2 = "0.10"
 # RuntimeSdk provisioning extracts the ruby src release in-process (no tar

--- a/crates/tfs-cli/Cargo.toml
+++ b/crates/tfs-cli/Cargo.toml
@@ -35,7 +35,7 @@ dwarfs-t = { version = "0.1.0", path = "../../../dwarfs-rs/dwarfs" }
 # The in-process LimniFS writer for `mkimage --format limnifs` (spec 20
 # §6) — pure Rust, no `limni` binary anywhere. Floor: post-flip line
 # rides 0.2.65's format (see crates/tfs).
-limnifs-write = "0.3.6"
+limnifs-write = "0.3.33"
 libc = "0.2"
 
 # tfs per-target: the SquashFS backend (squashfs-tools-ng) is
@@ -66,4 +66,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # the reader (spec 20 §5 constraint 1: no SharedInline handle anywhere)
 # — test-only, never linked into the shipped binary. Floor: see the
 # limnifs-write pin above (post-flip line is >= 0.3.0).
-limnifs-core = "0.3.6"
+limnifs-core = "0.3.33"

--- a/crates/tfs/Cargo.toml
+++ b/crates/tfs/Cargo.toml
@@ -62,7 +62,7 @@ sqfs-sys = { version = "2.0.0", path = "../sqfs-sys", optional = true }
 # rides the flip: images pressed by >= 0.3.0 need a >= 0.3.0-reader
 # runtime and vice versa; sha256 is the anchor (spec 20 §8's
 # format-evolution rule).
-limnifs-core = { version = "0.3.6", optional = true }
+limnifs-core = { version = "0.3.33", optional = true }
 # The ENC stacking transform (spec 10, backends_enc): AES-256-GCM per-block
 # confidentiality with HKDF-SHA256 subtree keys, DEK grant envelopes via
 # tebako-signer's rnp PKESK wrap/unwrap, mlock'd+zeroized plaintext
@@ -111,5 +111,5 @@ crc32fast = "1"
 # LimniFS golden fixtures are written in-process (never a limni binary) —
 # test-only, never linked into the shipped library. Floor: see the
 # limnifs-core pin above (post-flip line is >= 0.3.0).
-limnifs-write = "0.3.6"
+limnifs-write = "0.3.33"
 

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -26,4 +26,4 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 # The limnifs backend-pair golden class builds its fixture image
 # in-process (spec 20 §8) — never a `limni` binary.
-limnifs-write = "0.3.6"
+limnifs-write = "0.3.33"


### PR DESCRIPTION
## What

Raise the limnifs floor **0.3.6 → 0.3.33** (owner-ordered "update limnifs", 2026-09-04).

27 upstream releases since the 0.3.6 floor — mostly the omnizip dep train
(latest: 0.3.33, 2026-09-03, omnizip 0.21.49). Pins moved in: `tfs`
(limnifs-core + limnifs-write), `tfs-cli`, `tebako-cli`, `tests/contract`.

## Local proof

- `cargo check -p tfs --no-default-features --features backend-limnifs` — resolves exactly 0.3.33, green.
- `cargo test -p tebako-contract-tests --test limnifs_backend` — 3/3 green at 0.3.33:
  `backend_pair_golden_parity_vs_dwarfs`, `corrupt_image_mount_fails_named`, `offset_and_memory_mounts`.

## Notes

- Format compatibility: no slab-format flip in this range (the 0.3.0 flip
  landed in #476); existing limnifs images stay readable.
- The default-press era gate (PROGRESS/11) is unaffected — this is a floor
  raise on the same 0.3.x line.
