### PR TITLE
libtfs-preload: interpose the dup class (dup/dup2/fcntl F_DUPFD) — tebako#534

### DIFF
--- a/crates/libtfs-preload/src/route.rs
+++ b/crates/libtfs-preload/src/route.rs
@@ -252,6 +252,21 @@ pub fn vfs_close(fd: i32) -> Result<(), i32> {
     context().write().unwrap().close(fd)
 }
 
+/// The dup class (tebako#534): the engine clones the open-file
+/// description (the offset is SHARED) onto a fresh flagged fd; `min` is
+/// the fcntl(F_DUPFD) floor (0 for plain dup).
+pub fn vfs_dup(fd: i32, min: i32) -> Result<i32, i32> {
+    context().write().unwrap().dup(fd, min)
+}
+
+/// dup2 onto a memfs-flagged target number (the shim answers ENOTSUP
+/// for a host-numbered target before routing here): the engine
+/// atomically closes a live target and rebinds the number to the
+/// source's description.
+pub fn vfs_dup2(old: i32, new: i32) -> Result<i32, i32> {
+    context().write().unwrap().dup2(old, new)
+}
+
 pub fn vfs_closedir(id: usize) -> Result<(), i32> {
     context().write().unwrap().closedir(id)
 }

--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -270,6 +270,12 @@ real_fn!(
     unsafe extern "C" fn(c_int, libc::off_t, c_int) -> libc::off_t
 );
 real_fn!(real_close, c"close", unsafe extern "C" fn(c_int) -> c_int);
+real_fn!(real_dup, c"dup", unsafe extern "C" fn(c_int) -> c_int);
+real_fn!(
+    real_dup2,
+    c"dup2",
+    unsafe extern "C" fn(c_int, c_int) -> c_int
+);
 real_fn!(
     real_fcntl,
     c"fcntl",
@@ -584,6 +590,18 @@ pub(super) unsafe fn raw_lseek(fd: c_int, offset: libc::off_t, whence: c_int) ->
 #[cfg(target_pointer_width = "64")]
 pub(super) unsafe fn raw_close(fd: c_int) -> c_int {
     unsafe { libc::syscall(libc::SYS_close, fd) as c_int }
+}
+
+/// `dup` via SYS_dup.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_dup(fd: c_int) -> c_int {
+    unsafe { libc::syscall(libc::SYS_dup, fd) as c_int }
+}
+
+/// `dup2` via SYS_dup2.
+#[cfg(target_pointer_width = "64")]
+pub(super) unsafe fn raw_dup2(old: c_int, new: c_int) -> c_int {
+    unsafe { libc::syscall(libc::SYS_dup2, old, new) as c_int }
 }
 
 /// `fcntl` via SYS_fcntl (64-bit fcntl == fcntl64). Forwards the shim's

--- a/crates/libtfs-preload/src/sys/macos.rs
+++ b/crates/libtfs-preload/src/sys/macos.rs
@@ -201,6 +201,23 @@ interpose!(
     libc::close,
     unsafe extern "C" fn(c_int) -> c_int
 );
+// dup/dup2 are NOT variadic — no arm64 trampoline needed (unlike
+// open/openat/fcntl): the tuples bind the Rust bodies directly on both
+// Darwin arches.
+interpose!(
+    INTERPOSE_DUP,
+    real_dup,
+    super::dup,
+    libc::dup,
+    unsafe extern "C" fn(c_int) -> c_int
+);
+interpose!(
+    INTERPOSE_DUP2,
+    real_dup2,
+    super::dup2,
+    libc::dup2,
+    unsafe extern "C" fn(c_int, c_int) -> c_int
+);
 // `close` vs `close$NOCANCEL` (x86_64): the libc crate maps `libc::close`
 // to `close$NOCANCEL` on x86_64 darwin (libc's unix/mod.rs `link_name`),
 // so the tuple above covers ONLY the NOCANCEL spelling there — while C

--- a/crates/libtfs-preload/src/sys/mod.rs
+++ b/crates/libtfs-preload/src/sys/mod.rs
@@ -1271,17 +1271,90 @@ pub unsafe extern "C" fn close(fd: c_int) -> c_int {
     unsafe { plat::real_close()(fd) }
 }
 
