### PR TITLE
docs(spec31): §7 names the queued Windows extension (#542, TODO.v2-1/36)

### DIFF
--- a/docs/spec/31-macos-signing-notarization.md
+++ b/docs/spec/31-macos-signing-notarization.md
@@ -191,8 +191,8 @@ zip <stitched exe> && xcrun notarytool submit <zip> \
 
 Windows: Authenticode signing is a reputation input to SmartScreen, not a
 server-blessed gate — nothing here applies; a future Authenticode story
-would be its own spec riding the same sign-then-hash law. Linux: no
-platform gate at all.
+would be its own spec riding the same sign-then-hash law (queued: #542,
+TODO.v2-1/36 — Azure Artifact Signing). Linux: no platform gate at all.
 
 ## 8. Landing order
 


### PR DESCRIPTION
## What

One-line amendment to spec 31 §7 (non-normative comparison section): the future Authenticode spec now names its tracking issue (#542) and design file (TODO.v2-1/36 — Azure Artifact Signing).

## Why

The platform code-signing plane now has two extensions — macOS (this spec) and Windows (queued). The extension relationship was only visible from the TODO files and issue comments; the normative text should name it, so the next reader finds the queued work from the spec itself. No semantic change — §7 stays non-normative comparison; the sign-then-hash law it references is unchanged.

Harmonization context: #522's comment thread (the shared closed laws both extensions ride) and #542's owner runbook.
