### PR TITLE
Shim routing + version management: spec 07 amendment, [payload@]version pins, per-payload disable, use

### DIFF
--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -49,6 +49,8 @@ const USAGE: &str = "Usage:
   tebako update-registries             refresh the dispatch-time registry cache
   tebako install <ref | name[@ver]>    install a payload + register its shims
   tebako uninstall <name>              remove a payload's shims and cache entry
+  tebako shim <verb> …                 the dispatcher's management verbs (spec 07 §3;
+                                       ≡ tebako-shim <verb> …: list|use|enable|disable|which|doctor|install-shell|uninstall-shell)
   tebako info [topic] [--remote] [--json]
                                        the store/system surface (system|runtimes|payloads|shims|registries|store)
   tebako inspect <artifact> [flags]    payload/package introspection (spec 15);
@@ -156,6 +158,7 @@ fn run(args: &[String]) -> Result<(), CliExit> {
         "update-registries" => run_update_registries(rest),
         "install" => run_install(rest),
         "uninstall" => run_uninstall(rest),
+        "shim" => run_shim(rest),
         "info" => run_info(rest),
         "inspect" => run_inspect(rest),
         "publish" => run_publish(rest),
@@ -176,6 +179,40 @@ fn tebako_home() -> Result<PathBuf, CliExit> {
             i32::from(e.code),
         ))
     })
+}
+
+/// `tebako shim <verb> …` ≡ `tebako-shim <verb> …` (spec 07 §3's dual
+/// spelling): the shim crate is a library dependency (spec 14 §3 — no
+/// shell-outs), so the passthrough rebuilds argv with the shim's own
+/// argv0 and the management face answers (tebako-shim/src/main.rs's
+/// shape: Print → stdout + exit code; Exec is unreachable from the
+/// management verbs and maps to a named internal error, never an exec).
+fn run_shim(args: &[String]) -> Result<(), CliExit> {
+    let ctx = tebako_shim::Ctx::from_env()
+        .map_err(|e| CliExit::Error(TebakoError::new(e.message, i32::from(e.code))))?;
+    let mut argv: Vec<String> = Vec::with_capacity(args.len() + 1);
+    argv.push("tebako-shim".to_string());
+    argv.extend(args.iter().cloned());
+    match tebako_shim::run(&argv, &ctx) {
+        Ok(tebako_shim::Action::Print { text, code }) => {
+            print!("{text}");
+            if code != 0 {
+                return Err(CliExit::Error(TebakoError::new(
+                    format!("tebako shim: the verb exited with code {code}"),
+                    i32::from(code),
+                )));
+            }
+            Ok(())
+        }
+        Ok(tebako_shim::Action::Exec(_)) => Err(CliExit::Error(TebakoError::new(
+            "tebako shim: a management verb resolved to a dispatch plan — internal error (the dispatch face needs argv0 = the command name; invoke the shim link itself)",
+            74,
+        ))),
+        Err(e) => Err(CliExit::Error(TebakoError::new(
+            e.message,
+            i32::from(e.code),
+        ))),
+    }
 }
 
 /// `tebako info [topic] [--remote] [--json]` — the store/system surface.

--- a/crates/tebako-cli/tests/shim_passthrough.rs
+++ b/crates/tebako-cli/tests/shim_passthrough.rs
@@ -1,0 +1,62 @@
+//! `tebako shim <verb> …` ≡ `tebako-shim <verb> …` (spec 07 §3's dual
+//! spelling): the CLI calls the shim crate as a library, never spawned.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn tebako_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_tebako"))
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("tebako-cli-shim-{tag}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(home: &std::path::Path, args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(tebako_bin())
+        .args(args)
+        .env("TEBAKO_HOME", home)
+        .output()
+        .unwrap_or_else(|e| panic!("spawn failed: {e}"));
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn shim_list_on_an_empty_store_prints_the_empty_line() {
+    let dir = scratch("list");
+    let home = dir.join("home");
+    let (code, stdout, _stderr) = run(&home, &["shim", "list"]);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("no installed payloads"), "{stdout}");
+}
+
+#[test]
+fn shim_unknown_verb_is_ex_usage() {
+    let dir = scratch("usage");
+    let home = dir.join("home");
+    let (code, _stdout, _stderr) = run(&home, &["shim", "frobnicate"]);
+    assert_eq!(code, i32::from(tebako_shim::EX_USAGE));
+}
+
+#[test]
+fn shim_use_roundtrips_through_the_passthrough() {
+    let dir = scratch("use");
+    let home = dir.join("home");
+    let (code, stdout, _stderr) = run(&home, &["shim", "use", "pandoc", "pandorc@1.2.0"]);
+    assert_eq!(code, 0, "{stdout}");
+    let cfg = fs::read_to_string(home.join("config.yaml")).unwrap();
+    assert!(cfg.contains("pandoc"), "{cfg}");
+    assert!(cfg.contains("pandorc@1.2.0"), "{cfg}");
+    let (code, stdout, _stderr) = run(&home, &["shim", "use", "--clear", "pandoc"]);
+    assert_eq!(code, 0, "{stdout}");
+    let cfg = fs::read_to_string(home.join("config.yaml")).unwrap();
+    assert!(!cfg.contains("pandoc"), "{cfg}");
+}

--- a/crates/tebako-shim/src/config.rs
+++ b/crates/tebako-shim/src/config.rs
@@ -46,7 +46,11 @@ pub struct RuntimePref {
     pub version: String,
     /// The tebako (launcher) abi version the runtime was built with,
     /// e.g. `0.16.0` — the `<ver>` of the cache layout
-    /// `runtimes/<lang>-<lv>-<ver>-<triplet>/`.
+    /// `runtimes/<lang>-<lv>-<ver>-<triplet>/`. Absent/empty when written
+    /// by `tebako-shim use --runtime <engine>@<langver>` without the
+    /// `:<tebako>` part — readers treat it as the product default line
+    /// (tebako-resolve::DEFAULT_TEBAKO_VERSION).
+    #[serde(default)]
     pub tebako: String,
 }
 
@@ -230,6 +234,161 @@ pub fn set_runtime_prefs(
 }
 
 // ---------------------------------------------------------------------
+// the `tebako-shim use` write path (spec 07 §0/§3 — the authored-config
+// write verb beside add_registry; spec 07 §2 step 0.5 amendment)
+// ---------------------------------------------------------------------
+
+/// Load `~/.tebako/config.yaml` (missing → an empty mapping), apply
+/// `edit` to its root mapping, and write it back tmp + rename — the
+/// shared scaffolding of every authored-config write (structural
+/// surgery: keys preserved, comments not).
+fn edit_config(
+    home: &Path,
+    edit: impl FnOnce(&mut serde_yaml::Mapping) -> Result<(), ShimError>,
+) -> Result<(), ShimError> {
+    let path = config_path(home);
+    let mut root: serde_yaml::Value = match std::fs::read_to_string(&path) {
+        Ok(t) => serde_yaml::from_str(&t).map_err(|e| {
+            ShimError::new(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "cannot parse {} ({e}) — fix or remove it; run `tebako-shim doctor`",
+                    path.display()
+                ),
+            )
+        })?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            serde_yaml::Value::Mapping(serde_yaml::Mapping::new())
+        }
+        Err(e) => return fail(EX_TEBAKO_IO, format!("cannot read {}: {e}", path.display())),
+    };
+    let mapping = root.as_mapping_mut().ok_or_else(|| {
+        ShimError::new(
+            EX_TEBAKO_MANIFEST,
+            format!("{} must be a YAML mapping", path.display()),
+        )
+    })?;
+    edit(mapping)?;
+    let text = serde_yaml::to_string(&root).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_IO,
+            format!("cannot serialize {}: {e}", path.display()),
+        )
+    })?;
+    std::fs::create_dir_all(home).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_IO,
+            format!("cannot create {}: {e}", home.display()),
+        )
+    })?;
+    let tmp = home.join(format!("config.yaml.{}.tmp", std::process::id()));
+    std::fs::write(&tmp, text).map_err(|e| {
+        ShimError::new(EX_TEBAKO_IO, format!("cannot write {}: {e}", tmp.display()))
+    })?;
+    std::fs::rename(&tmp, &path).map_err(|e| {
+        ShimError::new(
+            EX_TEBAKO_IO,
+            format!("cannot install {}: {e}", path.display()),
+        )
+    })?;
+    Ok(())
+}
+
+/// Set or clear (`None`) the user-default pin for `tool` — the
+/// `use <tool> <pin>` / `use --clear <tool>` write. The caller validates
+/// the pin against `tpkg::toolpin::ToolPin` BEFORE calling. Returns
+/// whether the file changed.
+pub fn set_default(home: &Path, tool: &str, pin: Option<&str>) -> Result<bool, ShimError> {
+    let mut changed = false;
+    edit_config(home, |mapping| {
+        let key = serde_yaml::Value::String("defaults".to_string());
+        match pin {
+            Some(pin) => {
+                let entry = mapping
+                    .entry(key)
+                    .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+                let defaults = entry.as_mapping_mut().ok_or_else(|| {
+                    ShimError::new(
+                        EX_TEBAKO_MANIFEST,
+                        format!(
+                            "{}: `defaults` must be a mapping",
+                            config_path(home).display()
+                        ),
+                    )
+                })?;
+                let tool_key = serde_yaml::Value::String(tool.to_string());
+                let new = serde_yaml::Value::String(pin.to_string());
+                if defaults.get(&tool_key) != Some(&new) {
+                    defaults.insert(tool_key, new);
+                    changed = true;
+                }
+            }
+            None => {
+                if let Some(entry) = mapping.get_mut(&key) {
+                    let defaults = entry.as_mapping_mut().ok_or_else(|| {
+                        ShimError::new(
+                            EX_TEBAKO_MANIFEST,
+                            format!(
+                                "{}: `defaults` must be a mapping",
+                                config_path(home).display()
+                            ),
+                        )
+                    })?;
+                    changed = defaults
+                        .remove(serde_yaml::Value::String(tool.to_string()))
+                        .is_some();
+                }
+            }
+        }
+        Ok(())
+    })?;
+    Ok(changed)
+}
+
+/// The `use --runtime <engine>@<langver>[:<tebako>]` write: one engine's
+/// runtime preference. Without the `:<tebako>` part only `version` is
+/// written — the tebako line then follows the product default at read
+/// time (see [`RuntimePref::tebako`]).
+pub fn set_runtime_pref(
+    home: &Path,
+    engine: &str,
+    version: &str,
+    tebako: Option<&str>,
+) -> Result<(), ShimError> {
+    edit_config(home, |mapping| {
+        let key = serde_yaml::Value::String("runtimes".to_string());
+        let entry = mapping
+            .entry(key)
+            .or_insert_with(|| serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+        let rt_map = entry.as_mapping_mut().ok_or_else(|| {
+            ShimError::new(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "{}: `runtimes` must be a mapping",
+                    config_path(home).display()
+                ),
+            )
+        })?;
+        let mut pref = serde_yaml::Mapping::new();
+        pref.insert(
+            serde_yaml::Value::String("version".to_string()),
+            serde_yaml::Value::String(version.to_string()),
+        );
+        if let Some(tebako) = tebako {
+            pref.insert(
+                serde_yaml::Value::String("tebako".to_string()),
+                serde_yaml::Value::String(tebako.to_string()),
+            );
+        }
+        rt_map.insert(
+            serde_yaml::Value::String(engine.to_string()),
+            serde_yaml::Value::Mapping(pref),
+        );
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------
 // the registry-default chain link (spec 07 §2.1, last resort)
 // ---------------------------------------------------------------------
 
@@ -330,8 +489,7 @@ pub fn save_disabled(home: &Path, disabled: &Disabled) -> Result<(), ShimError> 
 pub fn is_disabled(disabled: &Disabled, tool: &str, payload: &str, version: &str) -> bool {
     disabled.get(tool).is_some_and(|selectors| {
         selectors.iter().any(|s| {
-            tpkg::toolpin::DisableSelector::parse(s)
-                .is_ok_and(|sel| sel.matches(payload, version))
+            tpkg::toolpin::DisableSelector::parse(s).is_ok_and(|sel| sel.matches(payload, version))
         })
     })
 }

--- a/crates/tebako-shim/src/config.rs
+++ b/crates/tebako-shim/src/config.rs
@@ -258,7 +258,10 @@ pub fn registry_default(
 // disabled state (shim-managed; never interleaved with authored config)
 // ---------------------------------------------------------------------
 
-/// Tool name → list of disabled selectors: exact versions, or `all`.
+/// Tool name → list of disabled selectors (strings on disk; parsed
+/// through `tpkg::toolpin::DisableSelector`, the ONE grammar — spec 00
+/// invariant 10): `all`, a bare version, `payload@all`, or
+/// `payload@version` (spec 07 §0, the 2026-09-05 routing amendment).
 pub type Disabled = BTreeMap<String, Vec<String>>;
 
 pub fn disabled_path(home: &Path) -> PathBuf {
@@ -272,12 +275,26 @@ pub fn load_disabled(home: &Path) -> Result<Disabled, ShimError> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Disabled::default()),
         Err(e) => return fail(EX_TEBAKO_IO, format!("cannot read {}: {e}", path.display())),
     };
-    serde_yaml::from_str(&text).map_err(|e| {
+    let disabled: Disabled = serde_yaml::from_str(&text).map_err(|e| {
         ShimError::new(
             EX_TEBAKO_MANIFEST,
             format!("cannot parse {} ({e})", path.display()),
         )
-    })
+    })?;
+    // Every selector validates at LOAD (invariant 9 — an unknown string
+    // is a named error naming the file and entry, never silently
+    // ignored).
+    for (tool, selectors) in &disabled {
+        for selector in selectors {
+            tpkg::toolpin::DisableSelector::parse(selector).map_err(|e| {
+                ShimError::new(
+                    EX_TEBAKO_MANIFEST,
+                    format!("{}: {tool}: {e}", path.display()),
+                )
+            })?;
+        }
+    }
+    Ok(disabled)
 }
 
 pub fn save_disabled(home: &Path, disabled: &Disabled) -> Result<(), ShimError> {
@@ -307,10 +324,33 @@ pub fn save_disabled(home: &Path, disabled: &Disabled) -> Result<(), ShimError> 
     })
 }
 
