### PR TITLE
spec 33: runtime-on-runtime composition (the jruby/truffleruby-jvm implementation)

### DIFF
--- a/crates/tebako-driver/src/driver.rs
+++ b/crates/tebako-driver/src/driver.rs
@@ -134,6 +134,14 @@ pub struct BootOutcome {
     pub argv: Vec<String>,
     pub layout: Option<crate::layout::ImageLayout>,
     pub runtime_root: String,
+    /// The runtime-on-runtime composition (spec 33) when the first
+    /// triple's mounted manifest declared it: the wrapper tail composes
+    /// and bridges around this. `None` on every other boot.
+    pub on_runtime: Option<crate::on_runtime::OnRuntimeMeta>,
+    /// The resolved entry's index in [`Self::argv`] when this boot
+    /// composed one (the path/bare-name entry arms) — the wrapper tail's
+    /// exec-cache bridge target. `None` on the entry-less forms.
+    pub entry_index: Option<usize>,
 }
 
 /// The mount-mode source (spec 17 §1, locked 2026-08-04): mount
@@ -406,8 +414,8 @@ fn resolve_image_inner(
 /// One established member of the boot's mount table: the point and a
 /// human-readable member description for the union journal (spec 17 §1:
 /// the union set — point + members + precedence — is journaled at boot).
-struct MountedMember {
-    point: String,
+pub(crate) struct MountedMember {
+    pub(crate) point: String,
     desc: String,
 }
 
@@ -796,7 +804,7 @@ fn apply_jail(env: &dyn Env) -> Result<(), DriverError> {
     Ok(())
 }
 
-fn in_mount(path: &str, mount_point: &str) -> bool {
+pub(crate) fn in_mount(path: &str, mount_point: &str) -> bool {
     let mp = mount_point.trim_end_matches('/');
     mp.is_empty() || path == mp || path.starts_with(&format!("{mp}/"))
 }
@@ -915,18 +923,13 @@ fn export_mount_vars(images: &[ImageSpec], env: &dyn Env) -> Result<Vec<String>,
 /// to the interpreter's own startup, not to the handoff).
 fn resolve_entry(
     h: &Handoff,
-    runtime_root: &str,
+    base: &str,
     mounted: &[MountedMember],
 ) -> Result<String, DriverError> {
     let entry = h
         .entry
         .as_deref()
         .ok_or_else(|| manifest("--tebako-entry is required when --tebako-image is given"))?;
-    let base = h
-        .images
-        .first()
-        .map(|i| i.mount.as_str())
-        .unwrap_or(runtime_root);
     let resolved = join_mount(base, entry);
     if mounted.iter().any(|m| in_mount(&resolved, &m.point)) {
         let mut ctx = context().write().unwrap();
@@ -1141,6 +1144,8 @@ pub fn boot_with_mount_modes(
                 argv: v,
                 layout: declaration,
                 runtime_root: runtime_root.to_string(),
+                on_runtime: None,
+                entry_index: None,
             })
         })();
         if result.is_err() {
@@ -1177,6 +1182,18 @@ pub fn boot_with_mount_modes(
             crate::alias::register(&alias_boot);
             crate::alias::export_path(env, &alias_boot.dirs);
         }
+        // spec 33 §1: discover the runtime-on-runtime composition from
+        // the FIRST triple's mounted manifest (the depending runtime's
+        // env image leads the triples at its declared mount). The
+        // remaining triples — ordinarily the app payload — are the boot's
+        // entry/spawn surface; the depending image itself is neither (its
+        // own spawned edges stay its standalone-boot surface, unchanged).
+        let on_runtime = crate::on_runtime::discover(&h.images, runtime_root)?;
+        let app_images: &[ImageSpec] = if on_runtime.is_some() {
+            h.images.get(1..).unwrap_or(&[])
+        } else {
+            &h.images[..]
+        };
         // The mounts are established — publish the discovery surface
         // (spec 22 §6; v2-1/20), capture the spawned-runtime edges
         // (spec 30 §2 — the expose map the FFI planner and the §3
@@ -1185,10 +1202,14 @@ pub fn boot_with_mount_modes(
         // tier embeds the shim's materialized copy when one is
         // delivered, so injection runs first).
         let mount_keys = export_mount_vars(&h.images, env)?;
-        crate::spawn::capture(&h.images, env, runtime_root, mount_keys)?;
+        crate::spawn::capture(app_images, env, runtime_root, mount_keys)?;
         let shim_host = crate::injection::export(env, declaration.as_ref(), runtime_root)?;
         crate::path_env::export(&h.images, env, shim_host.as_deref())?;
-        let rewritten = match h.entry.as_deref() {
+        let template: &[String] = on_runtime
+            .as_ref()
+            .map(|on| on.template.as_slice())
+            .unwrap_or(&[]);
+        let (rewritten, entry_index) = match h.entry.as_deref() {
             // No entry: the interpreter starts with its own args (the
             // bare `--tebako-image` invocation — the deploy-driver
             // smoke; v1 behavior).
@@ -1198,18 +1219,22 @@ pub fn boot_with_mount_modes(
                     v.push(program.clone());
                 }
                 v.extend(h.interpreter_args.iter().cloned());
-                v
+                (v, None)
             }
             // A bare name (never a path): the reserved `self` keyword is
             // dropped (the deploy self-check re-enters the interpreter
             // with its own args). Any OTHER bare name names an
-            // entrypoint — the FIRST payload image's own declaration
-            // first (spec 32 §2: the spawned-payload child leads its
-            // triples with the provider's image; spec 17 §1's bare-name
-            // rule), else the ENV image's runtimeProvides (spec 30 §2 —
-            // the spawned-runtime child boot). Both compose the
-            // declaration's args_default — the declaration is the single
-            // owner.
+            // entrypoint — on a runtime-on-runtime boot the DEPENDING
+            // runtime's own declaration (spec 33 §3: the user-facing
+            // commands are the depending runtime's; the owner's
+            // entrypoints stay spawn-only), else the FIRST payload
+            // image's own declaration (spec 32 §2: the spawned-payload
+            // child leads its triples with the provider's image; spec 17
+            // §1's bare-name rule), else the ENV image's
+            // runtimeProvides (spec 30 §2 — the spawned-runtime child
+            // boot). All compose the declaration's args_default — the
+            // declaration is the single owner; the composition boot
+            // composes the template FIRST (spec 33 §3).
             Some(keyword) if !keyword.contains('/') => {
                 if keyword == "self" {
                     let mut v = Vec::with_capacity(h.user_args.len() + 1);
@@ -1217,50 +1242,88 @@ pub fn boot_with_mount_modes(
                         v.push(program.clone());
                     }
                     v.extend(h.user_args.iter().cloned());
-                    v
+                    (v, None)
                 } else {
-                    let (resolved, defaults) =
-                        match resolve_payload_entrypoint(keyword, &h.images, &mounted)? {
+                    let (resolved, defaults) = match &on_runtime {
+                        Some(on) => crate::on_runtime::dep_entrypoint(keyword, on, &mounted)?,
+                        None => match resolve_payload_entrypoint(keyword, &h.images, &mounted)? {
                             Some(pair) => pair,
                             None => resolve_runtime_entrypoint(keyword, runtime_root, &mounted)?,
-                        };
-                    let mut v = Vec::with_capacity(h.user_args.len() + defaults.len() + 2);
+                        },
+                    };
+                    let mut v =
+                        Vec::with_capacity(h.user_args.len() + template.len() + defaults.len() + 2);
                     if let Some(program) = argv.first() {
                         v.push(program.clone());
                     }
+                    v.extend(template.iter().cloned());
+                    let index = v.len() + defaults.len();
                     v.extend(defaults);
                     v.push(resolved);
                     v.extend(h.user_args.iter().cloned());
-                    v
+                    (v, Some(index))
                 }
             }
-            Some(_) => {
-                let resolved = resolve_entry(&h, runtime_root, &mounted)?;
+            Some(entry) => {
+                // spec 33 §1's amendment: on a runtime-on-runtime boot
+                // the entry resolves against the first NON-depending
+                // mount (ordinarily the app payload), falling back to
+                // the depending runtime's own mount on the self-boot
+                // smoke form — and the entry-directed args_default come
+                // from the depending runtime's manifest (the single
+                // owner), never the app payload's.
+                let (resolved, defaults) = match &on_runtime {
+                    Some(on) => (
+                        resolve_entry(&h, crate::on_runtime::entry_base(on, app_images), &mounted)?,
+                        crate::on_runtime::dep_args_default(on, entry)?,
+                    ),
+                    None => (
+                        resolve_entry(
+                            &h,
+                            h.images
+                                .first()
+                                .map(|i| i.mount.as_str())
+                                .unwrap_or(runtime_root),
+                            &mounted,
+                        )?,
+                        crate::wrapper::args_default(&h, runtime_root)?,
+                    ),
+                };
                 // spec 17 §1 / tebako#503: the entrypoint's declared
                 // `args_default` composes between the interpreter and the
                 // resolved entry — the runtime side is its single owner
                 // (the shim appends it only in the zero-runtime case,
                 // where no driver exists). The rewritten argv keeps the
                 // interpreter's convention: argv[0] (the program name)
-                // first, then the defaults, then the resolved entry as
-                // the script, then the user's args verbatim. Dropping
-                // argv[0] makes the interpreter treat the entry as its
-                // own name and the first user arg as the script.
-                let defaults = crate::wrapper::args_default(&h, runtime_root)?;
-                let mut v = Vec::with_capacity(h.user_args.len() + defaults.len() + 2);
+                // first, then the composition template when present
+                // (spec 33 §3), then the defaults, then the resolved
+                // entry as the script, then the user's args verbatim.
+                // Dropping argv[0] makes the interpreter treat the entry
+                // as its own name and the first user arg as the script.
+                let mut v =
+                    Vec::with_capacity(h.user_args.len() + template.len() + defaults.len() + 2);
                 if let Some(program) = argv.first() {
                     v.push(program.clone());
                 }
+                v.extend(template.iter().cloned());
+                let index = v.len() + defaults.len();
                 v.extend(defaults);
                 v.push(resolved);
                 v.extend(h.user_args.iter().cloned());
-                v
+                (v, Some(index))
             }
         };
         Ok(BootOutcome {
             argv: rewritten,
             layout: declaration,
             runtime_root: runtime_root.to_string(),
+            on_runtime: on_runtime
+                .as_ref()
+                .map(|on| crate::on_runtime::OnRuntimeMeta {
+                    template_len: on.template.len(),
+                    mount: on.mount.clone(),
+                }),
+            entry_index,
         })
     })();
     if result.is_err() {

--- a/crates/tebako-driver/src/lib.rs
+++ b/crates/tebako-driver/src/lib.rs
@@ -46,6 +46,7 @@ pub mod handoff;
 pub mod injection;
 pub mod layout;
 pub mod materialize;
+pub mod on_runtime;
 pub mod path_env;
 pub mod spawn;
 pub mod wrapper;

--- a/crates/tebako-driver/src/on_runtime.rs
+++ b/crates/tebako-driver/src/on_runtime.rs
@@ -1,0 +1,218 @@
+//! Runtime-on-runtime composition (spec 33) — the driver side. The
+//! loader composes the handoff (the OWNER's exe receives the wire, its
+//! env image rides `TEBAKO_RUNTIME_IMAGE`, the depending runtime's env
+//! image leads the `--tebako-image` triples at its declared mount); the
+//! driver discovers the composition from that first triple's mounted
+//! manifest (the `on_runtime` block), never from a new wire token:
+//!
+//! 1. [`discover`] reads the first triple's in-image manifest after the
+//!    mounts: a `kind: runtime` payload carrying `provides.on_runtime`
+//!    is the depending env image. The shard-lie cross-check fires here —
+//!    the loader composed the triple from the release-index mirror
+//!    (`on_runtime.mount`), and the mounted manifest is the authority: a
+//!    declared mount that does not qualify to the triple's point is the
+//!    release lying, a named 65, never a guessed-around composition.
+//! 2. The `{mount}` placeholder expands to the effective (qualified)
+//!    mount; an unknown placeholder or a post-expansion escape of the
+//!    mount is a named boot error 65 (spec 33 §2).
+//! 3. The entry surface (spec 33 §1/§3): a path entry resolves against
+//!    the first triple AFTER the depending image (ordinarily the app
+//!    payload), or against the depending mount itself on the self-boot
+//!    smoke form; a bare name resolves against the DEPENDING runtime's
+//!    `provides.entrypoints` — the owner's own entrypoints stay
+//!    spawn-only — and entry-directed `args_default` come from the
+//!    depending runtime's manifest (the single-owner rule), never from
+//!    the app payload's. There is NO direct-program form on this boot:
+//!    every entry composes through the template.
+//!
+//! The argv the boot composes is `[argv0, template…, args_default…,
+//! entry, user args…]` (spec 33 §3); the wrapper tail then swaps in the
+//! owner's materialized interpreter and bridges the template's VFS
+//! tokens plus the entry under exec-cache.
+
+use tpkg::Provides;
+
+use crate::driver::{
+    join_mount, manifest, mounted_manifest_at, qualify_mount, DriverError, MountedMember,
+};
+use crate::handoff::ImageSpec;
+
+/// The discovered composition (spec 33 §2's block, boot-resolved).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OnRuntime {
+    /// The depending env image's effective mount (drive-qualified on
+    /// windows) — the `{mount}` expansion value.
+    pub mount: String,
+    /// The expanded `argv_template` (placeholder-expanded, validated).
+    pub template: Vec<String>,
+}
+
+/// The BootOutcome mirror of the discovery: what the wrapper tail needs
+/// to compose and bridge around the boot's rewritten argv.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OnRuntimeMeta {
+    /// The expanded template's length — argv indices `1..=template_len`
+    /// are the template tokens.
+    pub template_len: usize,
+    /// The depending env image's effective mount (the `{mount}`
+    /// expansion value) — the template bridge's splice key.
+    pub mount: String,
+}
+
+/// Discover the composition from the FIRST triple's mounted manifest
+/// (spec 33 §1: the depending env image rides first). `Ok(None)` on
+/// every non-composition shape — no triples, an unreadable/absent
+/// manifest, a non-runtime payload, a runtime without the block (every
+/// runtime predating this spec); a corrupt manifest stays the named 65
+/// it is everywhere. Runs after the mounts (the manifest is read through
+/// the VFS) and before the entry resolution.
+pub(crate) fn discover(
+    images: &[ImageSpec],
+    runtime_root: &str,
+) -> Result<Option<OnRuntime>, DriverError> {
+    let Some(first) = images.first() else {
+        return Ok(None);
+    };
+    let Some(doc) = mounted_manifest_at(&first.mount)? else {
+        return Ok(None);
+    };
+    let Provides::Runtime(rt) = &doc.provides else {
+        return Ok(None);
+    };
+    let Some(on) = &rt.on_runtime else {
+        return Ok(None);
+    };
+    // The shard-lie cross-check (spec 33 §1): the in-image declaration
+    // is the authority; the triple's point is the loader's composition
+    // from the release-index mirror. A disagreement is the release lying.
+    let declared = qualify_mount(&on.mount, runtime_root);
+    if declared != first.mount {
+        return Err(manifest(format!(
+            "the depending runtime's on_runtime.mount declares '{}' but its env image is mounted at '{}' — the release index's on_runtime mirror contradicts the in-image manifest (spec 33 §1); the release is lying",
+            on.mount, first.mount
+        )));
+    }
+    let template = expand(&on.argv_template, &first.mount)?;
+    Ok(Some(OnRuntime {
+        mount: first.mount.clone(),
+        template,
+    }))
+}
+
+/// Expand `{mount}` against the effective mount and validate the result
+/// (spec 33 §2): an unknown placeholder (any surviving brace) or a
+/// mount-prefixed element escaping the mount through `..` is a named
+/// boot error 65 naming the template. Elements not addressing the mount
+/// (flags, class names) pass verbatim.
+fn expand(template: &[String], mount: &str) -> Result<Vec<String>, DriverError> {
+    let mut out = Vec::with_capacity(template.len());
+    for token in template {
+        let expanded = token.replace("{mount}", mount);
+        if let Some(start) = expanded.find('{') {
+            let end = expanded[start..]
+                .find('}')
+                .map(|i| start + i + 1)
+                .unwrap_or(start + 1);
+            let placeholder = &expanded[start..end.min(expanded.len())];
+            return Err(manifest(format!(
+                "on_runtime.argv_template names an unknown placeholder '{placeholder}' — the single placeholder is {{mount}} (spec 33 §2)"
+            )));
+        }
+        if expanded.contains('}') {
+            return Err(manifest(format!(
+                "on_runtime.argv_template element '{token}' carries a stray '}}' — the single placeholder is {{mount}} (spec 33 §2)"
+            )));
+        }
+        if let Some(rest) = expanded.strip_prefix(mount) {
+            if rest.split('/').any(|c| c == "..") {
+                return Err(manifest(format!(
+                    "on_runtime.argv_template element '{token}' escapes the depending runtime's mount '{mount}' after expansion — a named boot error, never a host path (spec 33 §2)"
+                )));
+            }
+        }
+        out.push(expanded);
+    }
+    Ok(out)
+}
+
+/// The entry-resolution base (spec 33 §1's amendment): the first triple
+/// after the depending image — ordinarily the app payload — or, with no
+/// payload triples, the depending runtime's own mount (the self-boot
+/// smoke form).
+pub(crate) fn entry_base<'m>(on: &'m OnRuntime, app_images: &'m [ImageSpec]) -> &'m str {
+    app_images
+        .first()
+        .map(|i| i.mount.as_str())
+        .unwrap_or(&on.mount)
+}
+
+/// The bare-name surface (spec 33 §3): `name` resolves against the
+/// DEPENDING runtime's `provides.entrypoints`, verified against the
+/// mounted tree; the owner's own entrypoints are never consulted (they
+/// stay spawn-only through spec 30 edges). Returns the resolved VFS path
+/// and the declaration's `args_default`.
+pub(crate) fn dep_entrypoint(
+    name: &str,
+    on: &OnRuntime,
+    mounted: &[MountedMember],
+) -> Result<(String, Vec<String>), DriverError> {
+    let doc = mounted_manifest_at(&on.mount)?.ok_or_else(|| {
+        manifest(format!(
+            "--tebako-entry '{name}' names a depending-runtime entrypoint but the manifest at '{}' is gone — the composition's discovery read it moments ago (spec 33 §3)",
+            on.mount
+        ))
+    })?;
+    let Provides::Runtime(rt) = &doc.provides else {
+        return Err(manifest(format!(
+            "--tebako-entry '{name}': the image mounted at '{}' is not the depending runtime (spec 33 §3)",
+            on.mount
+        )));
+    };
+    let ep = rt
+        .entrypoints
+        .iter()
+        .find(|e| e.name == name)
+        .ok_or_else(|| {
+            manifest(format!(
+                "--tebako-entry '{name}': the depending runtime declares no entrypoint of that name — on a runtime-on-runtime boot the bare-name surface is the depending runtime's (spec 33 §3); the owner's own entrypoints stay spawnable through spec 30 edges"
+            ))
+        })?;
+    let resolved = join_mount(&on.mount, &ep.path);
+    if mounted
+        .iter()
+        .any(|m| crate::driver::in_mount(&resolved, &m.point))
+    {
+        let mut ctx = tfs::context::context().write().unwrap();
+        match ctx.open(&resolved, libc::O_RDONLY) {
+            Ok(fd) => {
+                let _ = ctx.close(fd);
+            }
+            Err(_) => {
+                return Err(manifest(format!(
+                    "depending-runtime entrypoint '{name}' resolves to '{resolved}' but the path is absent from the mounted tree — the image's declaration lies (spec 33 §3)"
+                )));
+            }
+        }
+    }
+    Ok((resolved, ep.args_default.clone()))
+}
+
+/// The path-form entry's `args_default` (spec 33 §3 — entry-directed,
+/// the depending runtime's manifest the single owner): the dep
+/// runtime's entrypoint declaring that path, else none (never an
+/// error).
+pub(crate) fn dep_args_default(on: &OnRuntime, entry: &str) -> Result<Vec<String>, DriverError> {
+    let Some(doc) = mounted_manifest_at(&on.mount)? else {
+        return Ok(Vec::new());
+    };
+    let Provides::Runtime(rt) = &doc.provides else {
+        return Ok(Vec::new());
+    };
+    let spelled = format!("/{}", entry.trim_start_matches('/'));
+    Ok(rt
+        .entrypoints
+        .iter()
+        .find(|e| e.path == spelled)
+        .map(|e| e.args_default.clone())
+        .unwrap_or_default())
+}

--- a/crates/tebako-driver/src/wrapper.rs
+++ b/crates/tebako-driver/src/wrapper.rs
@@ -341,12 +341,22 @@ fn bridge_entry(
     mech: Mechanism,
     entry_index: Option<usize>,
 ) -> Result<(), DriverError> {
-    if mech != Mechanism::ExecCache {
-        return Ok(());
-    }
     let Some(index) = entry_index else {
         return Ok(());
     };
+    bridge_token(launch, mech, index)
+}
+
+/// The per-token bridge (spec 29 §3, extended by spec 33 §3): index
+/// `index` of `launch.argv`, when an embedded (VFS) path, is
+/// materialized to its host twin under exec-cache — the entry itself,
+/// and the runtime-on-runtime composition template's tokens (the jar
+/// lives in the DEPENDING runtime's image). Non-embedded tokens pass
+/// verbatim.
+fn bridge_token(launch: &mut Launch, mech: Mechanism, index: usize) -> Result<(), DriverError> {
+    if mech != Mechanism::ExecCache {
+        return Ok(());
+    }
     let Some(token) = launch.argv.get(index).cloned() else {
         return Ok(());
     };
@@ -375,6 +385,49 @@ fn bridge_entry(
                 ))
             }
         })?;