+/// Interposed `dup` (fd-flag dispatch; tebako#534 — libxml2's
+/// xmlInputFromFd calls dup(fd) unconditionally, and every VFS fd died
+/// EBADF on it). A memfs fd clones its open-file description in the
+/// engine — the offset is SHARED (POSIX open-file-description
+/// semantics); the clone carries FD_CLOEXEC OFF, as dup guarantees.
+/// A host fd passes through untouched.
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn dup(fd: c_int) -> c_int {
+    boot_arm!(plat::raw_dup, (fd));
+    if !route::is_memfs_fd(fd) {
+        // SAFETY: forwarding the original argument to the real dup.
+        return unsafe { plat::real_dup()(fd) };
+    }
+    match engine_call(|| route::vfs_dup(fd, 0)) {
+        Some(Ok(newfd)) => {
+            fd_table_note(newfd, false);
+            newfd
+        }
+        Some(Err(e)) => {
+            set_errno(e);
+            -1
+        }
+        None => {
+            set_errno(libc::EIO);
+            -1
+        }
+    }
+}
+
+/// Interposed `dup2` (fd-flag dispatch). A host-numbered SOURCE passes
+/// through to the real dup2 untouched (the target is then the kernel's
+/// business). A memfs source with a host-numbered TARGET is the
+/// genuinely impossible case: the fd routing keys on the
+/// `TEBAKO_FD_FLAG` bit, so a host number can never name a memfs
+/// description — ENOTSUP, the named error, never EBADF-by-default
+/// (spec 07 §8). A memfs-flagged target routes to the engine, which
+/// atomically closes a live target (full alias/promotion semantics) and
+/// rebinds the number to the source's description — the target then
+/// resolves to the SAME VFS file. `dup2(a, a)` is the POSIX no-op,
+/// liveness-checked by the engine (EBADF on a dead fd); FD_CLOEXEC on
+/// the target is cleared by dup2 and left alone by the no-op.
+#[cfg_attr(target_os = "linux", no_mangle)]
+pub unsafe extern "C" fn dup2(old: c_int, new: c_int) -> c_int {
+    boot_arm!(plat::raw_dup2, (old, new));
+    if !route::is_memfs_fd(old) {
+        // SAFETY: forwarding the original arguments to the real dup2.
+        return unsafe { plat::real_dup2()(old, new) };
+    }
+    if !route::is_memfs_fd(new) {
+        set_errno(libc::ENOTSUP);
+        return -1;
+    }
+    match engine_call(|| route::vfs_dup2(old, new)) {
+        Some(Ok(newfd)) => {
+            if newfd != old {
+                fd_table_purge(newfd);
+                fd_table_note(newfd, false);
+            }
+            newfd
+        }
+        Some(Err(e)) => {
+            set_errno(e);
+            -1
+        }
+        None => {
+            set_errno(libc::EIO);
+            -1
+        }
+    }
+}
+
 /// Interposed `fcntl` (fd-flag dispatch). Only the descriptor commands
 /// are meaningful on a memfs fd: F_GETFD/F_SETFD read/write the shim's
 /// fd table; F_GETFL answers the truthful read-only status word (payload
 /// images are always ro, spec 11 — O_RDONLY, never O_APPEND/O_NONBLOCK);
 /// F_SETFL is an accepted no-op (a memfs read never blocks and there is
-/// no kernel status word to mutate). The dup class (F_DUPFD and kin) is
-/// NOT modeled — duplicating a memfs fd is the engine's to own, and no
-/// tier-1 consumer (the CPython/JDK boot paths) calls it: EINVAL, like
-/// every other unrecognized command on a LIVE memfs fd ("cmd is not
-/// valid" — the fd is open, so EBADF would lie). A flagged-but-closed fd
-/// is EBADF. Host fds pass through untouched.
+/// no kernel status word to mutate). The dup class (tebako#534) is the
+/// engine's, like the dup/dup2 shims: F_DUPFD clones the open-file
+/// description onto the lowest free number ≥ arg (FD_CLOEXEC OFF, per
+/// POSIX), F_DUPFD_CLOEXEC does the same with FD_CLOEXEC ON — the clone
+/// is a shim-managed fd carrying the same VFS target, never an
+/// EBADF-by-default. Every other unrecognized command on a LIVE memfs fd
+/// is EINVAL ("cmd is not valid" — the fd is open, so EBADF would lie).
+/// A flagged-but-closed fd is EBADF. Host fds pass through untouched.
 ///
 /// ABI note: fcntl is variadic like open — on Darwin arm64 the third
 /// argument rides the STACK (the first variadic slot at [sp, 0]), so the
@@ -1326,6 +1399,20 @@ pub unsafe extern "C" fn fcntl_impl(fd: c_int, cmd: c_int, arg: c_int) -> c_int 
         }
         libc::F_GETFL => libc::O_RDONLY,
         libc::F_SETFL => 0,
