### PR TITLE
libtfs-preload: BOOT_LIVE gate + raw early-boot passthrough — the dlsym/engine-alloc deadlock under jemalloc init (fixes #527)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,13 +94,17 @@ jobs:
         # the system libbz2.dylib identically). Until rnp-rs ≥ 0.1.10.
         # mono-complete: vcpkg's NuGet binary-cache provider drives
         # nuget.exe through mono on non-Windows (macos runners ship mono).
+        # libjemalloc-dev: the tebako#527 e2e regression probe links a
+        # STATIC jemalloc into an --export-dynamic exe (the spec 29 link
+        # unit's shape); without it that test skips and the linux-gnu
+        # init_lock deadlock loses its in-CI pin.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build pkg-config \
             autoconf automake autoconf-archive libtool \
             curl zip unzip tar ca-certificates \
-            libbz2-dev mono-complete
+            libbz2-dev mono-complete libjemalloc-dev
 
       - name: Install native build tools (macos)
         if: runner.os == 'macOS'

--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -10,6 +10,49 @@
 //! (macOS cannot use this mechanism — dyld interpose redirects dlsym
 //! results too — so the real-function plumbing is per-platform.)
 //!
+//! ## The early-boot rule (tebako#527)
+//!
+//! Interposed calls can arrive BEFORE this library's constructor runs:
+//! an earlier-initialized dependency's constructor allocates (libstdc++'s
+//! does), and with a `--export-dynamic` exe carrying a STATIC jemalloc
+//! (the spec 29 link unit) that allocation enters jemalloc's lazy
+//! `malloc_init_hard`, which holds the NON-recursive `init_lock` while
+//! its own setup performs syscalls — the arena-base `pages_map` mmap,
+//! and `pages_boot`'s THP probe `open`/`read` of
+//! `/sys/kernel/mm/transparent_hugepage/*`. Those syscalls re-enter THIS
+//! shim. Two links then each self-deadlock the single thread:
+//!
+//! 1. the engine path allocates (path normalization's Vec, the lazy
+//!    mount pass) — re-entering jemalloc under `init_lock`;
+//! 2. the host passthrough's lazy `dlsym(RTLD_NEXT, …)` ALLOCATES too
+//!    (glibc's `_dl_find_object` growth / dlerror buffer) — same lock.
+//!
+//! So, on 64-bit linux: until the constructor's mount pass completes
+//! (`BOOT_LIVE`, sys/mod.rs), the engine is barred (`engine_call`
+//! answers None — every shim's "pass through" arm) and the thin-syscall
+//! bodies answer from the RAW SYSCALL layer below — no engine, no
+//! dlsym, no allocation. A pre-constructor call is definitionally
+//! loader/allocator host IO: the VFS mounts exist only after the
+//! constructor, so the raw host answer is the truthful one. The mm
+//! family goes further and NEVER dlsyms (always raw): mmap is the
+//! allocator's own primitive, called on every era's path including the
+//! engine's own anonymous fills. glibc's `syscall(2)` wrapper sets errno
+//! from the kernel's -errno return itself, and on 64-bit linux the
+//! at-family syscalls carry byte offsets with the kernel's stat layout
+//! equal to glibc's — the raw arms are byte-identical passthroughs
+//! (aarch64 has no SYS_open/SYS_stat at all; the at-forms are what
+//! glibc's wrappers call). The libc-composite surface (the DIR*/FILE*
+//! families, realpath, dlopen, posix_spawn) keeps the lazy-dlsym
+//! resolution: no allocator init builds a DIR*, and a library
+//! constructor calling one BEFORE the preload's init entry is not
+//! observed and is absurd by construction (documented residual risk).
+//! 32-bit linux keeps the historical resolution everywhere (old_mmap's
+//! arg-block ABI and mmap2's page-granular offset make the raw form
+//! non-portable; no shipped runtime is 32-bit). musl and macOS never
+//! wedged — musl's dlsym and macOS's dyld interpose never allocate — but
+//! musl shares the raw arms (same law, same code); macOS takes the gate
+//! only (its `real_*` come from interpose tuples, already dlsym-free).
+//!
 //! Coverage note: binaries built against glibc ≥ 2.33 call
 //! `stat`/`lstat`/`fstat`/`fstatat` directly and are covered; binaries
 //! built against older glibc use the versioned `__xstat`/`__lxstat`/
@@ -161,16 +204,56 @@ real_fn!(
     c"pread",
     unsafe extern "C" fn(c_int, *mut c_void, usize, libc::off_t) -> libc::ssize_t
 );
+// The mm family answers through the RAW SYSCALL, never dlsym — the
+// module doc's tebako#527 paragraph has the full deadlock chain. glibc's
+// syscall(2) wrapper sets errno from the kernel's -errno return itself,
+// so these are byte-identical passthroughs on 64-bit linux (the shipped
+// form; `mmap64` carries the same signature there). 32-bit linux keeps
+// the dlsym resolution: old_mmap's arg-block ABI and mmap2's
+// page-granular offset make the raw form non-portable, and no shipped
+// runtime is 32-bit.
+#[cfg(target_pointer_width = "64")]
+pub(super) fn real_mmap(
+) -> unsafe extern "C" fn(*mut c_void, usize, c_int, c_int, c_int, libc::off_t) -> *mut c_void {
+    unsafe extern "C" fn via_syscall(
+        addr: *mut c_void,
+        len: usize,
+        prot: c_int,
+        flags: c_int,
+        fd: c_int,
+        offset: libc::off_t,
+    ) -> *mut c_void {
+        unsafe { libc::syscall(libc::SYS_mmap, addr, len, prot, flags, fd, offset) as *mut c_void }
+    }
+    via_syscall
+}
+#[cfg(not(target_pointer_width = "64"))]
 real_fn!(
     real_mmap,
     c"mmap",
     unsafe extern "C" fn(*mut c_void, usize, c_int, c_int, c_int, libc::off_t) -> *mut c_void
 );
+#[cfg(target_pointer_width = "64")]
+pub(super) fn real_munmap() -> unsafe extern "C" fn(*mut c_void, usize) -> c_int {
+    unsafe extern "C" fn via_syscall(addr: *mut c_void, len: usize) -> c_int {
+        unsafe { libc::syscall(libc::SYS_munmap, addr, len) as c_int }
+    }
+    via_syscall
+}
+#[cfg(not(target_pointer_width = "64"))]
 real_fn!(
     real_munmap,
     c"munmap",
     unsafe extern "C" fn(*mut c_void, usize) -> c_int
 );
+#[cfg(target_pointer_width = "64")]
+pub(super) fn real_mprotect() -> unsafe extern "C" fn(*mut c_void, usize, c_int) -> c_int {
+    unsafe extern "C" fn via_syscall(addr: *mut c_void, len: usize, prot: c_int) -> c_int {
+        unsafe { libc::syscall(libc::SYS_mprotect, addr, len, prot) as c_int }
+    }
+    via_syscall
+}
+#[cfg(not(target_pointer_width = "64"))]
 real_fn!(
     real_mprotect,
     c"mprotect",
@@ -227,7 +310,36 @@ real_fn!(
     c"fstatat64",
     unsafe extern "C" fn(c_int, *const c_char, *mut libc::stat, c_int) -> c_int
 );
-#[cfg(not(target_env = "musl"))]
+#[cfg(target_pointer_width = "64")]
+pub(super) fn real_statx() -> unsafe extern "C" fn(
+    c_int,
+    *const c_char,
+    c_int,
+    libc::c_uint,
+    *mut super::statx_abi::statx,
+) -> c_int {
+    raw_statx
+}
+
+/// statx via SYS_statx (the resolver above's target, and the shim body's
+/// early arm). The kernel uapi is one ABI on 64-bit linux and glibc's
+/// wrapper IS the syscall; the kernel answers ENOSYS where it predates
+/// statx(2) — the truthful passthrough, and inert where no caller can
+/// name statx at all. (musl's wrapper arrived only in 1.2.4 — alpine >=
+/// 3.19 — so RTLD_NEXT finds nothing on the 3.17 floor either way;
+/// glibc's dlsym resolution ALLOCATES, the tebako#527 hazard this layer
+/// removes.)
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe extern "C" fn raw_statx(
+    dirfd: c_int,
+    path: *const c_char,
+    flags: c_int,
+    mask: libc::c_uint,
+    stx: *mut super::statx_abi::statx,
+) -> c_int {
+    unsafe { libc::syscall(libc::SYS_statx, dirfd, path, flags, mask, stx) as c_int }
+}
+#[cfg(all(not(target_pointer_width = "64"), not(target_env = "musl")))]
 real_fn!(
     real_statx,
     c"statx",
@@ -239,7 +351,7 @@ real_fn!(
         *mut super::statx_abi::statx,
     ) -> c_int
 );
-#[cfg(target_env = "musl")]
+#[cfg(all(not(target_pointer_width = "64"), target_env = "musl"))]
 pub(super) fn real_statx() -> unsafe extern "C" fn(
     c_int,
     *const c_char,
@@ -247,12 +359,8 @@ pub(super) fn real_statx() -> unsafe extern "C" fn(
     libc::c_uint,
     *mut super::statx_abi::statx,
 ) -> c_int {
-    // musl gained the statx(2) wrapper only in 1.2.4 (alpine >= 3.19):
-    // RTLD_NEXT finds nothing on the 3.17 floor and the real_fn! assert
-    // would panic. The kernel uapi is one ABI — answer through the raw
-    // syscall (musl's syscall() sets errno itself; ENOSYS where the
-    // kernel predates statx(2) — the truthful passthrough, and inert
-    // where no caller can name statx at all).
+    // 32-bit keeps the historical resolution; on musl the wrapper is
+    // absent before 1.2.4, so the raw syscall answers there too.
     unsafe extern "C" fn via_syscall(
         dirfd: c_int,
         path: *const c_char,
@@ -399,6 +507,185 @@ real_fn!(
         *const *mut c_char,
     ) -> c_int
 );
+
+// ---------------------------------------------------------------------
+// The raw syscall layer (the module doc's early-boot rule, tebako#527).
+// Each fn is the byte-identical passthrough of glibc's thin wrapper on
+// 64-bit linux: `syscall(2)` sets errno from the kernel's -errno return,
+// the at-family forms are what glibc's wrappers call (asm-generic —
+// aarch64 — has no SYS_open/SYS_stat/SYS_access/SYS_mkdir/SYS_unlink/
+// SYS_rename at all), and the kernel's stat layout IS glibc's on every
+// shipped 64-bit target. 64-bit only: old_mmap's arg-block ABI, mmap2's
+// page-granular offset, and the 32-bit stat/fcntl64 splits make the raw
+// form non-portable there — and no shipped runtime is 32-bit. The shim
+// bodies call these from their `boot_arm!` early arm; they are never on
+// the post-constructor path (the dlsym'd real_* answer there).
+// ---------------------------------------------------------------------
+
+/// `open` via SYS_openat(AT_FDCWD, …).
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_open(path: *const c_char, flags: c_int, mode: c_int) -> c_int {
+    unsafe { libc::syscall(libc::SYS_openat, libc::AT_FDCWD, path, flags, mode) as c_int }
+}
+
+/// `openat` via SYS_openat.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_openat(
+    dirfd: c_int,
+    path: *const c_char,
+    flags: c_int,
+    mode: c_int,
+) -> c_int {
+    unsafe { libc::syscall(libc::SYS_openat, dirfd, path, flags, mode) as c_int }
+}
+
+/// `read` via SYS_read.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_read(fd: c_int, buf: *mut c_void, nbyte: usize) -> libc::ssize_t {
+    unsafe { libc::syscall(libc::SYS_read, fd, buf, nbyte) as libc::ssize_t }
+}
+
+/// `__read_chk`: the fortify contract (a request larger than the
+/// compiler-known buffer aborts — glibc's `__chk_fail` prints a note
+/// first, cosmetic-only) over the raw read. abort(3) raises SIGABRT
+/// without allocating, safe inside the allocator's own init.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw___read_chk(
+    fd: c_int,
+    buf: *mut c_void,
+    nbyte: usize,
+    buflen: usize,
+) -> libc::ssize_t {
+    if nbyte > buflen {
+        // SAFETY: plain libc call; never returns.
+        unsafe { libc::abort() }
+    }
+    unsafe { raw_read(fd, buf, nbyte) }
+}
+
+/// `pread` via SYS_pread64 (the only pread syscall on 64-bit).
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_pread(
+    fd: c_int,
+    buf: *mut c_void,
+    nbyte: usize,
+    offset: libc::off_t,
+) -> libc::ssize_t {
+    unsafe { libc::syscall(libc::SYS_pread64, fd, buf, nbyte, offset) as libc::ssize_t }
+}
+
+/// `lseek` via SYS_lseek (64-bit off_t on both shipped arches).
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_lseek(fd: c_int, offset: libc::off_t, whence: c_int) -> libc::off_t {
+    unsafe { libc::syscall(libc::SYS_lseek, fd, offset, whence) as libc::off_t }
+}
+
+/// `close` via SYS_close.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_close(fd: c_int) -> c_int {
+    unsafe { libc::syscall(libc::SYS_close, fd) as c_int }
+}
+
+/// `fcntl` via SYS_fcntl (64-bit fcntl == fcntl64). Forwards the shim's
+/// fixed third argument exactly as the dlsym'd passthrough does.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_fcntl(fd: c_int, cmd: c_int, arg: c_int) -> c_int {
+    unsafe { libc::syscall(libc::SYS_fcntl, fd, cmd, arg) as c_int }
+}
+
+/// `mkdir` via SYS_mkdirat(AT_FDCWD, …).
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_mkdir(path: *const c_char, mode: libc::mode_t) -> c_int {
+    unsafe { libc::syscall(libc::SYS_mkdirat, libc::AT_FDCWD, path, mode) as c_int }
+}
+
+/// `unlink` via SYS_unlinkat(AT_FDCWD, …, 0) (no flags — a directory
+/// unlink (AT_REMOVEDIR) is rmdir(2), a different name).
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_unlink(path: *const c_char) -> c_int {
+    unsafe { libc::syscall(libc::SYS_unlinkat, libc::AT_FDCWD, path, 0) as c_int }
+}
+
+/// `rename` via SYS_renameat(AT_FDCWD, …, AT_FDCWD, …).
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_rename(old: *const c_char, new: *const c_char) -> c_int {
+    unsafe { libc::syscall(libc::SYS_renameat, libc::AT_FDCWD, old, libc::AT_FDCWD, new) as c_int }
+}
+
+/// `stat` via SYS_newfstatat(AT_FDCWD, …, 0) — follows symlinks, as
+/// stat(2) does.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_stat(path: *const c_char, st: *mut libc::stat) -> c_int {
+    unsafe { libc::syscall(libc::SYS_newfstatat, libc::AT_FDCWD, path, st, 0) as c_int }
+}
+
+/// `lstat` via SYS_newfstatat(…, AT_SYMLINK_NOFOLLOW).
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_lstat(path: *const c_char, st: *mut libc::stat) -> c_int {
+    unsafe {
+        libc::syscall(
+            libc::SYS_newfstatat,
+            libc::AT_FDCWD,
+            path,
+            st,
+            libc::AT_SYMLINK_NOFOLLOW,
+        ) as c_int
+    }
+}
+
+/// `fstat` via SYS_fstat.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_fstat(fd: c_int, st: *mut libc::stat) -> c_int {
+    unsafe { libc::syscall(libc::SYS_fstat, fd, st) as c_int }
+}
+
+/// `fstatat` via SYS_newfstatat. The versioned `__xstat`/`__lxstat`/
+/// `__fxstat(at)`(+64) entries share these arms — the ver argument is a
+/// no-op where the kernel struct IS the glibc struct (the *64 delegation
+/// rationale above), and the LFS `stat64`/`fstat64`/`fstatat64` spellings
+/// are layout-identical on 64-bit.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_fstatat(
+    dirfd: c_int,
+    path: *const c_char,
+    st: *mut libc::stat,
+    flags: c_int,
+) -> c_int {
+    unsafe { libc::syscall(libc::SYS_newfstatat, dirfd, path, st, flags) as c_int }
+}
+
+/// `access` via SYS_faccessat(AT_FDCWD, …) — the 3-arg (flags-less)
+/// form, whose real-id semantics are access(2)'s exactly (glibc's access
+/// wrapper makes the same call).
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_access(path: *const c_char, mode: c_int) -> c_int {
+    unsafe { libc::syscall(libc::SYS_faccessat, libc::AT_FDCWD, path, mode) as c_int }
+}
+
+/// `faccessat` with flags == 0 via SYS_faccessat. Callers carrying flags
+/// (AT_EACCESS/AT_SYMLINK_NOFOLLOW) fall through to the dlsym'd wrapper —
+/// the pre-5.8-kernel emulation glibc performs for them is not ours to
+/// re-create, and no early-boot caller passes flags.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_faccessat(dirfd: c_int, path: *const c_char, mode: c_int) -> c_int {
+    unsafe { libc::syscall(libc::SYS_faccessat, dirfd, path, mode) as c_int }
+}
+
+/// `getdents64` via SYS_getdents64.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_getdents64(fd: c_int, dirp: *mut c_void, count: usize) -> libc::ssize_t {
+    unsafe { libc::syscall(libc::SYS_getdents64, fd, dirp, count) as libc::ssize_t }
+}
+
+/// `execve` via SYS_execve.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_execve(
+    path: *const c_char,
+    argv: *const *mut c_char,
+    envp: *const *mut c_char,
+) -> c_int {
+    unsafe { libc::syscall(libc::SYS_execve, path, argv, envp) as c_int }
+}
 
 /// Library constructor: establish the namespace before the program's main.
 #[used]

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -29,6 +29,14 @@
 //! `IN_FORK_CHILD` guard below) — a `pthread_atfork` child handler arms a
 //! process-global flag, and every engine entry in a fork child gets `None`
 //! (the same "pass through to the real libc" answer re-entrancy gets).