+    Ok(())
+}
+
+/// The compound template token's bridge (spec 33 §3): a token EMBEDDING
+/// the depending mount inside a larger argument (`-D…home={mount}`,
+/// `--module-path={mount}/…`) cannot ride the per-token path bridge —
+/// the token is not a path. Under exec-cache the mount's materialized
+/// home-tree root splices in place of the VFS spelling: the host-plain
+/// owner reads the home arbitrarily, so the whole tree is the honest
+/// unit and the depending image must carry the home annotation
+/// (`identity.annotations.java_home`, spec 22 §3) — an unannotated image
+/// answers the per-file closure walk, which cannot serve those reads, so
+/// the boot refuses by name (65) instead of handing the owner a partial
+/// home. Tokens not addressing the mount never reach here.
+fn bridge_template_compound(
+    launch: &mut Launch,
+    mech: Mechanism,
+    index: usize,
+    mount: &str,
+) -> Result<(), DriverError> {
+    if mech != Mechanism::ExecCache {
+        return Ok(());
+    }
+    let Some(token) = launch.argv.get(index).cloned() else {
+        return Ok(());
+    };
+    let host = {
+        let mut ctx = context().write().unwrap();
+        if cfg!(windows) {
+            ctx.exec_materialize_for_spawn(mount)
+        } else {
+            ctx.exec_materialize(mount)
+        }
+    };
+    let host = host
+        .map(|c| c.to_string_lossy().into_owned())
+        .map_err(|e| {
+            manifest(format!(
+                "on_runtime.argv_template token '{token}' embeds the depending runtime's mount '{mount}' but the image does not materialize as a home tree ({}) — the depending image must carry identity.annotations.java_home marking its root a tool home (spec 33 §3, spec 22 §3); a per-file closure cannot serve the host-plain owner's reads",
+                errno_text(e)
+            ))
+        })?;
+    launch.argv[index] = token.replace(mount, &host);
     Ok(())
 }
 
@@ -500,10 +553,16 @@ fn tail(h: &Handoff, outcome: &BootOutcome, env: &dyn Env) -> Result<BootAction,
     // an in-image script the INTERPRETER runs, so it falls through to
     // the composition below (the boot already resolved it against the
     // provider's image and composed the declaration's args_default).
