### PR TITLE
libtfs-preload: export fcntl64 — the glibc _FILE_OFFSET_BITS=64 redirect bypass (fixes #529)

### DIFF
--- a/crates/libtfs-preload/src/lib.rs
+++ b/crates/libtfs-preload/src/lib.rs
@@ -34,7 +34,9 @@
 //! `fstatat` (+`fstatat64`/`__xstat`/`__lxstat`/`__fxstat`/`__fxstatat`/
 //! `__xstat64`/`__lxstat64`/`__fxstat64`/`__fxstatat64`/`statx`/
 //! `getdents64` and the LFS `open64`/`openat64`/`stat64`/`lstat64`/
-//! `fstat64`/`pread64` family on Linux — roadmap 39; the fortified
+//! `fstat64`/`pread64`/`lseek64`/`fcntl64` family on Linux — roadmap 39
+//! (fcntl64: glibc's `_FILE_OFFSET_BITS=64` header redirect, the gnu
+//! CPython boot's actual entry point — tebako#529); the fortified
 //! `__read_chk` and `__openat_2`, and `fopen64` — tebako#439:
 //! libcrypto's `o_fopen.c` defines `_FILE_OFFSET_BITS=64` itself on
 //! linux, so every `BIO_new_file`/`X509_LOOKUP_load_file` binds

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -1333,6 +1333,21 @@ pub unsafe extern "C" fn fcntl_impl(fd: c_int, cmd: c_int, arg: c_int) -> c_int 
     }
 }
 