+//!
+//! Early boot: interposed calls can arrive BEFORE the constructor's
+//! mounts exist (an earlier-initialized dependency's constructor, or the
+//! host allocator's own first init probing open/mmap). The `BOOT_LIVE`
+//! gate bars the engine then (the same `None` answer), and on 64-bit
+//! linux the thin-syscall bodies answer from a raw syscall layer —
+//! nothing in the shim may allocate or dlsym inside the allocator's init
+//! (tebako#527; sys/linux.rs's module doc has the full chain).
 
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -124,8 +132,9 @@ static INIT_PID: AtomicI32 = AtomicI32::new(0);
 
 /// True when the current process is not the one the shim initialized in
 /// (a fork/vfork child before its exec). The `p != 0` arm keeps calls
-/// made BEFORE the constructor ran (an early-loading dependency's own
-/// constructor) on the historical ungated path.
+/// made BEFORE the constructor ran pid-ungated; the boot gate
+/// (BOOT_LIVE) bars those from the engine on its own terms — a
+/// pre-constructor call is loader/ctor host IO by construction.
 fn in_foreign_process() -> bool {
     let p = INIT_PID.load(Ordering::Relaxed);
     // SAFETY: plain libc call; no glibc pid cache exists to go stale.
@@ -163,6 +172,56 @@ pub(crate) fn register_fork_guard() {
     }
 }
 
