### PR TITLE
cache: payload prune + pin protection (spec 05 §4) — shim-routing PART B

### DIFF
--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -61,6 +61,7 @@ fn err(code: i32, message: impl Into<String>) -> TebakoError {
 pub(crate) fn map_resolve(e: ResolveError) -> TebakoError {
     let code = match &e {
         ResolveError::Reference(_) | ResolveError::GitPathRequired { .. } => EX_USAGE,
+        ResolveError::PruneNeedsSelector => EX_USAGE,
         ResolveError::Sha256Mismatch { .. } => EX_TEBAKO_SHA,
         ResolveError::NotFound { .. }
         | ResolveError::DownloadFailed { .. }

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -10,7 +10,7 @@
 //!                per-entry imaging + slots + the type-2 package manifest,
 //!                spec 03 §6)
 //!   tebako cache list
-//!   tebako cache prune [--all] [--older-than Nd]
+//!   tebako cache prune [--runtimes] [--payloads] [--all] [--older-than Nd]
 //!   tebako add-registry <ref>
 //!   tebako list-registries
 //!   tebako update-registries
@@ -1005,26 +1005,55 @@ fn clean_output(opts: &PressOptions) {
 pub fn cache_list() {
     let manager = Resolver::new();
     let entries = manager.entries();
+    let payloads = tebako_resolve::PayloadCache::with_root(&manager.cache_root).list();
     if entries.is_empty() {
         println!(
             "Runtime package cache is empty ({})",
             manager.cache_root.join("runtimes").display()
         );
+    } else {
+        let mut total = 0u64;
+        for entry in &entries {
+            total += entry.size_bytes;
+            println!(
+                "{:<44} {:>9}  {}",
+                entry.name,
+                human_size(entry.size_bytes),
+                human_age(entry.installed_at)
+            );
+        }
+        println!(
+            "{:<44} {:>9}",
+            format!("Total ({} package(s))", entries.len()),
+            human_size(total)
+        );
+    }
+    if payloads.is_empty() {
         return;
     }
+    // The payload section: the JSON form's fields (name/version/size)
+    // plus the age column the runtime lines carry.
+    println!(
+        "Payload cache ({}):",
+        manager.cache_root.join("payloads").display()
+    );
     let mut total = 0u64;
-    for entry in &entries {
-        total += entry.size_bytes;
+    for entry in &payloads {
+        let size = fs::metadata(&entry.path).map(|m| m.len()).unwrap_or(0);
+        total += size;
+        let installed_at = fs::metadata(&entry.path)
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
         println!(
             "{:<44} {:>9}  {}",
-            entry.name,
-            human_size(entry.size_bytes),
-            human_age(entry.installed_at)
+            format!("{}@{}", entry.name, entry.version),
+            human_size(size),
+            human_age(installed_at)
         );
     }
     println!(
         "{:<44} {:>9}",
-        format!("Total ({} package(s))", entries.len()),
+        format!("Total ({} payload(s))", payloads.len()),
         human_size(total)
     );
 }
@@ -1105,21 +1134,160 @@ pub fn cache_list_json() {
     println!("{}", json_to_string(&doc));
 }
 
-pub fn cache_prune(all: bool, older_than: Option<&str>) -> Result<(), TebakoError> {
-    let manager = Resolver::new();
-    let removed = if all {
-        manager.prune(true, None)?
-    } else if let Some(days) = older_than.and_then(parse_days) {
-        manager.prune(false, Some(days))?
-    } else {
+/// `tebako cache prune [--runtimes] [--payloads] [--all | --older-than Nd]`.
+/// Bare (no area flags) prunes runtimes only — today's behavior,
+/// unchanged. The payload arm rides tebako-resolve's `PayloadCache::prune`
+/// with the protected set ALWAYS applied (no opt-out; `--all` respects it
+/// too — prune never strands a pin): config `defaults:` pins, exact
+/// `.disabled.yaml` `payload@version` selectors, and the newest installed
+/// version of every payload (the roll-forward floor).
+pub fn cache_prune(
+    runtimes: bool,
+    payloads: bool,
+    all: bool,
+    older_than: Option<&str>,
+) -> Result<(), TebakoError> {
+    let days = match (all, older_than) {
+        (true, _) => Some(None),
+        (false, Some(spec)) => parse_days(spec).map(Some),
+        (false, None) => None,
+    };
+    let Some(days) = days else {
         println!("Nothing to do: pass --all or --older-than Nd");
         return Ok(());
     };
-    for name in &removed {
-        println!("Removed {name}");
+    let manager = Resolver::new();
+    if project_pins_near_cwd() {
+        println!(
+            "project pins (.tebako-tools.yaml) are per-directory and not visible to prune — pinned-but-old versions may be removed and will re-fetch on next dispatch (offline: named error)."
+        );
     }
-    println!("{} cached runtime package(s) removed", removed.len());
+    if runtimes || !payloads {
+        let removed = manager.prune(all, days)?;
+        for name in &removed {
+            println!("Removed {name}");
+        }
+        println!("{} cached runtime package(s) removed", removed.len());
+    }
+    if payloads {
+        let (protected, notes) = protected_payload_versions(&manager.cache_root)?;
+        for note in &notes {
+            println!("{note}");
+        }
+        let cache = tebako_resolve::PayloadCache::with_root(&manager.cache_root);
+        let removed = cache
+            .prune(all, days, &protected)
+            .map_err(crate::install::map_resolve)?;
+        for (name, version) in &removed {
+            println!("Removed {name}@{version}");
+        }
+        println!("{} cached payload(s) removed", removed.len());
+    }
     Ok(())
+}
+
+/// The prune protected set (spec 07 §2's pins, the parts prune CAN see):
+/// config `defaults:` values through `tpkg::toolpin::ToolPin` (a
+/// qualified `payload@version` protects exactly that pair; a bare value
+/// protects `(provider, version)` only when the provider scan is
+/// unambiguous — otherwise a note and nothing extra), exact
+/// `payload@version` selectors from `.disabled.yaml`, and the newest
+/// installed version of every payload (the roll-forward floor). The env
+/// and per-directory `.tebako-tools.yaml` links are dispatch-time state
+/// and stay invisible (the caveat line covers them). Loading the pin
+/// state fails CLOSED: pruning without the pins could strand one.
+fn protected_payload_versions(
+    home: &Path,
+) -> Result<(tebako_resolve::ProtectedSet, Vec<String>), TebakoError> {
+    let mut protected = tebako_resolve::ProtectedSet::new();
+    let mut notes = Vec::new();
+
+    // The roll-forward floor: never prune a name's newest installed
+    // version (the dispatch default when nothing is pinned).
+    let entries = tebako_resolve::PayloadCache::with_root(home).list();
+    let mut by_name: std::collections::BTreeMap<&String, Vec<&String>> =
+        std::collections::BTreeMap::new();
+    for entry in &entries {
+        by_name.entry(&entry.name).or_default().push(&entry.version);
+    }
+    for (name, versions) in &by_name {
+        if let Some(newest) = tpkg::versions::newest(versions.iter().copied()) {
+            protected.insert((name.to_string(), newest));
+        }
+    }
+
+    // Config defaults (the user-pin link, `tebako shim use`).
+    let cfg = tebako_shim::config::load_config(home).map_err(|e| {
+        plain_error(format!(
+            "cannot build the prune protected set: {}",
+            e.message
+        ))
+    })?;
+    for (tool, value) in &cfg.defaults {
+        let pin = tpkg::toolpin::ToolPin::parse(value)
+            .map_err(|e| plain_error(format!("config.yaml default `{tool}: {e}")))?;
+        match pin.payload {
+            Some(payload) => {
+                protected.insert((payload, pin.version));
+            }
+            None => {
+                match tebako_shim::resolve::provider_for_bare_default(home, tool).map_err(|e| {
+                    plain_error(format!(
+                        "cannot build the prune protected set: {}",
+                        e.message
+                    ))
+                })? {
+                    tebako_shim::resolve::BareProvider::One(payload) => {
+                        protected.insert((payload, pin.version));
+                    }
+                    tebako_shim::resolve::BareProvider::Ambiguous(claims) => {
+                        notes.push(format!(
+                        "default `{tool}: {value}` is bare and more than one payload provides it ({}) — protecting nothing extra; pin `{tool}: <payload>@{version}` to protect exactly",
+                        claims.join(", "),
+                        version = pin.version,
+                    ));
+                    }
+                    tebako_shim::resolve::BareProvider::None => {}
+                }
+            }
+        }
+    }
+
+    // Exact `payload@version` disable selectors pin a version out of
+    // dispatch — keep those bytes too (`all` / `payload@all` / bare
+    // versions name no exact pair and protect nothing here).
+    let disabled = tebako_shim::config::load_disabled(home).map_err(|e| {
+        plain_error(format!(
+            "cannot build the prune protected set: {}",
+            e.message
+        ))
+    })?;
+    for selectors in disabled.values() {
+        for selector in selectors {
+            if let Ok(tpkg::toolpin::DisableSelector::PayloadVersion(p, v)) =
+                tpkg::toolpin::DisableSelector::parse(selector)
+            {
+                protected.insert((p, v));
+            }
+        }
+    }
+    Ok((protected, notes))
+}
+
+/// `.tebako-tools.yaml` reachable from the cwd (the shim's walk-up
+/// lookup direction): the caveat line prints once per prune.
+fn project_pins_near_cwd() -> bool {
+    let Ok(mut dir) = std::env::current_dir() else {
+        return false;
+    };
+    loop {
+        if dir.join(".tebako-tools.yaml").is_file() {
+            return true;
+        }
+        if !dir.pop() {
+            return false;
+        }
+    }
 }
 
 fn parse_days(spec: &str) -> Option<u64> {

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -43,7 +43,10 @@ const USAGE: &str = "Usage:
                [--runtime <exe> --runtime-image <env.tfs>]
                                        the payload's in-image acceptance checks (spec 26 §2)
   tebako cache list [--json]
-  tebako cache prune [--all] [--older-than Nd]
+  tebako cache prune [--runtimes] [--payloads] [--all] [--older-than Nd]
+                                       bare = runtimes only; the payload arm never
+                                       prunes a pinned or a name's newest version
+                                       (no opt-out — prune never strands a pin)
   tebako add-registry <ref>            register a tpkg-registry.yaml (spec 04 §2)
   tebako list-registries               list the registered registries
   tebako update-registries             refresh the dispatch-time registry cache
@@ -684,11 +687,15 @@ fn run_cache(args: &[String]) -> Result<(), CliExit> {
             Ok(())
         }
         "prune" => {
+            let mut runtimes = false;
+            let mut payloads = false;
             let mut all = false;
             let mut older_than: Option<String> = None;
             let mut i = 1;
             while i < args.len() {
                 match args[i].as_str() {
+                    "--runtimes" => runtimes = true,
+                    "--payloads" => payloads = true,
                     "--all" => all = true,
                     "--older-than" => {
                         i += 1;
@@ -701,7 +708,7 @@ fn run_cache(args: &[String]) -> Result<(), CliExit> {
                 }
                 i += 1;
             }
-            cache_prune(all, older_than.as_deref())?;
+            cache_prune(runtimes, payloads, all, older_than.as_deref())?;
             Ok(())
         }
         other => Err(CliExit::Usage(format!(

--- a/crates/tebako-cli/tests/cache_prune.rs
+++ b/crates/tebako-cli/tests/cache_prune.rs
@@ -1,0 +1,201 @@
+//! `tebako cache prune --payloads` + the human `cache list` payload
+//! section (spec 15 §4, the 2026-09-05 routing amendment's prune
+//! protection): pins from config defaults, `.disabled.yaml` pairs and the
+//! per-name newest floor are NEVER pruned — not even by `--all`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn tebako_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_tebako"))
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("tebako-cli-cache-{tag}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(home: &Path, cwd: &Path, args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(tebako_bin())
+        .args(args)
+        .env("TEBAKO_HOME", home)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|e| panic!("spawn failed: {e}"));
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// An installed payload record (image + trust anchor + origin; the
+/// mirror only when the provider scan must read entrypoints).
+fn write_payload(home: &Path, name: &str, version: &str, manifest_yaml: Option<&str>) {
+    let dir = home.join("payloads").join(name);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join(format!("{version}.tfs")), b"image").unwrap();
+    fs::write(
+        dir.join(format!("{version}.tfs.sha256")),
+        format!("{}  {version}.tfs\n", "a".repeat(64)),
+    )
+    .unwrap();
+    fs::write(dir.join(format!("{version}.tfs.origin")), "file:///x\n").unwrap();
+    if let Some(m) = manifest_yaml {
+        fs::write(dir.join(format!("{version}.manifest.yaml")), m).unwrap();
+    }
+}
+
+/// The manifest-mirror shape the provider scan parses (the tebako-shim
+/// fixture's, minimal): kind app with one entrypoint.
+fn app_manifest(name: &str, version: &str, tool: &str) -> String {
+    format!(
+        "identity:\n  schema_version: 1\n  kind: app\n  name: {name}\n  version: \"{version}\"\n  producer: {{tool: tebako-cli-tests, tool_version: \"1\"}}\n  created: \"2026-07-27T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{tree}\"\n    blob_sha256: {blob}\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n  entrypoints:\n    - name: {tool}\n      path: /app/bin/{tool}\n  platforms: universal\n  capabilities: {{exec: true, read: true}}\n",
+        tree = "a".repeat(64),
+        blob = "b".repeat(64),
+    )
+}
+
+#[test]
+fn prune_payloads_all_keeps_pins_and_the_newest_floor() {
+    let dir = scratch("protect");
+    let home = dir.join("home");
+    for v in ["1.0", "2.0", "3.0"] {
+        write_payload(&home, "tool", v, None);
+    }
+    fs::write(home.join("config.yaml"), "defaults: {tool: \"tool@1.0\"}\n").unwrap();
+
+    let (code, stdout, _stderr) = run(&home, &dir, &["cache", "prune", "--payloads", "--all"]);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Removed tool@2.0"), "{stdout}");
+    assert!(!stdout.contains("Removed tool@1.0"), "{stdout}");
+    assert!(!stdout.contains("Removed tool@3.0"), "{stdout}");
+    assert!(stdout.contains("1 cached payload(s) removed"), "{stdout}");
+    assert!(!home.join("payloads/tool/2.0.tfs").exists());
+    assert!(!home.join("payloads/tool/2.0.tfs.sha256").exists());
+    assert!(home.join("payloads/tool/1.0.tfs").is_file());
+    assert!(home.join("payloads/tool/3.0.tfs").is_file());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn bare_prune_all_touches_runtimes_only() {
+    let dir = scratch("bare");
+    let home = dir.join("home");
+    // 1.0 would go under `--payloads --all` (2.0 is the newest floor).
+    write_payload(&home, "tool", "1.0", None);
+    write_payload(&home, "tool", "2.0", None);
+
+    let (code, stdout, _stderr) = run(&home, &dir, &["cache", "prune", "--all"]);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(
+        stdout.contains("0 cached runtime package(s) removed"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("payload"), "{stdout}");
+    assert!(home.join("payloads/tool/1.0.tfs").is_file());
+    assert!(home.join("payloads/tool/2.0.tfs").is_file());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn prune_payloads_older_than_prunes_old_unprotected() {
+    let dir = scratch("older-than");
+    let home = dir.join("home");
+    write_payload(&home, "tool", "1.0", None);
+    write_payload(&home, "tool", "2.0", None);
+
+    // 0d: everything is old — the floor still keeps 2.0.
+    let (code, stdout, _stderr) = run(
+        &home,
+        &dir,
+        &["cache", "prune", "--payloads", "--older-than", "0d"],
+    );
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Removed tool@1.0"), "{stdout}");
+    assert!(!home.join("payloads/tool/1.0.tfs").exists());
+    assert!(home.join("payloads/tool/2.0.tfs").is_file());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn cache_list_human_shows_the_payload_section() {
+    let dir = scratch("list");
+    let home = dir.join("home");
+    write_payload(&home, "tool", "1.0", None);
+
+    let (code, stdout, _stderr) = run(&home, &dir, &["cache", "list"]);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Payload cache"), "{stdout}");
+    assert!(stdout.contains("tool@1.0"), "{stdout}");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn prune_prints_the_project_pin_caveat_when_pins_exist() {
+    let dir = scratch("caveat");
+    let home = dir.join("home");
+    write_payload(&home, "tool", "1.0", None);
+    let proj = dir.join("proj");
+    fs::create_dir_all(&proj).unwrap();
+    fs::write(proj.join(".tebako-tools.yaml"), "tool: 1.0\n").unwrap();
+
+    let (code, stdout, _stderr) = run(&home, &proj, &["cache", "prune", "--payloads", "--all"]);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(
+        stdout.contains(
+            "project pins (.tebako-tools.yaml) are per-directory and not visible to prune"
+        ),
+        "{stdout}"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn ambiguous_bare_default_prints_the_note_and_protects_nothing_extra() {
+    let dir = scratch("ambiguous");
+    let home = dir.join("home");
+    write_payload(
+        &home,
+        "suite-a",
+        "1.0",
+        Some(&app_manifest("suite-a", "1.0", "mn")),
+    );
+    write_payload(
+        &home,
+        "suite-b",
+        "1.0",
+        Some(&app_manifest("suite-b", "1.0", "mn")),
+    );
+    fs::write(home.join("config.yaml"), "defaults: {mn: \"1.0\"}\n").unwrap();
+
+    let (code, stdout, _stderr) = run(&home, &dir, &["cache", "prune", "--payloads", "--all"]);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("protecting nothing extra"), "{stdout}");
+    assert!(stdout.contains("suite-a"), "{stdout}");
+    assert!(stdout.contains("suite-b"), "{stdout}");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn disabled_selector_pairs_are_protected() {
+    let dir = scratch("disabled");
+    let home = dir.join("home");
+    write_payload(&home, "tool", "1.0", None);
+    write_payload(&home, "tool", "2.0", None);
+    write_payload(&home, "tool", "3.0", None);
+    let shims = home.join("shims");
+    fs::create_dir_all(&shims).unwrap();
+    fs::write(shims.join(".disabled.yaml"), "tool:\n  - tool@1.0\n").unwrap();
+
+    let (code, stdout, _stderr) = run(&home, &dir, &["cache", "prune", "--payloads", "--all"]);
+    assert_eq!(code, 0, "{stdout}");
+    assert!(stdout.contains("Removed tool@2.0"), "{stdout}");
+    assert!(home.join("payloads/tool/1.0.tfs").is_file());
+    assert!(!home.join("payloads/tool/2.0.tfs").exists());
+    assert!(home.join("payloads/tool/3.0.tfs").is_file());
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/tebako-resolve/src/cache.rs
+++ b/crates/tebako-resolve/src/cache.rs
@@ -89,6 +89,10 @@ pub struct CacheEntry {
     pub origin: Option<String>,
 }
 
+/// The prune protected set: exact `(name, version)` pairs prune never
+/// removes (`PayloadCache::prune`).
+pub type ProtectedSet = std::collections::BTreeSet<(String, String)>;
+
 /// The `payloads/` tree of the shared machine cache.
 pub struct PayloadCache {
     root: PathBuf,
@@ -217,7 +221,70 @@ impl PayloadCache {
         out
     }
 
-    /// Cache hit or install: fetch (via `fetch`), verify against
+    /// Prune cached payload versions (the payload arm of `cache prune`,
+    /// spec 15 §4): the same cutoff math as tebako-cli's runtime
+    /// `Resolver::prune` — `all` drops everything, `older_than_days`
+    /// drops entries whose artifact mtime is older than now − N days, and
+    /// one of the two is required ([`ResolveError::PruneNeedsSelector`]).
+    /// `(name, version)` pairs in `protected` are NEVER removed, even
+    /// under `all` (the locked rule: prune never strands a pin — the
+    /// caller builds the set from config defaults, disabled selectors,
+    /// and the per-name newest floor). Removal deletes the version's
+    /// whole record — `<v>.tfs`, the `.tfs.sha256`/`.tfs.origin` markers,
+    /// the `<v>.manifest.yaml` mirror, a materialized `<v>.tree/`, the
+    /// install lock — and the `<name>/` dir when it goes empty. Returns
+    /// the removed pairs in `list()` order (name, then version).
+    pub fn prune(
+        &self,
+        all: bool,
+        older_than_days: Option<u64>,
+        protected: &ProtectedSet,
+    ) -> Result<Vec<(String, String)>, ResolveError> {
+        if !all && older_than_days.is_none() {
+            return Err(ResolveError::PruneNeedsSelector);
+        }
+        let cutoff = older_than_days
+            .map(|d| std::time::SystemTime::now() - std::time::Duration::from_secs(d * 86_400));
+        let mut removed = Vec::new();
+        for entry in self.list() {
+            let key = (entry.name.clone(), entry.version.clone());
+            if protected.contains(&key) {
+                continue;
+            }
+            let installed_at = fs::metadata(&entry.path)
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            if !(all || cutoff.is_some_and(|c| installed_at < c)) {
+                continue;
+            }
+            let dir = self.root.join("payloads").join(&entry.name);
+            // The artifact is 0444/readonly (item 30b) — clear the bit
+            // first so removal works where readonly blocks unlink.
+            make_writable(&entry.path).map_err(|e| cache_io("chmod", &entry.path, e))?;
+            for file in [
+                entry.path.clone(),
+                sha_marker(&entry.path),
+                origin_marker(&entry.path),
+                dir.join(format!("{}.manifest.yaml", entry.version)),
+                dir.join(format!(".install-{}.lock", entry.version)),
+            ] {
+                match fs::remove_file(&file) {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => return Err(cache_io("pruning", &file, e)),
+                }
+            }
+            let tree = dir.join(format!("{}.tree", entry.version));
+            if tree.is_dir() {
+                fs::remove_dir_all(&tree).map_err(|e| cache_io("pruning", &tree, e))?;
+            }
+            // Only succeeds when nothing else remains under the name.
+            let _ = fs::remove_dir(&dir);
+            removed.push(key);
+        }
+        Ok(removed)
+    }
+
     /// `expected_sha256` when given (registry-supplied trust anchor), and
     /// place atomically under the per-entry flock. A digest mismatch
     /// deletes the download and caches nothing (spec 04 §3).
@@ -513,6 +580,39 @@ fn make_readonly(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// The inverse of [`make_readonly`], for prune: 0644 on unix; on Windows
+/// the readonly attribute cleared (DeleteFile refuses a readonly file).
+#[cfg(unix)]
+fn make_writable(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o644);
+    std::fs::set_permissions(path, perms)
+}
+
+#[cfg(windows)]
+fn make_writable(path: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileAttributesW, SetFileAttributesW, FILE_ATTRIBUTE_READONLY, INVALID_FILE_ATTRIBUTES,
+    };
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    unsafe {
+        let attrs = GetFileAttributesW(wide.as_ptr());
+        if attrs == INVALID_FILE_ATTRIBUTES {
+            return Err(std::io::Error::last_os_error());
+        }
+        if SetFileAttributesW(wide.as_ptr(), attrs & !FILE_ATTRIBUTE_READONLY) == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
 /// The per-entry lock pair, one shape on each platform (no op-value
 /// passing — named operations only):
 ///
@@ -586,6 +686,89 @@ mod tests {
             origin: "https://cdn.example.com/tool.tfs".to_string(),
             sha256: crate::fetch::sha256_hex(bytes),
         }
+    }
+
+    /// Backdate a file's mtime (prune-age fixtures). The same libc/Win32
+    /// pair this module's flock uses — no new dependency.
+    #[cfg(unix)]
+    fn set_age_days(path: &Path, days: u64) {
+        use std::os::unix::ffi::OsStrExt as _;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let at = libc::timespec {
+            tv_sec: now - (days * 86_400) as i64,
+            tv_nsec: 0,
+        };
+        let times = [at, at];
+        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        // SAFETY: a valid NUL-terminated path and a two-element times array.
+        let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+        assert_eq!(rc, 0, "utimensat failed for {}", path.display());
+    }
+
+    /// Backdate a file's mtime (prune-age fixtures) — the Win32 arm.
+    #[cfg(windows)]
+    fn set_age_days(path: &Path, days: u64) {
+        use std::os::windows::ffi::OsStrExt as _;
+        use windows_sys::Win32::Foundation::{CloseHandle, FILETIME, INVALID_HANDLE_VALUE};
+        use windows_sys::Win32::Storage::FileSystem::{
+            CreateFileW, SetFileTime, FILE_ATTRIBUTE_NORMAL, FILE_WRITE_ATTRIBUTES, OPEN_EXISTING,
+        };
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let then = now - days * 86_400 + 11_644_473_600;
+        let ticks = (then as u128 * 10_000_000) as u64;
+        let ft = FILETIME {
+            dwLowDateTime: ticks as u32,
+            dwHighDateTime: (ticks >> 32) as u32,
+        };
+        let wide: Vec<u16> = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        // SAFETY: a valid wide path; the handle is checked and closed.
+        let handle = unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                FILE_WRITE_ATTRIBUTES,
+                0,
+                std::ptr::null(),
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_ne!(handle, INVALID_HANDLE_VALUE);
+        // SAFETY: a live handle and a valid FILETIME.
+        let rc = unsafe { SetFileTime(handle, std::ptr::null(), std::ptr::null(), &ft) };
+        // SAFETY: a live handle.
+        unsafe { CloseHandle(handle) };
+        assert_ne!(rc, 0, "SetFileTime failed for {}", path.display());
+    }
+
+    fn install_aged(
+        cache: &PayloadCache,
+        root: &Path,
+        name: &str,
+        version: &str,
+        bytes: &[u8],
+        days: u64,
+    ) {
+        cache
+            .install(name, version, None, || Ok(fetched(bytes)))
+            .unwrap();
+        set_age_days(
+            &root
+                .join("payloads")
+                .join(name)
+                .join(format!("{version}.tfs")),
+            days,
+        );
     }
 
     #[test]
@@ -845,6 +1028,79 @@ mod tests {
             .unwrap();
         std::env::remove_var("TEBAKO_OFFLINE");
         assert_eq!(outcome, SeedOutcome::Seeded);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn prune_requires_a_selector() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let root = scratch();
+        let cache = PayloadCache::with_root(&root);
+        let protected = std::collections::BTreeSet::new();
+        let err = cache.prune(false, None, &protected).unwrap_err();
+        assert!(matches!(err, ResolveError::PruneNeedsSelector));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn prune_older_than_removes_only_old_unprotected_versions() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let root = scratch();
+        let cache = PayloadCache::with_root(&root);
+        install_aged(&cache, &root, "tool", "1.0", b"one", 40);
+        install_aged(&cache, &root, "tool", "2.0", b"two", 40);
+        install_aged(&cache, &root, "tool", "3.0", b"three", 1);
+        install_aged(&cache, &root, "other", "0.1", b"other", 40);
+        let protected: std::collections::BTreeSet<(String, String)> =
+            [("tool".to_string(), "2.0".to_string())]
+                .into_iter()
+                .collect();
+        let removed = cache.prune(false, Some(30), &protected).unwrap();
+        assert_eq!(
+            removed,
+            vec![
+                ("other".to_string(), "0.1".to_string()),
+                ("tool".to_string(), "1.0".to_string())
+            ]
+        );
+        // the protected and the fresh versions keep their full records
+        for v in ["2.0", "3.0"] {
+            assert!(root.join(format!("payloads/tool/{v}.tfs")).is_file());
+            assert!(root.join(format!("payloads/tool/{v}.tfs.sha256")).is_file());
+        }
+        assert!(!root.join("payloads/tool/1.0.tfs").exists());
+        assert!(!root.join("payloads/tool/1.0.tfs.sha256").exists());
+        assert!(!root.join("payloads/tool/1.0.tfs.origin").exists());
+        // a fully pruned name loses its directory
+        assert!(!root.join("payloads/other").exists());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn prune_all_respects_protected_and_removes_the_whole_record() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let root = scratch();
+        let cache = PayloadCache::with_root(&root);
+        install_aged(&cache, &root, "tool", "1.0", b"one", 0);
+        install_aged(&cache, &root, "tool", "2.0", b"two", 0);
+        // the record is more than the artifact: manifest mirror,
+        // materialized zero-runtime tree, install lock
+        fs::create_dir_all(root.join("payloads/tool/1.0.tree/local")).unwrap();
+        fs::write(root.join("payloads/tool/1.0.tree/local/x.rb"), b"x").unwrap();
+        fs::write(root.join("payloads/tool/1.0.manifest.yaml"), b"manifest").unwrap();
+        fs::write(root.join("payloads/tool/2.0.manifest.yaml"), b"manifest").unwrap();
+        let protected: std::collections::BTreeSet<(String, String)> =
+            [("tool".to_string(), "2.0".to_string())]
+                .into_iter()
+                .collect();
+        let removed = cache.prune(true, None, &protected).unwrap();
+        assert_eq!(removed, vec![("tool".to_string(), "1.0".to_string())]);
+        assert!(!root.join("payloads/tool/1.0.tfs").exists());
+        assert!(!root.join("payloads/tool/1.0.tree").exists());
+        assert!(!root.join("payloads/tool/1.0.manifest.yaml").exists());
+        assert!(!root.join("payloads/tool/.install-1.0.lock").exists());
+        assert!(root.join("payloads/tool/2.0.tfs").is_file());
+        assert!(root.join("payloads/tool/2.0.manifest.yaml").is_file());
         let _ = fs::remove_dir_all(&root);
     }
 }

--- a/crates/tebako-resolve/src/error.rs
+++ b/crates/tebako-resolve/src/error.rs
@@ -141,6 +141,9 @@ pub enum ResolveError {
     LockTimeout { lockfile: PathBuf, waited_secs: u64 },
     /// A cache key (name or version) is not path-safe.
     InvalidCacheKey { key: String, reason: String },
+    /// `PayloadCache::prune` without `all` or `older_than_days` (the same
+    /// rule tebako-cli's runtime `Resolver::prune` enforces).
+    PruneNeedsSelector,
     /// An I/O failure inside the cache, with operation and path context.
     CacheIo {
         op: &'static str,
@@ -224,6 +227,9 @@ impl fmt::Display for ResolveError {
             ),
             ResolveError::InvalidCacheKey { key, reason } => {
                 write!(f, "invalid cache key '{key}': {reason}")
+            }
+            ResolveError::PruneNeedsSelector => {
+                write!(f, "prune requires --all or --older-than Nd")
             }
             ResolveError::CacheIo { op, path, reason } => {
                 write!(f, "{reason} ({op} {})", path.display())

--- a/crates/tebako-resolve/src/lib.rs
+++ b/crates/tebako-resolve/src/lib.rs
@@ -35,7 +35,9 @@ pub mod registry;
 pub mod store;
 pub mod transport;
 
-pub use cache::{default_cache_root, CacheEntry, InstallStatus, PayloadCache, SeedOutcome};
+pub use cache::{
+    default_cache_root, CacheEntry, InstallStatus, PayloadCache, ProtectedSet, SeedOutcome,
+};
 pub use contract::{ContractError, ContractSet};
 pub use error::{ReferenceError, RegistryError, ResolveError};
 pub use fetch::{sha256_hex, FetchedPayload, Fetcher};

--- a/crates/tebako-shim/src/resolve.rs
+++ b/crates/tebako-shim/src/resolve.rs
@@ -140,19 +140,32 @@ fn routing_hint(tool: &str) -> String {
 /// only — a sole-but-disabled claim falls through to resolve_named's
 /// per-version refusal (the historical shape), several all-disabled
 /// claims answer the no-provider error.
-fn providing_payload(
+/// One pass over the installed payloads (the walks [`providing_payload`]
+/// and [`provider_for_bare_default`] share): the own-name fast path, the
+/// entrypoint claims, the expose claims — the scan skips NOTHING here;
+/// the callers apply the disabled-claim rules (spec 07 §2 step 0.5).
+/// `None` when the payloads dir does not exist at all.
+struct ClaimScan {
+    /// `payloads/<tool>/` exists and its claim is not disabled at
+    /// `all` / `<tool>@all` (the fast path).
+    own_fast: bool,
+    /// Payloads with an entrypoint claim (sorted, deterministic).
+    providers: Vec<String>,
+    /// Payloads with an expose claim (sorted, deterministic).
+    exposers: Vec<String>,
+}
+
+fn claim_scan(
     home: &Path,
     tool: &str,
     disabled: &config::Disabled,
-) -> Result<Provider, ShimError> {
-    manifest::check_path_component("command name", tool)?;
-    if home.join("payloads").join(tool).is_dir() && !config::claim_disabled(disabled, tool, tool) {
-        return Ok(Provider::Own(tool.to_string()));
-    }
+) -> Result<Option<ClaimScan>, ShimError> {
+    let own_fast =
+        home.join("payloads").join(tool).is_dir() && !config::claim_disabled(disabled, tool, tool);
     let payloads_dir = home.join("payloads");
     let rd = match std::fs::read_dir(&payloads_dir) {
         Ok(rd) => rd,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(no_provider(home, tool)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => {
             return fail(
                 crate::EX_TEBAKO_IO,
@@ -181,6 +194,29 @@ fn providing_payload(
             }
         }
     }
+    providers.sort();
+    exposers.sort();
+    Ok(Some(ClaimScan {
+        own_fast,
+        providers,
+        exposers,
+    }))
+}
+
+fn providing_payload(
+    home: &Path,
+    tool: &str,
+    disabled: &config::Disabled,
+) -> Result<Provider, ShimError> {
+    manifest::check_path_component("command name", tool)?;
+    let Some(scan) = claim_scan(home, tool, disabled)? else {
+        return Err(no_provider(home, tool));
+    };
+    if scan.own_fast {
+        return Ok(Provider::Own(tool.to_string()));
+    }
+    let providers = scan.providers;
+    let exposers = scan.exposers;
     let enabled: Vec<&String> = providers
         .iter()
         .filter(|p| !config::claim_disabled(disabled, tool, p))
@@ -224,6 +260,63 @@ fn providing_payload(
                 routing_hint(tool)
             ),
         ),
+    }
+}
+
+/// The prune-protection view of the provider scan (`tebako cache prune
+/// --payloads`): which payload a BARE `tool → version` default would
+/// dispatch to. Unlike dispatch, ambiguity and absence are DATA, never
+/// errors — the caller prints its note and protects nothing extra.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BareProvider {
+    /// Exactly one claim would answer (an enabled one, or the sole
+    /// disabled one — dispatch would name it in its refusal).
+    One(String),
+    /// Several enabled claims — the collision case; protect nothing
+    /// extra (the claims are sorted, deterministic).
+    Ambiguous(Vec<String>),
+    /// No payload claims the command.
+    None,
+}
+
+/// [`providing_payload`]'s scan (same disabled-claim rules, spec 07 §2
+/// step 0.5) with the dispatch errors flattened to [`BareProvider`].
+pub fn provider_for_bare_default(home: &Path, tool: &str) -> Result<BareProvider, ShimError> {
+    manifest::check_path_component("command name", tool)?;
+    let disabled = config::load_disabled(home)?;
+    let Some(scan) = claim_scan(home, tool, &disabled)? else {
+        return Ok(BareProvider::None);
+    };
+    if scan.own_fast {
+        return Ok(BareProvider::One(tool.to_string()));
+    }
+    let enabled: Vec<&String> = scan
+        .providers
+        .iter()
+        .filter(|p| !config::claim_disabled(&disabled, tool, p))
+        .collect();
+    match (enabled.len(), scan.providers.len()) {
+        (1, _) => return Ok(BareProvider::One(enabled[0].clone())),
+        (0, 1) => return Ok(BareProvider::One(scan.providers[0].clone())),
+        (n, _) if n >= 2 => {
+            return Ok(BareProvider::Ambiguous(
+                enabled.iter().map(|s| s.to_string()).collect(),
+            ))
+        }
+        _ => {}
+    }
+    let enabled_ex: Vec<&String> = scan
+        .exposers
+        .iter()
+        .filter(|p| !config::claim_disabled(&disabled, tool, p))
+        .collect();
+    match (enabled_ex.len(), scan.exposers.len()) {
+        (1, _) => Ok(BareProvider::One(enabled_ex[0].clone())),
+        (0, 1) => Ok(BareProvider::One(scan.exposers[0].clone())),
+        (0, _) => Ok(BareProvider::None),
+        _ => Ok(BareProvider::Ambiguous(
+            enabled_ex.iter().map(|s| s.to_string()).collect(),
+        )),
     }
 }
 

--- a/crates/tebako-shim/tests/resolve.rs
+++ b/crates/tebako-shim/tests/resolve.rs
@@ -454,3 +454,54 @@ fn two_exposers_route_through_the_same_pin_and_disable_surface() {
     assert_eq!(res.payload_name, "expa");
     assert!(matches!(res.provider, resolve::ProviderKind::Exposed));
 }
+
+#[test]
+fn provider_for_bare_default_reports_one_ambiguous_none() {
+    let tmp = TempDir::new("bare-provider");
+    let home = tmp.path().join("home");
+
+    // no payloads at all → None
+    assert!(matches!(
+        resolve::provider_for_bare_default(&home, "ghost").unwrap(),
+        resolve::BareProvider::None
+    ));
+
+    // one suite claim → One (the scan, not the own-name path)
+    write_payload(
+        &home,
+        "metanorma",
+        "1.2.3",
+        &app_manifest("metanorma", "1.2.3", &entrypoint_yaml(NATIVE_ENTRY, "mn")),
+    );
+    match resolve::provider_for_bare_default(&home, "mn").unwrap() {
+        resolve::BareProvider::One(p) => assert_eq!(p, "metanorma"),
+        other => panic!("expected One, got {other:?}"),
+    }
+
+    // the own-name fast path: payloads/<tool>/ exists, no manifest needed
+    match resolve::provider_for_bare_default(&home, "metanorma").unwrap() {
+        resolve::BareProvider::One(p) => assert_eq!(p, "metanorma"),
+        other => panic!("expected One, got {other:?}"),
+    }
+
+    // a second claim → Ambiguous (sorted, deterministic)
+    write_payload(
+        &home,
+        "metanorma-b",
+        "2.0.0",
+        &app_manifest("metanorma-b", "2.0.0", &entrypoint_yaml(NATIVE_ENTRY, "mn")),
+    );
+    match resolve::provider_for_bare_default(&home, "mn").unwrap() {
+        resolve::BareProvider::Ambiguous(ps) => {
+            assert_eq!(ps, vec!["metanorma".to_string(), "metanorma-b".to_string()])
+        }
+        other => panic!("expected Ambiguous, got {other:?}"),
+    }
+
+    // disabling one claim disambiguates (the routing amendment's skip)
+    write_disabled(&home, "mn:\n  - metanorma-b@all\n");
+    match resolve::provider_for_bare_default(&home, "mn").unwrap() {
+        resolve::BareProvider::One(p) => assert_eq!(p, "metanorma"),
+        other => panic!("expected One, got {other:?}"),
+    }
+}

--- a/docs/spec/05-resolution-and-cache.md
+++ b/docs/spec/05-resolution-and-cache.md
@@ -124,8 +124,19 @@ installs, pre-identity manifests).
   tree; press seeds its environment by extracting in-process through the
   TFS ABI and rebuilds per press.
 - `TEBAKO_OFFLINE=1` — cache hit or hard error.
-- `tebako cache list` / `cache prune [--all] [--older-than Nd]` manage
-  the cache.
+- `tebako cache list` (runtimes and payloads) / `cache prune
+  [--runtimes] [--payloads] [--all | --older-than Nd]` manage the cache.
+  Bare `cache prune` touches runtimes only; `--payloads` adds the
+  payload arm, which NEVER removes a pinned version — the protected set
+  (config `defaults:` pins through the spec 07 §2 toolpin grammar, exact
+  `payload@version` disable selectors, and each name's newest installed
+  version, the roll-forward floor) binds even under `--all`: prune never
+  strands a pin. Per-directory `.tebako-tools.yaml` pins are
+  dispatch-time state and invisible to prune (a reachable one prints the
+  caveat once). Removal deletes the version's whole record — the `.tfs`,
+  its `.sha256` / `.origin` markers, the `.manifest.yaml` mirror, a
+  materialized `.tree/`, the install lock — and the name dir when it
+  goes empty.
 - **A run is a run** (TODO.v2-1/12): executing a package NEVER installs
   its payload slices. `tebako install <path>` installs a local package's
   payload slices explicitly — trailer slot digests are the anchors for


### PR DESCRIPTION
## What — PART B of the shim-routing / version-management arc (plan: `docs/superpowers/plans/2026-09-05-shim-routing-version-management.md`, Tasks 7–8)

The local payload library surface, on top of PR-A (#533, merged):

**`PayloadCache::prune` (tebako-resolve)** — the payload arm of `cache prune`. Same cutoff math as the runtime `Resolver::prune` (`--all` or `--older-than Nd` on the artifact mtime; one required — the new named `ResolveError::PruneNeedsSelector`, EX_USAGE at the CLI). The protected `(name, version)` set is never removed, even under `--all` — **prune never strands a pin**. Removal deletes the version's whole record: `.tfs`, `.tfs.sha256`, `.tfs.origin`, the `.manifest.yaml` mirror, a materialized `.tree/`, the install lock — and the name dir when it goes empty (the readonly artifact bit is cleared first, per platform).

**`tebako cache prune [--runtimes] [--payloads]` (tebako-cli)** — bare stays runtimes-only (byte-identical to today). `--payloads` applies the protected set ALWAYS (no opt-out):
- config `defaults:` pins via `tpkg::toolpin::ToolPin` — a qualified `payload@version` protects exactly; a bare value protects `(provider, version)` only when the provider scan is unambiguous (ambiguous → a printed note, nothing extra protected);
- exact `payload@version` selectors from `.disabled.yaml`;
- every payload's newest installed version (the roll-forward floor).
- Loading the pin state fails CLOSED; a `.tebako-tools.yaml` reachable from cwd prints the once-per-prune caveat (project pins are per-directory, invisible to prune).

`cache list` (human) gains the payload section (name@version, size, age).

**`provider_for_bare_default` (tebako-shim)** — `providing_payload`'s claim scan extracted verbatim as `claim_scan` so dispatch and prune share ONE scan (spec 00 invariant 10, SSOT); `BareProvider::One / Ambiguous / None` flattens the dispatch errors to data for prune's use.

**Spec sync:** spec 05 §4 documents the payload arm (the code commits' "spec 15 §4" citation was a slip — the cache rules live in spec 05 §4; the spec commit in this branch says so).

## Test plan

- 7 new `tebako-cli/tests/cache_prune.rs` cases: pins+floor survive `--payloads --all`; bare `prune --all` touches runtimes only (regression); `--older-than` prunes only old unprotected; `cache list` shows the payload section; the project-pin caveat prints; ambiguous bare default → note + nothing extra; disabled-selector pairs protected.
- tebako-shim: `provider_for_bare_default` One/Ambiguous/None coverage.
- tebako-resolve: prune unit tests (backdated-mtime fixtures via the same libc/Win32 pair the flock uses — no new dependency).
- Gates: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test -p tpkg -p tebako-resolve -p tebako-cli -p tebako-shim` (debug) — results in the PR checks.

Companion docs (the curated `file://` library guide): tamatebako/tebako.org#71.