-pub fn is_disabled(disabled: &Disabled, tool: &str, version: &str) -> bool {
-    disabled
-        .get(tool)
-        .is_some_and(|selectors| selectors.iter().any(|s| s == "all" || s == version))
+/// Is the claim `payload` makes for `tool` at `version` gated?
+/// Selectors parse through `tpkg::toolpin::DisableSelector` (validated
+/// at load — a stored selector always parses).
+pub fn is_disabled(disabled: &Disabled, tool: &str, payload: &str, version: &str) -> bool {
+    disabled.get(tool).is_some_and(|selectors| {
+        selectors.iter().any(|s| {
+            tpkg::toolpin::DisableSelector::parse(s)
+                .is_ok_and(|sel| sel.matches(payload, version))
+        })
+    })
+}
+
+/// The provider scan's skip test: is the payload's WHOLE claim for
+/// `tool` gated? Only `all` and `<payload>@all` gate a whole claim —
+/// a version selector leaves the claim routable at its other versions.
+pub fn claim_disabled(disabled: &Disabled, tool: &str, payload: &str) -> bool {
+    disabled.get(tool).is_some_and(|selectors| {
+        selectors.iter().any(|s| {
+            matches!(
+                tpkg::toolpin::DisableSelector::parse(s),
+                Ok(tpkg::toolpin::DisableSelector::All)
+            ) || matches!(
+                tpkg::toolpin::DisableSelector::parse(s),
+                Ok(tpkg::toolpin::DisableSelector::PayloadAll(ref p)) if p == payload
+            )
+        })
+    })
 }
 
 #[cfg(test)]

--- a/crates/tebako-shim/src/manage.rs
+++ b/crates/tebako-shim/src/manage.rs
@@ -120,7 +120,9 @@ fn cmd_list(ctx: &Ctx) -> Result<Action, ShimError> {
             versions
                 .iter()
                 .map(|v| {
-                    let is_dis = tools.iter().any(|t| config::is_disabled(&disabled, t, v));
+                    let is_dis = tools
+                        .iter()
+                        .any(|t| config::is_disabled(&disabled, t, name, v));
                     if is_dis {
                         format!("{v} [disabled]")
                     } else {

--- a/crates/tebako-shim/src/manage.rs
+++ b/crates/tebako-shim/src/manage.rs
@@ -21,11 +21,17 @@ const USAGE: &str = "tebako-shim — the tebako dispatcher and version manager (
 
 invoked as ~/.tebako/shims/<tool> it dispatches; invoked as tebako-shim it manages:
 
-  tebako-shim list                     installed payloads, versions, defaults, shim links
-  tebako-shim enable <tool>[@<ver>]    re-enable a disabled tool or version
-  tebako-shim disable <tool>[@<ver>]   refuse dispatch of a tool or version
-  tebako-shim which <tool>             show the resolved version, runtime, mounts, argv
-  tebako-shim doctor                   diagnose the shim layer (missing/corrupt records)
+  tebako-shim list [--json]            installed payloads, versions, defaults, shim links
+  tebako-shim use <tool> <pin>         write the user default ([payload@]version) to config.yaml
+  tebako-shim use --clear <tool>       remove the tool's user default
+  tebako-shim use --runtime <engine>@<langver>[:<tebako>]
+                                       write the engine's runtime preference
+  tebako-shim enable <tool>[@<ver>] [--of <payload>]
+                                       re-enable a disabled tool, version, or payload claim
+  tebako-shim disable <tool>[@<ver>] [--of <payload>]
+                                       refuse dispatch of a tool, version, or payload claim
+  tebako-shim which <tool>             show the resolved provider, version, runtime, mounts, argv
+  tebako-shim doctor                   diagnose the shim layer (missing/corrupt records, routing)
   tebako-shim install-shell [--shell bash|zsh|fish|csh]
                                        prepend ~/.tebako/shims to PATH in the shell startup file
   tebako-shim uninstall-shell [--shell bash|zsh|fish|csh]
@@ -36,11 +42,17 @@ const USAGE: &str = "tebako-shim — the tebako dispatcher and version manager (
 
 invoked as <TEBAKO_HOME>\\shims\\<tool>.exe it dispatches; invoked as tebako-shim it manages:
 
-  tebako-shim list                     installed payloads, versions, defaults, shim links
-  tebako-shim enable <tool>[@<ver>]    re-enable a disabled tool or version
-  tebako-shim disable <tool>[@<ver>]   refuse dispatch of a tool or version
-  tebako-shim which <tool>             show the resolved version, runtime, mounts, argv
-  tebako-shim doctor                   diagnose the shim layer (missing/corrupt records)
+  tebako-shim list [--json]            installed payloads, versions, defaults, shim links
+  tebako-shim use <tool> <pin>         write the user default ([payload@]version) to config.yaml
+  tebako-shim use --clear <tool>       remove the tool's user default
+  tebako-shim use --runtime <engine>@<langver>[:<tebako>]
+                                       write the engine's runtime preference
+  tebako-shim enable <tool>[@<ver>] [--of <payload>]
+                                       re-enable a disabled tool, version, or payload claim
+  tebako-shim disable <tool>[@<ver>] [--of <payload>]
+                                       refuse dispatch of a tool, version, or payload claim
+  tebako-shim which <tool>             show the resolved provider, version, runtime, mounts, argv
+  tebako-shim doctor                   diagnose the shim layer (missing/corrupt records, routing)
   tebako-shim install-shell            prepend the shim dir to the user PATH (registry)
   tebako-shim uninstall-shell          remove exactly our PATH entry";
 
@@ -53,7 +65,8 @@ pub fn run_command(args: &[String], ctx: &Ctx) -> Result<Action, ShimError> {
     };
     let rest = &args[1..];
     match cmd.as_str() {
-        "list" => cmd_list(ctx),
+        "list" => cmd_list(rest, ctx),
+        "use" => cmd_use(rest, ctx),
         "enable" => cmd_enable(rest, ctx, true),
         "disable" => cmd_enable(rest, ctx, false),
         "which" => cmd_which(rest, ctx),
@@ -69,10 +82,148 @@ pub fn run_command(args: &[String], ctx: &Ctx) -> Result<Action, ShimError> {
 }
 
 // ---------------------------------------------------------------------
+// use (spec 07 §3 — the authored-config write verb, §0's write
+// relaxation; tmp + rename in config.rs's edit_config)
+// ---------------------------------------------------------------------
+
+fn cmd_use(args: &[String], ctx: &Ctx) -> Result<Action, ShimError> {
+    match args.first().map(String::as_str) {
+        Some("--clear") => {
+            let Some(tool) = args.get(1) else {
+                return fail(EX_USAGE, "usage: tebako-shim use --clear <tool>");
+            };
+            if args.len() > 2 {
+                return fail(EX_USAGE, "usage: tebako-shim use --clear <tool>");
+            }
+            manifest::check_path_component("command name", tool)?;
+            let changed = config::set_default(&ctx.home, tool, None)?;
+            let text = if changed {
+                format!("cleared the user default for {tool}\n")
+            } else {
+                format!("{tool} had no user default\n")
+            };
+            Ok(Action::Print { text, code: 0 })
+        }
+        Some("--runtime") => {
+            let Some(spec) = args.get(1) else {
+                return fail(
+                    EX_USAGE,
+                    "usage: tebako-shim use --runtime <engine>@<langver>[:<tebako>]",
+                );
+            };
+            if args.len() > 2 {
+                return fail(
+                    EX_USAGE,
+                    "usage: tebako-shim use --runtime <engine>@<langver>[:<tebako>]",
+                );
+            }
+            let (engine, rest) = spec.split_once('@').ok_or_else(|| {
+                ShimError::new(
+                    EX_USAGE,
+                    format!(
+                        "invalid runtime preference \"{spec}\" — the grammar is <engine>@<langver>[:<tebako>]"
+                    ),
+                )
+            })?;
+            if engine.is_empty() || rest.is_empty() {
+                return fail(
+                    EX_USAGE,
+                    format!(
+                        "invalid runtime preference \"{spec}\" — the grammar is <engine>@<langver>[:<tebako>]"
+                    ),
+                );
+            }
+            manifest::check_path_component("engine", engine)?;
+            let (version, tebako) = match rest.split_once(':') {
+                Some((v, t)) if !v.is_empty() && !t.is_empty() => (v, Some(t)),
+                Some(_) => {
+                    return fail(
+                        EX_USAGE,
+                        format!(
+                            "invalid runtime preference \"{spec}\" — the grammar is <engine>@<langver>[:<tebako>]"
+                        ),
+                    )
+                }
+                None => (rest, None),
+            };
+            config::set_runtime_pref(&ctx.home, engine, version, tebako)?;
+            let text = match tebako {
+                Some(t) => format!(
+                    "runtime preference {engine}: version {version}, tebako {t} (~/.tebako/config.yaml)\n"
+                ),
+                None => format!(
+                    "runtime preference {engine}: version {version} (~/.tebako/config.yaml; the tebako line follows the product default)\n"
+                ),
+            };
+            Ok(Action::Print { text, code: 0 })
+        }
+        Some(tool) => {
+            let Some(pin) = args.get(1) else {
+                return fail(EX_USAGE, "usage: tebako-shim use <tool> <pin>");
+            };
+            if args.len() > 2 {
+                return fail(EX_USAGE, "usage: tebako-shim use <tool> <pin>");
+            }
+            manifest::check_path_component("command name", tool)?;
+            // Validate against the ONE grammar (tpkg::toolpin) BEFORE
+            // writing — a bad pin is the named grammar error and the file
+            // is untouched (spec 07 §0/§7).
+            tpkg::toolpin::ToolPin::parse(pin).map_err(|e| {
+                ShimError::new(
+                    crate::EX_TEBAKO_MANIFEST,
+                    format!("use {tool}: {e}"),
+                )
+            })?;
+            config::set_default(&ctx.home, tool, Some(pin))?;
+            Ok(Action::Print {
+                text: format!("default {tool}: {pin} (~/.tebako/config.yaml)\n"),
+                code: 0,
+            })
+        }
+        None => fail(
+            EX_USAGE,
+            "usage: tebako-shim use <tool> <pin> | use --clear <tool> | use --runtime <engine>@<langver>[:<tebako>]",
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------
 // list
 // ---------------------------------------------------------------------
 
-fn cmd_list(ctx: &Ctx) -> Result<Action, ShimError> {
+/// One command row of `list`: the declaring payload, the shim link, the
+/// effective resolution (provider payload + kind, version + source) or
+/// the named failure, and the tool's disabled selectors.
+struct CommandRow {
+    tool: String,
+    payload: String,
+    shim: PathBuf,
+    resolved: Option<(String, String, String, resolve::ProviderKind)>,
+    error: Option<String>,
+    selectors: Vec<String>,
+}
+
+/// One payload row of `list`: name, (version, disabled) marks, and the
+/// newest version's commands.
+struct PayloadRow {
+    name: String,
+    versions: Vec<(String, bool)>,
+    tools: Vec<String>,
+}
+
+fn cmd_list(args: &[String], ctx: &Ctx) -> Result<Action, ShimError> {
+    let mut json = false;
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json = true,
+            other => {
+                return fail(
+                    EX_USAGE,
+                    format!("unexpected argument \"{other}\" — usage: tebako-shim list [--json]"),
+                )
+            }
+        }
+    }
     let payloads_dir = ctx.home.join("payloads");
     let mut names: Vec<String> = Vec::new();
     match std::fs::read_dir(&payloads_dir) {
@@ -94,14 +245,8 @@ fn cmd_list(ctx: &Ctx) -> Result<Action, ShimError> {
     names.sort();
 
     let disabled = config::load_disabled(&ctx.home)?;
-    let mut out = String::new();
-    if names.is_empty() {
-        let _ = writeln!(
-            out,
-            "no installed payloads under {}",
-            payloads_dir.display()
-        );
-    }
+    let mut payloads: Vec<PayloadRow> = Vec::new();
+    let mut commands: Vec<CommandRow> = Vec::new();
     for name in &names {
         let versions = resolve::installed_versions(&ctx.home, name)?;
         // every entrypoint of the newest installed version is a command
@@ -113,17 +258,71 @@ fn cmd_list(ctx: &Ctx) -> Result<Action, ShimError> {
                 tools = m.entrypoints().iter().map(|e| e.name.clone()).collect();
             }
         }
+        let version_marks: Vec<(String, bool)> = versions
+            .iter()
+            .map(|v| {
+                let is_dis = tools
+                    .iter()
+                    .any(|t| config::is_disabled(&disabled, t, name, v));
+                (v.clone(), is_dis)
+            })
+            .collect();
+        for tool in &tools {
+            let shim = ctx.home.join("shims").join(tool);
+            let row = match resolve::resolve(tool, ctx) {
+                Ok(res) => CommandRow {
+                    tool: tool.clone(),
+                    payload: name.clone(),
+                    shim,
+                    resolved: Some((
+                        res.version,
+                        res.source.to_string(),
+                        res.payload_name,
+                        res.provider,
+                    )),
+                    error: None,
+                    selectors: disabled.get(tool).cloned().unwrap_or_default(),
+                },
+                Err(e) => CommandRow {
+                    tool: tool.clone(),
+                    payload: name.clone(),
+                    shim,
+                    resolved: None,
+                    error: Some(first_line(&e.message).to_string()),
+                    selectors: disabled.get(tool).cloned().unwrap_or_default(),
+                },
+            };
+            commands.push(row);
+        }
+        payloads.push(PayloadRow {
+            name: name.clone(),
+            versions: version_marks,
+            tools,
+        });
+    }
+
+    if json {
+        return cmd_list_json(ctx, &payloads, &commands);
+    }
+
+    let mut out = String::new();
+    if payloads.is_empty() {
+        let _ = writeln!(
+            out,
+            "no installed payloads under {}",
+            payloads_dir.display()
+        );
+    }
+    for row in &payloads {
+        let name = &row.name;
         let _ = writeln!(out, "{name}");
         let _ = writeln!(
             out,
             "  versions: {}",
-            versions
+            row.versions
                 .iter()
-                .map(|v| {
-                    let is_dis = tools
-                        .iter()
-                        .any(|t| config::is_disabled(&disabled, t, name, v));
-                    if is_dis {
+                .map(|(v, is_dis)| {
+                    if *is_dis {
                         format!("{v} [disabled]")
                     } else {
                         v.clone()
@@ -132,32 +331,123 @@ fn cmd_list(ctx: &Ctx) -> Result<Action, ShimError> {
                 .collect::<Vec<_>>()
                 .join(" ")
         );
-        for tool in &tools {
-            let shim = ctx.home.join("shims").join(tool);
+        for crow in commands.iter().filter(|r| r.payload == row.name) {
             let _ = writeln!(
                 out,
-                "  command {tool}: shim {}",
-                if shim.exists() {
-                    shim.display().to_string()
+                "  command {}: shim {}",
+                crow.tool,
+                if crow.shim.exists() {
+                    crow.shim.display().to_string()
                 } else {
                     "(not linked)".to_string()
                 }
             );
-            match resolve::resolve(tool, ctx) {
-                Ok(res) => {
-                    let _ = writeln!(out, "    resolved: {} (from {})", res.version, res.source);
+            match &crow.resolved {
+                Some((version, source, provider, kind)) => {
+                    let _ = writeln!(
+                        out,
+                        "    resolved: {version} (from {source}) [provider {provider} ({kind})]"
+                    );
                 }
-                Err(e) => {
+                None => {
                     let _ = writeln!(
                         out,
                         "    resolved: (unresolvable: {})",
-                        first_line(&e.message)
+                        crow.error.as_deref().unwrap_or("unknown")
                     );
                 }
             }
         }
     }
     Ok(Action::Print { text: out, code: 0 })
+}
+
+/// `tebako-shim list --json` (spec 07 §3): one `"info_schema": 1`
+/// document, mirroring `tebako cache list --json`'s convention
+/// (tebako-cli's cache_list_json).
+fn cmd_list_json(
+    ctx: &Ctx,
+    payloads: &[PayloadRow],
+    commands: &[CommandRow],
+) -> Result<Action, ShimError> {
+    use tebako_json::Value as J;
+
+    let s = |v: &str| J::String(v.to_string());
+    let payload_docs = payloads
+        .iter()
+        .map(|row| {
+            J::Object(vec![
+                ("name".to_string(), s(&row.name)),
+                (
+                    "versions".to_string(),
+                    J::Array(
+                        row.versions
+                            .iter()
+                            .map(|(v, is_dis)| {
+                                J::Object(vec![
+                                    ("version".to_string(), s(v)),
+                                    ("disabled".to_string(), J::Bool(*is_dis)),
+                                ])
+                            })
+                            .collect(),
+                    ),
+                ),
+                (
+                    "commands".to_string(),
+                    J::Array(row.tools.iter().map(|t| s(t)).collect()),
+                ),
+            ])
+        })
+        .collect();
+    let command_docs = commands
+        .iter()
+        .map(|row| {
+            let mut obj = vec![
+                ("name".to_string(), s(&row.tool)),
+                ("payload".to_string(), s(&row.payload)),
+                (
+                    "shim".to_string(),
+                    if row.shim.exists() {
+                        s(&row.shim.display().to_string())
+                    } else {
+                        J::Null
+                    },
+                ),
+            ];
+            match &row.resolved {
+                Some((version, source, provider, kind)) => {
+                    obj.push(("provider".to_string(), s(provider)));
+                    obj.push(("provider_kind".to_string(), s(&kind.to_string())));
+                    obj.push(("version".to_string(), s(version)));
+                    obj.push(("source".to_string(), s(source)));
+                }
+                None => {
+                    obj.push((
+                        "error".to_string(),
+                        s(row.error.as_deref().unwrap_or("unknown")),
+                    ));
+                }
+            }
+            obj.push((
+                "disabled".to_string(),
+                J::Array(row.selectors.iter().map(|sel| s(sel)).collect()),
+            ));
+            J::Object(obj)
+        })
+        .collect();
+    let doc = J::Object(vec![
+        ("info_schema".to_string(), J::Number("1".to_string())),
+        (
+            "store".to_string(),
+            J::String(ctx.home.display().to_string()),
+        ),
+        ("payloads".to_string(), J::Array(payload_docs)),
+        ("commands".to_string(), J::Array(command_docs)),
+    ]);
+    Ok(Action::Print {
+        text: format!("{}\n", tebako_json::to_string(&doc)),
+        code: 0,
+    })
 }
 
 fn first_line(message: &str) -> &str {
@@ -200,20 +490,73 @@ fn parse_target(arg: &str) -> Result<(String, Option<String>), ShimError> {
 
 fn cmd_enable(args: &[String], ctx: &Ctx, enable: bool) -> Result<Action, ShimError> {
     let verb = if enable { "enable" } else { "disable" };
-    let Some(target) = args.first() else {
+    let mut target: Option<&str> = None;
+    let mut of: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        if arg == "--of" {
+            i += 1;
+            match args.get(i) {
+                Some(p) => of = Some(p.clone()),
+                None => {
+                    return fail(
+                        EX_USAGE,
+                        format!("--of expects a payload name — usage: tebako-shim {verb} <tool>[@<version>] [--of <payload>]"),
+                    )
+                }
+            }
+        } else if let Some(p) = arg.strip_prefix("--of=") {
+            of = Some(p.to_string());
+        } else if target.is_none() && !arg.starts_with('-') {
+            target = Some(arg);
+        } else {
+            return fail(
+                EX_USAGE,
+                format!(
+                    "unexpected argument \"{arg}\" — usage: tebako-shim {verb} <tool>[@<version>] [--of <payload>]"
+                ),
+            );
+        }
+        i += 1;
+    }
+    let Some(target) = target else {
         return fail(
             EX_USAGE,
-            format!("usage: tebako-shim {verb} <tool>[@<version>]"),
+            format!("usage: tebako-shim {verb} <tool>[@<version>] [--of <payload>]"),
         );
     };
     let (tool, version) = parse_target(target)?;
-    let selector = version.clone().unwrap_or_else(|| "all".to_string());
+    if let Some(p) = &of {
+        if p.is_empty() {
+            return fail(
+                EX_USAGE,
+                format!("--of expects a payload name — usage: tebako-shim {verb} <tool>[@<version>] [--of <payload>]"),
+            );
+        }
+        manifest::check_path_component("payload name", p)?;
+    }
+    // The selector grammar (tpkg::toolpin::DisableSelector owns it —
+    // these writes produce exactly its four spellings, spec 07 §0).
+    let selector = match (&version, &of) {
+        (None, None) => "all".to_string(),
+        (Some(v), None) => v.clone(),
+        (None, Some(p)) => format!("{p}@all"),
+        (Some(v), Some(p)) => format!("{p}@{v}"),
+    };
+    let target_desc = match (&version, &of) {
+        (None, None) => tool.clone(),
+        (Some(v), None) => format!("{tool}@{v}"),
+        (None, Some(p)) => format!("{tool} --of {p}"),
+        (Some(v), Some(p)) => format!("{tool}@{v} --of {p}"),
+    };
     let mut disabled = config::load_disabled(&ctx.home)?;
     let selectors = disabled.entry(tool.clone()).or_default();
     let changed = if enable {
-        // `enable <tool>` clears every selector; `enable <tool>@v` drops v.
+        // `enable <tool>` clears every selector; `enable <tool>@v
+        // [--of p]` drops exactly the computed selector.
         let before = selectors.len();
-        if version.is_none() {
+        if version.is_none() && of.is_none() {
             selectors.clear();
         } else {
             selectors.retain(|s| s != &selector);
@@ -231,14 +574,15 @@ fn cmd_enable(args: &[String], ctx: &Ctx, enable: bool) -> Result<Action, ShimEr
     if changed {
         config::save_disabled(&ctx.home, &disabled)?;
     }
-    let target_desc = match &version {
-        Some(v) => format!("{tool}@{v}"),
-        None => tool.clone(),
+    let suffix = if of.is_some() {
+        format!(" ({selector})")
+    } else {
+        String::new()
     };
     let text = match (enable, changed) {
-        (true, true) => format!("enabled {target_desc}\n"),
+        (true, true) => format!("enabled {target_desc}{suffix}\n"),
         (true, false) => format!("{target_desc} was not disabled\n"),
-        (false, true) => format!("disabled {target_desc}\n"),
+        (false, true) => format!("disabled {target_desc}{suffix}\n"),
         (false, false) => format!("{target_desc} was already disabled\n"),
     };
     // Enabling a DECLARED-but-unlinked command (spec 03 §2.2's
@@ -285,7 +629,20 @@ fn cmd_which(args: &[String], ctx: &Ctx) -> Result<Action, ShimError> {
     let mut out = String::new();
     let _ = writeln!(out, "tool: {tool}");
     let _ = writeln!(out, "payload: {} {}", res.payload_name, res.version);
-    let _ = writeln!(out, "  version source: {}", res.source);
+    let _ = writeln!(out, "  provider: {} ({})", res.payload_name, res.provider);
+    match res.provider {
+        resolve::ProviderKind::Pinned => {
+            // The pin won both dimensions — show the qualified value.
+            let _ = writeln!(
+                out,
+                "  version source: {} (pin {}@{})",
+                res.source, res.payload_name, res.version
+            );
+        }
+        _ => {
+            let _ = writeln!(out, "  version source: {}", res.source);
+        }
+    }
     let _ = writeln!(out, "  image: {}", res.record.image.display());
     let _ = writeln!(out, "entrypoint: {}", entry.path);
     match &plan.runtime {
@@ -451,6 +808,10 @@ fn cmd_doctor(ctx: &Ctx) -> Result<Action, ShimError> {
         }
     }
 
+    // Routing health (spec 07 §3, the 2026-09-05 amendment): collisions,
+    // dangling pins, disabled-but-pinned conflicts.
+    doctor_routing(ctx, &mut problems);
+
     let mut out = String::new();
     for note in &notes {
         let _ = writeln!(out, "ok: {note}");
@@ -464,6 +825,194 @@ fn cmd_doctor(ctx: &Ctx) -> Result<Action, ShimError> {
         }
         let _ = writeln!(out, "tebako-shim doctor: {} problem(s)", problems.len());
         Ok(Action::Print { text: out, code: 1 })
+    }
+}
+
+/// The routing health reports (spec 07 §3, the 2026-09-05 amendment):
+/// collisions (a command with more than one ENABLED claim), dangling pins
+/// (project-file/config pins naming an uninstalled payload or version —
+/// the env link is per-invocation and not inspectable), and
+/// disabled-but-pinned conflicts. Diagnose-only, like every doctor
+/// finding.
+fn doctor_routing(ctx: &Ctx, problems: &mut Vec<String>) {
+    use std::collections::BTreeMap;
+
+    // command → claiming payloads (declared entrypoints + expose edges)
+    let mut claims: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let payloads_dir = ctx.home.join("payloads");
+    if let Ok(rd) = std::fs::read_dir(&payloads_dir) {
+        for entry in rd.flatten() {
+            if !entry.path().is_dir() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let versions = resolve::installed_versions(&ctx.home, &name).unwrap_or_default();
+            for v in versions {
+                let record = manifest::payload_record(&ctx.home, &name, &v);
+                if let Ok(m) = manifest::Manifest::load(&record.manifest_mirror) {
+                    let mut claim = |cmd: &str| {
+                        let entry = claims.entry(cmd.to_string()).or_default();
+                        if !entry.contains(&name) {
+                            entry.push(name.clone());
+                        }
+                    };
+                    for e in m.entrypoints() {
+                        claim(&e.name);
+                    }
+                    for r in m.requires() {
+                        let expose = match r {
+                            tpkg::Requirement::Runtime { expose, .. } => expose,
+                            tpkg::Requirement::Executable { expose, .. } => expose,
+                            _ => continue,
+                        };
+                        for e in expose {
+                            claim(e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let disabled = match config::load_disabled(&ctx.home) {
+        Ok(d) => d,
+        Err(e) => {
+            problems.push(format!(".disabled.yaml: {}", first_line(&e.message)));
+            return;
+        }
+    };
+
+    // collisions: more than one ENABLED claim (disabled claims route out)
+    for (cmd, ps) in &claims {
+        let enabled: Vec<&String> = ps
+            .iter()
+            .filter(|p| !config::claim_disabled(&disabled, cmd, p))
+            .collect();
+        if enabled.len() > 1 {
+            problems.push(format!(
+                "command {cmd}: claimed by more than one enabled payload ({}) — pin `{cmd}: <payload>@<version>` in .tebako-tools.yaml, or disable one claim (`tebako-shim disable {cmd} --of <payload>`)",
+                enabled
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    }
+
+    // pins: config defaults + project files (nearest-wins per tool)
+    let mut pins: Vec<(String, String, String)> = Vec::new(); // (tool, value, origin)
+    if let Ok(cfg) = config::load_config(&ctx.home) {
+        for (tool, value) in &cfg.defaults {
+            pins.push((
+                tool.clone(),
+                value.clone(),
+                "~/.tebako/config.yaml defaults".to_string(),
+            ));
+        }
+    }
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut dir: Option<&std::path::Path> = Some(&ctx.cwd);
+    while let Some(d) = dir {
+        let candidate = d.join(".tebako-tools.yaml");
+        if candidate.is_file() {
+            match std::fs::read_to_string(&candidate)
+                .map_err(|e| e.to_string())
+                .and_then(|text| {
+                    serde_yaml::from_str::<serde_yaml::Value>(&text).map_err(|e| e.to_string())
+                }) {
+                Ok(value) => {
+                    if let Some(m) = value.as_mapping() {
+                        for (k, v) in m {
+                            if let (Some(tool), Some(pin)) = (k.as_str(), v.as_str()) {
+                                if seen.insert(tool.to_string()) {
+                                    pins.push((
+                                        tool.to_string(),
+                                        pin.to_string(),
+                                        format!("project {}", candidate.display()),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => problems.push(format!("{}: {e}", candidate.display())),
+            }
+        }
+        dir = d.parent();
+    }
+
+    for (tool, value, origin) in &pins {
+        let pin = match tpkg::toolpin::ToolPin::parse(value) {
+            Ok(pin) => pin,
+            Err(e) => {
+                problems.push(format!("pin \"{value}\" for {tool} ({origin}): {e}"));
+                continue;
+            }
+        };
+        match &pin.payload {
+            Some(payload) => {
+                if !ctx.home.join("payloads").join(payload).is_dir() {
+                    problems.push(format!(
+                        "dangling pin: \"{pin}\" for {tool} ({origin}) names payload \"{payload}\", which is not installed"
+                    ));
+                    continue;
+                }
+                let installed = resolve::installed_versions(&ctx.home, payload).unwrap_or_default();
+                if !installed.iter().any(|v| v == &pin.version) {
+                    problems.push(format!(
+                        "dangling pin: \"{pin}\" for {tool} ({origin}) names version {} of \"{payload}\" — installed: {}",
+                        pin.version,
+                        installed.join(", ")
+                    ));
+                    continue;
+                }
+                if config::is_disabled(&disabled, tool, payload, &pin.version) {
+                    problems.push(format!(
+                        "disabled but pinned: \"{pin}\" for {tool} ({origin}) — dispatch refuses it until `tebako-shim enable {tool}@{version} --of {payload}`",
+                        version = pin.version
+                    ));
+                }
+            }
+            None => {
+                let Some(ps) = claims.get(tool) else {
+                    problems.push(format!(
+                        "dangling pin: no installed payload provides or exposes \"{tool}\" (pinned \"{pin}\" at {origin})"
+                    ));
+                    continue;
+                };
+                let with_version: Vec<&String> = ps
+                    .iter()
+                    .filter(|p| {
+                        resolve::installed_versions(&ctx.home, p)
+                            .map(|vs| vs.iter().any(|v| v == &pin.version))
+                            .unwrap_or(false)
+                    })
+                    .collect();
+                if with_version.is_empty() {
+                    problems.push(format!(
+                        "dangling pin: version {} of \"{tool}\" (pinned at {origin}) is not installed in any claiming payload ({})",
+                        pin.version,
+                        ps.join(", ")
+                    ));
+                    continue;
+                }
+                if with_version
+                    .iter()
+                    .all(|p| config::is_disabled(&disabled, tool, p, &pin.version))
+                {
+                    problems.push(format!(
+                        "disabled but pinned: version {} of \"{tool}\" ({origin}) is disabled for every claiming payload ({})",
+                        pin.version,
+                        with_version
+                            .iter()
+                            .map(|s| s.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
+                }
+            }
+        }
     }
 }
 

--- a/crates/tebako-shim/src/resolve.rs
+++ b/crates/tebako-shim/src/resolve.rs
@@ -353,7 +353,7 @@ fn resolve_named(tool: &str, payload_name: &str, ctx: &Ctx) -> Result<Resolution
     }
 
     let disabled = config::load_disabled(&ctx.home)?;
-    if config::is_disabled(&disabled, tool, &version) {
+    if config::is_disabled(&disabled, tool, payload_name, &version) {
         return fail(
             EX_TEBAKO_UNAVAILABLE,
             format!(

--- a/crates/tebako-shim/src/resolve.rs
+++ b/crates/tebako-shim/src/resolve.rs
@@ -3,12 +3,21 @@
 //! 0. argv0 is the selector: command name → the installed payload whose
 //!    manifest provides an entrypoint of that name (multi-command suites:
 //!    N shims → one payload, each entry resolved independently).
+//!
+//! 0.5. PROVIDER ROUTING (the 2026-09-05 amendment): the chain VALUE
+//!    grammar is `[payload@]version` (`tpkg::toolpin` is the SSOT parser).
+//!    A payload-qualified value makes the named payload THE provider; the
+//!    provider scan skips claims disabled at `<payload>@all` /
+//!    `<payload>@version`; a registry never routes commands.
+//!
 //! 1. Payload VERSION resolution, first match wins:
 //!    `TEBAKO_<TOOL>_VERSION` env → nearest `.tebako-tools.yaml` walking
 //!    up from cwd → user default (`~/.tebako/config.yaml` `defaults:`,
-//!    written by `tebako use`) → registry `default:` (spec 04 §2).
+//!    written by `tebako-shim use`) → registry `default:` (spec 04 §2).
 
 use std::path::{Path, PathBuf};
+
+use tpkg::toolpin::ToolPin;
 
 use crate::config;
 use crate::manifest::{self, Manifest, PayloadRecord};
@@ -38,6 +47,28 @@ impl std::fmt::Display for VersionSource {
     }
 }
 
+/// How the provider payload was chosen (spec 07 §2 step 0.5; `which` /
+/// `list` render it).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderKind {
+    /// The payload declares the command as its own entrypoint.
+    Own,
+    /// The payload EXPOSES the command through a spawn edge (spec 30/32).
+    Exposed,
+    /// A payload-qualified chain pin named this payload THE provider.
+    Pinned,
+}
+
+impl std::fmt::Display for ProviderKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProviderKind::Own => f.write_str("own"),
+            ProviderKind::Exposed => f.write_str("exposed"),
+            ProviderKind::Pinned => f.write_str("pinned"),
+        }
+    }
+}
+
 /// The fully resolved dispatch target.
 #[derive(Debug)]
 pub struct Resolution {
@@ -48,6 +79,8 @@ pub struct Resolution {
     pub payload_name: String,
     pub version: String,
     pub source: VersionSource,
+    /// How the provider was chosen (spec 07 §2 step 0.5).
+    pub provider: ProviderKind,
     pub record: PayloadRecord,
     pub manifest: Manifest,
     /// spec 30 §3 + spec 32 §3: when the command resolved through the
@@ -90,14 +123,30 @@ enum Provider {
     Exposed(String),
 }
 
+/// The corrected collision hint (spec 07 §7, 2026-09-05 amendment): the
+/// routing verbs, not a dangling "remove one".
+fn routing_hint(tool: &str) -> String {
+    format!(
+        "pin `{tool}: <payload>@<version>` in .tebako-tools.yaml, or disable one claim (`tebako-shim disable {tool} --of <payload>`)"
+    )
+}
+
 /// Command name → payload name. Fast path: a payload of the same name.
 /// Suite path: scan every installed payload's manifest mirror for an
 /// entrypoint of this name (spec 07 §2.0 multi-command suites). Only when
 /// NO payload declares the entrypoint does the expose surface answer
-/// (spec 30 §3).
-fn providing_payload(home: &Path, tool: &str) -> Result<Provider, ShimError> {
+/// (spec 30 §3). The scan skips claims disabled at `all` / `<payload>@all`
+/// (spec 07 §2 step 0.5); the collision error fires among ENABLED claims
+/// only — a sole-but-disabled claim falls through to resolve_named's
+/// per-version refusal (the historical shape), several all-disabled
+/// claims answer the no-provider error.
+fn providing_payload(
+    home: &Path,
+    tool: &str,
+    disabled: &config::Disabled,
+) -> Result<Provider, ShimError> {
     manifest::check_path_component("command name", tool)?;
-    if home.join("payloads").join(tool).is_dir() {
+    if home.join("payloads").join(tool).is_dir() && !config::claim_disabled(disabled, tool, tool) {
         return Ok(Provider::Own(tool.to_string()));
     }
     let payloads_dir = home.join("payloads");
@@ -132,27 +181,47 @@ fn providing_payload(home: &Path, tool: &str) -> Result<Provider, ShimError> {
             }
         }
     }
-    match providers.len() {
-        1 => return Ok(Provider::Own(providers.pop().unwrap_or_default())),
-        n if n > 1 => {
+    let enabled: Vec<&String> = providers
+        .iter()
+        .filter(|p| !config::claim_disabled(disabled, tool, p))
+        .collect();
+    match (enabled.len(), providers.len()) {
+        (1, _) => return Ok(Provider::Own(enabled[0].clone())),
+        (0, 1) => return Ok(Provider::Own(providers[0].clone())),
+        (0, _) => {}
+        _ => {
             return fail(
                 EX_TEBAKO_MANIFEST,
                 format!(
-                    "command \"{tool}\" is provided by more than one installed payload ({}) — remove one, or pin the payload with .tebako-tools.yaml",
-                    providers.join(", ")
+                    "command \"{tool}\" is provided by more than one installed payload ({}) — {}",
+                    enabled
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    routing_hint(tool)
                 ),
             )
         }
-        _ => {}
     }
-    match exposers.len() {
-        0 => Err(no_provider(home, tool)),
-        1 => Ok(Provider::Exposed(exposers.pop().unwrap_or_default())),
+    let enabled_ex: Vec<&String> = exposers
+        .iter()
+        .filter(|p| !config::claim_disabled(disabled, tool, p))
+        .collect();
+    match (enabled_ex.len(), exposers.len()) {
+        (1, _) => Ok(Provider::Exposed(enabled_ex[0].clone())),
+        (0, 1) => Ok(Provider::Exposed(exposers[0].clone())),
+        (0, _) => Err(no_provider(home, tool)),
         _ => fail(
             EX_TEBAKO_MANIFEST,
             format!(
-                "command \"{tool}\" is exposed by more than one installed payload ({}) — remove one, or pin the payload with .tebako-tools.yaml",
-                exposers.join(", ")
+                "command \"{tool}\" is exposed by more than one installed payload ({}) — {}",
+                enabled_ex
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                routing_hint(tool)
             ),
         ),
     }
@@ -216,11 +285,120 @@ fn project_pin(start: &Path, tool: &str) -> Result<Option<(String, PathBuf)>, Sh
     Ok(None)
 }
 
+/// The chain's first three links (env → project pin → config default),
+/// parsed as ONE `[payload@]version` value (the registry default is
+/// payload-keyed and stays in [`resolve_named`]). An unparseable value is
+/// a NAMED grammar error naming the link and value (spec 07 §0/§7 —
+/// spec 23 §14's env-parse rule extended to every link), never a silent
+/// skip.
+pub fn chain_pick(
+    tool: &str,
+    ctx: &Ctx,
+    cfg: &config::UserConfig,
+) -> Result<Option<(ToolPin, VersionSource)>, ShimError> {
+    let var = version_env_var(tool);
+    let raw: Option<(String, VersionSource)> =
+        if let Some(v) = ctx.env_get(&var).filter(|v| !v.is_empty()) {
+            Some((v.to_string(), VersionSource::Env(var.clone())))
+        } else if let Some((v, path)) = project_pin(&ctx.cwd, tool)? {
+            Some((v, VersionSource::ProjectFile(path)))
+        } else {
+            cfg.defaults
+                .get(tool)
+                .filter(|v| !v.is_empty())
+                .map(|v| (v.clone(), VersionSource::UserDefault))
+        };
+    match raw {
+        Some((value, source)) => {
+            let pin = ToolPin::parse(&value)
+                .map_err(|e| ShimError::new(EX_TEBAKO_MANIFEST, format!("{source}: {e}")))?;
+            Ok(Some((pin, source)))
+        }
+        None => Ok(None),
+    }
+}
+
+/// The expose edge of `m` that names `tool` (spec 30 §3 + spec 32 §3).
+fn expose_edge(m: &Manifest, tool: &str) -> Option<tpkg::Requirement> {
+    m.requires()
+        .iter()
+        .find(|r| {
+            let expose = match r {
+                tpkg::Requirement::Runtime { expose, .. } => expose,
+                tpkg::Requirement::Executable { expose, .. } => expose,
+                _ => return false,
+            };
+            expose.iter().any(|e| e == tool)
+        })
+        .cloned()
+}
+
 /// Resolve the dispatch target for `tool` through the full chain.
 pub fn resolve(tool: &str, ctx: &Ctx) -> Result<Resolution, ShimError> {
-    match providing_payload(&ctx.home, tool)? {
+    let cfg = config::load_config(&ctx.home)?;
+    // The routing amendment reads the chain FIRST (spec 07 §2 step 0.5):
+    // a payload-qualified value won BOTH dimensions — the provider is the
+    // named payload, the version is the pin's, and the remaining links
+    // are not consulted for this dispatch.
+    if let Some((pin, source)) = chain_pick(tool, ctx, &cfg)? {
+        if let Some(payload_name) = pin.payload.clone() {
+            return resolve_pinned(tool, &payload_name, &pin, source, ctx);
+        }
+        // Unqualified: the value is a bare version — pre-seed today's
+        // flow (identical to the chain's first match, already parsed).
+        return resolve_scanned(tool, ctx, Some((pin.version, source)));
+    }
+    resolve_scanned(tool, ctx, None)
+}
+
+/// The qualified-pin route: the named payload IS the provider — it must
+/// be installed (resolve_named's existing named errors) and DECLARE or
+/// EXPOSE the command, else NotAProvider.
+fn resolve_pinned(
+    tool: &str,
+    payload_name: &str,
+    pin: &ToolPin,
+    source: VersionSource,
+    ctx: &Ctx,
+) -> Result<Resolution, ShimError> {
+    manifest::check_path_component("payload name", payload_name)?;
+    let mut res = resolve_named(
+        tool,
+        payload_name,
+        ctx,
+        Some((pin.version.clone(), source.clone())),
+    )?;
+    res.provider = ProviderKind::Pinned;
+    if res.manifest.entrypoint(tool).is_some() {
+        return Ok(res);
+    }
+    match expose_edge(&res.manifest, tool) {
+        Some(edge) => {
+            res.exposed = Some(edge);
+            Ok(res)
+        }
+        None => fail(
+            EX_TEBAKO_MANIFEST,
+            format!(
+                "pin \"{pin}\" (from {source}): payload \"{payload_name}\" {version} neither declares nor exposes the command \"{tool}\" (NotAProvider)\n  the qualified form pins a PROVIDER — name one of the payloads claiming \"{tool}\", or pin the bare version",
+                version = res.version,
+            ),
+        ),
+    }
+}
+
+/// Today's flow: the provider scan (fast path → suite scan → expose
+/// scan), with the amendment's disabled-claim skips.
+fn resolve_scanned(
+    tool: &str,
+    ctx: &Ctx,
+    preseed: Option<(String, VersionSource)>,
+) -> Result<Resolution, ShimError> {
+    let disabled = config::load_disabled(&ctx.home)?;
+    match providing_payload(&ctx.home, tool, &disabled)? {
         Provider::Own(payload_name) => {
-            let res = resolve_named(tool, &payload_name, ctx)?;
+            let mut res = resolve_named(tool, &payload_name, ctx, preseed)?;
+            res.provider = ProviderKind::Own;
             if res.manifest.entrypoint(tool).is_none() {
                 return fail(
                     EX_TEBAKO_MANIFEST,
@@ -234,23 +412,11 @@ pub fn resolve(tool: &str, ctx: &Ctx) -> Result<Resolution, ShimError> {
             Ok(res)
         }
         Provider::Exposed(payload_name) => {
-            let mut res = resolve_named(tool, &payload_name, ctx)?;
+            let mut res = resolve_named(tool, &payload_name, ctx, preseed)?;
+            res.provider = ProviderKind::Exposed;
             // The edge comes from the PICKED version's manifest — the
             // exposing scan established the payload, not the version.
-            let edge = res
-                .manifest
-                .requires()
-                .iter()
-                .find(|r| {
-                    let expose = match r {
-                        tpkg::Requirement::Runtime { expose, .. } => expose,
-                        tpkg::Requirement::Executable { expose, .. } => expose,
-                        _ => return false,
-                    };
-                    expose.iter().any(|e| e == tool)
-                })
-                .cloned();
-            match edge {
+            match expose_edge(&res.manifest, tool) {
                 Some(edge) => {
                     res.exposed = Some(edge);
                     Ok(res)
@@ -279,13 +445,22 @@ pub fn resolve_payload(payload_name: &str, ctx: &Ctx) -> Result<Resolution, Shim
     if !ctx.home.join("payloads").join(payload_name).is_dir() {
         return Err(no_provider(&ctx.home, payload_name));
     }
-    resolve_named(payload_name, payload_name, ctx)
+    let mut res = resolve_named(payload_name, payload_name, ctx, None)?;
+    res.provider = ProviderKind::Own;
+    Ok(res)
 }
 
 /// The shared resolution tail: version chain → disabled gate → record →
 /// mirror load. `tool` keys the version chain (env var, project pin,
-/// defaults); `payload_name` keys the store record.
-fn resolve_named(tool: &str, payload_name: &str, ctx: &Ctx) -> Result<Resolution, ShimError> {
+/// defaults); `payload_name` keys the store record. `preseed` carries an
+/// already-resolved (version, source) — the routing amendment's pin won
+/// the chain, so no link (registry default included) is consulted again.
+fn resolve_named(
+    tool: &str,
+    payload_name: &str,
+    ctx: &Ctx,
+    preseed: Option<(String, VersionSource)>,
+) -> Result<Resolution, ShimError> {
     manifest::check_path_component("payload name", payload_name)?;
     let installed = installed_versions(&ctx.home, payload_name)?;
     if installed.is_empty() {
@@ -300,31 +475,35 @@ fn resolve_named(tool: &str, payload_name: &str, ctx: &Ctx) -> Result<Resolution
 
     let cfg = config::load_config(&ctx.home)?;
 
-    // The chain, first match wins (spec 07 §2.1).
-    let mut picked: Option<(String, VersionSource)> = None;
+    // The chain, first match wins (spec 07 §2.1). A preseed (the
+    // amendment's pin) won it already; otherwise the four links run.
+    let mut picked: Option<(String, VersionSource)> = preseed;
 
-    // 1. TEBAKO_<TOOL>_VERSION
     let var = version_env_var(tool);
-    if let Some(version) = ctx.env_get(&var).filter(|v| !v.is_empty()) {
-        picked = Some((version.to_string(), VersionSource::Env(var.clone())));
-    }
-    // 2. nearest .tebako-tools.yaml walking up from cwd
     if picked.is_none() {
-        if let Some((version, path)) = project_pin(&ctx.cwd, tool)? {
-            picked = Some((version, VersionSource::ProjectFile(path)));
+        // 1. TEBAKO_<TOOL>_VERSION
+        if let Some(version) = ctx.env_get(&var).filter(|v| !v.is_empty()) {
+            picked = Some((version.to_string(), VersionSource::Env(var.clone())));
         }
-    }
-    // 3. user default (tebako use <tool>@<version>)
-    if picked.is_none() {
-        if let Some(version) = cfg.defaults.get(tool).filter(|v| !v.is_empty()) {
-            picked = Some((version.clone(), VersionSource::UserDefault));
+        // 2. nearest .tebako-tools.yaml walking up from cwd
+        if picked.is_none() {
+            if let Some((version, path)) = project_pin(&ctx.cwd, tool)? {
+                picked = Some((version, VersionSource::ProjectFile(path)));
+            }
         }
-    }
-    // 4. registry default
-    if picked.is_none() {
-        if let Some((version, reg)) = config::registry_default(&ctx.home, &cfg, payload_name, ctx)?
-        {
-            picked = Some((version, VersionSource::RegistryDefault(reg)));
+        // 3. user default (tebako-shim use <tool> <pin>)
+        if picked.is_none() {
+            if let Some(version) = cfg.defaults.get(tool).filter(|v| !v.is_empty()) {
+                picked = Some((version.clone(), VersionSource::UserDefault));
+            }
+        }
+        // 4. registry default
+        if picked.is_none() {
+            if let Some((version, reg)) =
+                config::registry_default(&ctx.home, &cfg, payload_name, ctx)?
+            {
+                picked = Some((version, VersionSource::RegistryDefault(reg)));
+            }
         }
     }
 
@@ -332,7 +511,7 @@ fn resolve_named(tool: &str, payload_name: &str, ctx: &Ctx) -> Result<Resolution
         ShimError::new(
             EX_TEBAKO_UNAVAILABLE,
             format!(
-                "no version resolved for \"{tool}\" — the chain found nothing:\n  TEBAKO_{} env: unset\n  .tebako-tools.yaml from {}: none pins it\n  ~/.tebako/config.yaml defaults: none\n  registry default: none\n  pin a version (`tebako use {tool}@<version>`) or install one; installed: {}",
+                "no version resolved for \"{tool}\" — the chain found nothing:\n  TEBAKO_{} env: unset\n  .tebako-tools.yaml from {}: none pins it\n  ~/.tebako/config.yaml defaults: none\n  registry default: none\n  pin a version (`tebako-shim use {tool} <version>`) or install one; installed: {}",
                 var.trim_start_matches("TEBAKO_"),
                 ctx.cwd.display(),
                 installed.join(", ")
@@ -379,6 +558,7 @@ fn resolve_named(tool: &str, payload_name: &str, ctx: &Ctx) -> Result<Resolution
         payload_name: payload_name.to_string(),
         version,
         source,
+        provider: ProviderKind::Own, // the caller stamps the real kind
         record,
         manifest,
         exposed: None,

--- a/crates/tebako-shim/src/runtime.rs
+++ b/crates/tebako-shim/src/runtime.rs
@@ -142,7 +142,16 @@ pub fn resolve_runtime(
     // pin: the release index on the default line picks the newest
     // interpreter satisfying the constraint for this platform.
     let (pref_owned, prefless) = match pref {
-        Some(p) => (p.clone(), false),
+        Some(p) => {
+            let mut p = p.clone();
+            if p.tebako.is_empty() {
+                // `tebako-shim use --runtime <engine>@<langver>` without
+                // `:<tebako>` pins the language version and follows the
+                // product default line (config.rs RuntimePref::tebako).
+                p.tebako = tebako_resolve::DEFAULT_TEBAKO_VERSION.to_string();
+            }
+            (p, false)
+        }
         None => (
             RuntimePref {
                 version: String::new(),

--- a/crates/tebako-shim/tests/manage.rs
+++ b/crates/tebako-shim/tests/manage.rs
@@ -31,6 +31,47 @@ fn seed(home: &std::path::Path) {
     write_runtime(home, "4.0.6", "0.16.0", false);
 }
 
+#[test]
+fn disabled_selectors_gain_the_payload_dimension() {
+    use tebako_shim::config::{claim_disabled, is_disabled, Disabled};
+    let mut disabled = Disabled::default();
+    // a bare version gates that version of ANY claim
+    disabled.insert("pandoc".to_string(), vec!["1.0".to_string()]);
+    assert!(is_disabled(&disabled, "pandoc", "anypayload", "1.0"));
+    assert!(!is_disabled(&disabled, "pandoc", "anypayload", "1.1"));
+    assert!(!claim_disabled(&disabled, "pandoc", "anypayload"));
+    // `all` gates every claim
+    disabled.insert("pandoc".to_string(), vec!["all".to_string()]);
+    assert!(is_disabled(&disabled, "pandoc", "p", "9.9"));
+    assert!(claim_disabled(&disabled, "pandoc", "p"));
+    // p@all gates only payload p's claim
+    disabled.insert("pandoc".to_string(), vec!["pandorc@all".to_string()]);
+    assert!(is_disabled(&disabled, "pandoc", "pandorc", "1.2.0"));
+    assert!(!is_disabled(&disabled, "pandoc", "pandora", "1.2.0"));
+    assert!(claim_disabled(&disabled, "pandoc", "pandorc"));
+    assert!(!claim_disabled(&disabled, "pandoc", "pandora"));
+    // p@1.0 gates exactly that pair (and is not a full-claim gate)
+    disabled.insert("pandoc".to_string(), vec!["pandorc@1.0".to_string()]);
+    assert!(is_disabled(&disabled, "pandoc", "pandorc", "1.0"));
+    assert!(!is_disabled(&disabled, "pandoc", "pandorc", "1.1"));
+    assert!(!claim_disabled(&disabled, "pandoc", "pandorc"));
+}
+
+#[test]
+fn an_unknown_selector_string_is_a_named_load_error() {
+    let tmp = TempDir::new("bad-selector");
+    let home = tmp.path().join("home");
+    std::fs::create_dir_all(home.join("shims")).unwrap();
+    std::fs::write(
+        home.join("shims").join(".disabled.yaml"),
+        "pandoc:\n  - \"bogus@\"\n",
+    )
+    .unwrap();
+    let err = tebako_shim::config::load_disabled(&home).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_MANIFEST);
+    assert!(err.message.contains("bogus@"), "{}", err.message);
+}
+
 fn pinned_ctx(home: &std::path::Path, cwd: &std::path::Path) -> Ctx {
     let mut ctx = ctx(home, cwd);
     ctx.env

--- a/crates/tebako-shim/tests/manage.rs
+++ b/crates/tebako-shim/tests/manage.rs
@@ -388,3 +388,332 @@ fn link_and_unlink_use_the_platform_shim_name() {
     assert_eq!(removed, vec![home.join("shims").join(want)]);
     assert!(!home.join("shims").join(want).exists());
 }
+
+// ---------------------------------------------------------------------
+// The verb surface of the 2026-09-05 routing amendment (spec 07 §3):
+// use / enable|disable --of / list --json / which provider / doctor.
+// ---------------------------------------------------------------------
+
+fn seed_two_providers(home: &std::path::Path) {
+    write_payload(
+        home,
+        "pandora",
+        "1.0.0",
+        &app_manifest("pandora", "1.0.0", &entrypoint_yaml(RUBY_ENTRY, "pandoc")),
+    );
+    write_payload(
+        home,
+        "pandorc",
+        "1.2.0",
+        &app_manifest("pandorc", "1.2.0", &entrypoint_yaml(RUBY_ENTRY, "pandoc")),
+    );
+    write_runtime(home, "4.0.6", "0.16.0", false);
+}
+
+#[test]
+fn use_writes_clears_and_preserves_the_authored_config() {
+    let tmp = TempDir::new("use-roundtrip");
+    let home = tmp.path().join("home");
+    write_config(
+        &home,
+        "registries:\n  - file:///opt/lib/tpkg-registry.yaml\ndefaults: {other: 9.9}\n",
+    );
+    let ctx = ctx(&home, tmp.path());
+
+    // use <tool> <pin> writes the qualified default
+    let (text, code) = printed(run_ok(
+        &[
+            "tebako-shim".into(),
+            "use".into(),
+            "pandoc".into(),
+            "pandorc@1.2.0".into(),
+        ],
+        &ctx,
+    ));
+    assert_eq!(code, 0, "{text}");
+    let cfg = tebako_shim::config::load_config(&home).unwrap();
+    assert_eq!(
+        cfg.defaults.get("pandoc").map(String::as_str),
+        Some("pandorc@1.2.0")
+    );
+    assert_eq!(cfg.defaults.get("other").map(String::as_str), Some("9.9"));
+    assert_eq!(
+        cfg.registries,
+        vec!["file:///opt/lib/tpkg-registry.yaml".to_string()]
+    );
+
+    // a second use edits in place
+    run_ok(
+        &[
+            "tebako-shim".into(),
+            "use".into(),
+            "pandoc".into(),
+            "1.0.0".into(),
+        ],
+        &ctx,
+    );
+    let cfg = tebako_shim::config::load_config(&home).unwrap();
+    assert_eq!(
+        cfg.defaults.get("pandoc").map(String::as_str),
+        Some("1.0.0")
+    );
+
+    // --clear removes exactly the key
+    run_ok(
+        &[
+            "tebako-shim".into(),
+            "use".into(),
+            "--clear".into(),
+            "pandoc".into(),
+        ],
+        &ctx,
+    );
+    let cfg = tebako_shim::config::load_config(&home).unwrap();
+    assert!(!cfg.defaults.contains_key("pandoc"));
+    assert_eq!(cfg.defaults.get("other").map(String::as_str), Some("9.9"));
+
+    // an unparseable pin is the named grammar error, and writes nothing
+    let err = tebako_shim::run(
+        &[
+            "tebako-shim".into(),
+            "use".into(),
+            "pandoc".into(),
+            "pandorc@".into(),
+        ],
+        &ctx,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_MANIFEST);
+    assert!(err.message.contains("pandorc@"), "{}", err.message);
+    let cfg = tebako_shim::config::load_config(&home).unwrap();
+    assert!(!cfg.defaults.contains_key("pandoc"));
+}
+
+#[test]
+fn use_runtime_writes_the_runtimes_preference() {
+    let tmp = TempDir::new("use-runtime");
+    let home = tmp.path().join("home");
+    let ctx = ctx(&home, tmp.path());
+
+    run_ok(
+        &[
+            "tebako-shim".into(),
+            "use".into(),
+            "--runtime".into(),
+            "ruby@3.4.2".into(),
+        ],
+        &ctx,
+    );
+    let cfg = tebako_shim::config::load_config(&home).unwrap();
+    assert_eq!(
+        cfg.runtimes.get("ruby").map(|r| r.version.as_str()),
+        Some("3.4.2")
+    );
+
+    // the full form pins the tebako (launcher abi) line too
+    run_ok(
+        &[
+            "tebako-shim".into(),
+            "use".into(),
+            "--runtime".into(),
+            "ruby@3.4.2:2.2.0".into(),
+        ],
+        &ctx,
+    );
+    let cfg = tebako_shim::config::load_config(&home).unwrap();
+    let pref = cfg.runtimes.get("ruby").expect("ruby pref");
+    assert_eq!(pref.version, "3.4.2");
+    assert_eq!(pref.tebako, "2.2.0");
+
+    // no engine is a usage error
+    let err = tebako_shim::run(
+        &[
+            "tebako-shim".into(),
+            "use".into(),
+            "--runtime".into(),
+            "3.4.2".into(),
+        ],
+        &ctx,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_USAGE);
+}
+
+#[test]
+fn disable_of_writes_the_qualified_selector() {
+    let tmp = TempDir::new("disable-of");
+    let home = tmp.path().join("home");
+    seed_two_providers(&home);
+    // the env pin lets enable's link-on-demand resolve (spec 07 §3)
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env
+        .insert("TEBAKO_PANDOC_VERSION".into(), "1.0.0".into());
+
+    // --of alone → payload@all
+    let (text, _) = printed(run_ok(
+        &[
+            "tebako-shim".into(),
+            "disable".into(),
+            "pandoc".into(),
+            "--of".into(),
+            "pandorc".into(),
+        ],
+        &ctx,
+    ));
+    assert!(text.contains("pandorc@all"), "{text}");
+    let disabled = tebako_shim::config::load_disabled(&home).unwrap();
+    assert_eq!(
+        disabled.get("pandoc"),
+        Some(&vec!["pandorc@all".to_string()])
+    );
+
+    // <tool>@<version> --of → payload@version
+    run_ok(
+        &[
+            "tebako-shim".into(),
+            "disable".into(),
+            "pandoc@1.2.0".into(),
+            "--of".into(),
+            "pandorc".into(),
+        ],
+        &ctx,
+    );
+    let disabled = tebako_shim::config::load_disabled(&home).unwrap();
+    assert_eq!(
+        disabled.get("pandoc"),
+        Some(&vec![
+            "pandorc@all".to_string(),
+            "pandorc@1.2.0".to_string()
+        ])
+    );
+
+    // enable drops exactly the computed selector
+    run_ok(
+        &[
+            "tebako-shim".into(),
+            "enable".into(),
+            "pandoc@1.2.0".into(),
+            "--of".into(),
+            "pandorc".into(),
+        ],
+        &ctx,
+    );
+    let disabled = tebako_shim::config::load_disabled(&home).unwrap();
+    assert_eq!(
+        disabled.get("pandoc"),
+        Some(&vec!["pandorc@all".to_string()])
+    );
+}
+
+#[test]
+fn list_json_is_a_machine_document_with_provider_fields() {
+    let tmp = TempDir::new("list-json");
+    let home = tmp.path().join("home");
+    seed(&home);
+    let ctx = pinned_ctx(&home, tmp.path());
+
+    let (text, code) = printed(run_ok(
+        &["tebako-shim".into(), "list".into(), "--json".into()],
+        &ctx,
+    ));
+    assert_eq!(code, 0, "{text}");
+    let doc = tebako_json::parse(&text).expect("list --json parses as JSON");
+    assert_eq!(doc.find("info_schema").and_then(|v| v.as_u64()), Some(1));
+    let commands = doc.find("commands").expect("commands");
+    let tebako_json::Value::Array(commands) = commands else {
+        panic!("commands is an array");
+    };
+    let cmd = commands
+        .iter()
+        .find(|c| c.find("name").and_then(|v| v.as_string()).as_deref() == Some("metanorma"))
+        .expect("the metanorma command entry");
+    assert_eq!(
+        cmd.find("provider").and_then(|v| v.as_string()).as_deref(),
+        Some("metanorma")
+    );
+    assert_eq!(
+        cmd.find("provider_kind")
+            .and_then(|v| v.as_string())
+            .as_deref(),
+        Some("own")
+    );
+    assert_eq!(
+        cmd.find("version").and_then(|v| v.as_string()).as_deref(),
+        Some("1.2.3")
+    );
+    assert!(
+        cmd.find("source")
+            .and_then(|v| v.as_string())
+            .is_some_and(|s| s.contains("TEBAKO_METANORMA_VERSION")),
+        "the source string"
+    );
+}
+
+#[test]
+fn which_names_the_provider_and_its_kind() {
+    let tmp = TempDir::new("which-provider");
+    let home = tmp.path().join("home");
+    seed(&home);
+    let ctx = pinned_ctx(&home, tmp.path());
+
+    let (text, code) = printed(run_ok(
+        &["tebako-shim".into(), "which".into(), "metanorma".into()],
+        &ctx,
+    ));
+    assert_eq!(code, 0);
+    assert!(text.contains("provider: metanorma (own)"), "{text}");
+}
+
+#[test]
+fn which_shows_the_qualified_source_when_pinned() {
+    let tmp = TempDir::new("which-pinned");
+    let home = tmp.path().join("home");
+    let proj = tmp.path().join("proj");
+    std::fs::create_dir_all(&proj).unwrap();
+    seed_two_providers(&home);
+    std::fs::write(proj.join(".tebako-tools.yaml"), "pandoc: pandorc@1.2.0\n").unwrap();
+    let ctx = ctx(&home, &proj);
+
+    let (text, code) = printed(run_ok(
+        &["tebako-shim".into(), "which".into(), "pandoc".into()],
+        &ctx,
+    ));
+    assert_eq!(code, 0, "{text}");
+    assert!(text.contains("provider: pandorc (pinned)"), "{text}");
+    assert!(text.contains("pandorc@1.2.0"), "{text}");
+}
+
+#[test]
+fn doctor_reports_collisions_dangling_pins_and_disabled_but_pinned() {
+    let tmp = TempDir::new("doctor-routing");
+    let home = tmp.path().join("home");
+    seed_two_providers(&home);
+    let shims = home.join("shims");
+    std::fs::create_dir_all(&shims).unwrap();
+    std::fs::write(shims.join("pandoc"), b"shim link placeholder\n").unwrap();
+    std::fs::write(shims.join(".disabled.yaml"), "pandoc:\n  - pandora@1.0.0\n").unwrap();
+    write_config(
+        &home,
+        "defaults: {pandoc: \"pandora@1.0.0\", ghost: \"ghostcmd@9.9\"}\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "PATH".into(),
+        std::env::join_paths([&shims, std::path::Path::new("/usr/bin")])
+            .unwrap()
+            .to_string_lossy()
+            .into_owned(),
+    );
+
+    let (text, _code) = printed(run_ok(&["tebako-shim".into(), "doctor".into()], &ctx));
+    assert!(text.contains("more than one enabled"), "{text}");
+    assert!(text.contains("ghostcmd@9.9"), "{text}");
+    assert!(
+        text.contains("dangling") || text.contains("not installed"),
+        "{text}"
+    );
+    assert!(
+        text.contains("disabled") && text.contains("pandora@1.0.0"),
+        "{text}"
+    );
+}

--- a/crates/tebako-shim/tests/resolve.rs
+++ b/crates/tebako-shim/tests/resolve.rs
@@ -220,3 +220,237 @@ fn suite_commands_map_to_their_own_payload() {
         "/app/bin/beta"
     );
 }
+
+// ---------------------------------------------------------------------
+// The 2026-09-05 routing amendment (spec 07 §2 step 0.5): qualified
+// `[payload@]version` pins + per-payload disable route the PROVIDER.
+// ---------------------------------------------------------------------
+
+fn seed_two_providers(home: &std::path::Path) {
+    write_payload(
+        home,
+        "pandora",
+        "1.0.0",
+        &app_manifest("pandora", "1.0.0", &entrypoint_yaml(NATIVE_ENTRY, "pandoc")),
+    );
+    write_payload(
+        home,
+        "pandorc",
+        "1.2.0",
+        &app_manifest("pandorc", "1.2.0", &entrypoint_yaml(NATIVE_ENTRY, "pandoc")),
+    );
+}
+
+fn write_disabled(home: &std::path::Path, yaml: &str) {
+    let shims = home.join("shims");
+    std::fs::create_dir_all(&shims).unwrap();
+    std::fs::write(shims.join(".disabled.yaml"), yaml).unwrap();
+}
+
+#[test]
+fn two_providers_unqualified_is_the_collision_error_with_the_routing_hint() {
+    let tmp = TempDir::new("collision");
+    let home = tmp.path().join("home");
+    seed_two_providers(&home);
+    let err = resolve::resolve("pandoc", &ctx(&home, tmp.path())).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_MANIFEST);
+    assert!(err.message.contains("more than one"), "{}", err.message);
+    assert!(
+        err.message.contains("pandoc: <payload>@<version>"),
+        "{}",
+        err.message
+    );
+    assert!(
+        err.message
+            .contains("tebako-shim disable pandoc --of <payload>"),
+        "{}",
+        err.message
+    );
+}
+
+#[test]
+fn a_qualified_project_pin_routes_the_named_provider() {
+    let tmp = TempDir::new("pin-project");
+    let home = tmp.path().join("home");
+    let proj = tmp.path().join("proj");
+    std::fs::create_dir_all(&proj).unwrap();
+    seed_two_providers(&home);
+    std::fs::write(proj.join(".tebako-tools.yaml"), "pandoc: pandorc@1.2.0\n").unwrap();
+
+    let res = resolve::resolve("pandoc", &ctx(&home, &proj)).unwrap();
+    assert_eq!(res.payload_name, "pandorc");
+    assert_eq!(res.version, "1.2.0");
+    assert!(matches!(res.source, VersionSource::ProjectFile(_)));
+    assert!(matches!(res.provider, resolve::ProviderKind::Pinned));
+}
+
+#[test]
+fn an_qualified_env_pin_overrides_the_project_pin() {
+    let tmp = TempDir::new("pin-env");
+    let home = tmp.path().join("home");
+    let proj = tmp.path().join("proj");
+    std::fs::create_dir_all(&proj).unwrap();
+    seed_two_providers(&home);
+    std::fs::write(proj.join(".tebako-tools.yaml"), "pandoc: pandorc@1.2.0\n").unwrap();
+    let mut ctx = ctx(&home, &proj);
+    ctx.env
+        .insert("TEBAKO_PANDOC_VERSION".into(), "pandora@1.0.0".into());
+
+    let res = resolve::resolve("pandoc", &ctx).unwrap();
+    assert_eq!(res.payload_name, "pandora");
+    assert_eq!(res.version, "1.0.0");
+    assert!(matches!(res.source, VersionSource::Env(_)));
+}
+
+#[test]
+fn a_pin_naming_a_non_provider_is_the_notaprovider_error() {
+    let tmp = TempDir::new("pin-notaprovider");
+    let home = tmp.path().join("home");
+    let proj = tmp.path().join("proj");
+    std::fs::create_dir_all(&proj).unwrap();
+    seed_two_providers(&home);
+    write_payload(
+        &home,
+        "othertools",
+        "9.9",
+        &app_manifest("othertools", "9.9", &entrypoint_yaml(NATIVE_ENTRY, "other")),
+    );
+    std::fs::write(proj.join(".tebako-tools.yaml"), "pandoc: othertools@9.9\n").unwrap();
+
+    let err = resolve::resolve("pandoc", &ctx(&home, &proj)).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_MANIFEST);
+    assert!(err.message.contains("othertools@9.9"), "{}", err.message);
+    assert!(err.message.contains("NotAProvider"), "{}", err.message);
+    assert!(err.message.contains("pandoc"), "{}", err.message);
+}
+
+#[test]
+fn a_pin_naming_an_uninstalled_version_is_the_not_installed_error() {
+    let tmp = TempDir::new("pin-uninstalled");
+    let home = tmp.path().join("home");
+    let proj = tmp.path().join("proj");
+    std::fs::create_dir_all(&proj).unwrap();
+    seed_two_providers(&home);
+    std::fs::write(proj.join(".tebako-tools.yaml"), "pandoc: pandorc@9.9.9\n").unwrap();
+
+    let err = resolve::resolve("pandoc", &ctx(&home, &proj)).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_MANIFEST);
+    assert!(err.message.contains("9.9.9"), "{}", err.message);
+    assert!(err.message.contains("not installed"), "{}", err.message);
+}
+
+#[test]
+fn an_unparseable_chain_value_is_the_named_grammar_error() {
+    let tmp = TempDir::new("pin-bad");
+    let home = tmp.path().join("home");
+    seed_metanorma(&home);
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env
+        .insert("TEBAKO_METANORMA_VERSION".into(), "metanorma@".into());
+    let err = resolve::resolve("metanorma", &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_MANIFEST);
+    assert!(
+        err.message.contains("TEBAKO_METANORMA_VERSION"),
+        "{}",
+        err.message
+    );
+    assert!(err.message.contains("metanorma@"), "{}", err.message);
+}
+
+#[test]
+fn disabling_all_but_one_claim_routes_without_a_pin() {
+    let tmp = TempDir::new("route-by-disable");
+    let home = tmp.path().join("home");
+    seed_two_providers(&home);
+    // `tebako-shim disable pandoc --of pandorc` writes exactly this.
+    write_disabled(&home, "pandoc:\n  - pandorc@all\n");
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env
+        .insert("TEBAKO_PANDOC_VERSION".into(), "1.0.0".into());
+
+    let res = resolve::resolve("pandoc", &ctx).unwrap();
+    assert_eq!(res.payload_name, "pandora");
+    assert_eq!(res.version, "1.0.0");
+    assert!(matches!(res.provider, resolve::ProviderKind::Own));
+}
+
+#[test]
+fn both_claims_disabled_is_the_no_provider_error() {
+    let tmp = TempDir::new("route-all-disabled");
+    let home = tmp.path().join("home");
+    seed_two_providers(&home);
+    write_disabled(&home, "pandoc:\n  - pandorc@all\n  - pandora@all\n");
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env
+        .insert("TEBAKO_PANDOC_VERSION".into(), "1.0.0".into());
+
+    let err = resolve::resolve("pandoc", &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_MANIFEST);
+    assert!(
+        err.message
+            .contains("no installed payload provides or exposes"),
+        "{}",
+        err.message
+    );
+}
+
+// spec 30 §3 exposers: the SAME routing surface (S9).
+
+const JAVA_EDGE: &str =
+    "requires:\n  - {kind: runtime, engine: java, constraint: \">= 21\", expose: [java]}\n";
+
+fn seed_two_exposers(home: &std::path::Path) {
+    for (name, version) in [("expa", "1.0.0"), ("expb", "2.0.0")] {
+        write_payload(
+            home,
+            name,
+            version,
+            &app_manifest_requires(
+                name,
+                version,
+                &entrypoint_yaml(NATIVE_ENTRY, name),
+                JAVA_EDGE,
+            ),
+        );
+    }
+}
+
+#[test]
+fn two_exposers_route_through_the_same_pin_and_disable_surface() {
+    let tmp = TempDir::new("route-exposed");
+    let home = tmp.path().join("home");
+    seed_two_exposers(&home);
+
+    // unqualified → the collision error with the routing hint
+    let err = resolve::resolve("java", &ctx(&home, tmp.path())).unwrap_err();
+    assert!(
+        err.message.contains("exposed by more than one"),
+        "{}",
+        err.message
+    );
+    assert!(
+        err.message
+            .contains("tebako-shim disable java --of <payload>"),
+        "{}",
+        err.message
+    );
+
+    // a qualified env pin routes the named exposer
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env
+        .insert("TEBAKO_JAVA_VERSION".into(), "expb@2.0.0".into());
+    let res = resolve::resolve("java", &ctx).unwrap();
+    assert_eq!(res.payload_name, "expb");
+    assert_eq!(res.version, "2.0.0");
+    assert!(matches!(res.provider, resolve::ProviderKind::Pinned));
+    assert!(res.exposed.is_some(), "the expose edge rides");
+
+    // disabling expb's claim routes to expa with a bare-version pin
+    write_disabled(&home, "java:\n  - expb@all\n");
+    let mut ctx2 = common::ctx(&home, tmp.path());
+    ctx2.env
+        .insert("TEBAKO_JAVA_VERSION".into(), "1.0.0".into());
+    let res = resolve::resolve("java", &ctx2).unwrap();
+    assert_eq!(res.payload_name, "expa");
+    assert!(matches!(res.provider, resolve::ProviderKind::Exposed));
+}

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -159,6 +159,7 @@ pub mod payload_store;
 mod region;
 pub mod runtime_store;
 pub mod settings;
+pub mod toolpin;
 pub mod versions;
 
 pub use codec::{

--- a/crates/tpkg/src/toolpin.rs
+++ b/crates/tpkg/src/toolpin.rs
@@ -1,0 +1,176 @@
+//! The `[payload@]version` grammar — the chain VALUE grammar of spec 07
+//! §2.1's version chain and the selector grammar of the disabled-state
+//! file (`~/.tebako/shims/.disabled.yaml`), ONE parser for both (spec 00
+//! invariant 10 — the grammar SSOT; every consumer flows this module).
+//!
+//! The split rule is FIRST-`@`, at most one `@`: `@` never appears in
+//! payload names or command names (the name grammar), so the split is
+//! unambiguous. The spec-32 lock row's `name@version` (`crate::package`'s
+//! digest-carrying record) is a DIFFERENT record that happens to share
+//! the same split rule; it stays where it is.
+//!
+//! A payload-only pin (`name@`) does NOT exist: an incomplete link would
+//! create cross-link partial application; route-out rides the
+//! disable-selector side (`disable <tool> --of <payload>` →
+//! `<payload>@all`).
+
+use std::fmt;
+
+/// A chain-value grammar error (the shim wraps it in
+/// `EX_TEBAKO_MANIFEST`, naming the chain link and value).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolPinError(pub String);
+
+impl fmt::Display for ToolPinError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ToolPinError {}
+
+/// A version-chain value: `version` or `payload@version` (spec 07 §2.1,
+/// 2026-09-05 routing amendment). A payload-qualified value makes the
+/// named payload THE provider — it must be installed and declare or
+/// expose the command, else the named NotAProvider error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolPin {
+    pub payload: Option<String>,
+    pub version: String,
+}
+
+impl ToolPin {
+    pub fn parse(value: &str) -> Result<ToolPin, ToolPinError> {
+        let err = |why: &str| {
+            ToolPinError(format!(
+                "invalid pin \"{value}\" ({why}) — the grammar is [payload@]version"
+            ))
+        };
+        match value.split('@').collect::<Vec<_>>().as_slice() {
+            [version] if !version.is_empty() => Ok(ToolPin {
+                payload: None,
+                version: (*version).to_string(),
+            }),
+            [payload, version] if !payload.is_empty() && !version.is_empty() => Ok(ToolPin {
+                payload: Some((*payload).to_string()),
+                version: (*version).to_string(),
+            }),
+            ["", _] => Err(err("empty payload")),
+            [_, ""] => Err(err(
+                "payload-only pins do not exist — route out with disable",
+            )),
+            [_, _, ..] => Err(err("at most one '@'")),
+            [_] => Err(err("empty version")),
+            _ => Err(err("empty value")),
+        }
+    }
+}
+
+impl fmt::Display for ToolPin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.payload {
+            Some(payload) => write!(f, "{payload}@{}", self.version),
+            None => f.write_str(&self.version),
+        }
+    }
+}
+
+/// A `.disabled.yaml` selector: which claims of a command are gated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DisableSelector {
+    /// Every claim of the command.
+    All,
+    /// Every claim AT this version, whatever the payload.
+    Version(String),
+    /// Every claim BY this payload.
+    PayloadAll(String),
+    /// Exactly this (payload, version) claim.
+    PayloadVersion(String, String),
+}
+
+impl DisableSelector {
+    pub fn parse(value: &str) -> Result<DisableSelector, ToolPinError> {
+        let err = |why: &str| {
+            ToolPinError(format!(
+                "invalid disable selector \"{value}\" ({why}) — the grammar is all | version | payload@all | payload@version"
+            ))
+        };
+        if value == "all" {
+            return Ok(DisableSelector::All);
+        }
+        match value.split('@').collect::<Vec<_>>().as_slice() {
+            [version] if !version.is_empty() => {
+                Ok(DisableSelector::Version((*version).to_string()))
+            }
+            [payload, tail] if !payload.is_empty() && !tail.is_empty() => Ok(if *tail == "all" {
+                DisableSelector::PayloadAll((*payload).to_string())
+            } else {
+                DisableSelector::PayloadVersion((*payload).to_string(), (*tail).to_string())
+            }),
+            [_, _, ..] => Err(err("at most one '@'")),
+            _ => Err(err(
+                "a selector names a version, a payload, or both — never none",
+            )),
+        }
+    }
+
+    /// Does this selector gate the claim `payload` makes at `version`?
+    pub fn matches(&self, payload: &str, version: &str) -> bool {
+        match self {
+            DisableSelector::All => true,
+            DisableSelector::Version(v) => v == version,
+            DisableSelector::PayloadAll(p) => p == payload,
+            DisableSelector::PayloadVersion(p, v) => p == payload && v == version,
+        }
+    }
+}
+
+impl fmt::Display for DisableSelector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DisableSelector::All => f.write_str("all"),
+            DisableSelector::Version(v) => f.write_str(v),
+            DisableSelector::PayloadAll(p) => write!(f, "{p}@all"),
+            DisableSelector::PayloadVersion(p, v) => write!(f, "{p}@{v}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toolpin_grammar() {
+        let p = ToolPin::parse("3.34.0").unwrap();
+        assert_eq!(p.payload, None);
+        assert_eq!(p.version, "3.34.0");
+        let q = ToolPin::parse("xml2rfc-b@3.34.0").unwrap();
+        assert_eq!(q.payload.as_deref(), Some("xml2rfc-b"));
+        assert_eq!(q.version, "3.34.0");
+        assert!(ToolPin::parse("").is_err());
+        assert!(ToolPin::parse("@3.34.0").is_err()); // empty payload
+        assert!(ToolPin::parse("xml2rfc-b@").is_err()); // payload-only pins do not exist — route-out rides disable
+        assert!(ToolPin::parse("a@b@c").is_err()); // one @ max
+    }
+
+    #[test]
+    fn disable_selector_grammar_and_matching() {
+        assert!(DisableSelector::parse("all").unwrap().matches("any", "1.0"));
+        assert!(DisableSelector::parse("3.34.0")
+            .unwrap()
+            .matches("any", "3.34.0"));
+        assert!(!DisableSelector::parse("3.34.0")
+            .unwrap()
+            .matches("any", "3.35.0"));
+        assert!(DisableSelector::parse("xml2rfc-b@all")
+            .unwrap()
+            .matches("xml2rfc-b", "9.9"));
+        assert!(!DisableSelector::parse("xml2rfc-b@all")
+            .unwrap()
+            .matches("xml2rfc", "9.9"));
+        assert!(DisableSelector::parse("a@1.0").unwrap().matches("a", "1.0"));
+        assert!(!DisableSelector::parse("a@1.0").unwrap().matches("b", "1.0"));
+        assert!(DisableSelector::parse("a@").is_err());
+    }
+}

--- a/docs/spec/00-INDEX.md
+++ b/docs/spec/00-INDEX.md
@@ -39,7 +39,7 @@ spec 02 §6).
 4. [04 — References and registries](04-references-and-registry.md) — MECE reference syntax
 5. [05 — Resolution and cache](05-resolution-and-cache.md) — runtime_ref, release index, machine cache
 6. [06 — Launcher ABI](06-launcher-abi.md) — bootstrap → runtime handoff, exit codes
-7. [07 — Shims and dispatch](07-shims-and-dispatch.md) — executable registration and version management
+7. [07 — Shims and dispatch](07-shims-and-dispatch.md) — executable registration and version management (+ the 2026-09-05 routing amendment)
 8. [08 — Jails](08-jails.md) — host-access policy, bind-mount semantics
 9. [09 — Trust and signing](09-trust-and-signing.md) — chain of trust, authenticated releases
 10. [10 — Encryption](10-encryption.md) — encrypted volumes, key model, PQC

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -10,23 +10,43 @@ spec 04 §2), and the dispatch-time registry cache ships with roadmap 33
 tebako-resolve behind `~/.tebako/registries/<sha>.yaml` — 24 h TTL,
 `tebako update-registries`, `TEBAKO_OFFLINE` = cache-or-named-error;
 `tebako add-registry` primes the cache with the bytes it fetched).
-Still PLANNED: `tebako use` writing the user default (v1: author
-`~/.tebako/config.yaml` directly), jail application (spec 08), and a
+The 2026-09-05 routing amendment (qualified pins, per-payload disable,
+`tebako-shim use`) SHIPS with this spec's PR-A — the status lines below
+reflect it. Still PLANNED: jail application (spec 08), and a
 runtime registry (v1 downloads resolve through the `runtimes:` preference
 in `config.yaml` as the exact ref).
 
 ## 0. v1 concrete choices (normative where the sections above were open)
 
 - **Project pin file** `.tebako-tools.yaml` is a FLAT YAML mapping of
-  command name → version; a nearer file that does not pin the command
+  command name → pin; a nearer file that does not pin the command
   does not shadow a farther one that does.
-- **`~/.tebako/config.yaml` keys:** `defaults:` (command → version),
-  `registries:` (spec 04 refs), `runtimes:` (engine → `{version,
-  tebako, source?}` runtime preference; `source:` pins the engine's
-  download base — spec 05 §2's per-engine chain, PLANNED TODO.v2-1/30).
-  The shim never writes this file.
+- **The chain-value grammar (2026-09-05 amendment):** every link of the
+  version chain — `TEBAKO_<TOOL>_VERSION`, `.tebako-tools.yaml`,
+  `config.yaml defaults:` — carries `[payload@]version` (split on the
+  FIRST `@`; `tpkg::toolpin::ToolPin` is the ONE parser — spec 00
+  invariant 10). `payload@version` makes the named payload THE provider
+  (§2 step 0.5); bare `version` keeps today's scan. A payload-only pin
+  (`payload@`) does NOT exist — route-out rides disable, never an
+  incomplete link. An unparseable chain value is the NAMED grammar
+  error (`EX_TEBAKO_MANIFEST`, naming the link and value), never a
+  silent skip.
+- **`~/.tebako/config.yaml` keys:** `defaults:` (command →
+  `[payload@]version`), `registries:` (spec 04 refs), `runtimes:`
+  (engine → `{version, tebako, source?}` runtime preference; `source:`
+  pins the engine's download base — spec 05 §2's per-engine chain,
+  PLANNED TODO.v2-1/30). The shim never writes this file — except
+  through `tebako-shim use`, the explicit verb (tmp + rename, the same
+  discipline as `add-registry`; a structural edit that preserves keys,
+  not comments).
 - **Disabled state** is shim-managed state, not authored config:
-  `~/.tebako/shims/.disabled.yaml` (command → `[versions] | [all]`).
+  `~/.tebako/shims/.disabled.yaml` (command → selector list). The
+  selector grammar (2026-09-05 amendment — `tpkg::toolpin::
+  DisableSelector` is the ONE parser): `all` gates every claim of the
+  command; `version` gates that version of ANY claim; `payload@all`
+  gates the named payload's claim; `payload@version` gates exactly that
+  (payload, version) claim. An unknown selector string in the file is a
+  NAMED parse error at load, never silently ignored (invariant 9).
 - **Installed payload record** (the dispatcher-visible manifest mirror,
   spec 03 §4 tier 3 rationale): `payloads/<name>/<version>.tfs`,
   `<version>.tfs.sha256`, `<version>.manifest.yaml`.
@@ -59,6 +79,20 @@ four jobs:
   the thing on PATH that picks version + runtime per invocation and hands
   off.
 
+**Provider routing (2026-09-05 amendment):** two installed payloads may
+provide the SAME command (forks, alternative distributions, a suite and
+a standalone tool). Provider resolution consults two LOCAL surfaces —
+the version chain's payload-qualified pins (§2 step 0.5) and the
+disabled-state file's payload-qualified selectors — never the registry:
+a registry's `default:` stays payload-keyed, and a registry NEVER routes
+commands (routing is local state by design; a future registry
+`default_payload:` cold-start hint is a separate extension point, not
+this spec). The version chain itself is a DYNAMIC per-tool family
+(`TEBAKO_<TOOL>_VERSION` — an unbounded name set) with its own four-link
+chain (§2.1); it is NOT a citizen of spec 23 §14's settings registry
+(§14 owns FIXED-NAME press/machine knobs) — the two surfaces never drift
+into each other.
+
 **argv0 integrity (locked 2026-08-29):** command selection rides argv0 —
 the invoked name must reach the process as its own argv[0]. Symlinks,
 hardlinks, and byte copies preserve it. Wrapper generators that spawn the
@@ -77,10 +111,19 @@ per declared entrypoint name — never as re-exec wrappers.
    shims — each dispatches to its own image AND ITS OWN runtime
    requirement; two commands in one package may run different runtime
    versions simultaneously.
+0.5. **PROVIDER ROUTING (2026-09-05 amendment):** the chain VALUE grammar is
+   `[payload@]version` (`tpkg::toolpin` is the SSOT parser). A
+   payload-qualified value makes the named payload THE provider — it must
+   be installed and declare or expose the command, else the named
+   NotAProvider error. The provider scan skips claims disabled at
+   `<payload>@all` or `<payload>@version`, so disabling all-but-one claims
+   routes without a pin. Unqualified values fall through to today's scan
+   (payload-of-command-name fast path → suite scan → expose scan). A
+   registry never routes commands: routing is local state.
 1. **Payload VERSION resolution** (first match wins):
    `TEBAKO_<TOOL>_VERSION` env → nearest `.tebako-tools.yaml` walking up
-   from cwd (per-project pinning) → user default (`tebako use
-   <tool>@<version>`) → registry's `default`.
+   from cwd (per-project pinning) → user default (`tebako-shim use
+   <tool> <pin>`) → registry's `default`.
 2. **RUNTIME resolution:** the entrypoint's `runtime_requirement` →
    newest COMPATIBLE cached runtime (no download) → else download newest
    compatible (spec 05 §5). **Swapping runtimes needs no payload change**
@@ -110,8 +153,32 @@ per declared entrypoint name — never as re-exec wrappers.
   nothing. A one-off act never claims PATH names.
 - NO eval-init hook for switching: the dispatcher reads the project file
   itself (the mise model, not the rbenv `eval "$(… init -)"` model).
-- `tebako use / disable / list / doctor` manage shims
-  (link/remove/inspect/diagnose); enable/disable specific versions.
+- `tebako-shim use / disable / enable / list / which / doctor` manage
+  shims (link/remove/inspect/diagnose); enable/disable specific versions.
+  The verbs spell identically through the CLI: `tebako shim <verb> …` ≡
+  `tebako-shim <verb> …` (tebako-cli calls the shim crate as a library —
+  never a shell-out).
+  - **`use <tool> <pin>`** writes the user-default link
+    (`config.yaml defaults:` — the explicit authored-config write verb
+    beside `add-registry`, tmp + rename, keys preserved); the pin is the
+    `[payload@]version` grammar of §0. `use --clear <tool>` removes
+    exactly that key; `use --runtime <engine>@<langver>[:<tebako>]`
+    writes `runtimes:`.
+  - **`enable|disable <tool>[@<version>] [--of <payload>]`** edit the
+    disabled-state selectors of §0: bare → `all`; `@<version>` →
+    `version`; `--of <payload>` alone → `payload@all`; with
+    `@<version>` → `payload@version`.
+  - **`which <tool>`** names the provider payload and provider kind
+    (own / exposed / pinned) beside the version and its source.
+  - **`list [--json]`** shows per command the provider payload, provider
+    kind, resolved version + source, and disabled marks; `--json` emits
+    one `"info_schema": 1` document (mirroring `tebako cache list
+    --json`).
+  - **`doctor`** additionally reports: commands with MORE THAN ONE
+    enabled claim (collisions), dangling pins (project-file/config pins
+    naming an uninstalled payload or version), and disabled-but-pinned
+    conflicts. Doctor stays diagnose-only: findings print, the exit code
+    is unchanged (0 / 1 with problems).
   **Enable links on demand** (locked 2026-08-29): `enable <tool>` whose
   command is declared by an installed payload but was never linked
   (spec 03 §2.2's `active: false` default) materializes the shim link
@@ -149,6 +216,22 @@ signed `.tfs` per (version × ruby line) → registry → dispatcher).
   error, never a segfault.
 - Shim target payload missing/corrupt → named error pointing at
   `tebako doctor`.
+- More than one ENABLED claim for a command (2026-09-05 amendment) →
+  `EX_TEBAKO_MANIFEST`, naming every claiming payload; the hint names
+  the routing verbs: pin `<cmd>: <payload>@<version>` in
+  `.tebako-tools.yaml`, or disable one claim (`tebako-shim disable <cmd>
+  --of <payload>`).
+- A payload-qualified chain value whose payload is not installed, or is
+  installed but neither declares nor exposes the command → the
+  NotAProvider named error (`EX_TEBAKO_MANIFEST`), naming the pin, the
+  payload, and the chain link the pin came from.
+- A payload-only pin (`payload@`, empty version) → the grammar error
+  (`EX_TEBAKO_MANIFEST`, §0): route out with `tebako-shim disable <cmd>
+  --of <payload>`, never with an incomplete pin.
+- An unparseable chain value at ANY link (env, project file, config
+  default) → the grammar error, naming the link and the value (spec 23
+  §14's env-parse rule, extended to every chain link) — never a silent
+  skip to the next link.
 
 ## 8. Native exec from inside an image (the whole-chain model, locked)
 

--- a/docs/spec/23-declarative-composition.md
+++ b/docs/spec/23-declarative-composition.md
@@ -633,3 +633,10 @@ The registry's citizens:
 
 Every NEW setting declares its channels in the registry first; existing
 channels migrate into the registry as they are touched.
+
+One family is explicitly NOT a citizen here: the per-tool version chain
+(`TEBAKO_<TOOL>_VERSION` → `.tebako-tools.yaml` → config `defaults:` →
+registry default) is a DYNAMIC family — an unbounded name set keyed by
+command name — with its own four-link chain owned by spec 07 (§2.1, the
+2026-09-05 routing amendment); it never enters this registry, so the two
+surfaces cannot drift into each other.

--- a/docs/spec/schemas/store-config.yaml
+++ b/docs/spec/schemas/store-config.yaml
@@ -3,9 +3,9 @@
 #
 # The user-authored configuration of the local store (~/.tebako), plus the
 # store's own layout marker. The dispatcher only READS config.yaml; the
-# one authored-config write the toolchain performs is `tebako
-# add-registry` (a structural edit, tmp + rename). Shim-managed state
-# (shims/.disabled.yaml) is kept OUT of the authored file.
+# authored-config writes the toolchain performs are `tebako add-registry`
+# and `tebako-shim use` (structural edits, tmp + rename). Shim-managed
+# state (shims/.disabled.yaml) is kept OUT of the authored file.
 #
 # SSOT: this file owns the grammar; the store-layout module (today:
 # crates/tebako-shim/src/config.rs — one model, parse + validate) mirrors
@@ -16,7 +16,7 @@
 
 schema: store-config
 schema_version: 1 # MAJOR — breaking changes only
-schema_minor: 1 # MINOR — additive changes only (1: runtimes.*.source)
+schema_minor: 2 # MINOR — additive changes only (1: runtimes.*.source; 2: defaults/runtimes accept the [payload@]version qualified grammar — tebako-shim use writes them)
 status: normative
 owner: crates/tebako-shim (the config model of record) in tamatebako/tebako
 edge: C13 (everything local → store)
@@ -59,9 +59,14 @@ declaration:
 
 grammar:
   defaults:
-    type: map(command name → version string)
+    type: map(command name → [payload@]version pin string)
     required: false
-    notes: per-tool version pins, written by `tebako use <tool>@<version>` — the version chain's user-default link (S28)
+    notes: >-
+      Per-tool version pins, written by `tebako-shim use <tool> <pin>` —
+      the version chain's user-default link (S28). MINOR 2: the pin VALUE
+      is the [payload@]version qualified grammar (spec 07 §0/§2 step 0.5;
+      tpkg::toolpin::ToolPin is the ONE parser) — a payload-qualified
+      value makes the named payload THE provider.
   registries:
     type: list of string
     required: false
@@ -71,7 +76,9 @@ grammar:
     required: false
     notes: >-
       Per-engine runtime preference (the download fallback of spec 05 §5
-      needs an exact ref), written by `tebako use --runtime <engine>@<version>`.
+      needs an exact ref), written by `tebako-shim use --runtime
+      <engine>@<langver>[:<tebako>]` (MINOR 2 — the verb parses the
+      qualified form and writes this structured shape).
       version = the language version (e.g. "4.0.6"); tebako = the tebako
       (launcher) abi version the runtime was built with — the <ver> of the
       cache layout runtimes/<lang>-<lv>-<ver>-<triplet>/.
@@ -95,5 +102,10 @@ refusals:
     behavior: the named migration — never a silent mix
   - case: config.yaml unparseable
     behavior: named error ("fix or remove it") — the dispatcher never guesses
+  - case: an unparseable "[payload@]version" value in "defaults:"
+    behavior: >-
+      the NAMED grammar error at READ (EX_TEBAKO_MANIFEST, naming the
+      chain link and the value — spec 07 §0/§7), never a silent skip to
+      the next chain link
 
 deprecated: [] # no field is in a deprecation window

--- a/docs/spec/schemas/store-config.yaml
+++ b/docs/spec/schemas/store-config.yaml
@@ -78,7 +78,9 @@ grammar:
       Per-engine runtime preference (the download fallback of spec 05 §5
       needs an exact ref), written by `tebako-shim use --runtime
       <engine>@<langver>[:<tebako>]` (MINOR 2 — the verb parses the
-      qualified form and writes this structured shape).
+      qualified form and writes this structured shape). `tebako` may be
+      ABSENT when written without the `:<tebako>` part — readers treat it
+      as the product default line.
       version = the language version (e.g. "4.0.6"); tebako = the tebako
       (launcher) abi version the runtime was built with — the <ver> of the
       cache layout runtimes/<lang>-<lv>-<ver>-<triplet>/.


### PR DESCRIPTION
# Shim routing + version management — spec 07 amendment, qualified pins, per-payload disable, `use`

Implements the [2026-09-05 routing amendment](docs/spec/07-shims-and-dispatch.md) (PART A of the plan `docs/superpowers/plans/2026-09-05-shim-routing-version-management.md`; TODO.v2-1/31). Closes the cross-payload command-routing gap: two payloads providing the same executable name was a hard named error whose hint ("pin the payload") was a **dangling promise** — the pin grammar was command→version with no payload qualifier, and the provider scan ran before the version chain.

## The design (one new grammar, zero new channels)

- **`[payload@]version` chain values on every link** of the existing four-link version chain (env `TEBAKO_<TOOL>_VERSION` → `.tebako-tools.yaml` → `config.yaml defaults:` → registry default). First-`@` split; version REQUIRED when a payload qualifier is present (payload-only routing rides `disable --of` — no incomplete links).
- **One parser:** `tpkg::toolpin` (`ToolPin` + `DisableSelector` + `ToolPinError`) is the grammar SSOT (invariant 10); shim config/resolve/manage all consume it.
- **Provider scan consults pins + disabled state:** a payload-qualified pin makes the named payload THE provider (installed + declares-or-exposes, else the named NotAProvider error); the scan skips claims disabled at `payload@all` / `payload@version`, so disabling all-but-one claims routes without a pin; collisions fire among ENABLED claims only, with a hint that names the real routing verbs.
- **No new env vars, no registry grammar change** — routing is local state by design; registry `default:` stays payload-keyed (a `default_payload:` cold-start hint is a noted extension point, not this PR).
- **`tebako-shim use <tool> <pin>`** lands the long-PLANNED write path: tmp+rename structural edit of `config.yaml` (`use --clear`, `use --runtime <engine>@<langver>[:<tebako>]`), the authored-config write verb beside `add-registry`.
- **Dual spelling:** `tebako shim <verb> …` ≡ `tebako-shim <verb> …` (tebako-cli calls the shim crate as a library — never a shell-out; Exec arm maps to a named internal error).
- **Machine surfaces:** `list --json` (`info_schema: 1`), `which` names provider + provider kind (own/exposed/pinned) + pin provenance, `doctor` reports collisions / dangling pins / disabled-but-pinned (exit-code semantics unchanged).

## Commits

1. `tpkg`: the `[payload@]version` + disable-selector grammar SSOT
2. **spec 07 amendment** (+ `store-config.yaml` schema_minor 2, the spec 23 §14 boundary sentence, 00-INDEX note) — lands before its consumers
3. `tebako-shim`: payload-aware disabled selectors (`.disabled.yaml` strings validated at load — unknown selector = named parse error, invariant 9)
4. `tebako-shim`: provider routing (`chain_pick`, `ProviderKind::{Own,Exposed,Pinned}`, scan skips, error-text fixes)
5. `tebako-shim`: the verb surface (use / enable|disable --of / list --json / which / doctor reports)
6. `tebako-cli`: the `tebako shim` passthrough

## Verification (debug, vcpkg env)

- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` exit 0.
- `cargo test -p tpkg -p tebako-shim -p tebako-cli`: **657 passed / 0 failed** across 40 test binaries (incl. the 653 s cli_e2e press suite). New coverage: the toolpin grammar matrix, the selector matrix through `is_disabled`/`claim_disabled`, the two-provider routing scenarios (pin via each chain link, env-overrides-project, NotAProvider, uninstalled pin target, disable-routes-without-pin, both-disabled, spec-30 exposer routing), use/enable/disable round-trips, list --json shape, doctor reports, the passthrough.
- `store-config.yaml` parses (`YAML.unsafe_load_file`).

## Deliberate deviations from the plan doc

1. **doctor exit code:** routing findings join `problems` → doctor exits 1, keeping today's asserted semantics (the plan's "exit 0 with findings" parenthetical was wrong against the existing test).
2. **`RuntimePref.tebako` became `#[serde(default)]`** with empty→`DEFAULT_TEBAKO_VERSION` normalization at the single read site, so `use --runtime ruby@3.4.2` without `:<tebako>` writes a loadable config.
3. No inherent `ToolPin::to_string` — Display/ToString (clippy::inherent_to_string).
4. `tebako shim frobnicate` exits 64 via the CLI's existing error shape.

PART B (payload cache prune + `tebako cache` surface + the tebako.org curated-library page) is a separate PR per the plan.