+// ---------------------------------------------------------------------
+// The boot gate (tebako#527 — sys/linux.rs's module doc has the full
+// deadlock chain)
+// ---------------------------------------------------------------------
+
+/// False until the constructor's mount pass completes. An interposed
+/// call arriving before that is loader/ctor/allocator host IO — the VFS
+/// mounts exist only after the constructor, so no engine answer can be
+/// needed yet. The gate bars the engine ([`engine_call`] answers None —
+/// every shim's "pass through to the real libc / fail safe" arm) and the
+/// thin-syscall bodies answer from sys/linux.rs's raw syscall layer
+/// instead, so NOTHING in the shim allocates or resolves a libc symbol
+/// while the host allocator's own first init may be mid-flight holding
+/// its non-recursive init lock. The static is process-fresh after exec,
+/// exactly like INIT_PID.
+static BOOT_LIVE: AtomicBool = AtomicBool::new(false);
+
+/// The boot gate's read side (Acquire pairs the constructor's Release
+/// store with the mounts' visibility).
+fn boot_live() -> bool {
+    BOOT_LIVE.load(Ordering::Acquire)
+}
+
+/// The early arm of a thin-syscall shim body: pre-gate, answer from the
+/// raw syscall layer and return — before ANY other body statement runs
+/// (an env lookup, a path normalize, a resolve_dirfd each allocates).
+/// Linux 64-bit only; every other platform compiles the arm away (macOS
+/// resolution is allocation-free interpose tuples; 32-bit linux keeps
+/// the historical resolution — no shipped runtime is 32-bit).
+macro_rules! boot_arm {
+    // A conditional arm first (the `if`-led form can never parse as the
+    // path-led one): faccessat — only the flags-less form has a raw
+    // answer; glibc's flags emulation is not ours to re-create.
+    (if $cond:expr; $raw:path, ($($arg:expr),*)) => {
+        #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+        if !boot_live() && $cond {
+            // SAFETY: forwarding the original arguments; the raw arm is
+            // the byte-identical passthrough (sys/linux.rs).
+            return unsafe { $raw($($arg),*) };
+        }
+    };
+    ($raw:path, ($($arg:expr),*)) => {
+        #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+        if !boot_live() {
+            // SAFETY: as above.
+            return unsafe { $raw($($arg),*) };
+        }
+    };
+}
+
 /// Run `f` (a route-layer engine call) unless this thread is already
 /// inside the engine: re-entrant calls (the engine's own host IO) get
 /// `None` and the shim passes them straight to the real implementation.