+        libc::F_DUPFD | libc::F_DUPFD_CLOEXEC => match engine_call(|| route::vfs_dup(fd, arg)) {
+            Some(Ok(newfd)) => {
+                fd_table_note(newfd, cmd == libc::F_DUPFD_CLOEXEC);
+                newfd
+            }
+            Some(Err(e)) => {
+                set_errno(e);
+                -1
+            }
+            None => {
+                set_errno(libc::EIO);
+                -1
+            }
+        },
         _ => {
             set_errno(libc::EINVAL);
             -1

--- a/crates/libtfs-preload/tests/e2e.rs
+++ b/crates/libtfs-preload/tests/e2e.rs
@@ -162,6 +162,7 @@ fn build_fixtures() -> Option<Fixtures> {
         "mmap-probe",
         "close-probe",
         "fcntl-probe",
+        "dup-probe",
         "fork-exec",
         "alias-probe",
         "realpath-probe",
@@ -1173,6 +1174,26 @@ fn fcntl_on_a_memfs_fd() {
     let r = run(f, "fcntl-probe", &[path.as_str()], None);
     assert_eq!(r.rc, 0, "fcntl-probe failed, stderr: {}", r.stderr);
     assert!(r.stdout.contains("fcntl-probe:ok"), "stdout: {}", r.stdout);
+}
+
+/// tebako#534 — libxml2's `xmlInputFromFd` dup()s its fd unconditionally
+/// and every VFS-fed parse died EBADF (the xml2rfc feedstock's lxml
+/// compat shim is the workaround this fix retires). The probe pins the
+/// whole dup class end-to-end: dup of a memfs fd clones the open-file
+/// description (a read through the clone continues the ORIGINAL's
+/// position; an lseek through the clone moves it), dup clears FD_CLOEXEC
+/// while F_DUPFD_CLOEXEC sets it, dup2 onto a second live memfs fd
+/// rebinds the number to the source's description (the regression pin),
+/// dup2(fd, fd) is the liveness-checked no-op, a host-numbered dup2
+/// target is ENOTSUP (the named error), a dead fd is EBADF, and host
+/// fds pass through untouched.
+#[test]
+fn dup_family_on_a_memfs_fd() {
+    let Some(f) = fixtures() else { return };
+    let path = format!("{MOUNT}/data/secret.txt");
+    let r = run(f, "dup-probe", &[path.as_str()], None);
+    assert_eq!(r.rc, 0, "dup-probe failed, stderr: {}", r.stderr);
+    assert!(r.stdout.contains("dup-probe:ok"), "stdout: {}", r.stdout);
 }
 
 /// The 2026-08-22 fork/exec deadlock regression pin (runtime 0.16.4: a

--- a/crates/libtfs-preload/tests/fixtures/dup-probe.c
+++ b/crates/libtfs-preload/tests/fixtures/dup-probe.c
@@ -1,0 +1,110 @@
+/* tebako#534: libxml2's xmlInputFromFd unconditionally dup()s its fd —
+ * on a shim-managed (flag-bit) memfs fd the real dup answered EBADF and
+ * every VFS-fed XML parse died (the xml2rfc feedstock's lxml shim). The
+ * dup class is now the engine's: dup/dup2/fcntl(F_DUPFD/F_DUPFD_CLOEXEC)
+ * clone the open-file description — the offset is SHARED, exactly like
+ * POSIX — and the clone is itself a flagged fd the shim owns. A memfs
+ * source with a HOST-numbered dup2 target is ENOTSUP (the fd routing
+ * keys on the flag bit, so a host number can never name a memfs
+ * description — the named error, never EBADF-by-default). The file
+ * content is "VFS-SECRET-E2E\n" (15 bytes). Cross-platform: the dup
+ * family is plain POSIX. */
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+static int expect_read(int fd, const char *want, int rc, const char *what) {
+    char buf[8];
+    ssize_t n = read(fd, buf, strlen(want));
+    if (n != (ssize_t)strlen(want) || memcmp(buf, want, strlen(want)) != 0) {
+        fprintf(stderr, "%s: got %.8s (n=%zd), want %s\n", what, buf, n, want);
+        return rc;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    int fd, c1, c2, c3, fd2, hfd, r;
+    if (argc < 2) return 64;
+    /* O_CLOEXEC at open: the dup clones must carry the bit OFF. */
+    fd = open(argv[1], O_RDONLY | O_CLOEXEC);
+    if (fd < 0) { perror("open"); return 65; }
+
+    /* THE #534 PIN: dup of a memfs fd must NOT die EBADF. */
+    c1 = dup(fd);
+    if (c1 < 0) { perror("dup"); return 66; }
+    /* The clone shares the open-file description: read "VFS-" through
+     * the original, the clone continues at "SECR". */
+    if ((r = expect_read(fd, "VFS-", 67, "read orig")) != 0) return r;
+    if ((r = expect_read(c1, "SECR", 68, "read clone (shared offset)")) != 0) return r;
+    /* dup cleared FD_CLOEXEC on the clone (POSIX), even though the
+     * original was opened O_CLOEXEC. */
+    if (fcntl(c1, F_GETFD) != 0) { fprintf(stderr, "dup clone kept FD_CLOEXEC\n"); return 69; }
+    /* An lseek through the clone moves the original's position. */
+    if (lseek(c1, 0, SEEK_SET) != 0) { perror("lseek clone"); return 70; }
+    if ((r = expect_read(fd, "VFS-", 71, "read orig after clone lseek")) != 0) return r;
+
+    /* fcntl(F_DUPFD, min): another shared clone; the kernel returns the
+     * NEW fd from this command. */
+    c2 = fcntl(fd, F_DUPFD, 0);
+    if (c2 < 0) { perror("fcntl(F_DUPFD)"); return 72; }
+    if ((r = expect_read(c2, "SECR", 73, "read F_DUPFD clone")) != 0) return r;
+    if (fcntl(c2, F_GETFD) != 0) { fprintf(stderr, "F_DUPFD clone kept FD_CLOEXEC\n"); return 74; }
+
+    /* F_DUPFD_CLOEXEC: the clone with the bit SET. */
+    c3 = fcntl(fd, F_DUPFD_CLOEXEC, 0);
+    if (c3 < 0) { perror("fcntl(F_DUPFD_CLOEXEC)"); return 75; }
+    if ((fcntl(c3, F_GETFD) & FD_CLOEXEC) == 0) {
+        fprintf(stderr, "F_DUPFD_CLOEXEC clone lost FD_CLOEXEC\n");
+        return 76;
+    }
+
+    /* THE REGRESSION PIN: dup2 of a memfs fd onto a SECOND live memfs
+     * fd (an independent open of the same file) — the target's own
+     * description dies and the number rebinds to the source's: reading
+     * the target continues the SOURCE's position. */
+    fd2 = open(argv[1], O_RDONLY);
+    if (fd2 < 0) { perror("open 2"); return 77; }
+    if (lseek(fd, 0, SEEK_SET) != 0) { perror("lseek"); return 78; }
+    if ((r = expect_read(fd, "VFS-", 79, "read source pre-dup2")) != 0) return r;
+    if (dup2(fd, fd2) != fd2) { perror("dup2 onto memfs target"); return 80; }
+    if ((r = expect_read(fd2, "SECR", 81, "dup2 target reads source's pos")) != 0) return r;
+    if (close(fd2) != 0) { perror("close rebound target"); return 82; }
+    /* …and the source reads on (the alias close kept the description). */
+    if ((r = expect_read(fd, "ET-E", 83, "source after alias close")) != 0) return r;
+
+    /* dup2(fd, fd): the POSIX no-op — returns fd, position untouched. */
+    if (dup2(fd, fd) != fd) { perror("dup2 no-op"); return 84; }
+    if ((r = expect_read(fd, "2E\n", 85, "read after dup2 no-op")) != 0) return r;
+
+    /* The named error: a memfs source with a HOST-numbered dup2 target
+     * is ENOTSUP (a host number cannot carry the flag bit), never a
+     * silent EBADF — and the host fd survives untouched. */
+    hfd = open("/dev/null", O_RDONLY);
+    if (hfd < 0) { perror("open /dev/null"); return 86; }
+    errno = 0;
+    if (dup2(fd, hfd) != -1 || errno != ENOTSUP) {
+        fprintf(stderr, "dup2 onto host fd: rc/errno wrong (errno=%d)\n", errno);
+        return 87;
+    }
+    if (close(hfd) != 0) { perror("host fd survived"); return 88; }
+
+    /* dup of a dead memfs fd: EBADF, exactly the kernel's answer. */
+    if (close(fd) != 0) { perror("close"); return 89; }
+    errno = 0;
+    if (dup(fd) != -1 || errno != EBADF) {
+        fprintf(stderr, "dup of closed fd: rc/errno wrong (errno=%d)\n", errno);
+        return 90;
+    }
+    /* Host fds pass through to the real dup untouched. */
+    hfd = open("/dev/null", O_RDONLY);
+    if (hfd < 0) { perror("open /dev/null 2"); return 91; }
+    c1 = dup(hfd);
+    if (c1 < 0) { perror("dup host"); return 92; }
+    if (close(c1) != 0 || close(hfd) != 0) { perror("close host pair"); return 93; }
+
+    puts("dup-probe:ok");
+    return 0;
+}

--- a/crates/libtfs-preload/tests/fixtures/fcntl-probe.c
+++ b/crates/libtfs-preload/tests/fixtures/fcntl-probe.c
@@ -10,9 +10,9 @@
  * the seed), F_GETFL answers the truthful read-only status word,
  * F_SETFL is an accepted no-op, and a flagged-but-closed fd is EBADF —
  * the kernel's own answer. A host fd must pass through untouched.
- * The dup class (F_DUPFD and kin) is EINVAL by design (duplicating a
- * memfs fd is the engine's to own) and is deliberately not pinned
- * here. Cross-platform: fcntl's fd commands are plain POSIX. */
+ * The dup class (F_DUPFD/F_DUPFD_CLOEXEC) is now interposed too — the
+ * dup-probe fixture owns those pins (tebako#534). Cross-platform:
+ * fcntl's fd commands are plain POSIX. */
 #include <errno.h>
 #include <stdio.h>
 #include <fcntl.h>

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -159,6 +159,12 @@ enum DlSurface {
 pub struct FsContext {
     mounts: BTreeMap<i32, Mount>,
     fd_table: BTreeMap<i32, FdEntry>,
+    /// The dup class (tebako#534, spec 07 §8): alias internal fd → the
+    /// canonical internal fd holding the shared open-file description.
+    /// An alias carries no FdEntry of its own — every fd operation
+    /// resolves through the canonical number, so the description's
+    /// position is shared exactly like a POSIX dup.
+    fd_alias: BTreeMap<i32, i32>,
     dir_table: BTreeMap<usize, DirState>,
     next_handle: i32,
     next_fd: i32,
@@ -207,6 +213,7 @@ impl FsContext {
         FsContext {
             mounts: BTreeMap::new(),
             fd_table: BTreeMap::new(),
+            fd_alias: BTreeMap::new(),
             dir_table: BTreeMap::new(),
             next_handle: 0,
             next_fd: 1,
@@ -470,6 +477,9 @@ impl FsContext {
             trace_start.and_then(|_| self.mounts.get(&handle).map(|m| m.mount_point.clone()));
         let result = if self.mounts.contains_key(&handle) {
             self.fd_table.retain(|_, e| e.owner != handle);
+            // Aliases whose description died with the mount die too.
+            self.fd_alias
+                .retain(|_, canon| self.fd_table.contains_key(canon));
             self.dir_table.retain(|_, e| e.owner != handle);
             self.mounts.remove(&handle);
             if self.compat_handle == Some(handle) {
@@ -509,6 +519,7 @@ impl FsContext {
         }
         self.mounts.clear();
         self.fd_table.clear();
+        self.fd_alias.clear();
         self.dir_table.clear();
         self.next_fd = 1;
         self.next_dir_id = 1;
@@ -863,7 +874,11 @@ impl FsContext {
         }
         let owner = mount.handle;
         let trace_point = trace_start.map(|_| mount.mount_point.clone());
-        let fd = self.next_fd;
+        // Alias numbers (the dup class) are live fds too — skip them.
+        let mut fd = self.next_fd;
+        while self.fd_alias.contains_key(&fd) {
+            fd += 1;
+        }
         if fd > TEBAKO_FD_MAX {
             if let Some(start) = trace_start {
                 trace::emit(
@@ -874,7 +889,7 @@ impl FsContext {
             }
             return Err(libc::EMFILE);
         }
-        self.next_fd += 1;
+        self.next_fd = fd + 1;
         self.fd_table.insert(
             fd,
             FdEntry {
@@ -892,11 +907,18 @@ impl FsContext {
         Ok(fd | TEBAKO_FD_FLAG)
     }
 
+    /// The canonical internal number for an internal number: a dup alias
+    /// resolves to the description holder, anything else is its own
+    /// canonical.
+    fn canonical_fd(&self, internal: i32) -> i32 {
+        self.fd_alias.get(&internal).copied().unwrap_or(internal)
+    }
+
     fn lookup_fd(&self, fd: i32) -> Option<(i32, &FdEntry)> {
         if (fd & TEBAKO_FD_FLAG) == 0 {
             return None;
         }
-        let internal = fd & !TEBAKO_FD_FLAG;
+        let internal = self.canonical_fd(fd & !TEBAKO_FD_FLAG);
         self.fd_table.get(&internal).map(|e| (internal, e))
     }
 
@@ -904,7 +926,7 @@ impl FsContext {
         if (fd & TEBAKO_FD_FLAG) == 0 {
             return None;
         }
-        let internal = fd & !TEBAKO_FD_FLAG;
+        let internal = self.canonical_fd(fd & !TEBAKO_FD_FLAG);
         self.fd_table.get_mut(&internal).map(|e| (internal, e))
     }
 
@@ -965,15 +987,92 @@ impl FsContext {
         Ok(target)
     }
 
-    /// tebako_fs_close.
+    /// tebako_fs_close. An alias close drops only the alias (the
+    /// description lives on); closing the description holder while
+    /// aliases live PROMOTES the lowest-numbered alias — POSIX's "the
+    /// description dies with its last fd".
     pub fn close(&mut self, fd: i32) -> Result<(), i32> {
         if (fd & TEBAKO_FD_FLAG) == 0 {
             return Err(libc::EBADF);
         }
-        match self.fd_table.remove(&(fd & !TEBAKO_FD_FLAG)) {
-            Some(_) => Ok(()),
+        let internal = fd & !TEBAKO_FD_FLAG;
+        if self.fd_alias.remove(&internal).is_some() {
+            return Ok(());
+        }
+        match self.fd_table.remove(&internal) {
+            Some(entry) => {
+                let promoted = self
+                    .fd_alias
+                    .iter()
+                    .find(|(_, canon)| **canon == internal)
+                    .map(|(alias, _)| *alias);
+                if let Some(alias) = promoted {
+                    self.fd_alias.remove(&alias);
+                    // The remaining clones follow the description to its
+                    // new holder number.
+                    for canon in self.fd_alias.values_mut() {
+                        if *canon == internal {
+                            *canon = alias;
+                        }
+                    }
+                    self.fd_table.insert(alias, entry);
+                }
+                Ok(())
+            }
             None => Err(libc::EBADF),
         }
+    }
+
+    /// The dup class (tebako#534, spec 07 §8): clone `fd`'s open-file
+    /// description onto the lowest free internal number ≥ `min` (the
+    /// fcntl(F_DUPFD) shape; the shim's plain dup passes 0). The clone is
+    /// an alias record, not a second FdEntry — the description's
+    /// position is shared. Errors: EBADF (`fd` is not a live memfs fd),
+    /// EINVAL (negative `min` — the kernel's F_DUPFD answer), EMFILE
+    /// (the flagged fd space is exhausted).
+    pub fn dup(&mut self, fd: i32, min: i32) -> Result<i32, i32> {
+        let (canonical, _) = self.lookup_fd(fd).ok_or(libc::EBADF)?;
+        if min < 0 {
+            return Err(libc::EINVAL);
+        }
+        let mut n = min.max(1);
+        while self.fd_table.contains_key(&n) || self.fd_alias.contains_key(&n) {
+            n += 1;
+        }
+        if n > TEBAKO_FD_MAX {
+            return Err(libc::EMFILE);
+        }
+        self.fd_alias.insert(n, canonical);
+        Ok(n | TEBAKO_FD_FLAG)
+    }
+
+    /// dup2: `new` (a flagged number the shim chose) is atomically closed
+    /// when live and rebound as an alias of `old`'s description; the
+    /// target resolves to the SAME VFS file. `new == old` is the POSIX
+    /// no-op, EBADF-checked first. An unflagged `new` is EINVAL here —
+    /// the shim answers ENOTSUP for a HOST-numbered target before the
+    /// engine is consulted (a host number cannot carry the flag bit the
+    /// fd routing keys on, spec 07 §8).
+    pub fn dup2(&mut self, old: i32, new: i32) -> Result<i32, i32> {
+        let _ = self.lookup_fd(old).ok_or(libc::EBADF)?;
+        if new == old {
+            return Ok(new);
+        }
+        if (new & TEBAKO_FD_FLAG) == 0 {
+            return Err(libc::EINVAL);
+        }
+        let internal_new = new & !TEBAKO_FD_FLAG;
+        if internal_new == 0 {
+            return Err(libc::EINVAL);
+        }
+        // Close a live target with full alias/promotion semantics. In the
+        // edge where the target HELD old's description, the close
+        // promoted an alias — re-resolve through old afterwards so the
+        // rebind lands on the description wherever it now lives.
+        let _ = self.close(new);
+        let (canonical, _) = self.lookup_fd(old).ok_or(libc::EBADF)?;
+        self.fd_alias.insert(internal_new, canonical);
+        Ok(new)
     }
 
     // ---------------------------------------------------------------
@@ -2798,6 +2897,202 @@ mod tests {
         let bytes = writer.finish().unwrap().into_inner();
         std::fs::write(&path, bytes).unwrap();
         path
+    }
+
+    /// A context with the fixture zip mounted at /tfs: (ctx, handle).
+    fn ctx_with_fixture(dir: &std::path::Path) -> (FsContext, i32) {
+        let image = fixture_zip(dir);
+        let mut ctx = FsContext::new();
+        let mount = crate::mount::build_from_file(image.to_str().unwrap(), "/tfs").unwrap();
+        let handle = ctx.mount_checked(mount).unwrap();
+        (ctx, handle)
+    }
+
+    #[test]
+    fn dup_shares_the_open_file_description() {
+        // tebako#534: a dup'd fd is the SAME open-file description — the
+        // offset is shared (libxml2's xmlInputFromFd reads through the
+        // clone and expects the original's position to move with it).
+        let dir = std::env::temp_dir().join(format!("tfs-dup-share-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let (mut ctx, _h) = ctx_with_fixture(&dir);
+        let a = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+        let b = ctx.dup(a, 0).unwrap();
+        assert_ne!(a, b);
+        assert_eq!(b & TEBAKO_FD_FLAG, TEBAKO_FD_FLAG);
+        // "hush": read "hu" through the original…
+        let mut buf = [0u8; 2];
+        assert_eq!(ctx.read(a, &mut buf).unwrap(), 2);
+        assert_eq!(&buf, b"hu");
+        // …the clone continues at "sh": the position is shared.
+        assert_eq!(ctx.read(b, &mut buf).unwrap(), 2);
+        assert_eq!(&buf, b"sh");
+        // An lseek through the clone moves the original's position too.
+        assert_eq!(ctx.lseek(b, 0, libc::SEEK_SET).unwrap(), 0);
+        let mut buf = [0u8; 1];
+        assert_eq!(ctx.read(a, &mut buf).unwrap(), 1);
+        assert_eq!(&buf, b"h");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dup_answers_ebadf_on_host_and_dead_fds() {
+        let dir = std::env::temp_dir().join(format!("tfs-dup-ebadf-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let (mut ctx, _h) = ctx_with_fixture(&dir);
+        // A host fd (no flag bit) is not the engine's to clone.
+        assert_eq!(ctx.dup(3, 0), Err(libc::EBADF));
+        // A flagged number nobody holds.
+        assert_eq!(ctx.dup(7 | TEBAKO_FD_FLAG, 0), Err(libc::EBADF));
+        let a = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+        ctx.close(a).unwrap();
+        assert_eq!(ctx.dup(a, 0), Err(libc::EBADF));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dup_min_is_honored_fcntl_shape() {
+        // fcntl(F_DUPFD, min): the clone lands on the lowest free internal
+        // number ≥ min; a negative min is EINVAL (the kernel's answer).
+        let dir = std::env::temp_dir().join(format!("tfs-dup-min-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let (mut ctx, _h) = ctx_with_fixture(&dir);
+        let a = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+        let b = ctx.dup(a, 10).unwrap();
+        assert_eq!(b & !TEBAKO_FD_FLAG, 10);
+        let c = ctx.dup(a, 10).unwrap();
+        assert_eq!(c & !TEBAKO_FD_FLAG, 11);
+        assert_eq!(ctx.dup(a, -1), Err(libc::EINVAL));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn close_of_the_original_promotes_the_lowest_alias() {
+        // POSIX: the description dies with its LAST fd. Closing the
+        // original while clones live promotes the lowest-numbered clone
+        // to description holder; reads keep flowing through every clone.
+        let dir = std::env::temp_dir().join(format!("tfs-dup-promote-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let (mut ctx, _h) = ctx_with_fixture(&dir);
+        let a = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+        let b = ctx.dup(a, 0).unwrap();
+        let c = ctx.dup(a, 0).unwrap();
+        ctx.close(a).unwrap();
+        let mut buf = [0u8; 2];
+        assert_eq!(ctx.read(c, &mut buf).unwrap(), 2, "alias c reads on");
+        assert_eq!(&buf, b"hu");
+        assert_eq!(ctx.read(b, &mut buf).unwrap(), 2, "promoted b reads on");
+        assert_eq!(&buf, b"sh");
+        // Closing the promoted holder promotes the next alias in turn.
+        ctx.close(b).unwrap();
+        assert_eq!(ctx.lseek(c, 0, libc::SEEK_SET).unwrap(), 0);
+        ctx.close(c).unwrap();
+        assert_eq!(ctx.read(c, &mut buf), Err(libc::EBADF));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn close_of_an_alias_keeps_the_original() {
+        let dir = std::env::temp_dir().join(format!("tfs-dup-closealias-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let (mut ctx, _h) = ctx_with_fixture(&dir);
+        let a = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+        let b = ctx.dup(a, 0).unwrap();
+        ctx.close(b).unwrap();
+        let mut buf = [0u8; 1];
+        assert_eq!(ctx.read(a, &mut buf).unwrap(), 1, "the original reads on");
+        assert_eq!(ctx.close(b), Err(libc::EBADF), "a dead alias stays dead");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dup2_replaces_a_live_memfs_target() {
+        // The #534 regression pin: dup2 onto a live memfs fd closes the
+        // target's own description and rebinds the number to the
+        // SOURCE's — the target resolves to the same VFS file, sharing
+        // its position.
+        let dir = std::env::temp_dir().join(format!("tfs-dup2-target-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let (mut ctx, _h) = ctx_with_fixture(&dir);
+        let a = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+        let b = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+        let mut buf = [0u8; 1];
+        assert_eq!(ctx.read(a, &mut buf).unwrap(), 1);
+        assert_eq!(ctx.dup2(a, b), Ok(b));
+        // b now shares a's description: the next byte is "u", not "h".
+        assert_eq!(ctx.read(b, &mut buf).unwrap(), 1);
+        assert_eq!(&buf, b"u");
+        // b's own description died: closing the alias leaves a live.
+        ctx.close(b).unwrap();
+        assert_eq!(ctx.read(a, &mut buf).unwrap(), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dup2_fresh_and_unflagged_targets_and_the_noop() {
+        let dir = std::env::temp_dir().join(format!("tfs-dup2-misc-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let (mut ctx, _h) = ctx_with_fixture(&dir);
+        let a = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+        // dup2(a, a) is the POSIX no-op — still EBADF-checked.
+        assert_eq!(ctx.dup2(a, a), Ok(a));
+        // A fresh flagged number is aliased outright.
+        let n = 42 | TEBAKO_FD_FLAG;
+        assert_eq!(ctx.dup2(a, n), Ok(n));
+        let mut buf = [0u8; 1];
+        assert_eq!(ctx.read(n, &mut buf).unwrap(), 1);
+        // An unflagged target is EINVAL here (the shim answers ENOTSUP
+        // for a host-numbered target before the engine is consulted).
+        assert_eq!(ctx.dup2(a, 42), Err(libc::EINVAL));
+        // A dead source is EBADF, no-op shape or not.
+        ctx.close(n).unwrap();
+        assert_eq!(ctx.dup2(n, n), Err(libc::EBADF));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unmount_drops_aliases_with_their_description() {
+        let dir = std::env::temp_dir().join(format!("tfs-dup-unmount-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let (mut ctx, h) = ctx_with_fixture(&dir);
+        let a = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+        let b = ctx.dup(a, 0).unwrap();
+        ctx.unmount_handle(h).unwrap();
+        let mut buf = [0u8; 1];
+        assert_eq!(ctx.read(a, &mut buf), Err(libc::EBADF));
+        assert_eq!(ctx.read(b, &mut buf), Err(libc::EBADF));
+        assert_eq!(ctx.dup(a, 0), Err(libc::EBADF));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn open_never_allocates_an_alias_number() {
+        // An alias number stays out of the open allocator's way even when
+        // it sits at next_fd.
+        let dir = std::env::temp_dir().join(format!("tfs-dup-alloc-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let (mut ctx, _h) = ctx_with_fixture(&dir);
+        let a = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+        let b = ctx.dup(a, 2).unwrap();
+        assert_eq!(b & !TEBAKO_FD_FLAG, 2);
+        let c = ctx.open("/tfs/data/secret.txt", libc::O_RDONLY).unwrap();
+        assert_eq!(c & !TEBAKO_FD_FLAG, 3, "open skips the alias at 2");
+        let d = ctx.dup(a, 0).unwrap();
+        assert_eq!(
+            d & !TEBAKO_FD_FLAG,
+            4,
+            "dup skips 1/2/3 (entry, alias, entry)"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -267,12 +267,27 @@ The locked model is three tiers — **interposition-first, never FUSE**:
    close(+the plain and $NOCANCEL spellings on x86_64 darwin — the libc
    crate maps `libc::close` to `close$NOCANCEL` there, C binaries
    (the JVM's libjava/libjli/libzip) import plain `close`; both route
-   to the shim)/fcntl(the descriptor commands on a memfs fd are served
+   to the shim)/dup/dup2(tebako#534 — libxml2's xmlInputFromFd calls
+   dup(fd) unconditionally, so every VFS fd died EBADF there: the clone
+   lands on a shim-managed flagged fd carrying the SAME open-file
+   description — the offset is shared, per POSIX; dup and
+   fcntl(F_DUPFD) leave FD_CLOEXEC off the clone, F_DUPFD_CLOEXEC sets
+   it; dup2 atomically closes a live memfs target and rebinds the
+   number to the source's description (the target resolves to the same
+   VFS file), and dup2(fd, fd) is the liveness-checked no-op; a memfs
+   source with a HOST-numbered dup2 target is the named error ENOTSUP
+   — the fd routing keys on the flag bit, so a host number can never
+   name a memfs description — never EBADF-by-default; a dead memfs fd
+   is EBADF, the kernel's own answer; host-numbered dup/dup2 sources
+   pass through untouched)/fcntl(the descriptor commands on a memfs fd
+   are served
    from the shim's own fd table — open/openat seed the close-on-exec
    bit from O_CLOEXEC, F_GETFD/F_SETFD read/write it, F_GETFL answers
    the truthful read-only status word, F_SETFL is an accepted no-op, a
-   flagged-but-closed fd is EBADF, the dup class (F_DUPFD and kin) is
-   EINVAL, host fds pass through untouched — CPython's io.FileIO boot
+   flagged-but-closed fd is EBADF, the dup-class commands
+   F_DUPFD/F_DUPFD_CLOEXEC clone the open-file description exactly
+   like the dup/dup2 shims above, host fds pass through untouched —
+   CPython's io.FileIO boot
    path fcntls every fresh source fd with raise=1, so unshimmed the
    interpreter died importing `encodings` before any user code)/mkdir/unlink/rename + dlopen + execve/posix_spawn/posix_spawnp
    + the realpath family (realpath, plus macOS's realpath$DARWIN_EXTSN;
@@ -320,6 +335,8 @@ The locked model is three tiers — **interposition-first, never FUSE**:
    and a fork child
    that execs re-enters a fresh shim through the inherited preload env,
    so the grandchild rule above is unaffected; not interposed: fork,
+   `dup3` (linux-only, no tier-1 consumer — its flags argument would
+   need the cloexec plumbing the POSIX dup class already has),
    `openat2` (glibc exposes no wrapper
    or symbol on linux-gnu — nothing to interpose; a raw `syscall(2)`
    caller bypasses userland interposition by construction), fstatat64 on


### PR DESCRIPTION
## Summary

Links #534.

`libtfs-preload` did not interpose the dup class, so libxml2's
`xmlInputFromFd` — which calls `dup(fd)` unconditionally — died `EBADF`
on every shim-managed (flag-bit) VFS fd. The xml2rfc feedstock carries
the `tebako_lxml_vfs.py` compat shim as the workaround for exactly this;
**removal condition: this issue's fix ships** (i.e. this PR merges and a
release carries it).

This is also a **spec amendment**: spec 07 §8's coverage clause
previously pinned the opposite behavior ("the dup class (F_DUPFD and
kin) is EINVAL"). The clause now states the shipped semantics (below).

## What changes

**`tfs` engine (`crates/tfs/src/context.rs`)** — the dup class is the
engine's, because a dup'd fd must SHARE the open-file description
(offset), per POSIX:

- New `fd_alias: BTreeMap<i32, i32>` on `FsContext` — alias internal fd →
  canonical internal fd. Every fd op (`read`/`pread`/`lseek`/`fstat`)
  resolves through the canonical number, so the clone shares the
  description's position.
- `dup(fd, min)` — clone onto the lowest free internal number ≥ `min`
  (the `fcntl(F_DUPFD)` shape). `EBADF` on a non-live/host fd, `EINVAL`
  on negative `min`, `EMFILE` when the flagged space is exhausted.
- `dup2(old, new)` — `new == old` is the liveness-checked POSIX no-op;
  a live memfs target is atomically closed (full alias/promotion
  semantics) and the number rebinds to the source's description — the
  target resolves to the SAME VFS file.
- `close` of an alias drops only the alias; `close` of the description
  holder while aliases live PROMOTES the lowest-numbered alias (the
  description dies with its last fd). `open` never allocates an alias
  number; `unmount`/`unmount_handle` drop aliases with their
  description.

No new C-ABI export and no `tebako-driver` change: the shim links `tfs`
as a crate and the engine fd table is the only VFS-fd record.

**`libtfs-preload` shim** (`crates/libtfs-preload/src/`):

- New `dup`/`dup2` interpositions (`sys/mod.rs` bodies; `real_dup`/
  `real_dup2` + `raw_dup`/`raw_dup2` early-boot arms on linux; two
  `interpose!` tuples on macOS — neither is variadic, so no arm64
  trampoline). Host-numbered sources pass through untouched.
- `dup2` with a memfs source and a HOST-numbered target answers the
  named error `ENOTSUP`: fd routing keys on the `TEBAKO_FD_FLAG` bit, so
  a host number can never name a memfs description — never
  EBADF-by-default (#534's acceptance rule).
- `fcntl` gains `F_DUPFD` (clone, `FD_CLOEXEC` off) and
  `F_DUPFD_CLOEXEC` (clone, bit on) — the kernel returns the new fd from
  these commands; the shim's fd table tracks the clone's cloexec state.
- `dup3` stays un-interposed (linux-only, no tier-1 consumer) and is
  named in the spec's not-interposed list.

**Spec 07 §8** — the coverage clause now pins the shipped dup-class
semantics; the not-interposed list names `dup3`.

## Verification (debug, never --release)

- `cargo test -p tfs --lib` — 204 passed (9 new: shared offset, min
  floor, promotion, alias close, dup2 rebind, no-op, unmount, allocator
  skip, EBADF cases).
- `cargo test -p libtfs-preload` — 16 unit + 27 e2e passed, including
  the new `dup_family_on_a_memfs_fd` end-to-end pin (`tests/fixtures/
  dup-probe.c`, run under the real interposed dylib): dup shares the
  offset, `lseek` through the clone moves the original, dup2 onto a
  second live memfs fd resolves to the same VFS file (the regression
  pin), `F_DUPFD`/`F_DUPFD_CLOEXEC` cloexec semantics, host-target
  `ENOTSUP`, dead-fd `EBADF`, host passthrough.
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace
  --all-targets -- -D warnings` clean; `cargo test -p tebako-driver`
  green (unchanged crate, gate run for completeness).

## Out of scope

- `dup3` (named in the spec's not-interposed list).
- Table-driven fd routing that would let a host-numbered dup2 target
  carry a VFS description — the flag-bit routing makes that genuinely
  impossible today; `ENOTSUP` is the named error per #534's acceptance.