-    let mut bare_payload_entry = false;
-    if let Some(name) = h.entry.as_deref() {
-        if !name.contains('/') && name != "self" {
-            if payload_entrypoint(h, &outcome.runtime_root, name)?.is_none() {
+    // spec 33 §3: on a runtime-on-runtime boot there is NO
+    // direct-program form — the boot already resolved the bare name
+    // against the DEPENDING runtime's entrypoints and composed it
+    // through the template; the owner's own entrypoints stay spawn-only.
+    if outcome.on_runtime.is_none() {
+        if let Some(name) = h.entry.as_deref() {
+            if !name.contains('/')
+                && name != "self"
+                && payload_entrypoint(h, &outcome.runtime_root, name)?.is_none()
+            {
                 let ep = runtime_entrypoint(&outcome.runtime_root, name)?;
                 let program = materialize(
                     &join_mount(&outcome.runtime_root, &ep.path),
@@ -516,22 +575,30 @@ fn tail(h: &Handoff, outcome: &BootOutcome, env: &dyn Env) -> Result<BootAction,
                 argv.extend(h.user_args.iter().cloned());
                 return Ok(BootAction::Launch(Launch { program, argv }));
             }
-            bare_payload_entry = true;
         }
     }
     let program = materialize(&vfs, mech, &outcome.runtime_root)?;
-    let defaults = args_default(h, &outcome.runtime_root)?;
-    let entry_index = if h.entry.as_deref().is_some_and(|e| e.contains('/')) || bare_payload_entry {
-        // [program, defaults…, ENTRY, user args…] — the boot composed
-        // the defaults into outcome.argv (tebako#503; spec 32 §2's bare
-        // payload name composes identically); the entry's index is fixed
-        // at composition.
-        Some(1 + defaults.len())
-    } else {
-        None
-    };
     let mut launch = compose(program, outcome);
-    bridge_entry(&mut launch, mech, entry_index)?;
+    // spec 33 §3: the composition template's VFS tokens bridge to their
+    // host twins under exec-cache exactly like the entry — the jar lives
+    // in the DEPENDING runtime's image, and the host-plain owner cannot
+    // read the VFS. A token EMBEDDING the mount in a larger argument
+    // (`-D…home={mount}`, `--module-path={mount}/…`) splices the mount's
+    // materialized home-tree root instead.
+    if let Some(meta) = &outcome.on_runtime {
+        for index in 1..=meta.template_len {
+            let Some(token) = launch.argv.get(index).cloned() else {
+                continue;
+            };
+            let path_form = token == meta.mount || token.starts_with(&format!("{}/", meta.mount));
+            if token.contains(&meta.mount) && !path_form {
+                bridge_template_compound(&mut launch, mech, index, &meta.mount)?;
+            } else {
+                bridge_token(&mut launch, mech, index)?;
+            }
+        }
+    }
+    bridge_entry(&mut launch, mech, outcome.entry_index)?;
     Ok(BootAction::Launch(launch))
 }
 
@@ -654,6 +721,8 @@ mod tests {
             ],
             layout: None,
             runtime_root: "/__tfs__".to_string(),
+            on_runtime: None,
+            entry_index: None,
         };
         let launch = compose("/cache/java".to_string(), &outcome);
         assert_eq!(launch.program, "/cache/java");
@@ -663,6 +732,8 @@ mod tests {
             argv: vec!["wrapper".to_string(), "--version".to_string()],
             layout: None,
             runtime_root: "/__tfs__".to_string(),
+            on_runtime: None,
+            entry_index: None,
         };
         let launch = compose("/cache/java".to_string(), &outcome);
         assert_eq!(launch.argv, vec!["/cache/java", "--version"]);

--- a/crates/tebako-driver/tests/wrapper.rs
+++ b/crates/tebako-driver/tests/wrapper.rs
@@ -787,3 +787,463 @@ fn linked_and_wrapper_boots_compose_identically() {
     assert_eq!(wrapper_tail, linked_tail, "the rewritten argv tails");
     assert_eq!(launch.argv[1], "-jar", "the entrypoint's args_default");
 }
+
+// ---------------------------------------------------------------------
+// spec 33: the runtime-on-runtime boot — the owner provides the process
+// (its env image rides TEBAKO_RUNTIME_IMAGE), the depending runtime's
+// env image leads the triples at its declared mount, and the driver
+// discovers the composition from that image's on_runtime block.
+// ---------------------------------------------------------------------
+
+/// The depending runtime's env image: kind runtime carrying the owner
+/// edge + the on_runtime block (mount `declared_mount`, the jruby-shaped
+/// template), an entrypoint with its own args_default, and the files the
+/// template/entrypoint name.
+fn write_dep_runtime_image(dir: &Path, declared_mount: &str) -> PathBuf {
+    let manifest = format!(
+        "identity:\n  schema_version: 1\n  kind: runtime\n  name: tebako-runtime-jruby\n  version: 9.4.8.0\n  \
+         producer: {{tool: t, tool_version: \"1\"}}\n  \
+         created: \"2026-09-07T00:00:00Z\"\n  \
+         digest: {{tree_hash: sha256:{z}, blob_sha256: {z}}}\n  \
+         signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+         provides:\n  \
+         provides: {{engine: ruby, implementation: jruby, version: 9.4.8.0, abi_line: \"9.4\", platform: aarch64-macos}}\n  \
+         built_from: {{src_sha256: {z}, patch_set: v2.4.0}}\n  \
+         entrypoints: [{{name: jruby, path: /bin/jruby, args_default: [\"-X+O\"]}}]\n  \
+         on_runtime:\n    \
+         mount: {declared_mount}\n    \
+         argv_template: [\"-classpath\", \"{{mount}}/lib/jruby.jar\", \"org.jruby.Main\"]\n  \
+         capabilities: {{exec: true, read: true, runtime: true}}\n\
+         requires:\n  - {{kind: runtime, engine: java, constraint: \">= 21\"}}\n",
+        z = "0".repeat(64)
+    );
+    let p = dir.join("jruby-env.tfs");
+    build_zip(
+        &p,
+        &["bin/", "lib/", "__tpkg__/"],
+        &[
+            ("bin/jruby", b"#!/bin/sh\necho jruby\n".as_slice()),
+            ("lib/jruby.jar", b"jar bytes\n".as_slice()),
+            ("__tpkg__/manifest.yaml", manifest.as_bytes()),
+        ],
+    );
+    p
+}
+
+/// The dep image with a caller-authored template (the failure-matrix
+/// cases). Files: the jar + bin/jruby as above.
+fn write_dep_runtime_image_template(dir: &Path, template: &str) -> PathBuf {
+    let manifest = format!(
+        "identity:\n  schema_version: 1\n  kind: runtime\n  name: tebako-runtime-jruby\n  version: 9.4.8.0\n  \
+         producer: {{tool: t, tool_version: \"1\"}}\n  \
+         created: \"2026-09-07T00:00:00Z\"\n  \
+         digest: {{tree_hash: sha256:{z}, blob_sha256: {z}}}\n  \
+         signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+         provides:\n  \
+         provides: {{engine: ruby, implementation: jruby, version: 9.4.8.0, abi_line: \"9.4\", platform: aarch64-macos}}\n  \
+         built_from: {{src_sha256: {z}, patch_set: v2.4.0}}\n  \
+         on_runtime:\n    \
+         mount: /__runners__/jruby\n    \
+         argv_template: {template}\n  \
+         capabilities: {{exec: true, read: true, runtime: true}}\n\
+         requires:\n  - {{kind: runtime, engine: java, constraint: \">= 21\"}}\n",
+        z = "0".repeat(64)
+    );
+    let p = dir.join("jruby-env.tfs");
+    build_zip(
+        &p,
+        &["bin/", "lib/", "__tpkg__/"],
+        &[
+            ("bin/jruby", b"#!/bin/sh\necho jruby\n".as_slice()),
+            ("lib/jruby.jar", b"jar bytes\n".as_slice()),
+            ("__tpkg__/manifest.yaml", manifest.as_bytes()),
+        ],
+    );
+    p
+}
+
+#[test]
+fn on_runtime_composes_template_then_entry_under_the_owner() {
+    let g = guard("onrt-compose");
+    let env_image = write_env_image(g.path(), EXEC_CACHE, false);
+    let dep = write_dep_runtime_image(g.path(), "/__runners__/jruby");
+    let app = write_app_image(g.path());
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    let launch = launch_of(
+        run(
+            &argv(&[
+                "tebako-runtime-launcher",
+                "--tebako-image",
+                &format!("{}:-:/__runners__/jruby", dep.display()),
+                "--tebako-image",
+                &format!("{}:-:/", app.display()),
+                "--tebako-entry",
+                "/bin/app",
+                "user1",
+            ]),
+            WRAPPER_RUNTIME_ROOT,
+            &env,
+        )
+        .unwrap(),
+    );
+
+    // [owner interpreter, template…, entry, user args…] (spec 33 §3) —
+    // the APP payload's own args_default (["-jar"]) does NOT compose:
+    // entry-directed defaults belong to the depending runtime's manifest
+    // on this boot (the single-owner rule).
+    assert_eq!(launch.argv.len(), 6, "{:?}", launch.argv);
+    assert_eq!(launch.argv[0], launch.program);
+    assert_eq!(launch.argv[1], "-classpath");
+    assert_eq!(launch.argv[3], "org.jruby.Main");
+    // The template's jar token lives in the depending image — the
+    // host-plain owner (exec-cache) receives its materialized host twin.
+    assert_eq!(std::fs::read(&launch.argv[2]).unwrap(), b"jar bytes\n");
+    // The entry resolved against the APP payload (the second triple —
+    // the first non-depending mount), bridged the same way.
+    assert_eq!(
+        std::fs::read(&launch.argv[4]).unwrap(),
+        b"#!/usr/bin/env java\necho app\n"
+    );
+    assert_eq!(launch.argv[5], "user1");
+    assert_eq!(std::fs::read(&launch.program).unwrap(), STUB);
+}
+
+#[test]
+fn on_runtime_bare_name_resolves_against_the_depending_runtime() {
+    let g = guard("onrt-bare");
+    let env_image = write_env_image(g.path(), EXEC_CACHE, false);
+    let dep = write_dep_runtime_image(g.path(), "/__runners__/jruby");
+    let app = write_app_image(g.path());
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    let launch = launch_of(
+        run(
+            &argv(&[
+                "tebako-runtime-launcher",
+                "--tebako-image",
+                &format!("{}:-:/__runners__/jruby", dep.display()),
+                "--tebako-image",
+                &format!("{}:-:/", app.display()),
+                "--tebako-entry",
+                "jruby",
+                "-v",
+            ]),
+            WRAPPER_RUNTIME_ROOT,
+            &env,
+        )
+        .unwrap(),
+    );
+
+    // The bare name is the depending runtime's user-facing command
+    // (spec 33 §3): its declared path + args_default compose THROUGH the
+    // template — never the direct-program form (that belongs to
+    // owner-pattern boots).
+    assert_eq!(launch.argv.len(), 7, "{:?}", launch.argv);
+    assert_eq!(launch.argv[1], "-classpath");
+    assert_eq!(launch.argv[3], "org.jruby.Main");
+    assert_eq!(launch.argv[4], "-X+O");
+    assert_eq!(
+        std::fs::read(&launch.argv[5]).unwrap(),
+        b"#!/bin/sh\necho jruby\n"
+    );
+    assert_eq!(launch.argv[6], "-v");
+}
+
+#[test]
+fn on_runtime_self_boot_resolves_against_the_depending_mount() {
+    // No payload triples: the entry resolves against the depending
+    // runtime's own mount (the runtime's self-boot smoke form).
+    let g = guard("onrt-self");
+    let env_image = write_env_image(g.path(), EXEC_CACHE, false);
+    let dep = write_dep_runtime_image(g.path(), "/__runners__/jruby");
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    let launch = launch_of(
+        run(
+            &argv(&[
+                "tebako-runtime-launcher",
+                "--tebako-image",
+                &format!("{}:-:/__runners__/jruby", dep.display()),
+                "--tebako-entry",
+                "/bin/jruby",
+            ]),
+            WRAPPER_RUNTIME_ROOT,
+            &env,
+        )
+        .unwrap(),
+    );
+
+    // The path form matches the depending runtime's declared entrypoint —
+    // its args_default composes after the template (single owner).
+    assert_eq!(launch.argv.len(), 6, "{:?}", launch.argv);
+    assert_eq!(launch.argv[1], "-classpath");
+    assert_eq!(launch.argv[3], "org.jruby.Main");
+    assert_eq!(launch.argv[4], "-X+O");
+    assert_eq!(
+        std::fs::read(&launch.argv[5]).unwrap(),
+        b"#!/bin/sh\necho jruby\n"
+    );
+}
+
+#[test]
+fn on_runtime_unknown_placeholder_is_a_named_boot_error() {
+    let g = guard("onrt-badph");
+    let env_image = write_env_image(g.path(), EXEC_CACHE, false);
+    let dep = write_dep_runtime_image_template(g.path(), "[\"{home}/lib/jruby.jar\"]");
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    let err = run(
+        &argv(&[
+            "tebako-runtime-launcher",
+            "--tebako-image",
+            &format!("{}:-:/__runners__/jruby", dep.display()),
+            "--tebako-entry",
+            "/bin/jruby",
+        ]),
+        WRAPPER_RUNTIME_ROOT,
+        &env,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{err}");
+    assert!(err.message.contains("{home}"), "{err}");
+    assert!(err.message.contains("argv_template"), "{err}");
+}
+
+#[test]
+fn on_runtime_template_escape_is_a_named_boot_error() {
+    let g = guard("onrt-escape");
+    let env_image = write_env_image(g.path(), EXEC_CACHE, false);
+    let dep = write_dep_runtime_image_template(g.path(), "[\"{mount}/../evil.jar\"]");
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    let err = run(
+        &argv(&[
+            "tebako-runtime-launcher",
+            "--tebako-image",
+            &format!("{}:-:/__runners__/jruby", dep.display()),
+            "--tebako-entry",
+            "/bin/jruby",
+        ]),
+        WRAPPER_RUNTIME_ROOT,
+        &env,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{err}");
+    assert!(err.message.contains("argv_template"), "{err}");
+}
+
+#[test]
+fn on_runtime_mount_mismatch_is_the_shard_lying() {
+    // The loader composed the triple at /__runners__/other but the
+    // mounted image declares /__runners__/jruby — the release-index
+    // mirror contradicts the in-image authority (spec 33 §1's
+    // cross-check): a named 65, never a guessed-around composition.
+    let g = guard("onrt-lie");
+    let env_image = write_env_image(g.path(), EXEC_CACHE, false);
+    let dep = write_dep_runtime_image(g.path(), "/__runners__/jruby");
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    let err = run(
+        &argv(&[
+            "tebako-runtime-launcher",
+            "--tebako-image",
+            &format!("{}:-:/__runners__/other", dep.display()),
+            "--tebako-entry",
+            "/bin/jruby",
+        ]),
+        WRAPPER_RUNTIME_ROOT,
+        &env,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{err}");
+    assert!(err.message.contains("on_runtime"), "{err}");
+    assert!(err.message.contains("/__runners__/jruby"), "{err}");
+}
+
+/// The depending runtime's env image WITH the home annotation
+/// (`identity.annotations.java_home`, spec 22 §3's whole-tree signal)
+/// and a caller-authored template — the truffleruby-jvm shape: a
+/// compound `-D…home={mount}` token plus a `--module-path {mount}/…`
+/// pair. Files: the module jar + the entrypoint script.
+fn write_dep_runtime_image_home(dir: &Path, template: &str) -> PathBuf {
+    let manifest = format!(
+        "identity:\n  annotations:\n    java_home: \"/\"\n  schema_version: 1\n  kind: runtime\n  name: tebako-runtime-truffleruby-jvm\n  version: 34.0.1\n  \
+         producer: {{tool: t, tool_version: \"1\"}}\n  \
+         created: \"2026-09-07T00:00:00Z\"\n  \
+         digest: {{tree_hash: sha256:{z}, blob_sha256: {z}}}\n  \
+         signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+         provides:\n  \
+         provides: {{engine: ruby, implementation: truffleruby, version: 34.0.1, abi_line: \"34\", platform: aarch64-macos}}\n  \
+         built_from: {{src_sha256: {z}, patch_set: v2.4.0}}\n  \
+         entrypoints: [{{name: ruby, path: /bin/ruby}}]\n  \
+         on_runtime:\n    \
+         mount: /__runners__/truffleruby\n    \
+         argv_template: {template}\n  \
+         capabilities: {{exec: true, read: true, runtime: true}}\n\
+         requires:\n  - {{kind: runtime, engine: java, implementation: graalvm, constraint: \">= 24\"}}\n",
+        z = "0".repeat(64)
+    );
+    let p = dir.join("truffleruby-env.tfs");
+    build_zip(
+        &p,
+        &["bin/", "modules/", "__tpkg__/"],
+        &[
+            ("bin/ruby", b"#!/bin/sh\necho truffleruby\n".as_slice()),
+            ("modules/truffleruby.jar", b"jar bytes\n".as_slice()),
+            ("__tpkg__/manifest.yaml", manifest.as_bytes()),
+        ],
+    );
+    p
+}
+
+#[test]
+fn on_runtime_compound_token_splices_the_home_tree_root() {
+    // The truffleruby-jvm launch line (spec 33 §3's worked shape): the
+    // compound `-D…home={mount}` token embeds the depending mount inside
+    // a larger argument; the host-plain owner (java) cannot read the VFS,
+    // so the mount's materialized home-tree root splices in place.
+    let g = guard("onrt-compound");
+    let env_image = write_env_image(g.path(), EXEC_CACHE, false);
+    let dep = write_dep_runtime_image_home(
+        g.path(),
+        "[\"-Dorg.graalvm.language.ruby.home={mount}\", \"--module-path\", \"{mount}/modules\", \"-m\", \"dev.truffleruby.launcher/org.truffleruby.launcher.RubyLauncher\"]",
+    );
+    let app = write_app_image(g.path());
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    let launch = launch_of(
+        run(
+            &argv(&[
+                "tebako-runtime-launcher",
+                "--tebako-image",
+                &format!("{}:-:/__runners__/truffleruby", dep.display()),
+                "--tebako-image",
+                &format!("{}:-:/", app.display()),
+                "--tebako-entry",
+                "/bin/app",
+                "user1",
+            ]),
+            WRAPPER_RUNTIME_ROOT,
+            &env,
+        )
+        .unwrap(),
+    );
+
+    assert_eq!(launch.argv.len(), 8, "{:?}", launch.argv);
+    // The compound token: prefix verbatim, the mount spliced to the
+    // whole-tree root — and the tree carries the home's files.
+    let root = launch.argv[1]
+        .strip_prefix("-Dorg.graalvm.language.ruby.home=")
+        .expect("the -D prefix rides verbatim");
+    assert!(
+        root.contains("tebako-home-"),
+        "the splice answers the home-tree root, not the VFS spelling: {root}"
+    );
+    let root = std::path::PathBuf::from(root);
+    assert_eq!(
+        std::fs::read(root.join("modules/truffleruby.jar")).unwrap(),
+        b"jar bytes\n"
+    );
+    assert_eq!(
+        std::fs::read(root.join("bin/ruby")).unwrap(),
+        b"#!/bin/sh\necho truffleruby\n"
+    );
+    // The pure-path template token answers its host twin inside the same
+    // tree; flags and class names pass verbatim.
+    assert_eq!(launch.argv[2], "--module-path");
+    assert_eq!(
+        std::path::PathBuf::from(&launch.argv[3]),
+        root.join("modules"),
+        "the module path is the tree's own modules dir"
+    );
+    assert_eq!(launch.argv[4], "-m");
+    assert_eq!(
+        launch.argv[5],
+        "dev.truffleruby.launcher/org.truffleruby.launcher.RubyLauncher"
+    );
+    // The entry (app payload) bridges as before; user args ride last.
+    assert_eq!(
+        std::fs::read(&launch.argv[6]).unwrap(),
+        b"#!/usr/bin/env java\necho app\n"
+    );
+    assert_eq!(launch.argv[7], "user1");
+}
+
+#[test]
+fn on_runtime_bare_mount_token_answers_the_home_tree_root() {
+    // The whole-token `{mount}` form splices the same tree root (never
+    // EISDIR) — the dep home IS the argument here.
+    let g = guard("onrt-baremount");
+    let env_image = write_env_image(g.path(), EXEC_CACHE, false);
+    let dep = write_dep_runtime_image_home(g.path(), "[\"{mount}\"]");
+    let app = write_app_image(g.path());
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    let launch = launch_of(
+        run(
+            &argv(&[
+                "tebako-runtime-launcher",
+                "--tebako-image",
+                &format!("{}:-:/__runners__/truffleruby", dep.display()),
+                "--tebako-image",
+                &format!("{}:-:/", app.display()),
+                "--tebako-entry",
+                "/bin/app",
+            ]),
+            WRAPPER_RUNTIME_ROOT,
+            &env,
+        )
+        .unwrap(),
+    );
+
+    assert_eq!(launch.argv.len(), 3, "{:?}", launch.argv);
+    let root = std::path::PathBuf::from(&launch.argv[1]);
+    assert!(root.is_dir(), "the tree root lands: {root:?}");
+    assert_eq!(
+        std::fs::read(root.join("bin/ruby")).unwrap(),
+        b"#!/bin/sh\necho truffleruby\n"
+    );
+}
+
+#[test]
+fn on_runtime_compound_token_without_the_home_annotation_is_a_named_error() {
+    // The compound token on an UNANNOTATED image: a per-file closure
+    // cannot serve a host-plain owner's arbitrary home reads — a named
+    // 65 demanding the annotation, never a partial answer.
+    let g = guard("onrt-nohome");
+    let env_image = write_env_image(g.path(), EXEC_CACHE, false);
+    let dep = write_dep_runtime_image_template(
+        g.path(),
+        "[\"-Dorg.graalvm.language.ruby.home={mount}\", \"{mount}/lib/jruby.jar\"]",
+    );
+    let app = write_app_image(g.path());
+    let mut env = MapEnv::new();
+    env.set("TEBAKO_RUNTIME_IMAGE", env_image.display().to_string());
+
+    let err = run(
+        &argv(&[
+            "tebako-runtime-launcher",
+            "--tebako-image",
+            &format!("{}:-:/__runners__/jruby", dep.display()),
+            "--tebako-image",
+            &format!("{}:-:/", app.display()),
+            "--tebako-entry",
+            "/bin/app",
+        ]),
+        WRAPPER_RUNTIME_ROOT,
+        &env,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65, "{err}");
+    assert!(err.message.contains("argv_template"), "{err}");
+    assert!(err.message.contains("java_home"), "{err}");
+}

--- a/crates/tebako-shim/src/dispatch.rs
+++ b/crates/tebako-shim/src/dispatch.rs
@@ -579,7 +579,7 @@ pub fn plan(
             ),
         )
     })?;
-    let mounts = compose_mounts(res, ctx)?;
+    let mut mounts = compose_mounts(res, ctx)?;
     let runtime =
         runtime::resolve_runtime(entry.runtime_requirement.as_ref(), allow_download, ctx)?;
     tebako_log::log!(
@@ -602,24 +602,90 @@ pub fn plan(
 
     let mut argv: Vec<String> = Vec::new();
     let mut env: Vec<(String, String)> = Vec::new();
-    let program = match &runtime {
+    let (program, runtime) = match runtime {
         RuntimeResolution::Ready(rt) => {
-            argv.push(rt.exe.to_string_lossy().into_owned());
-            for m in &mounts {
-                argv.push("--tebako-image".to_string());
-                argv.push(m.triple());
+            // spec 33 §1/§7: the resolved runtime's cached release-index
+            // shard may mirror an on_runtime block — then the OWNER's exe
+            // is the program and the depending runtime's env image
+            // co-mounts at the declared point as the FIRST triple (the
+            // driver-side discovery order), ahead of the payload stack.
+            let exe_name = rt
+                .exe
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let mirror = tpkg::runtime_store::on_runtime_mirror(&rt.dir, &exe_name)
+                .map_err(|e| ShimError::new(EX_TEBAKO_MANIFEST, e))?;
+            match mirror {
+                Some(mirror) => {
+                    let Some(dep_image) = rt.image.clone() else {
+                        return fail(
+                            EX_TEBAKO_UNAVAILABLE,
+                            format!(
+                                "the resolved {} runtime {} (tebako {}) declares on_runtime but carries no verified env image — the composition needs the image pair; re-install it with `tebako install`",
+                                rt.engine, rt.lang_version, rt.tebako_version
+                            ),
+                        );
+                    };
+                    let owner = runtime::resolve_owner(&mirror, allow_download, ctx)?;
+                    let owner_image = owner
+                        .image
+                        .clone()
+                        .expect("resolve_runtime_edge post-asserts the env image");
+                    tebako_log::log!(
+                        tebako_log::Level::Debug,
+                        "shim",
+                        "on_runtime: dep={} {} (tebako {}) owner={} {} (tebako {}) mount={}",
+                        rt.engine,
+                        rt.lang_version,
+                        rt.tebako_version,
+                        owner.engine,
+                        owner.lang_version,
+                        owner.tebako_version,
+                        mirror.mount
+                    );
+                    argv.push(owner.exe.to_string_lossy().into_owned());
+                    argv.push("--tebako-image".to_string());
+                    argv.push(format!("{}:0:{}", dep_image.display(), mirror.mount));
+                    for m in &mounts {
+                        argv.push("--tebako-image".to_string());
+                        argv.push(m.triple());
+                    }
+                    argv.push("--tebako-entry".to_string());
+                    argv.push(entry.path.clone());
+                    env.push((
+                        "TEBAKO_RUNTIME_IMAGE".to_string(),
+                        owner_image.to_string_lossy().into_owned(),
+                    ));
+                    mounts.insert(
+                        0,
+                        MountSpec {
+                            image: dep_image,
+                            slot: 0,
+                            mount: mirror.mount.clone(),
+                        },
+                    );
+                    (owner.exe.clone(), RuntimeResolution::Ready(Box::new(owner)))
+                }
+                None => {
+                    argv.push(rt.exe.to_string_lossy().into_owned());
+                    for m in &mounts {
+                        argv.push("--tebako-image".to_string());
+                        argv.push(m.triple());
+                    }
+                    argv.push("--tebako-entry".to_string());
+                    argv.push(entry.path.clone());
+                    if let Some(image) = &rt.image {
+                        // spec 06 §2: image-era drivers mount the env image; v1
+                        // runtimes ignore it (graceful degradation).
+                        env.push((
+                            "TEBAKO_RUNTIME_IMAGE".to_string(),
+                            image.to_string_lossy().into_owned(),
+                        ));
+                    }
+                    (rt.exe.clone(), RuntimeResolution::Ready(rt))
+                }
             }
-            argv.push("--tebako-entry".to_string());
-            argv.push(entry.path.clone());
-            if let Some(image) = &rt.image {
-                // spec 06 §2: image-era drivers mount the env image; v1
-                // runtimes ignore it (graceful degradation).
-                env.push((
-                    "TEBAKO_RUNTIME_IMAGE".to_string(),
-                    image.to_string_lossy().into_owned(),
-                ));
-            }
-            rt.exe.clone()
         }
         RuntimeResolution::Zero => {
             // Zero-runtime: the install-time materialization is the
@@ -651,7 +717,7 @@ pub fn plan(
             // path. The runtime path's driver composes them between the
             // interpreter and the entry instead (spec 17 §1).
             argv.extend(entry.args_default.iter().cloned());
-            entry_host
+            (entry_host, RuntimeResolution::Zero)
         }
     };
     argv.extend(user_args.iter().cloned());

--- a/crates/tebako-shim/src/runtime.rs
+++ b/crates/tebako-shim/src/runtime.rs
@@ -322,6 +322,54 @@ pub fn resolve_runtime_edge(
     Ok(*rt)
 }
 
+/// spec 33 §4: the on_runtime composition's OWNER pick — the depending
+/// runtime's shard-mirrored edge (spec 33 §1) resolved through the
+/// spawned-edge machinery (a primary-class resolution: cache-first; a
+/// miss rides the primary download machinery; the implementation axis
+/// re-asserts), then the owner-contract negotiation, fail-closed with
+/// the exit-75 class naming both sides — never a guessed-around boot.
+pub fn resolve_owner(
+    mirror: &tpkg::runtime_store::OnRuntimeMirror,
+    allow_download: bool,
+    ctx: &Ctx,
+) -> Result<CachedRuntime, ShimError> {
+    let owner = resolve_runtime_edge(
+        &mirror.engine,
+        mirror.implementation.as_deref(),
+        &mirror.constraint,
+        allow_download,
+        ctx,
+    )?;
+    let exe_name = owner
+        .exe
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let declared = tpkg::runtime_store::entry_contract_version(&owner.dir, &exe_name);
+    let want = mirror.owner_contract();
+    let satisfied = declared
+        .as_deref()
+        .is_some_and(|v| versions::from_validated(&want).matches(v));
+    if satisfied {
+        return Ok(owner);
+    }
+    fail(
+        EX_TEBAKO_CONTRACT,
+        format!(
+            "the resolved {} runtime {} (tebako {}) cannot own this composition: it declares {} but the depending runtime requires owner_contract \"{}\" (spec 33 §4)\n  install a {} runtime whose release declares a satisfying contract_version",
+            mirror.engine,
+            owner.lang_version,
+            owner.tebako_version,
+            match &declared {
+                Some(v) => format!("contract_version {v}"),
+                None => "no contract_version (a pre-era release)".to_string(),
+            },
+            want.as_str(),
+            mirror.engine,
+        ),
+    )
+}
+
 /// The release index's availability facet for `platform` (spec 13 §2a —
 /// the locked entry shape declares `{engine}_version` + `platform` +
 /// `tebako_version`): the `(lang_version, tebako_version)` of every

--- a/crates/tebako-shim/tests/common/mod.rs
+++ b/crates/tebako-shim/tests/common/mod.rs
@@ -368,3 +368,27 @@ pub fn write_runtime_engine_meta(
     .expect("manifest.json");
     exe
 }
+
+/// `write_runtime_engine` plus a release-index shard whose entry carries
+/// verbatim extra JSON keys (spec 33 fixtures: the `on_runtime` mirror on
+/// the depending runtime; `contract_version` + `implementation` on the
+/// owner). `extra_json` is spliced after `"filename": "<exe>"` — lead
+/// with a comma (`, "on_runtime": {…}`).
+pub fn write_runtime_engine_shard(
+    home: &Path,
+    engine: &str,
+    lv: &str,
+    ver: &str,
+    with_image: bool,
+    extra_json: &str,
+) -> PathBuf {
+    let exe = write_runtime_engine(home, engine, lv, ver, with_image);
+    let dir = exe.parent().expect("runtime entry dir").to_path_buf();
+    let exe_name = exe.file_name().expect("exe name").to_string_lossy();
+    std::fs::write(
+        dir.join("manifest.json"),
+        format!("[{{\"filename\": \"{exe_name}\"{extra_json}}}]\n"),
+    )
+    .expect("manifest.json");
+    exe
+}

--- a/crates/tebako-shim/tests/dispatch.rs
+++ b/crates/tebako-shim/tests/dispatch.rs
@@ -1099,3 +1099,168 @@ fn user_tightening_exports_the_hereditary_ceiling() {
     let plan = dispatch::dispatch("metanorma", &["compile".into()], &ctx).unwrap();
     assert_eq!(env_get(&plan, "TEBAKO_JAIL_TIGHTENING"), None);
 }
+
+// ---------------------------------------------------------------------
+// spec 33: runtime-on-runtime composition (the managed-mode handoff)
+// ---------------------------------------------------------------------
+
+/// The truffleruby shape (spec 33 §7): a ruby-engine DEPENDING runtime
+/// whose release-index shard mirrors the on_runtime block — the owner
+/// edge java:graalvm >= 24, the mount, the owner_contract constraint.
+const TR_ON_RUNTIME_SHARD: &str = ", \"on_runtime\": {\"engine\": \"java\", \"implementation\": \"graalvm\", \"constraint\": \">= 24\", \"mount\": \"/__runners__/truffleruby\", \"owner_contract\": \">= 2\"}";
+
+fn tr_entry(tool: &str) -> String {
+    format!("  entrypoints:\n    - name: {tool}\n      path: /app/bin/{tool}\n      runtime_requirement: {{engine: ruby, constraint: \">= 34\"}}\n")
+}
+
+#[test]
+fn on_runtime_dispatch_composes_the_owner_handoff() {
+    let tmp = TempDir::new("on-runtime-handoff");
+    let home = tmp.path().join("home");
+    let image = seed_tool(&home, "metanorma", &tr_entry("metanorma"), "1.2.3");
+    let dep_exe =
+        write_runtime_engine_shard(&home, "ruby", "34.0.1", "2.4.0", true, TR_ON_RUNTIME_SHARD);
+    let dep_image = dep_exe
+        .parent()
+        .unwrap()
+        .join(format!("tebako-runtime-2.4.0-34.0.1-{}.tfs", platform()));
+    let owner_exe = write_runtime_engine_shard(
+        &home,
+        "java",
+        "25.0.4.1",
+        "2.4.1",
+        true,
+        ", \"contract_version\": 2, \"implementation\": \"graalvm\"",
+    );
+    let owner_image = owner_exe
+        .parent()
+        .unwrap()
+        .join(format!("tebako-runtime-2.4.1-25.0.4.1-{}.tfs", platform()));
+    let mut ctx = ctx(&home, tmp.path());
+    pin_env(&mut ctx, "metanorma", "1.2.3");
+
+    let plan =
+        dispatch::dispatch("metanorma", &["compile".into(), "doc.xml".into()], &ctx).unwrap();
+
+    // The OWNER's exe is the program; the depending runtime's exe never
+    // runs — its env image co-mounts at the declared point, the first
+    // triple (spec 33 §7's discovery order), ahead of the payload stack.
+    assert_eq!(plan.program, owner_exe);
+    let expected: Vec<String> = vec![
+        owner_exe.to_string_lossy().into_owned(),
+        "--tebako-image".into(),
+        format!("{}:0:/__runners__/truffleruby", dep_image.display()),
+        "--tebako-image".into(),
+        format!("{}:0:/", image.display()),
+        "--tebako-entry".into(),
+        "/app/bin/metanorma".into(),
+        "compile".into(),
+        "doc.xml".into(),
+    ];
+    assert_eq!(plan.argv, expected);
+    // The OWNER's env image rides TEBAKO_RUNTIME_IMAGE (never the dep's).
+    assert_eq!(
+        env_get(&plan, "TEBAKO_RUNTIME_IMAGE").map(String::from),
+        Some(owner_image.to_string_lossy().into_owned())
+    );
+    // The plan's mount set is the full composition: dep image at its
+    // declared mount, then the payload at /.
+    assert_eq!(plan.mounts.len(), 2);
+    assert_eq!(plan.mounts[0].mount, "/__runners__/truffleruby");
+    assert_eq!(plan.mounts[0].image, dep_image);
+    assert_eq!(plan.mounts[1].mount, "/");
+    match plan.runtime {
+        RuntimeResolution::Ready(rt) => assert_eq!(rt.engine, "java"),
+        _ => panic!("the owner runtime is the plan's resolution"),
+    }
+}
+
+#[test]
+fn on_runtime_owner_contract_mismatch_fails_closed_75() {
+    for (owner_extra, want_named) in [
+        (
+            ", \"contract_version\": 1, \"implementation\": \"graalvm\"",
+            "contract_version 1",
+        ),
+        (", \"implementation\": \"graalvm\"", "no contract_version"),
+    ] {
+        let tmp = TempDir::new("on-runtime-contract");
+        let home = tmp.path().join("home");
+        seed_tool(&home, "metanorma", &tr_entry("metanorma"), "1.2.3");
+        write_runtime_engine_shard(&home, "ruby", "34.0.1", "2.4.0", true, TR_ON_RUNTIME_SHARD);
+        write_runtime_engine_shard(&home, "java", "25.0.4.1", "2.4.1", true, owner_extra);
+        let mut ctx = ctx(&home, tmp.path());
+        pin_env(&mut ctx, "metanorma", "1.2.3");
+
+        let err = dispatch::dispatch("metanorma", &[], &ctx).unwrap_err();
+        assert_eq!(err.code, tebako_shim::EX_TEBAKO_CONTRACT, "{err:?}");
+        assert!(err.message.contains(">= 2"), "{}", err.message);
+        assert!(err.message.contains(want_named), "{}", err.message);
+    }
+}
+
+#[test]
+fn on_runtime_owner_unresolvable_is_the_named_69() {
+    let tmp = TempDir::new("on-runtime-offline");
+    let home = tmp.path().join("home");
+    seed_tool(&home, "metanorma", &tr_entry("metanorma"), "1.2.3");
+    write_runtime_engine_shard(&home, "ruby", "34.0.1", "2.4.0", true, TR_ON_RUNTIME_SHARD);
+    // NO java runtime cached; TEBAKO_OFFLINE refuses the download.
+    let mut ctx = ctx(&home, tmp.path());
+    pin_env(&mut ctx, "metanorma", "1.2.3");
+    ctx.env
+        .insert("TEBAKO_OFFLINE".to_string(), "1".to_string());
+
+    let err = dispatch::dispatch("metanorma", &[], &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_UNAVAILABLE, "{err:?}");
+    assert!(err.message.contains("java"), "{}", err.message);
+}
+
+#[test]
+fn on_runtime_dep_without_image_is_a_named_error() {
+    let tmp = TempDir::new("on-runtime-no-image");
+    let home = tmp.path().join("home");
+    seed_tool(&home, "metanorma", &tr_entry("metanorma"), "1.2.3");
+    // The shard says on_runtime but the dep's env image pair never
+    // installed — the composition needs the image (it is what mounts).
+    write_runtime_engine_shard(&home, "ruby", "34.0.1", "2.4.0", false, TR_ON_RUNTIME_SHARD);
+    write_runtime_engine_shard(
+        &home,
+        "java",
+        "25.0.4.1",
+        "2.4.1",
+        true,
+        ", \"contract_version\": 2, \"implementation\": \"graalvm\"",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    pin_env(&mut ctx, "metanorma", "1.2.3");
+
+    let err = dispatch::dispatch("metanorma", &[], &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_UNAVAILABLE, "{err:?}");
+    assert!(
+        err.message.contains("no verified env image"),
+        "{}",
+        err.message
+    );
+}
+
+#[test]
+fn on_runtime_malformed_shard_is_a_manifest_error() {
+    let tmp = TempDir::new("on-runtime-bad-shard");
+    let home = tmp.path().join("home");
+    seed_tool(&home, "metanorma", &tr_entry("metanorma"), "1.2.3");
+    write_runtime_engine_shard(
+        &home,
+        "ruby",
+        "34.0.1",
+        "2.4.0",
+        true,
+        ", \"on_runtime\": \"garbage\"",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    pin_env(&mut ctx, "metanorma", "1.2.3");
+
+    let err = dispatch::dispatch("metanorma", &[], &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_MANIFEST, "{err:?}");
+    assert!(err.message.contains("on_runtime"), "{}", err.message);
+}

--- a/crates/tfs/src/context.rs
+++ b/crates/tfs/src/context.rs
@@ -1800,7 +1800,10 @@ impl FsContext {
     /// twin of `path` inside that tree. A home's data files
     /// (lib/modules, lib/jvm.cfg) never ride a linked-library closure,
     /// so the closure walk's answer boots a java that cannot find its
-    /// boot class path (the metanorma dogfood's jing failure). Any
+    /// boot class path (the metanorma dogfood's jing failure). The
+    /// mount ROOT itself answers the tree root (never EISDIR) — spec 33
+    /// §3's template bridge splices it for tokens naming the depending
+    /// runtime's mount (`-D…home={mount}`). Any
     /// other mount answers via dlmap2file's closure walk, unchanged.
     /// The `exec` trace event (spec 25 §2): `routed:<host>` with the
     /// `route` detail (`home-tree` | `dlmap-closure`), `host` on the
@@ -1861,16 +1864,6 @@ impl FsContext {
             }
             return result;
         };
-        if rel.is_empty() {
-            if let Some(start) = trace_start {
-                trace::emit(
-                    trace::Event::new(op, &normalized, format!("error:{}", libc::EISDIR))
-                        .with_errno(libc::EISDIR)
-                        .dur(start),
-                );
-            }
-            return Err(libc::EISDIR);
-        }
         let root = match self.home_tree_root(handle) {
             Ok(root) => root,
             Err(e) => {
@@ -1907,7 +1900,15 @@ impl FsContext {
                 return Err(e);
             }
         }
-        let host = root.join(&rel);
+        // spec 33 §3: the mount ROOT itself answers the tree root (the
+        // depending runtime's home is the template's `{mount}` expansion
+        // unit) — `root.join("")` would trail a separator the splice
+        // then doubles.
+        let host = if rel.is_empty() {
+            root.clone()
+        } else {
+            root.join(&rel)
+        };
         let result =
             std::ffi::CString::new(host.to_string_lossy().into_owned()).map_err(|_| libc::EIO);
         if let Some(start) = trace_start {
@@ -3518,6 +3519,45 @@ mod tests {
 
         // Idempotent within the process: a second exec reuses the tree.
         let again = ctx.exec_materialize("/tfs/bin/tool").unwrap();
+        assert_eq!(again, answer);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn exec_materialize_answers_the_tree_root_for_the_home_mount_root() {
+        // spec 33 §3's bridge: a runtime-on-runtime template token naming
+        // the depending mount ROOT (the `-Dorg.graalvm.language.ruby.home=
+        // {mount}` form) materializes the whole home tree and answers its
+        // root — the host-plain owner reads the home arbitrarily, so the
+        // tree is the honest unit; EISDIR is never the answer.
+        let dir = std::env::temp_dir().join(format!("tfs-home-root-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let image = fixture_home_zip(&dir, true);
+        let mut ctx = FsContext::new();
+        let mount = crate::mount::build_from_file(image.to_str().unwrap(), "/tfs").unwrap();
+        ctx.mount_checked(mount).unwrap();
+
+        let answer = ctx.exec_materialize("/tfs").unwrap();
+        let text = answer.to_string_lossy().into_owned();
+        let root = std::path::PathBuf::from(&text);
+        assert!(root.is_dir(), "the home tree root lands: {root:?}");
+        assert!(
+            !text.ends_with(std::path::MAIN_SEPARATOR),
+            "the root answer carries no trailing separator (template splices append their own): {text:?}"
+        );
+        assert_eq!(
+            std::fs::read(root.join("bin/tool")).unwrap(),
+            b"#!/bin/fake\n"
+        );
+        assert_eq!(
+            std::fs::read(root.join("lib/modules")).unwrap(),
+            b"jimage-bytes"
+        );
+
+        // Idempotent within the process: the tree extracts once.
+        let again = ctx.exec_materialize("/tfs").unwrap();
         assert_eq!(again, answer);
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/tpkg/src/lib.rs
+++ b/crates/tpkg/src/lib.rs
@@ -183,8 +183,8 @@ pub use manifest::{
     check_check_name, checks_map, AppProvides, BuiltFrom, Capabilities, Check, CheckEntry,
     CheckExpect, CheckNeed, CheckPlatform, CheckRequires, Constraint, DataProvides, Digest,
     Encryption, EncryptionPart, EncryptionState, EngineProvides, Entrypoint, Identity,
-    LibraryAlias, ManifestError, MountSemantics, PayloadKind, PayloadManifest, Platform, Platforms,
-    Producer, Provides, Requirement, RuntimeProvides, RuntimeRequirement, Sbom, Signing,
+    LibraryAlias, ManifestError, MountSemantics, OnRuntime, PayloadKind, PayloadManifest, Platform,
+    Platforms, Producer, Provides, Requirement, RuntimeProvides, RuntimeRequirement, Sbom, Signing,
     SigningMechanism, SigningState, Source, ToolkitExecutable, ToolkitLibrary, ToolkitProvides,
     PAYLOAD_MANIFEST_PATH, PAYLOAD_SCHEMA_VERSION,
 };

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -795,6 +795,70 @@ pub struct EngineProvides {
     pub implementation: Option<String>,
 }
 
+/// The runtime-on-runtime composition block (spec 33 §2 — additive,
+/// schema_minor 6; old readers ignore it, new readers enforce): a
+/// `kind: runtime` payload carrying an OWNER edge (an expose-less
+/// `requires` entry of `kind: runtime`) declares here how its env image
+/// composes onto the owner's boot — where the image mounts and the argv
+/// between the owner's interpreter token and the entry. REQUIRED iff the
+/// owner edge exists (the coupling is the manifest-level validator's —
+/// the JSON Schema cannot express it).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OnRuntime {
+    /// Where THIS runtime's env image mounts on the owner's boot —
+    /// POSIX-absolute (spec 17 §1's uniform namespace), never `/`.
+    pub mount: String,
+    /// The argv between the owner's interpreter token and the entry
+    /// (spec 33 §3): strings, the single placeholder `{mount}` expanding
+    /// to this boot's effective mount point at boot time (driver-side —
+    /// an unknown placeholder or a post-expansion escape of the mount is
+    /// the named boot error 65 there).
+    pub argv_template: Vec<String>,
+    /// The constraint the owner's `contract_version` must satisfy
+    /// (fail-closed at dispatch, the exit-75 class). Absent = the
+    /// default `>= 2`, applied at negotiation — never written back.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner_contract: Option<Constraint>,
+}
+
+impl OnRuntime {
+    /// The default owner-contract constraint (spec 33 §2): contract 2 is
+    /// the spec-17 widened grammar the composition's wire rides.
+    pub const DEFAULT_OWNER_CONTRACT: &'static str = ">= 2";
+
+    /// The effective owner-contract constraint (the declared one, else
+    /// [`Self::DEFAULT_OWNER_CONTRACT`]).
+    pub fn owner_contract(&self) -> Constraint {
+        self.owner_contract
+            .clone()
+            .unwrap_or_else(|| Constraint::new(Self::DEFAULT_OWNER_CONTRACT).unwrap())
+    }
+
+    fn validate(&self) -> Result<(), ManifestError> {
+        check_abs_path(
+            &self.mount,
+            "provides.on_runtime.mount must be absolute (spec 17 §1's uniform namespace)",
+        )?;
+        if self.mount == "/" {
+            return Err(ManifestError::Invalid(
+                "provides.on_runtime.mount must not be \"/\" — the depending runtime's env image never mounts over the owner's root (spec 33 §2)",
+            ));
+        }
+        if self.argv_template.is_empty() {
+            return Err(ManifestError::Invalid(
+                "provides.on_runtime.argv_template must not be empty — the template is the composition's rewrite (spec 33 §2)",
+            ));
+        }
+        for token in &self.argv_template {
+            check_non_empty(
+                token,
+                "provides.on_runtime.argv_template[] must not be empty",
+            )?;
+        }
+        Ok(())
+    }
+}
+
 /// Runtime provenance (`built_from: {src_sha256, patch_set}`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BuiltFrom {
@@ -824,6 +888,12 @@ pub struct RuntimeProvides {
     /// only as the primary co-mounted runtime.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entrypoints: Vec<Entrypoint>,
+    /// The runtime-on-runtime composition block (spec 33 §2 — additive,
+    /// schema_minor 6): present iff this runtime declares an owner edge
+    /// (the coupling validates at the manifest level). Old readers
+    /// ignore the key — and find no owner edge to act on either.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_runtime: Option<OnRuntime>,
     pub capabilities: Capabilities,
 }
 
@@ -1034,6 +1104,9 @@ impl RuntimeProvides {
             return Err(ManifestError::Invalid(
                 "provides.env keys must not be empty",
             ));
+        }
+        if let Some(on) = &self.on_runtime {
+            on.validate()?;
         }
         let caps = &self.capabilities;
         if !caps.exec || !caps.read || caps.runtime != Some(true) {
@@ -1841,6 +1914,40 @@ impl PayloadManifest {
         self.provides.validate()?;
         for req in &self.requires {
             req.validate()?;
+        }
+        // spec 33 §1/§2 (schema_minor 6): the on_runtime coupling. On a
+        // kind:runtime payload an expose-less `kind: runtime` requires
+        // entry is an OWNER edge — at most one, and the
+        // `provides.on_runtime` block exists iff one does (both
+        // directions named errors: the composition declares its rewrite
+        // or it is not a composition). On a NON-runtime payload an
+        // expose-less runtime edge is spec 30's ordinary dependency (it
+        // surfaces no shim names) — never an owner edge, and no block
+        // can exist (the field lives on RuntimeProvides only).
+        if let Provides::Runtime(rt) = &self.provides {
+            let owner_edges = self
+                .requires
+                .iter()
+                .filter(|r| matches!(r, Requirement::Runtime { expose, .. } if expose.is_empty()))
+                .count();
+            if owner_edges > 1 {
+                return Err(ManifestError::Invalid(
+                    "requires[] carries more than one owner edge (expose-less entries of kind: runtime) — a runtime composes on at most one owner; a runtime needing two process owners is two payloads (spec 33 §1)",
+                ));
+            }
+            match (owner_edges, &rt.on_runtime) {
+                (1, None) => {
+                    return Err(ManifestError::Invalid(
+                        "a kind: runtime payload with an owner edge (an expose-less requires entry of kind: runtime) must declare provides.on_runtime — the composition declares its rewrite or it is not a composition (spec 33 §2)",
+                    ));
+                }
+                (0, Some(_)) => {
+                    return Err(ManifestError::Invalid(
+                        "provides.on_runtime requires exactly one owner edge (an expose-less requires entry of kind: runtime) — the block declares the composition the edge names (spec 33 §2)",
+                    ));
+                }
+                _ => {}
+            }
         }
         // spec 30 §3, extended one class by spec 32 §1: an exposed
         // depended-entry name never collides with the payload's OWN

--- a/crates/tpkg/src/runtime_store.rs
+++ b/crates/tpkg/src/runtime_store.rs
@@ -177,6 +177,140 @@ pub fn entry_meta(entry_dir: &Path, exe_name: &str, key: &str) -> Option<String>
     })
 }
 
+/// The cached index entry's `contract_version` (spec 18) as a version
+/// string — the factory index writes it as a JSON NUMBER; the string
+/// spelling reads too. `None` when the mirror, the entry, or the key is
+/// absent (the pre-era signal — the caller's negotiation decides what
+/// absence means; spec 33 §4 fails it closed).
+pub fn entry_contract_version(entry_dir: &Path, exe_name: &str) -> Option<String> {
+    let text = std::fs::read_to_string(entry_dir.join("manifest.json")).ok()?;
+    let parsed = tebako_json::parse(&text).ok()?;
+    let tebako_json::Value::Array(entries) = &parsed else {
+        return None;
+    };
+    entries.iter().find_map(|entry| {
+        (entry
+            .find("filename")
+            .and_then(|f| f.as_string())
+            .as_deref()
+            == Some(exe_name))
+        .then(|| {
+            entry.find("contract_version").and_then(|v| match v {
+                tebako_json::Value::Number(n) => Some(n.clone()),
+                tebako_json::Value::String(s) => Some(s.clone()),
+                _ => None,
+            })
+        })
+        .flatten()
+    })
+}
+
+// ---------------------------------------------------------------------
+// spec 33 §1: the on_runtime release-index mirror
+// ---------------------------------------------------------------------
+
+/// The `on_runtime` key of a cached release-index entry (spec 33 §1):
+/// the depending runtime's owner edge + mount + owner-contract, flowed
+/// verbatim from the factory's release index. The in-image L1 block
+/// stays the sole authority — the DRIVER cross-checks this mirror
+/// against it at boot (a disagreement is "the release is lying", the
+/// named boot error 65); the loader side (no image reader) plans the
+/// composition from this mirror alone.
+#[derive(Debug, Clone)]
+pub struct OnRuntimeMirror {
+    /// The owner runtime's engine (`java`, …).
+    pub engine: String,
+    /// The owner runtime's implementation requirement (`graalvm`, …);
+    /// `None` = any implementation of the engine satisfies the edge.
+    pub implementation: Option<String>,
+    /// The owner runtime's language-version constraint.
+    pub constraint: crate::manifest::Constraint,
+    /// Where the depending runtime's env image mounts on the owner's
+    /// boot (the `--tebako-image <dep>:-:<mount>` triple's point).
+    pub mount: String,
+    /// The declared owner-contract constraint; `None` = the spec 33 §2
+    /// default, applied at negotiation, never written back.
+    pub owner_contract: Option<crate::manifest::Constraint>,
+}
+
+impl OnRuntimeMirror {
+    /// The effective owner-contract constraint (the declared one, else
+    /// [`crate::manifest::OnRuntime::DEFAULT_OWNER_CONTRACT`]).
+    pub fn owner_contract(&self) -> crate::manifest::Constraint {
+        self.owner_contract.clone().unwrap_or_else(|| {
+            crate::manifest::Constraint::new(crate::manifest::OnRuntime::DEFAULT_OWNER_CONTRACT)
+                .unwrap()
+        })
+    }
+}
+
+/// The `on_runtime` mirror of the cached index entry for the exe
+/// `exe_name` (spec 33 §1): `None` when the mirror file, the entry, or
+/// the key is absent (every pre-spec-33 runtime — no composition, the
+/// same compat window as [`entry_meta`]). A PRESENT but malformed key
+/// is the named error: the shard the resolution already trusted is
+/// lying — never a guessed composition.
+pub fn on_runtime_mirror(
+    entry_dir: &Path,
+    exe_name: &str,
+) -> Result<Option<OnRuntimeMirror>, String> {
+    let Ok(text) = std::fs::read_to_string(entry_dir.join("manifest.json")) else {
+        return Ok(None);
+    };
+    let Ok(parsed) = tebako_json::parse(&text) else {
+        return Ok(None);
+    };
+    let tebako_json::Value::Array(entries) = &parsed else {
+        return Ok(None);
+    };
+    let Some(entry) = entries
+        .iter()
+        .find(|e| e.find("filename").and_then(|f| f.as_string()).as_deref() == Some(exe_name))
+    else {
+        return Ok(None);
+    };
+    let Some(key) = entry.find("on_runtime") else {
+        return Ok(None);
+    };
+    let bad = |why: String| {
+        format!("the cached release index's on_runtime for {exe_name}: {why} (spec 33 §1)")
+    };
+    if !matches!(key, tebako_json::Value::Object(_)) {
+        return Err(bad("must be a map".to_string()));
+    }
+    let required = |name: &str| -> Result<String, String> {
+        key.find(name)
+            .and_then(|v| v.as_string())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| bad(format!("{name} is required")))
+    };
+    let parse_constraint =
+        |name: &str, src: String| -> Result<crate::manifest::Constraint, String> {
+            crate::manifest::Constraint::new(&src)
+                .map_err(|e| bad(format!("{name} is not a constraint: {e}")))
+        };
+    let engine = required("engine")?;
+    let implementation = key
+        .find("implementation")
+        .and_then(|v| v.as_string())
+        .filter(|s| !s.is_empty());
+    let constraint = parse_constraint("constraint", required("constraint")?)?;
+    let mount = required("mount")?;
+    let owner_contract = key
+        .find("owner_contract")
+        .and_then(|v| v.as_string())
+        .filter(|s| !s.is_empty())
+        .map(|s| parse_constraint("owner_contract", s))
+        .transpose()?;
+    Ok(Some(OnRuntimeMirror {
+        engine,
+        implementation,
+        constraint,
+        mount,
+        owner_contract,
+    }))
+}
+
 /// One store entry dir → a [`CachedRuntime`] when it is well-formed
 /// (parseable name for this platform, exe present); `None` otherwise.
 /// Lenient by design: malformed entries are invisible to resolution
@@ -523,10 +657,21 @@ mod tests {
         with_image: bool,
         index_entry: Option<String>,
     ) {
+        fixture_entry_engine(home, "java", lv, ver, with_image, index_entry)
+    }
+
+    fn fixture_entry_engine(
+        home: &Path,
+        engine: &str,
+        lv: &str,
+        ver: &str,
+        with_image: bool,
+        index_entry: Option<String>,
+    ) {
         let platform = platform_string();
         let dir = home
             .join("runtimes")
-            .join(format!("java-{lv}-{ver}-{platform}"));
+            .join(format!("{engine}-{lv}-{ver}-{platform}"));
         std::fs::create_dir_all(&dir).unwrap();
         let exe = entry_exe_name(lv, ver, platform);
         std::fs::write(dir.join(&exe), b"exe").unwrap();
@@ -766,5 +911,226 @@ mod tests {
         assert_eq!(home, PathBuf::from("C:/App/Local\\tebako"));
         // Nothing resolveable is a named error, never a guess.
         assert!(tebako_home(|_| None).is_err());
+    }
+
+    #[test]
+    fn entry_contract_version_reads_the_numeric_and_string_spellings() {
+        let tmp = std::env::temp_dir().join(format!(
+            "tpkg-contract-version-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+        ));
+        let platform = platform_string();
+        let exe = entry_exe_name("25.0.4.1", "2.4.1", platform);
+        // the factory index's spelling: a JSON NUMBER
+        fixture_entry(
+            &tmp,
+            "25.0.4.1",
+            "2.4.1",
+            true,
+            Some(format!(
+                "{{\"filename\": \"{exe}\", \"contract_version\": 2}}"
+            )),
+        );
+        let dir = tmp
+            .join("runtimes")
+            .join(format!("java-25.0.4.1-2.4.1-{platform}"));
+        assert_eq!(entry_contract_version(&dir, &exe).as_deref(), Some("2"));
+        // the string spelling reads too
+        fixture_entry(
+            &tmp,
+            "21.0.12",
+            "0.3.0",
+            true,
+            Some(format!(
+                "{{\"filename\": \"{}\", \"contract_version\": \"1\"}}",
+                entry_exe_name("21.0.12", "0.3.0", platform)
+            )),
+        );
+        let dir2 = tmp
+            .join("runtimes")
+            .join(format!("java-21.0.12-0.3.0-{platform}"));
+        let exe2 = entry_exe_name("21.0.12", "0.3.0", platform);
+        assert_eq!(entry_contract_version(&dir2, &exe2).as_deref(), Some("1"));
+        // absent key, absent entry, absent mirror: the pre-era None
+        let exe3 = entry_exe_name("21.0.11", "0.3.0", platform);
+        fixture_entry(&tmp, "21.0.11", "0.3.0", true, None);
+        let dir3 = tmp
+            .join("runtimes")
+            .join(format!("java-21.0.11-0.3.0-{platform}"));
+        assert_eq!(entry_contract_version(&dir3, &exe3), None);
+        assert_eq!(entry_contract_version(&dir3, "never-released"), None);
+        assert_eq!(entry_contract_version(&tmp.join("runtimes"), &exe3), None);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // -----------------------------------------------------------------
+    // spec 33 §1: the on_runtime release-index mirror
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn on_runtime_mirror_parses_the_full_shape() {
+        let tmp = std::env::temp_dir().join(format!(
+            "tpkg-on-runtime-mirror-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+        ));
+        let platform = platform_string();
+        let exe = entry_exe_name("34.0.1", "2.4.0", platform);
+        // the truffleruby shape: the DEPENDING runtime is a ruby engine
+        // whose on_runtime edge names the java owner
+        fixture_entry_engine(
+            &tmp,
+            "ruby",
+            "34.0.1",
+            "2.4.0",
+            true,
+            Some(format!(
+                "{{\"filename\": \"{exe}\", \"on_runtime\": {{\"engine\": \"java\", \"implementation\": \"graalvm\", \"constraint\": \">= 24\", \"mount\": \"/__runners__/truffleruby\", \"owner_contract\": \">= 2\"}}}}"
+            )),
+        );
+        let mirror = on_runtime_mirror(
+            &tmp.join("runtimes")
+                .join(format!("ruby-34.0.1-2.4.0-{platform}")),
+            &exe,
+        )
+        .unwrap()
+        .expect("the mirror parses");
+        assert_eq!(mirror.engine, "java");
+        assert_eq!(mirror.implementation.as_deref(), Some("graalvm"));
+        assert_eq!(mirror.constraint.as_str(), ">= 24");
+        assert_eq!(mirror.mount, "/__runners__/truffleruby");
+        assert_eq!(mirror.owner_contract().as_str(), ">= 2");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn on_runtime_mirror_minimal_and_absent() {
+        let tmp = std::env::temp_dir().join(format!(
+            "tpkg-on-runtime-min-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+        ));
+        let platform = platform_string();
+        let exe = entry_exe_name("9.4.8.0", "2.4.0", platform);
+        // minimal: no implementation, no owner_contract — the ">= 2"
+        // default applies at negotiation, never written back
+        // (the jruby shape: a ruby engine riding a java owner)
+        fixture_entry_engine(
+            &tmp,
+            "ruby",
+            "9.4.8.0",
+            "2.4.0",
+            true,
+            Some(format!(
+                "{{\"filename\": \"{exe}\", \"on_runtime\": {{\"engine\": \"java\", \"constraint\": \">= 21\", \"mount\": \"/__runners__/jruby\"}}}}"
+            )),
+        );
+        let dir = tmp
+            .join("runtimes")
+            .join(format!("ruby-9.4.8.0-2.4.0-{platform}"));
+        let mirror = on_runtime_mirror(&dir, &exe)
+            .unwrap()
+            .expect("minimal parses");
+        assert_eq!(mirror.implementation, None);
+        assert_eq!(
+            mirror.owner_contract().as_str(),
+            crate::manifest::OnRuntime::DEFAULT_OWNER_CONTRACT
+        );
+        // the key absent: no composition (every pre-spec-33 runtime)
+        fixture_entry(&tmp, "21.0.12", "0.3.0", true, None);
+        let platform2 = platform_string();
+        let exe2 = entry_exe_name("21.0.12", "0.3.0", platform2);
+        assert!(on_runtime_mirror(
+            &tmp.join("runtimes")
+                .join(format!("java-21.0.12-0.3.0-{platform2}")),
+            &exe2
+        )
+        .unwrap()
+        .is_none());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn on_runtime_mirror_malformed_is_a_named_error() {
+        let tmp = std::env::temp_dir().join(format!(
+            "tpkg-on-runtime-bad-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+        ));
+        let platform = platform_string();
+        // the key not a map
+        let exe = entry_exe_name("9.4.8.0", "2.4.0", platform);
+        fixture_entry(
+            &tmp,
+            "9.4.8.0",
+            "2.4.0",
+            true,
+            Some(format!(
+                "{{\"filename\": \"{exe}\", \"on_runtime\": \"garbage\"}}"
+            )),
+        );
+        let dir = tmp
+            .join("runtimes")
+            .join(format!("java-9.4.8.0-2.4.0-{platform}"));
+        let err = on_runtime_mirror(&dir, &exe).unwrap_err();
+        assert!(err.contains("on_runtime"), "{err}");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        // engine missing
+        let tmp2 = std::env::temp_dir().join(format!(
+            "tpkg-on-runtime-bad2-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+        ));
+        fixture_entry(
+            &tmp2,
+            "9.4.8.0",
+            "2.4.0",
+            true,
+            Some(format!(
+                "{{\"filename\": \"{exe}\", \"on_runtime\": {{\"constraint\": \">= 21\", \"mount\": \"/x\"}}}}"
+            )),
+        );
+        let dir2 = tmp2
+            .join("runtimes")
+            .join(format!("java-9.4.8.0-2.4.0-{platform}"));
+        let err = on_runtime_mirror(&dir2, &exe).unwrap_err();
+        assert!(err.contains("engine"), "{err}");
+        let _ = std::fs::remove_dir_all(&tmp2);
+
+        // a constraint that is not a constraint
+        let tmp3 = std::env::temp_dir().join(format!(
+            "tpkg-on-runtime-bad3-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+        ));
+        fixture_entry(
+            &tmp3,
+            "9.4.8.0",
+            "2.4.0",
+            true,
+            Some(format!(
+                "{{\"filename\": \"{exe}\", \"on_runtime\": {{\"engine\": \"java\", \"constraint\": \"bogus\", \"mount\": \"/x\"}}}}"
+            )),
+        );
+        let dir3 = tmp3
+            .join("runtimes")
+            .join(format!("java-9.4.8.0-2.4.0-{platform}"));
+        let err = on_runtime_mirror(&dir3, &exe).unwrap_err();
+        assert!(err.contains("constraint"), "{err}");
+        let _ = std::fs::remove_dir_all(&tmp3);
     }
 }

--- a/crates/tpkg/tests/manifest.rs
+++ b/crates/tpkg/tests/manifest.rs
@@ -1062,3 +1062,183 @@ fn spec_03_smoke_examples_parse() {
     assert_eq!(name, "iso-codes");
     assert_eq!(mount.as_deref(), Some("/__app__/share/iso-codes"));
 }
+
+// ---------------------------------------------------------------------
+// spec 33 (schema_minor 6): the on_runtime block — runtime-on-runtime
+// composition (the owner edge is an expose-less kind:runtime requires
+// on a kind:runtime payload).
+// ---------------------------------------------------------------------
+
+/// A jruby-style depending runtime manifest. `provides_extra` rides at
+/// the provides-level indent (the on_runtime block or nothing);
+/// `requires_block` at the top level ("" or "requires:\n  - …\n").
+fn on_runtime_manifest(provides_extra: &str, requires_block: &str) -> String {
+    format!(
+        "identity:\n  schema_version: 1\n  kind: runtime\n  name: tebako-runtime-jruby\n  version: 9.4.8.0\n\
+        \x20 producer: {{tool: tebako-cli, tool_version: 2.5.0}}\n  created: \"2026-09-07T00:00:00Z\"\n\
+        \x20 digest:\n    tree_hash: \"sha256:650f8ad9527c28dbb8ae43270215e4ef64c884cea06bec289918b060f3b69ee3\"\n\
+        \x20   blob_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1\n\
+        \x20 signing: {{state: unsigned}}\n  encryption: {{state: none}}\n\
+        provides:\n  provides: {{engine: ruby, implementation: jruby, version: 9.4.8.0, abi_line: \"9.4\", platform: aarch64-macos}}\n\
+        \x20 built_from: {{src_sha256: 7a5eb4446074d0193468f1a24cf5a94e4748cf1f033b0fdfcb8bfbaa901a81e1, patch_set: v2.4.0}}\n\
+        {provides_extra}\
+        \x20 capabilities: {{exec: true, read: true, runtime: true}}\n\
+        {requires_block}"
+    )
+}
+
+const ON_RUNTIME_BLOCK: &str = "  on_runtime:\n    mount: /__runners__/jruby\n    argv_template: [\"-classpath\", \"{mount}/lib/jruby.jar\", \"org.jruby.Main\"]\n    owner_contract: \">= 2\"\n";
+const OWNER_EDGE: &str = "requires:\n  - {kind: runtime, engine: java, constraint: \">= 21\"}\n";
+
+#[test]
+fn on_runtime_block_is_schema_legal() {
+    // spec 33 §2 (schema_minor 6): the additive on_runtime block under
+    // RuntimeProvides — the owner edge present, the block declaring the
+    // composition. The versioned JSON Schema admits it and the model
+    // round-trips it.
+    let text = on_runtime_manifest(ON_RUNTIME_BLOCK, OWNER_EDGE);
+    let m = PayloadManifest::from_yaml(&text).unwrap();
+    let Provides::Runtime(rt) = &m.provides else {
+        panic!("runtime provides, got {:?}", m.provides)
+    };
+    let on = rt.on_runtime.as_ref().expect("the on_runtime block parses");
+    assert_eq!(on.mount, "/__runners__/jruby");
+    assert_eq!(
+        on.argv_template,
+        vec![
+            "-classpath".to_string(),
+            "{mount}/lib/jruby.jar".to_string(),
+            "org.jruby.Main".to_string()
+        ]
+    );
+    assert_eq!(on.owner_contract.as_ref().map(|c| c.as_str()), Some(">= 2"));
+    // …and the schema agrees (MECE cross-check).
+    let validator = schema_validator();
+    validator
+        .validate(&yaml_text_to_json(&text))
+        .expect("on_runtime: is schema-legal");
+    let back = PayloadManifest::from_yaml(&m.to_yaml().unwrap()).unwrap();
+    assert_eq!(back, m);
+
+    // owner_contract omitted: the model keeps it absent (the ">= 2"
+    // default applies at negotiation, not at parse) and off the wire.
+    let block =
+        "  on_runtime:\n    mount: /__runners__/jruby\n    argv_template: [\"org.jruby.Main\"]\n";
+    let text = on_runtime_manifest(block, OWNER_EDGE);
+    let m = PayloadManifest::from_yaml(&text).unwrap();
+    let Provides::Runtime(rt) = &m.provides else {
+        panic!("runtime provides")
+    };
+    let on = rt.on_runtime.as_ref().expect("the on_runtime block parses");
+    assert!(on.owner_contract.is_none());
+    let wire = m.to_yaml().unwrap();
+    assert!(!wire.contains("owner_contract"), "{wire}");
+    assert!(wire.contains("on_runtime:"), "{wire}");
+    let back = PayloadManifest::from_yaml(&wire).unwrap();
+    assert_eq!(back, m);
+
+    // The block absent (an ordinary runtime) stays absent on the wire —
+    // a reader predating schema_minor 6 never sees the key.
+    let plain = on_runtime_manifest("", "");
+    let m = PayloadManifest::from_yaml(&plain).unwrap();
+    let Provides::Runtime(rt) = &m.provides else {
+        panic!("runtime provides")
+    };
+    assert!(rt.on_runtime.is_none());
+    let wire = m.to_yaml().unwrap();
+    assert!(!wire.contains("on_runtime"), "{wire}");
+}
+
+#[test]
+fn on_runtime_without_owner_edge_is_a_named_error() {
+    // spec 33 §2: the block is FORBIDDEN without the owner edge — the
+    // composition declares its rewrite or it is not a composition.
+    let text = on_runtime_manifest(ON_RUNTIME_BLOCK, "");
+    let err = PayloadManifest::from_yaml(&text).unwrap_err();
+    assert!(
+        err.to_string().contains("on_runtime"),
+        "the error names the key: {err}"
+    );
+}
+
+#[test]
+fn owner_edge_without_on_runtime_is_a_named_error() {
+    // spec 33 §2: an expose-less kind:runtime edge on a kind:runtime
+    // payload is an owner edge, and the owner edge REQUIRES the block.
+    let text = on_runtime_manifest("", OWNER_EDGE);
+    let err = PayloadManifest::from_yaml(&text).unwrap_err();
+    assert!(
+        err.to_string().contains("on_runtime"),
+        "the error names the missing block: {err}"
+    );
+}
+
+#[test]
+fn two_owner_edges_are_a_named_error() {
+    // spec 33 §1: at most ONE owner edge per payload — a runtime needing
+    // two process owners is two payloads.
+    let text = on_runtime_manifest(
+        ON_RUNTIME_BLOCK,
+        "requires:\n  - {kind: runtime, engine: java, constraint: \">= 21\"}\n  - {kind: runtime, engine: python, constraint: \">= 3.11\"}\n",
+    );
+    let err = PayloadManifest::from_yaml(&text).unwrap_err();
+    assert!(
+        err.to_string().contains("one owner edge") || err.to_string().contains("at most one"),
+        "the error names the cardinality: {err}"
+    );
+}
+
+#[test]
+fn spawned_edges_are_not_owner_edges() {
+    // spec 33 §1: a runtime MAY additionally carry spec-30 spawned edges
+    // (expose: present) — they never count toward the owner cardinality,
+    // and a runtime with ONLY a spawned edge declares no on_runtime.
+    let spawned_only = on_runtime_manifest(
+        "",
+        "requires:\n  - {kind: runtime, engine: java, constraint: \">= 21\", expose: [java]}\n",
+    );
+    PayloadManifest::from_yaml(&spawned_only).expect("a spawned edge alone needs no block");
+    let both = on_runtime_manifest(
+        ON_RUNTIME_BLOCK,
+        "requires:\n  - {kind: runtime, engine: java, constraint: \">= 21\"}\n  - {kind: runtime, engine: python, constraint: \">= 3.11\", expose: [python]}\n",
+    );
+    PayloadManifest::from_yaml(&both).expect("owner edge + spawned edge + block is legal");
+}
+
+#[test]
+fn on_runtime_field_validation() {
+    let cases = [
+        (
+            // mount must be POSIX-absolute
+            "  on_runtime:\n    mount: runners/jruby\n    argv_template: [\"org.jruby.Main\"]\n",
+            "absolute",
+        ),
+        (
+            // mount: / is invalid at validation (spec 33 §2)
+            "  on_runtime:\n    mount: /\n    argv_template: [\"org.jruby.Main\"]\n",
+            "must not be \"/\"",
+        ),
+        (
+            // the template must not be empty
+            "  on_runtime:\n    mount: /__runners__/jruby\n    argv_template: []\n",
+            "argv_template",
+        ),
+        (
+            // template elements must not be empty strings
+            "  on_runtime:\n    mount: /__runners__/jruby\n    argv_template: [\"-classpath\", \"\"]\n",
+            "argv_template",
+        ),
+    ];
+    for (block, want) in cases {
+        let text = on_runtime_manifest(block, OWNER_EDGE);
+        let err = PayloadManifest::from_yaml(&text).unwrap_err();
+        assert!(err.to_string().contains(want), "case wants '{want}': {err}");
+    }
+    // owner_contract must parse as a constraint (the model's type
+    // refuses garbage at deserialize).
+    let text = on_runtime_manifest(
+        "  on_runtime:\n    mount: /__runners__/jruby\n    argv_template: [\"org.jruby.Main\"]\n    owner_contract: \"bogus\"\n",
+        OWNER_EDGE,
+    );
+    assert!(PayloadManifest::from_yaml(&text).is_err());
+}

--- a/crates/tpkg/tests/manifest_props.rs
+++ b/crates/tpkg/tests/manifest_props.rs
@@ -316,6 +316,7 @@ fn arb_provides(kind: PayloadKind) -> impl Strategy<Value = Provides> {
                 },
                 env,
                 entrypoints: Vec::new(),
+                on_runtime: None,
                 capabilities: Capabilities {
                     exec: true,
                     read: true,

--- a/docs/spec/33-runtime-on-runtime.md
+++ b/docs/spec/33-runtime-on-runtime.md
@@ -1,6 +1,10 @@
 # Spec 33 — Runtime-on-runtime composition
 
-**Status: PLANNED (drafted 2026-09-07 — ecosystem TODO.jruby/01).**
+**Status: PLANNED (drafted 2026-09-07 — ecosystem TODO.jruby/01;
+managed-mode dispatch ships with tebako v2.5.0; the press/lock row and
+the standalone (bootstrap) composition ride spec 23 §13.6's
+implementation — until then a press against an on_runtime runtime fails
+closed at boot, never silently).**
 Amends spec 03 §2.3 (the `kind: runtime` edge's discriminator), spec 17
 §1 (mount order and entry resolution gain the depending-runtime clause),
 spec 23 §6 (the needs union covers both runtimes), spec 28 §8 (the
@@ -47,6 +51,24 @@ resolution chain.
   spec 05 §2/§5 chain exactly like a primary runtime (per-engine
   download base, cache-first, share-once into `runtimes/`), and
   version-locks at press per spec 23 §4 like any edge.
+- **The loader's read rides the cached release-index shard.** The shim
+  carries no image reader (its lean-linker rule stands); what it needs
+  at plan time — the owner edge's `{engine, implementation?,
+  constraint}`, the depending runtime's declared `mount`, and
+  `owner_contract` — mirrors onto the runtime's release-index entry as
+  the additive `on_runtime` key (JSON:
+  `{engine, implementation?, constraint, mount, owner_contract?}`),
+  authored by the factory from the very L1 block it wrote into the
+  image (one author moment, spec 00 §10). This is the established flow
+  of every dispatch-needed runtime facet (`contract_version`, `abi`,
+  `implementation`, `mount_root`): the in-image L1 block stays the sole
+  AUTHORITY; the shard is its mirror. The driver cross-checks at boot:
+  the mounted first triple's in-image `on_runtime` must exist and its
+  declared `mount` must equal the triple's mount point — a shard that
+  outruns or contradicts the image is the release lying, a named boot
+  error (65), never a guessed-around composition. A runtime whose shard
+  carries no `on_runtime` key boots exactly as before (every runtime
+  predating this spec).
 - **At dispatch the OWNER provides the process.** Its exe (the spec-29
   wrapper, or a linked exe) receives the spec-17 wire; the depending
   runtime contributes its env image. The loader composes the handoff:
@@ -105,6 +127,26 @@ provides:
   qualified on windows per spec 17 §1's qualification rule). An unknown
   `{…}` placeholder, or a template element that after expansion escapes
   the depending runtime's mount, is a named boot error (65).
+- **The bridge law (the owner is host-plain).** A template token
+  addressing `{mount}` is read by the OWNER's interpreter — a host
+  process that cannot see the VFS. Under exec-cache materialization
+  (spec 29 §3) the token bridges to its host twin; two forms exist:
+  - *Path tokens* — the token IS the mount or a path under it
+    (`{mount}`, `{mount}/modules/truffleruby.jar`): the per-token bridge
+    answers the materialized host twin. On a home-annotated image
+    (`identity.annotations.java_home`, spec 22 §3's whole-tree signal)
+    the whole tree extracts once and the bare `{mount}` root answers the
+    tree root (never EISDIR); on an unannotated image the per-file
+    closure copy answers (the jruby single-jar shape), and the bare-root
+    form is §4's named error.
+  - *Compound tokens* — the mount is embedded in a larger argument
+    (`-Dorg.graalvm.language.ruby.home={mount}`,
+    `--module-path={mount}/modules`): the materialized home-tree ROOT
+    splices in place of the mount spelling. This REQUIRES the home
+    annotation — a per-file closure cannot serve a home the owner reads
+    arbitrarily — so a depending runtime whose template carries a
+    compound token MUST annotate; an unannotated image is §4's named
+    error, never a partial home.
 - The template is DATA, not code: the driver and the wrapper crate carry
   no per-runtime knowledge (spec 29 §7's law extends — no per-runtime
   argv hardcoding either). jruby's classpath, truffleruby's launcher
@@ -149,6 +191,11 @@ they stay spawnable through spec 30 edges, unchanged.
   class, naming both contract versions.
 - `on_runtime.mount` colliding at boot: EEXIST, unmount everything,
   named error (spec 17 §1's law) — never a partial mount.
+- A compound template token (§2's bridge law) on an image WITHOUT the
+  home annotation: named boot error 65 naming the token and
+  `identity.annotations.java_home` — the release must declare the
+  whole-tree home; the closure walk never substitutes for it. The bare
+  `{mount}` root token on an unannotated image is the same named error.
 - A malformed `on_runtime` block (unknown placeholder, escaping
   template path, `mount: /`): named boot error 65 naming the key.
   Shape violations — the block without an owner edge, an owner edge
@@ -165,7 +212,11 @@ they stay spawnable through spec 30 edges, unchanged.
 - **Jail:** the needs union (spec 23 §6 step 2) gains the DEPENDING
   runtime's release-manifest needs beside the owner's — one union, one
   effective policy, computed before exec; the owner and the depending
-  runtime run in ONE process under ONE policy.
+  runtime run in ONE process under ONE policy. (The runtime-needs half
+  of spec 23 §6 step 2 is itself unshipped — today's primary boot
+  carries the payload's needs ∩ the operator tightening. When the
+  primary union lands, the on_runtime boot unions both runtimes
+  identically; this spec adds no second mechanism.)
 - **Spawn lock:** untouched. The owner resolution is a primary-class
   resolution, not a spawned edge; `TEBAKO_SPAWN_LOCK` keeps spec 30 §2's
   semantics for the payload's OWN spawned edges, and spec 30 §2's
@@ -180,6 +231,13 @@ they stay spawnable through spec 30 edges, unchanged.
   At run time the loader resolves the row into the store per §13.6
   (carried → slot install + digest-verify; shared → cache-hit on the
   locked identity else fetch+verify), then composes §1's handoff.
+  (Spec 23 §13.6's lock is itself unshipped — this row rides it. Until
+  it lands, pressing against an on_runtime runtime produces a package
+  whose boot fails closed: the standalone bootstrap hands the depending
+  runtime's own exe+image to the wrapper, the first triple is the APP
+  payload — no `on_runtime` discovery fires — and the depending image's
+  `layout.interpreter` refusal is the named 65. Never a silent wrong
+  boot.)
 - **Store:** UNCHANGED layout. The owner and the depending runtime are
   ordinary `runtimes/` entries; share-once holds in both directions (N
   depending runtimes share one owner; M payloads share the depending
@@ -200,9 +258,24 @@ store the named error of §4, never a slow silent run.
 
 ## 7. Worked example — truffleruby-jvm on graalvm
 
-The depending runtime's manifest (excerpt):
+The depending runtime's manifest (excerpt) — the template is the line
+the upstream JVM distribution's own launch verifies (each Truffle
+language home reaches the runtime through its
+`org.graalvm.language.<id>.home` system property — ruby's own, and
+sulong's at `lib/sulong` for the C-extension machinery; TruffleRuby's
+`RubyLauncher` is the module `dev.truffleruby.launcher`). The first
+token is the libgraal rule: the
+truffle-runtime jar JNI-links the OWNER's libgraal only when the two are
+the exact same GraalVM build, so an unpinned owner runs the Java-side
+Graal compiler instead (a recipe that pins its owner to the matching
+labsjdk build drops the token):
 
 ```yaml
+identity:
+  annotations:
+    java_home: "/"        # the image root IS the tool home (§2's bridge
+                          # law): the whole tree materializes for the
+                          # host-plain owner
 requires:
   - {kind: runtime, engine: java, implementation: graalvm, constraint: ">= 24"}
 provides:
@@ -210,14 +283,22 @@ provides:
              language_version: "3.4", abi_line: "34", platform: aarch64-macos}
   on_runtime:
     mount: /__runners__/truffleruby
-    argv_template: ["-classpath", "{mount}/lib/truffleruby.jar", "org.truffleruby.Main"]
+    argv_template:
+      - "-XX:-UseJVMCINativeLibrary"
+      - "-Dorg.graalvm.language.ruby.home={mount}"
+      - "-Dorg.graalvm.language.llvm.home={mount}/lib/sulong"
+      - "--module-path"
+      - "{mount}/modules"
+      - "-m"
+      - "dev.truffleruby.launcher/org.truffleruby.launcher.RubyLauncher"
 ```
 
 Dispatch of a payload whose `runtime_requirement` is
 `{engine: ruby, implementation: truffleruby, constraint: "~> 34"}`:
 
-1. The shim resolves the truffleruby-jvm runtime (spec 05 §5), reads its
-   L1 mirror, finds the owner edge.
+1. The shim resolves the truffleruby-jvm runtime (spec 05 §5), reads the
+   cached release-index shard's `on_runtime` mirror (§1 — the L1 block's
+   plan-time facet), finds the owner edge.
 2. It resolves `java:graalvm >= 24` — cache hit or download; a
    temurin-only store is the spec 28 §8 implementation named error.
 3. It checks the owner's `contract_version` against `owner_contract`
@@ -229,15 +310,24 @@ Dispatch of a payload whose `runtime_requirement` is
 5. The wrapper mounts the graalvm env first, then truffleruby's env,
    then the payload; discovers `on_runtime` in the first triple's
    mounted manifest; composes
-   `[java, -classpath, /__runners__/truffleruby/lib/truffleruby.jar,
-   org.truffleruby.Main, <entry>, <args…>]`; execs java.
+   `[java, -XX:-UseJVMCINativeLibrary,
+   -Dorg.graalvm.language.ruby.home=<home tree root>,
+   -Dorg.graalvm.language.llvm.home=<home tree root>/lib/sulong,
+   --module-path, <home tree root>/modules, -m,
+   dev.truffleruby.launcher/org.truffleruby.launcher.RubyLauncher,
+   <entry>, <args…>]` with the `{mount}` tokens bridged to the
+   materialized home tree (§2's bridge law); execs java.
 
 One process, one policy, two env images, zero per-runtime code.
 
 ## 8. Non-goals
 
 - No new wire token, no trailer change, no registry grammar change, no
-  third artifact class.
+  third artifact class. (The additive `on_runtime` key on the factory
+  release-INDEX entry — §1's shard mirror — is not the registry: it is
+  the same established facet flow as `contract_version` / `abi` /
+  `implementation` / `mount_root`, with the in-image L1 block the sole
+  authority and the driver cross-checking at boot.)
 - No multi-owner composition: one boot, at most one owner edge. A
   runtime needing two process owners is two payloads.
 - No owner edges on non-runtime payloads — that surface is spec 30/32's,


### PR DESCRIPTION
# spec 33: runtime-on-runtime composition (the jruby / truffleruby-jvm implementation)

Implements [spec 33](docs/spec/33-runtime-on-runtime.md) end to end: a `kind: runtime` payload whose `requires` edges a runtime owner composes ON that owner — the owner's exe is the process, the depending runtime's env image leads the `--tebako-image` triples at its declared mount, and the driver discovers the composition from the in-image `on_runtime` block (never a new wire token). This is the jruby/truffleruby-jvm enabler (TODO.jruby/02, TODO.truffleruby/03).

## The pieces

- **tpkg** — `OnRuntimeMirror` + `on_runtime_mirror(entry_dir, exe_name)`: the loader-side read of the release-index shard's `on_runtime` facet (absent → `None`, present-malformed → `Err` naming the key — a trusted shard never gets guessed around). `entry_contract_version` reads the factory's JSON-number `contract_version` (string spelling tolerated).
- **tebako-shim** — `resolve_owner` + the `plan()` Ready arm: the dep's mirror resolves the owner (engine + implementation + constraint, spec 28 §8's surface), the owner's `contract_version` is gated against `owner_contract` (default `>= 2`) fail-closed at exit 75 naming both sides, and the handoff execs the OWNER's exe with the dep image first, app payloads after, `TEBAKO_RUNTIME_IMAGE` = the owner's env image.
- **tebako-driver** — `on_runtime::discover` reads the first triple's mounted manifest post-mount (the in-image block is the sole authority; a mount disagreement with the shard mirror is "the release is lying", named 65). `{mount}` expansion refuses unknown placeholders and mount escapes (65). Bare-name entries resolve against the DEPENDING runtime's entrypoints (the owner's stay spawn-only, spec 30); `args_default` comes from the depending manifest (single-owner rule). The wrapper composes `[owner interpreter, template…, args_default…, entry, user args…]`.
- **The bridge law (§2/§3 amendment, dogfood-driven):** the owner's interpreter is host-plain — template tokens addressing `{mount}` must arrive as host paths. Path tokens ride the existing per-token exec-cache bridge; compound tokens (`-Dorg.graalvm.language.ruby.home={mount}`) splice the materialized home-tree ROOT. tfs `exec_materialize` on a home-annotated mount root now answers the tree root (previously EISDIR); a compound token on an unannotated image is a named 65 demanding `identity.annotations.java_home` — a per-file closure can never serve a home the owner reads arbitrarily.

## The e2e dogfood (hand-composed store, this machine)

truffleruby-community-jvm 34.0.1 (upstream tarball, computed sha256 pin `c1ca478c…`) composed on the graalvm CE java 25.0.4.1 runtime entry, dispatched by the worktree shim through a trjprobe 0.1.0 app payload:

- **P:** `trjprobe` prints `hello from truffleruby 3.4.9 (home …/tebako-home-1)` and `{"ok":true,"engine":"truffleruby"}` — the json **C-extension** loads through sulong inside the composed boot.
- **N1:** owner entry removed → exit 69 (`no compatible runtime for java ">= 24"…`), before any exec.
- **N2:** owner shard `contract_version` flipped to 1 → exit 75 naming both sides; restored.

The dogfood pinned three upstream facts now recorded in spec §7 and TODO.truffleruby/03: the `-Dorg.graalvm.language.{ruby,llvm}.home` property pair (ruby home + sulong's for cexts), and the libgraal rule (`-XX:-UseJVMCINativeLibrary` unless the owner is pinned to the exact GraalVM build the truffle-runtime jar came from).

## Test evidence

- tpkg: 169 lib tests (+ on_runtime mirror suite, property tests); tebako-shim: 138 incl. 5 spec-33 dispatch tests (composition argv/env shape, owner-absent 69, contract 75, malformed mirror, bare-name surface).
- tebako-driver: 213 (98 lib + 69 wrapper + 28 incl. the compound-splice, bare-mount-root, and unannotated-65 tests + 6+2+10).
- tfs: 205 lib incl. `exec_materialize_answers_the_tree_root_for_the_home_mount_root`.
- clippy clean (workspace, `--all-targets`), `cargo fmt --all` clean; final exclusive `cargo test --workspace` result cited below before merge.

No wire/trailer/registry changes; pre-spec-33 runtimes (no mirror key) are untouched on every path.