@@ -171,6 +230,12 @@ pub(crate) fn register_fork_guard() {
 /// the fail-safe reason on `IN_FORK_CHILD` above: the backends' worker
 /// threads do not survive `fork`, so an engine call there would wait on
 /// dead threads.
+///
+/// Pre-gate calls (before the constructor's mount pass completes) get
+/// `None` too — the boot gate: the engine's first entry would allocate
+/// into a host allocator whose own init may be mid-flight on this very
+/// thread (tebako#527), and no truthful VFS answer can be needed before
+/// the mounts exist.
 ///
 /// pub(crate) for the TEST seam: a test that calls the route layer
 /// directly must enter through this guard exactly like the shims do —
@@ -186,7 +251,7 @@ pub(crate) fn register_fork_guard() {
 /// binaries do not interpose in-process, so only Linux CI saw them).
 pub(crate) fn engine_call<T>(f: impl FnOnce() -> T) -> Option<T> {
     engine_call_inner(
-        IN_FORK_CHILD.load(Ordering::Relaxed) || in_foreign_process(),
+        IN_FORK_CHILD.load(Ordering::Relaxed) || in_foreign_process() || !boot_live(),
         f,
     )
 }
@@ -421,6 +486,7 @@ pub unsafe extern "C" fn open(path: *const c_char, flags: c_int, mode: c_int) ->
 /// The Rust body of the open shim (entry point per ABI, see above).
 #[no_mangle]
 pub unsafe extern "C" fn open_impl(path: *const c_char, flags: c_int, mode: c_int) -> c_int {
+    boot_arm!(plat::raw_open, (path, flags, mode));
     if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
         eprintln!("[preload] open flags={flags:#o} mode={mode:#o}");
     }
@@ -464,6 +530,7 @@ pub unsafe extern "C" fn openat_impl(
     flags: c_int,
     mode: c_int,
 ) -> c_int {
+    boot_arm!(plat::raw_openat, (dirfd, path, flags, mode));
     if std::env::var_os("TEBAKO_DEBUG_TFS").is_some() {
         eprintln!("[preload] openat flags={flags:#o} mode={mode:#o}");
     }
@@ -533,18 +600,21 @@ unsafe fn stat_via(
 /// Interposed `stat`.
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn stat(path: *const c_char, st: *mut libc::stat) -> c_int {
+    boot_arm!(plat::raw_stat, (path, st));
     unsafe { stat_via(c_path(path), path, st, |o, s| plat::real_stat()(o, s)) }
 }
 
 /// Interposed `lstat` (memfs has no symlink duality: lstat == stat).
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn lstat(path: *const c_char, st: *mut libc::stat) -> c_int {
+    boot_arm!(plat::raw_lstat, (path, st));
     unsafe { stat_via(c_path(path), path, st, |o, s| plat::real_lstat()(o, s)) }
 }
 
 /// Interposed `fstat` (fd-flag dispatch, no path).
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn fstat(fd: c_int, st: *mut libc::stat) -> c_int {
+    boot_arm!(plat::raw_fstat, (fd, st));
     if route::is_memfs_fd(fd) {
         if st.is_null() {
             set_errno(libc::EFAULT);
@@ -578,6 +648,7 @@ pub unsafe extern "C" fn fstat(fd: c_int, st: *mut libc::stat) -> c_int {
 /// Interposed `access`.
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn access(path: *const c_char, mode: c_int) -> c_int {
+    boot_arm!(plat::raw_access, (path, mode));
     let Some(p) = (unsafe { c_path(path) }) else {
         return unsafe { plat::real_access()(path, mode) };
     };
@@ -601,6 +672,7 @@ pub unsafe extern "C" fn faccessat(
     mode: c_int,
     flags: c_int,
 ) -> c_int {
+    boot_arm!(if flags == 0; plat::raw_faccessat, (dirfd, path, mode));
     let Some(p) = (unsafe { c_path(path) }) else {
         return unsafe { plat::real_faccessat()(dirfd, path, mode, flags) };
     };
@@ -702,6 +774,7 @@ pub unsafe extern "C" fn closedir(dirp: *mut libc::DIR) -> c_int {
 /// Interposed `read` (fd-flag dispatch).
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn read(fd: c_int, buf: *mut c_void, nbyte: usize) -> libc::ssize_t {
+    boot_arm!(plat::raw_read, (fd, buf, nbyte));
     if route::is_memfs_fd(fd) {
         if buf.is_null() && nbyte > 0 {
             set_errno(libc::EFAULT);
@@ -745,6 +818,10 @@ pub unsafe extern "C" fn __read_chk(
     nbyte: usize,
     buflen: usize,
 ) -> libc::ssize_t {
+    // The early arm keeps the fortify contract: the raw arm aborts
+    // (SIGABRT) on an overflow request, matching __chk_fail's never-
+    // return — glibc's own diagnostic print is cosmetic.
+    boot_arm!(plat::raw___read_chk, (fd, buf, nbyte, buflen));
     if !route::is_memfs_fd(fd) {
         return unsafe { plat::real___read_chk()(fd, buf, nbyte, buflen) };
     }
@@ -763,6 +840,7 @@ pub unsafe extern "C" fn pread(
     nbyte: usize,
     offset: libc::off_t,
 ) -> libc::ssize_t {
+    boot_arm!(plat::raw_pread, (fd, buf, nbyte, offset));
     if route::is_memfs_fd(fd) {
         if buf.is_null() && nbyte > 0 {
             set_errno(libc::EFAULT);
@@ -795,6 +873,7 @@ pub unsafe extern "C" fn pread(
 /// fseek on a memfs fd must stay on the VFS).
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn lseek(fd: c_int, offset: libc::off_t, whence: c_int) -> libc::off_t {
+    boot_arm!(plat::raw_lseek, (fd, offset, whence));
     if route::is_memfs_fd(fd) {
         return match engine_call(|| route::vfs_lseek(fd, offset, whence)) {
             Some(Ok(pos)) => pos,
@@ -860,6 +939,7 @@ pub unsafe extern "C" fn __openat_2(dirfd: c_int, path: *const c_char, flags: c_
 #[cfg(target_os = "linux")]
 #[no_mangle]
 pub unsafe extern "C" fn stat64(path: *const c_char, st: *mut libc::stat) -> c_int {
+    boot_arm!(plat::raw_stat, (path, st));
     unsafe { stat_via(c_path(path), path, st, |o, s| plat::real_stat64()(o, s)) }
 }
 
@@ -867,6 +947,7 @@ pub unsafe extern "C" fn stat64(path: *const c_char, st: *mut libc::stat) -> c_i
 #[cfg(target_os = "linux")]
 #[no_mangle]
 pub unsafe extern "C" fn lstat64(path: *const c_char, st: *mut libc::stat) -> c_int {
+    boot_arm!(plat::raw_lstat, (path, st));
     unsafe { stat_via(c_path(path), path, st, |o, s| plat::real_lstat64()(o, s)) }
 }
 
@@ -874,6 +955,7 @@ pub unsafe extern "C" fn lstat64(path: *const c_char, st: *mut libc::stat) -> c_
 #[cfg(target_os = "linux")]
 #[no_mangle]
 pub unsafe extern "C" fn fstat64(fd: c_int, st: *mut libc::stat) -> c_int {
+    boot_arm!(plat::raw_fstat, (fd, st));
     if route::is_memfs_fd(fd) {
         if st.is_null() {
             set_errno(libc::EFAULT);
@@ -952,7 +1034,11 @@ unsafe fn mmap_memfs_or_host(
     // conventional anonymous companion) has every bit set, TEBAKO_FD_FLAG
     // included, so the bare bit test lies exactly as it does for AT_FDCWD
     // (route::resolve_at_strict's discipline). The JVM's very first
-    // PaX-check mmap is anonymous and died here.
+    // PaX-check mmap is anonymous and died here. The passthrough itself
+    // never resolves a libc symbol: `real_mmap` answers through the raw
+    // syscall (sys/linux.rs), so a call landing here mid-allocator-init
+    // (jemalloc's arena-base pages_map, tebako#527) cannot re-enter the
+    // allocator through dlsym.
     if fd < 0 || flags & libc::MAP_ANONYMOUS != 0 || !route::is_memfs_fd(fd) {
         return unsafe { plat::real_mmap()(addr, len, prot, flags, fd, offset) };
     }
@@ -1167,6 +1253,7 @@ pub unsafe extern "C" fn __realpath_chk(
 /// real close).
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn close(fd: c_int) -> c_int {
+    boot_arm!(plat::raw_close, (fd));
     if route::is_memfs_fd(fd) {
         fd_table_purge(fd);
         return match engine_call(|| route::vfs_close(fd)) {
@@ -1211,6 +1298,7 @@ pub unsafe extern "C" fn fcntl(fd: c_int, cmd: c_int, arg: c_int) -> c_int {
 /// The Rust body of the fcntl shim (entry point per ABI, see above).
 #[no_mangle]
 pub unsafe extern "C" fn fcntl_impl(fd: c_int, cmd: c_int, arg: c_int) -> c_int {
+    boot_arm!(plat::raw_fcntl, (fd, cmd, arg));
     if !route::is_memfs_fd(fd) {
         // SAFETY: forwarding the original arguments to the real fcntl.
         return unsafe { plat::real_fcntl()(fd, cmd, arg) };
@@ -1248,6 +1336,7 @@ pub unsafe extern "C" fn fcntl_impl(fd: c_int, cmd: c_int, arg: c_int) -> c_int 
 /// Interposed `mkdir` (write-class: memfs → EROFS, host → policy-gated).
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn mkdir(path: *const c_char, mode: libc::mode_t) -> c_int {
+    boot_arm!(plat::raw_mkdir, (path, mode));
     let Some(p) = (unsafe { c_path(path) }) else {
         return unsafe { plat::real_mkdir()(path, mode) };
     };
@@ -1263,6 +1352,7 @@ pub unsafe extern "C" fn mkdir(path: *const c_char, mode: libc::mode_t) -> c_int
 /// Interposed `unlink` (write-class).
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn unlink(path: *const c_char) -> c_int {
+    boot_arm!(plat::raw_unlink, (path));
     let Some(p) = (unsafe { c_path(path) }) else {
         return unsafe { plat::real_unlink()(path) };
     };
@@ -1278,6 +1368,7 @@ pub unsafe extern "C" fn unlink(path: *const c_char) -> c_int {
 /// Interposed `rename` (write-class; both paths gated).
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn rename(old: *const c_char, new: *const c_char) -> c_int {
+    boot_arm!(plat::raw_rename, (old, new));
     let (Some(o), Some(n)) = (unsafe { c_path(old) }, unsafe { c_path(new) }) else {
         return unsafe { plat::real_rename()(old, new) };
     };
@@ -1423,6 +1514,7 @@ pub unsafe extern "C" fn fstatat(
     st: *mut libc::stat,
     flags: c_int,
 ) -> c_int {
+    boot_arm!(plat::raw_fstatat, (dirfd, path, st, flags));
     unsafe {
         fstatat_via(dirfd, path, st, || {
             plat::real_fstatat()(dirfd, path, st, flags)
@@ -1439,6 +1531,7 @@ pub unsafe extern "C" fn fstatat64(
     st: *mut libc::stat,
     flags: c_int,
 ) -> c_int {
+    boot_arm!(plat::raw_fstatat, (dirfd, path, st, flags));
     unsafe {
         fstatat_via(dirfd, path, st, || {
             plat::real_fstatat64()(dirfd, path, st, flags)
@@ -1460,6 +1553,7 @@ pub unsafe extern "C" fn statx(
     mask: libc::c_uint,
     stx: *mut statx_abi::statx,
 ) -> c_int {
+    boot_arm!(plat::raw_statx, (dirfd, path, flags, mask, stx));
     use tfs::backend::EntryType;
 
     let Some(p) = (unsafe { c_path(path) }) else {
@@ -1528,6 +1622,7 @@ pub unsafe extern "C" fn statx(
 #[cfg(target_os = "linux")]
 #[no_mangle]
 pub unsafe extern "C" fn getdents64(fd: c_int, dirp: *mut c_void, count: usize) -> libc::ssize_t {
+    boot_arm!(plat::raw_getdents64, (fd, dirp, count));
     if route::is_memfs_fd(fd) {
         set_errno(libc::ENOTDIR);
         return -1;
@@ -1540,6 +1635,10 @@ pub unsafe extern "C" fn getdents64(fd: c_int, dirp: *mut c_void, count: usize) 
 #[cfg(target_os = "linux")]
 #[no_mangle]
 pub unsafe extern "C" fn __xstat(ver: c_int, path: *const c_char, st: *mut libc::stat) -> c_int {
+    // The early arm drops `ver`: 64-bit linux has one stat ABI (the *64
+    // delegation rationale below), so the raw stat IS every live ver's
+    // answer.
+    boot_arm!(plat::raw_stat, (path, st));
     unsafe {
         stat_via(c_path(path), path, st, |o, s| {
             plat::real___xstat()(ver, o, s)
@@ -1551,6 +1650,7 @@ pub unsafe extern "C" fn __xstat(ver: c_int, path: *const c_char, st: *mut libc:
 #[cfg(target_os = "linux")]
 #[no_mangle]
 pub unsafe extern "C" fn __lxstat(ver: c_int, path: *const c_char, st: *mut libc::stat) -> c_int {
+    boot_arm!(plat::raw_lstat, (path, st));
     unsafe {
         stat_via(c_path(path), path, st, |o, s| {
             plat::real___lxstat()(ver, o, s)
@@ -1562,6 +1662,7 @@ pub unsafe extern "C" fn __lxstat(ver: c_int, path: *const c_char, st: *mut libc
 #[cfg(target_os = "linux")]
 #[no_mangle]
 pub unsafe extern "C" fn __fxstat(ver: c_int, fd: c_int, st: *mut libc::stat) -> c_int {
+    boot_arm!(plat::raw_fstat, (fd, st));
     if route::is_memfs_fd(fd) {
         if st.is_null() {
             set_errno(libc::EFAULT);
@@ -1602,6 +1703,7 @@ pub unsafe extern "C" fn __fxstatat(
     st: *mut libc::stat,
     flags: c_int,
 ) -> c_int {
+    boot_arm!(plat::raw_fstatat, (dirfd, path, st, flags));
     unsafe {
         fstatat_via(dirfd, path, st, || {
             plat::real___fxstatat()(ver, dirfd, path, st, flags)
@@ -1749,6 +1851,7 @@ pub unsafe extern "C" fn execve(
     argv: *const *mut c_char,
     envp: *const *mut c_char,
 ) -> c_int {
+    boot_arm!(plat::raw_execve, (path, argv, envp));
     let Some(p) = (unsafe { c_path(path) }) else {
         return unsafe { plat::real_execve()(path, argv, envp) };
     };
@@ -1906,6 +2009,10 @@ pub fn init() {
         // SAFETY: plain libc call.
         unsafe { libc::exit(crate::spec::EX_CONFIG) };
     }
+    // Open the boot gate LAST: only with the mounts live may interposed
+    // calls reach the engine; pre-gate calls take the raw early arms
+    // (tebako#527 — see BOOT_LIVE). Release pairs every boot_live() load.
+    BOOT_LIVE.store(true, Ordering::Release);
 }
 
 // ---------------------------------------------------------------------

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -691,6 +691,98 @@ fn union_member_remount_does_not_deadlock() {
     assert_eq!(r.stdout.matches(SECRET).count(), 1, "stdout: {}", r.stdout);
 }
 
+/// Regression (tebako#527, the python-factory gnu boot hang): a
+/// `--export-dynamic` exe carrying a STATIC jemalloc (the spec 29 link
+/// unit's shape) exports malloc/calloc from its own dynamic table, so a
+/// pre-constructor allocation (libstdc++'s ctor, the shim's own) enters
+/// the exe's jemalloc — whose lazy `malloc_init_hard` holds the
+/// non-recursive `init_lock` while its setup RE-ENTERS the shim: the
+/// arena-base `pages_map` mmap AND `pages_boot`'s THP-probe
+/// open/read of /sys/kernel/mm/transparent_hugepage/*. Pre-fix each
+/// entry self-deadlocked the single thread — the mmap passthrough's lazy
+/// `dlsym(RTLD_NEXT, …)` allocates (glibc's _dl_find_object growth), and
+/// the open's engine path allocates (path normalization's Vec). The boot
+/// gate now bars the engine until the constructor's mounts are live and
+/// the thin-syscall bodies answer from the raw syscall layer — no
+/// engine, no dlsym, no allocation — so jemalloc's init completes and
+/// the probe reaches exit 0. The deadline must live INSIDE the test:
+/// `run`'s `cmd.output()` waits forever, and a wedge would otherwise
+/// burn CI's 180 s watchdog as an anonymous hang instead of a named
+/// assertion. Skips with a note when no static libjemalloc is linkable
+/// (the CI ubuntu leg installs libjemalloc-dev; the python-factory gnu
+/// legs remain the end-to-end pin). Linux-only: macOS's dyld never
+/// allocates under interpose resolution and ruby/musl never engage this
+/// path.
+#[cfg(target_os = "linux")]
+#[test]
+fn jemalloc_init_mmap_does_not_deadlock() {
+    let Some(f) = fixtures() else { return };
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/jemalloc-probe.c");
+    let bin = f.dir.join("bin").join("jemalloc-probe");
+    let o = Command::new("cc")
+        .arg("-O2")
+        .arg("-o")
+        .arg(&bin)
+        .arg(&src)
+        // The wedge's three ingredients, each verified necessary: the exe
+        // exports its symbols (so dlsym's calloc binds to the exe's
+        // jemalloc), jemalloc is STATIC (a shared one would init before
+        // the shim's constructor), and the shim is preloaded with a mount
+        // (so the constructor allocates).
+        .args([
+            "-Wl,--export-dynamic",
+            "-Wl,--push-state,-Bstatic",
+            "-ljemalloc",
+            "-Wl,--pop-state",
+            "-lpthread",
+            "-ldl",
+        ])
+        .output()
+        .unwrap();
+    if !o.status.success() {
+        let stderr = String::from_utf8_lossy(&o.stderr);
+        if stderr.contains("cannot find -ljemalloc") {
+            eprintln!("skip: no static libjemalloc to link against (apt: libjemalloc-dev)");
+            return;
+        }
+        panic!("cc failed for {}: {stderr}", src.display());
+    }
+    let mut child = Command::new(&bin)
+        .env(preload_var(), &f.shim)
+        .env("TEBAKO_TFS_MOUNTS", format!("{}:{MOUNT}", f.zip.display()))
+        .env_remove("TEBAKO_JAIL")
+        .env_remove("DYLD_PRINT_LIBRARIES")
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    let status = loop {
+        if let Some(s) = child.try_wait().unwrap() {
+            break Some(s);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            break None;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    };
+    let Some(status) = status else {
+        panic!("jemalloc-probe wedged past 60 s — the tebako#527 init_lock deadlock is back");
+    };
+    let stderr = child
+        .stderr
+        .take()
+        .map(|mut e| {
+            let mut s = String::new();
+            use std::io::Read as _;
+            let _ = e.read_to_string(&mut s);
+            s
+        })
+        .unwrap_or_default();
+    assert_eq!(status.code(), Some(0), "stderr: {stderr}");
+}
+
 #[test]
 fn dlopen_memfs_library_via_dlmap2file() {
     let Some(f) = fixtures() else { return };

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -734,6 +734,9 @@ fn jemalloc_init_mmap_does_not_deadlock() {
             "-Wl,--push-state,-Bstatic",
             "-ljemalloc",
             "-Wl,--pop-state",
+            // Ubuntu's prof-enabled libjemalloc.a references libm
+            // (prof.o/prof_data.o: log/exp/round) — -lm must follow it.
+            "-lm",
             "-lpthread",
             "-ldl",
         ])

--- a/crates/libtfs-preload/tests/fixtures/jemalloc-probe.c
+++ b/crates/libtfs-preload/tests/fixtures/jemalloc-probe.c
@@ -1,0 +1,22 @@
+/* jemalloc-probe: the tebako#527 wedge in one binary.
+ *
+ * Linked with `-Wl,--export-dynamic` and a STATIC jemalloc (see the
+ * e2e.rs test for the exact flags), so the exe's own dynamic table
+ * exports malloc/free/calloc and every allocation in the process —
+ * including the ones glibc's dlsym makes — enters THIS jemalloc. The
+ * shim's constructor runs before main; its first allocation triggers
+ * jemalloc's lazy malloc_init_hard, whose arena-base pages_map mmap
+ * re-enters the shim's interposed mmap. Pre-fix that mmap resolved the
+ * real symbol with a lazy dlsym, whose allocation re-entered jemalloc
+ * and self-deadlocked the non-recursive init_lock: the process parked
+ * forever before main. Post-fix the shim's mm family answers through
+ * the raw syscall and main runs. A plain malloc/free pair is the whole
+ * probe — reaching `return 0` at all IS the assertion.
+ */
+#include <stdlib.h>
+
+int main(void) {
+    void *p = malloc(1);
+    free(p);
+    return p == NULL;
+}


### PR DESCRIPTION
## The bug (fixes #527)

A statically-linked jemalloc inside an `--export-dynamic` executable
deadlocks at process boot when `libtfs_preload.so` is LD_PRELOADed.
Three re-entry cycles, all dying on jemalloc's non-recursive
`init_lock` while lazy `malloc_init_hard` is in flight:

1. **mmap dlsym cycle.** Arena-base `pages_map` mmap re-enters the
   shim's `mmap_impl`; the lazy `dlsym(RTLD_NEXT, "mmap")` resolver
   allocates; the allocation re-enters jemalloc init → `init_lock`
   futex, held by the thread already inside it. Deadlock.
2. **THP-probe open cycle.** `je_pages_boot`'s transparent-hugepage
   probe `open("/sys/kernel/mm/transparent_hugepage/…")` re-enters the
   shim's `open_impl`; the engine path's `FsContext::normalize` grows a
   Vec → allocation → same deadlock. (This is why the first, mm-only
   fix attempt still wedged — the raw-syscall mm family alone does not
   cover cycles that enter through the *engine*.)
3. Both die by the same gate + raw layer.

gdb evidence (static-jemalloc probe, pre-fix):

```
je_pages_boot → tfs_preload::sys::open → FsContext::normalize Vec::push
  → je_malloc_default → malloc_init_hard → init_lock futex   (wedged)
```

## The fix

**`BOOT_LIVE` gate** (`src/sys/mod.rs`): an `AtomicBool`, false until
the constructor's mount pass completes (set with `Release` at the end
of `init()`). While the gate is down — or in a fork child, or in a
foreign (non-tebako) process — every thin-syscall shim body forwards
straight to a **raw syscall**, before any lazy dlsym and before any
engine path that can allocate. `engine_call` gains the same
`!boot_live()` clause.

- 28 one-line `boot_arm!(plat::raw_*, (…))` arms at the top of every
  thin-syscall body: open/openat, the stat/lstat/fstat/fstatat family
  (incl. 64 and `__xstat` variants), access/faccessat, read /
  `__read_chk` / pread / lseek, close, fcntl, mkdir, unlink, rename,
  statx, getdents64, execve. Delegating aliases (open64, openat64,
  `__openat_2`, pread64, lseek64, the `__*stat64` set) inherit through
  delegation.
- **`faccessat` is conditional**: only `flags == 0` arms raw; flags
  callers fall through to the lazy-dlsym path (raw `SYS_faccessat` is
  the 3-arg form).
- **Raw layer** (`src/sys/linux.rs`, 20 resolvers, all
  `#[cfg(target_pointer_width = "64")]`): `raw_open`/`raw_openat`
  (SYS_openat), `raw_read`, `raw___read_chk` (overflow → `abort()`),
  `raw_pread`, `raw_lseek`, `raw_close`, `raw_fcntl`, `raw_mkdir`,
  `raw_unlink`, `raw_rename`, `raw_stat`/`raw_lstat`/`raw_fstat`/
  `raw_fstatat` (SYS_newfstatat / SYS_fstat), `raw_access`/
  `raw_faccessat`, `raw_getdents64`, `raw_execve`, `raw_statx`. All via
  `libc::syscall(...)`, never dlsym. The mm family
  (`real_mmap`/`real_munmap`/`real_mprotect`, now joined by
  `real_statx` = `raw_statx` on 64-bit) stays always-raw — a dlsym
  resolver there is the original cycle. 32-bit keeps the existing
  `real_fn!` / gnu-dlsym+musl-syscall split.
- **Documented residual**: the libc-composite surface (DIR*/FILE*/
  realpath/dlopen/posix_spawn(p)/`__chk_fail`) keeps lazy dlsym — no
  allocator init builds a DIR*. The full early-boot rule is now a
  section in `linux.rs`'s module doc.

## The probe (regression test)

`tests/fixtures/jemalloc-probe.c` (malloc(1)/free/return) +
`tests/e2e.rs::jemalloc_init_mmap_does_not_deadlock`: compiles the
probe with

```
cc -O2 -Wl,--export-dynamic -Wl,--push-state,-Bstatic -ljemalloc -Wl,--pop-state -lpthread -ldl
```

then runs it under `LD_PRELOAD` + `TEBAKO_TFS_MOUNTS` with an in-test
60 s deadline (spawn/try_wait/kill — `cmd.output()` would wait forever
on a wedge). Skips with a note only when `cc` cannot find `-ljemalloc`.
CI gains `libjemalloc-dev` on the ubuntu apt line so the probe runs
there.

## Verification

- **gnu container (aarch64-linux-gnu, static libjemalloc.a), the wedge
  platform**: `cargo build -p libtfs-preload && cargo test -p
  libtfs-preload` → **28/28 passed in 0.88 s**, including
  `jemalloc_init_mmap_does_not_deadlock ... ok`. Pre-fix: wedge at the
  60 s deadline. (Note: `cargo test -p libtfs-preload` alone does NOT
  rebuild the cdylib — a stale `.so` masked this fix as still-failing
  until the build ran first.)
- **macOS arm64 host**: 26/26 passed in 5.11 s (probe is linux-only,
  correctly absent).
- `cargo fmt -p libtfs-preload -- --check`: clean.
- `cargo clippy -p libtfs-preload --all-targets` (container, clippy
  1.94): zero warnings in the new code. One pre-existing warning at
  `route.rs:683` (`u8 as u8`) surfaces only on targets where `c_char =
  u8` (aarch64-linux); untouched here — CI's clippy legs
  (x64-linux-static, arm64-osx) both have `c_char = i8` and never see
  it (main is green with the same code).

## Follow-up (bf912b9b): `-lm` in the probe link

The first CI run's ubuntu-24.04 leg failed at the probe's `cc` step:
Ubuntu 24.04's `libjemalloc.a` (5.3.0-2build1) is built with profiling
on and references libm (`log`/`exp`/`round` from prof.o/prof_data.o);
a static archive is searched once in order, so `-lm` must follow
`-ljemalloc`. The aarch64 container's libjemalloc.a has prof disabled,
which is why local verification never saw it. Reproduced on the exact
CI platform (`docker --platform linux/amd64 ubuntu:24.04 +
libjemalloc-dev`): without `-lm` the identical undefined-reference
failure; with `-lm` the probe links and exits 0. Container probe
re-run green (0.76 s); the test fn is `cfg(linux)`, macOS untouched.
All other legs of the first run were green (macos-14 23m15s, windows
×4, dogfood ×3, parity 10m0s — the vcpkg infra flake did not recur).
