### PR TITLE
libtfs-preload: dup2 early-boot arm via SYS_dup3 on aarch64-linux (unblocks v2.3.x arm64 release legs)

### DIFF
--- a/crates/libtfs-preload/src/sys/linux.rs
+++ b/crates/libtfs-preload/src/sys/linux.rs
@@ -599,9 +599,26 @@ pub(super) unsafe fn raw_dup(fd: c_int) -> c_int {
 }
 
 /// `dup2` via SYS_dup2.
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(target_pointer_width = "64", not(target_arch = "aarch64")))]
 pub(super) unsafe fn raw_dup2(old: c_int, new: c_int) -> c_int {
     unsafe { libc::syscall(libc::SYS_dup2, old, new) as c_int }
+}
+
+/// `dup2` via SYS_dup3 on aarch64-linux: the arm64 kernel never wired the
+/// dup2 syscall — libc spells `dup2` as `dup3(old, new, 0)`. `old == new`
+/// keeps the dup2 no-op semantics (a validity probe); dup3 answers EINVAL.
+#[cfg(all(target_pointer_width = "64", target_arch = "aarch64"))]
+pub(super) unsafe fn raw_dup2(old: c_int, new: c_int) -> c_int {
+    if old == new {
+        return unsafe {
+            if libc::syscall(libc::SYS_fcntl, old, libc::F_GETFD) >= 0 {
+                new
+            } else {
+                -1
+            }
+        };
+    }
+    unsafe { libc::syscall(libc::SYS_dup3, old, new, 0) as c_int }
 }
 
 /// `fcntl` via SYS_fcntl (64-bit fcntl == fcntl64). Forwards the shim's


### PR DESCRIPTION
## Root cause

The v2.3.1 release's `linux-gnu-arm64` / `linux-musl-arm64` legs failed 3× deterministically:

```
error[E0425]: cannot find value `SYS_dup2` in crate `libc`
```

The arm64 kernel never wired the `dup2` syscall — on aarch64-linux, libc spells `dup2` as `dup3(old, new, 0)`, so `libc::SYS_dup2` does not exist for that target. The dup-class interpose (8b3f0d89, #534) used the raw number in the early-boot arm; PR CI has no aarch64-linux compile leg (filed: #544), so the release legs were the first aarch64 compile of that code.

## Fix

`raw_dup2` splits per-arch:

- x86_64-linux: unchanged, `SYS_dup2`.
- aarch64-linux: `SYS_dup3(old, new, 0)`, with `old == new` handled first — `dup2(a, a)` is the POSIX validity-probe no-op while `dup3` answers `EINVAL`, so the guard preserves exact dup2 semantics (EBADF via `fcntl(F_GETFD)` on a dead fd).

## Verification

- Isolated typecheck harness (scratch crate, same `libc = "0.2"`): fixed code checks clean on `aarch64-unknown-linux-gnu`, `aarch64-unknown-linux-musl`, `x86_64-unknown-linux-gnu`; negative control (guard removed) reproduces the exact E0425 on aarch64.
- Host suite: `cargo test -p libtfs-preload` — 27/27 green; `cargo fmt --check` clean.
- The in-tree aarch64 proof lands on the release legs of the repair release (v2.3.2); #544 tracks closing the PR-CI gap permanently.