+/// Linux: `fcntl64` (the LFS alias of `fcntl`). glibc's headers redirect
+/// fcntl→fcntl64 whenever `_FILE_OFFSET_BITS=64` — which CPython's
+/// pyconfig.h sets on every gnu build — so a gnu interpreter's PEP-446
+/// cloexec probe (`get_inheritable`, Python/fileutils.c) names fcntl64,
+/// never fcntl: unexported, the call bound glibc's real fcntl64 and the
+/// shim's synthetic fd died EBADF at init_fs_encoding (tebako#529, the
+/// python factory's gnu legs). Delegates like the other LFS aliases;
+/// the descriptor-command semantics (and the early-boot raw arm) live in
+/// `fcntl_impl`.
+#[cfg(target_os = "linux")]
+#[no_mangle]
+pub unsafe extern "C" fn fcntl64(fd: c_int, cmd: c_int, arg: c_int) -> c_int {
+    fcntl_impl(fd, cmd, arg)
+}
+
 /// Interposed `mkdir` (write-class: memfs → EROFS, host → policy-gated).
 #[cfg_attr(target_os = "linux", no_mangle)]
 pub unsafe extern "C" fn mkdir(path: *const c_char, mode: libc::mode_t) -> c_int {

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -1160,7 +1160,11 @@ fn macos_plain_close_on_a_memfs_fd() {
 /// `encodings`, before any user code. The probe replays the exact
 /// sequence: O_CLOEXEC open → F_GETFD (bit set) → F_SETFD clear/set →
 /// F_GETFL (truthful read-only) → F_SETFL accepted no-op → read →
-/// close → EBADF on the dead fd → host-fd passthrough. Cross-platform:
+/// close → EBADF on the dead fd → host-fd passthrough; on linux the
+/// descriptor dance is replayed through `fcntl64` — glibc's headers
+/// redirect fcntl→fcntl64 under _FILE_OFFSET_BITS=64 (CPython's
+/// pyconfig.h sets it on every gnu build), so the gnu interpreter's
+/// probe names fcntl64, never fcntl (tebako#529). Cross-platform:
 /// fcntl's descriptor commands are plain POSIX.
 #[test]
 fn fcntl_on_a_memfs_fd() {

--- a/crates/libtfs-preload/tests/fixtures/fcntl-probe.c
+++ b/crates/libtfs-preload/tests/fixtures/fcntl-probe.c
@@ -18,6 +18,16 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#ifdef __linux__
+/* glibc's headers redirect fcntl→fcntl64 under _FILE_OFFSET_BITS=64 —
+ * which CPython's pyconfig.h sets on every gnu build — so a gnu
+ * interpreter's get_inheritable probe names fcntl64, never fcntl
+ * (tebako#529: the unexported alias bound glibc's real fcntl64 and the
+ * synthetic memfs fd died EBADF at init_fs_encoding). Declared by hand
+ * so no feature-test macro is needed. */
+extern int fcntl64(int fd, int cmd, ...);
+#endif
+
 int main(int argc, char **argv) {
     char buf[16];
     int fd, fl, hfd;
@@ -42,6 +52,18 @@ int main(int argc, char **argv) {
     if ((fl & O_ACCMODE) != O_RDONLY) { fprintf(stderr, "F_GETFL accmode: %#x\n", fl); return 71; }
     /* F_SETFL is an accepted no-op (a memfs read never blocks). */
     if (fcntl(fd, F_SETFL, O_NONBLOCK) != 0) { perror("fcntl(F_SETFL)"); return 72; }
+#ifdef __linux__
+    /* tebako#529: the same descriptor dance through the LFS alias —
+     * the gnu CPython binary's actual entry point. */
+    fl = fcntl64(fd, F_GETFD);
+    if (fl < 0 || !(fl & FD_CLOEXEC)) { perror("fcntl64(F_GETFD)"); return 79; }
+    if (fcntl64(fd, F_SETFD, 0) != 0) { perror("fcntl64(F_SETFD,0)"); return 80; }
+    fl = fcntl64(fd, F_GETFD);
+    if (fl != 0) { fprintf(stderr, "fcntl64 F_GETFD after clear: %#x\n", fl); return 81; }
+    fl = fcntl64(fd, F_GETFL);
+    if (fl < 0 || (fl & O_ACCMODE) != O_RDONLY) { fprintf(stderr, "fcntl64 F_GETFL: %#x\n", fl); return 82; }
+    if (fcntl64(fd, F_SETFD, FD_CLOEXEC) != 0) { perror("fcntl64(F_SETFD,CLOEXEC)"); return 83; }
+#endif
     /* The fd still reads after the flag dances. */
     if (read(fd, buf, sizeof(buf)) <= 0) { perror("read"); return 73; }
     if (close(fd) != 0) { perror("close"); return 74; }


### PR DESCRIPTION
## The bug (fixes #529)

A gnu-built CPython runtime died at boot, before user code:

```
Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
OSError: [Errno 9] Bad file descriptor
```

— the python runtime factory's six gnu boot-smoke legs
(tebako-runtime-python PR #2, on the v2.1.9 link unit). musl, macOS
and windows legs were green.

## Root cause

glibc's headers redirect `fcntl` → **`fcntl64`** whenever
`_FILE_OFFSET_BITS=64` — which CPython's `pyconfig.h` sets on every
gnu build, on every glibc version. The shim exported `fcntl` but not
`fcntl64`, so the call bound glibc's real `fcntl64` and the shim's
userspace-only synthetic fds (bit 30) hit the kernel:

```
fcntl(1073741825, F_GETFD) = -1 EBADF
```

The first such call is CPython's PEP-446 cloexec probe:
`_io_FileIO___init___impl` (Modules/_io/fileio.c:432) →
`set_inheritable` → `get_inheritable` → `fcntl(fd, F_GETFD)`
(Python/fileutils.c:1113) with `raise=1` → bare
`PyErr_SetFromErrno(OSError)` — hence the filename-less die.

Why boot-only: at REPL the same open works because
`_Py_open_cloexec_works` is already 1 (proven on host fds during
init), so `set_inheritable` skips the fcntl on the VFS fd. Boot fails
because the FIRST cloexec verification lands on a synthetic fd.
Why gnu-only: musl's headers do not perform the
`_FILE_OFFSET_BITS=64` redirects.

## Evidence (local repro: aarch64-gnu container, distro python3.8 + shim + dwarfs stdlib image)

- `PYTHONHOME=/__tfs__` boot died EBADF at init_fs_encoding — the
  exact CI signature; the same file read post-init worked.
- `TEBAKO_TRACE`: the opens route `image:/__tfs__` correctly; gdb
  showed no `vfs_fstat`/`vfs_read` before the raise.
- strace: `fcntl(1073741825…830, F_GETFD) = -1 EBADF` ×6 — host
  syscalls on synthetic fds, none through the shim.
- gdb with python3.8-dbg: the raise is `get_inheritable` →
  `PyErr_SetFromErrno`, from `_io_FileIO___init___impl`.

## The fix

`fcntl64` export in `crates/libtfs-preload` delegating to
`fcntl_impl` (the `lseek64`/`pread64`/`fstat64` precedent); the
descriptor-command semantics and the early-boot raw arm live there.
The lib.rs surface doc gains `fcntl64` (and the previously
undocumented `lseek64`).

## Regression pin

`tests/fixtures/fcntl-probe.c` (the #524 oracle) replays the same
descriptor dance through `fcntl64` — F_GETFD (cloexec set) →
F_SETFD clear/set → F_GETFL (truthful read-only) — citing #529.
RED first: `fcntl64(F_GETFD): Bad file descriptor`; with the export,
GREEN.

## Verification

- gnu container (aarch64): e2e 28/28 in 0.77 s + unit 6/6; the probe's
  RED→GREEN transition shown above.
- The end-to-end boot repro: `PYTHONHOME=/__tfs__ python3 -c "import
  encodings, io, codecs"` → `PY-BOOT-OK`, rc 0 — the exact CI failure
  scenario now boots.
- macOS arm64 host: 26/26 + 16/16 (the export is `cfg(linux)`; macOS
  compiles untouched).
- `cargo fmt --check` clean; clippy shows only the pre-existing
  route.rs:683 aarch64-signedness lint (CI's clippy legs never see it).

Deliberately out of scope: `__open64_2` (fortified open64) — imported
by distro pythons but not exercised on this path, and the python
factory's vanilla build is not fortified; if a leg ever proves it,
that fix lands with its own evidence.
