### PR TITLE
release: v2.5.0 — workspace version bump (2.4.0 → 2.5.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-runtime-launcher", "crates/tebako-arscope", "crates/tebako-bench", "tests/contract"]
 
 [workspace.package]
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"


### PR DESCRIPTION
# release: v2.5.0 — workspace version bump (2.4.0 → 2.5.0)

Minor bump carrying PR #550 (spec 33, runtime-on-runtime composition — merged a555767a):

- `on_runtime` L1 block + release-index mirror (tpkg), shim-side owner resolution + `owner_contract` negotiation (exit 75), driver discovery + template compose, the bridge law (compound `{mount}` tokens splice the materialized home-tree root; unannotated → named 65), tfs home-root materialization.
- Dogfood-proven end to end: truffleruby-jvm 34.0.1 composed on the graalvm CE java runtime boots and loads C-extensions through sulong; failure cells 69/75/65 all named.

Intra-workspace pins stay at `^2.0.0` — not boundary-crossing; no pin moves. Bump shape mirrors d0da8a9b (the v2.4.0 bump).

Merge → tag `v2.5.0` → release.yml.
