### PR TITLE
tpkg: the abi⇒implementation rule is an authoring gate, not a consumer refusal (#556)

### DIFF
--- a/crates/tebako-cli/src/publish.rs
+++ b/crates/tebako-cli/src/publish.rs
@@ -732,7 +732,7 @@ pub fn publish_full(
                 ),
             )
         })?;
-    let embedded = tpkg::PayloadManifest::from_yaml(&manifest_text).map_err(|e| {
+    let embedded = tpkg::PayloadManifest::from_yaml_authoring(&manifest_text).map_err(|e| {
         err(
             EX_TEBAKO_MANIFEST,
             format!(
@@ -800,7 +800,7 @@ pub fn publish_full(
     for input in opts.payloads.iter().skip(1) {
         // every triplet's manifest must agree (the registry mirrors ONE set)
         if let Some(text) = image_manifest::read_embedded_manifest(&input.path)? {
-            let other = tpkg::PayloadManifest::from_yaml(&text).map_err(|e| {
+            let other = tpkg::PayloadManifest::from_yaml_authoring(&text).map_err(|e| {
                 err(
                     EX_TEBAKO_MANIFEST,
                     format!(

--- a/crates/tpkg/src/manifest.rs
+++ b/crates/tpkg/src/manifest.rs
@@ -733,7 +733,10 @@ impl Capabilities {
 /// iff the payload carries native extensions — the version line and the
 /// platform line are orthogonal constraints and resolution checks both
 /// (spec 05 §5). An `abi` in force REQUIRES `implementation` (an ABI is
-/// per-implementation by construction — the validator enforces).
+/// per-implementation by construction) — an AUTHORING rule, enforced by
+/// `PayloadManifest::validate_authoring` at press/publish; consumers
+/// never refuse a pre-axis published manifest over it (tebako#556, the
+/// schema evolution law).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeRequirement {
     pub engine: String,
@@ -1123,11 +1126,10 @@ impl AppProvides {
                             abi,
                             "provides.entrypoints[].runtime_requirement.abi must not be empty when present",
                         )?;
-                        if req.implementation.is_none() {
-                            return Err(ManifestError::Invalid(
-                                "provides.entrypoints[].runtime_requirement: an abi in force requires implementation (an ABI is per-implementation by construction, spec 28 §8)",
-                            ));
-                        }
+                        // The abi⇒implementation refusal lives in
+                        // `validate_authoring` — an authoring rule, never a
+                        // consumer refusal of a pre-axis published manifest
+                        // (tebako#556, the schema evolution law).
                     }
                 }
                 if reqs.entries().len() > 1 && reqs.entries().iter().any(|r| r.abi.is_some()) {
@@ -2004,9 +2006,51 @@ impl<'de> Deserialize<'de> for PayloadManifest {
 
 impl PayloadManifest {
     /// Parse and validate a payload manifest from YAML text.
+    ///
+    /// This is the CONSUMER arm (dispatch/install/spawn/info): it never
+    /// refuses a published, previously valid artifact — the schema
+    /// evolution law (spec 18 §3) forbids a MINOR-era reader tightening
+    /// that invalidates pre-existing documents (tebako#556). Rules that
+    /// discipline NEW authoring live in [`Self::validate_authoring`].
     pub fn from_yaml(text: &str) -> Result<PayloadManifest, ManifestError> {
         let manifest: PayloadManifest = serde_yml::from_str(text)?;
         manifest.validate()?;
+        Ok(manifest)
+    }
+
+    /// The PRODUCER arm (`tebako publish` — the registry-emission gate):
+    /// everything `validate()` checks, plus the authoring rules that a
+    /// pre-axis published manifest legitimately violates and must
+    /// therefore never hit a consumer path. First such rule (spec 28
+    /// §8): an `abi` in force REQUIRES `implementation` — an ABI is
+    /// per-implementation by construction. Pre-axis artifacts
+    /// (metanorma 1.16.9-*, xml2rfc 3.34.0) declare `abi` without it and
+    /// stay dispatchable, installable, checkable, and composable through
+    /// the compat window; anything newly PUBLISHED must name the
+    /// implementation (nothing authoring-dirty becomes resolvable).
+    pub fn validate_authoring(&self) -> Result<(), ManifestError> {
+        self.validate()?;
+        if let Provides::App(app) = &self.provides {
+            for ep in &app.entrypoints {
+                if let Some(reqs) = &ep.runtime_requirement {
+                    for req in reqs.entries() {
+                        if req.abi.is_some() && req.implementation.is_none() {
+                            return Err(ManifestError::Invalid(
+                                "provides.entrypoints[].runtime_requirement: an abi in force requires implementation (an ABI is per-implementation by construction, spec 28 §8 — authoring rule, enforced at press/publish; pre-axis published manifests stay dispatchable)",
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Parse + the authoring validation (the producer arm of
+    /// [`Self::from_yaml`]) — the publish call shape.
+    pub fn from_yaml_authoring(text: &str) -> Result<PayloadManifest, ManifestError> {
+        let manifest: PayloadManifest = serde_yml::from_str(text)?;
+        manifest.validate_authoring()?;
         Ok(manifest)
     }
 

--- a/crates/tpkg/tests/manifest.rs
+++ b/crates/tpkg/tests/manifest.rs
@@ -310,17 +310,37 @@ fn any_of_mixed_engines_is_a_named_manifest_error() {
 }
 
 #[test]
-fn abi_without_implementation_is_a_named_manifest_error() {
+fn abi_without_implementation_is_a_named_authoring_error() {
     // spec 28 §8: an ABI is per-implementation by construction — a native
-    // requirement must name its implementation.
+    // requirement must name its implementation. The rule disciplines NEW
+    // authoring only: `tebako publish` (the registry-emission gate) is the
+    // enforcement point (tebako#556).
     let text = app_with_requirement(
         "      runtime_requirement: {engine: ruby, constraint: \"~> 3.3.0\", abi: arm64-darwin-23}\n",
     );
-    let err = PayloadManifest::from_yaml(&text).unwrap_err();
+    let err = PayloadManifest::from_yaml_authoring(&text).unwrap_err();
     assert!(
-        err.to_string().contains("requires implementation"),
-        "abi without implementation is named: {err}"
+        err.to_string().contains("requires implementation")
+            && err.to_string().contains("authoring rule"),
+        "abi without implementation is named at publish: {err}"
     );
+}
+
+#[test]
+fn pre_axis_abi_without_implementation_stays_dispatchable() {
+    // tebako#556 (the schema evolution law, spec 18 §3): pre-axis published
+    // manifests (metanorma 1.16.9-*, xml2rfc 3.34.0) declare `abi` without
+    // `implementation` — a MINOR-era reader tightening that invalidates
+    // them is forbidden. The consumer arm accepts the same document the
+    // authoring gate refuses above.
+    let text = app_with_requirement(
+        "      runtime_requirement: {engine: ruby, constraint: \"~> 3.3.0\", abi: arm64-darwin-23}\n",
+    );
+    let m = PayloadManifest::from_yaml(&text).unwrap();
+    let yaml = m.to_yaml().unwrap();
+    let reparsed = PayloadManifest::from_yaml(&yaml).unwrap();
+    assert_eq!(reparsed, m);
+    assert!(schema_validator().is_valid(&yaml_text_to_json(&text)));
 }
 
 #[test]
@@ -348,6 +368,9 @@ fn native_requirement_with_implementation_round_trips() {
     let yaml = m.to_yaml().unwrap();
     let reparsed = PayloadManifest::from_yaml(&yaml).unwrap();
     assert_eq!(reparsed, m);
+    // …and the authoring gate accepts the shape it demands
+    // (implementation + abi on the one entry)
+    PayloadManifest::from_yaml_authoring(&text).unwrap();
     assert!(schema_validator().is_valid(&yaml_text_to_json(&text)));
 }
 

--- a/docs/spec/28-runtime-variants.md
+++ b/docs/spec/28-runtime-variants.md
@@ -257,13 +257,23 @@ same law applies to every future multi-implementation language.
   are both named MANIFEST errors, never a guessed union.
 - A NATIVE-extension payload (an `abi:` in force) is locked to ONE
   implementation's ABI by construction: `implementation` is REQUIRED
-  alongside `abi` — a native requirement without it is a named manifest
-  error — and the list form is forbidden (a second implementation means
-  a second build, i.e. a second VARIANT: `{engine: ruby,
-  implementation: mri, constraint: "~> 3.3.0", abi: …}` → variant id
-  `ruby-mri-3.3`; the truffleruby build of the same payload version is
-  a sibling variant `ruby-truffleruby-24.1`, published when its
+  alongside `abi` — and the list form is forbidden (a second
+  implementation means a second build, i.e. a second VARIANT: `{engine:
+  ruby, implementation: mri, constraint: "~> 3.3.0", abi: …}` → variant
+  id `ruby-mri-3.3`; the truffleruby build of the same payload version
+  is a sibling variant `ruby-truffleruby-24.1`, published when its
   toolchain exists — TODO.truffleruby).
+  **The enforcement point is PUBLISH** (2026-09-08, tebako#556): the
+  abi⇒implementation rule is an AUTHORING rule — `tebako publish` (the
+  registry-emission gate) refuses the document with a named manifest
+  error, so nothing authoring-dirty becomes resolvable. It is NOT a
+  consumer rule: manifests published before the axis landed (metanorma
+  1.16.9-*, xml2rfc 3.34.0) declare `abi` without `implementation`, and
+  the schema evolution law (spec 18 §3) forbids a reader tightening
+  that invalidates them — dispatch/install/check/compose parse them
+  through the compat window (an `implementation`-less entry matches at
+  the language level). The list-form ban, by contrast, is a parse-shape
+  rule and stays a consumer named error.
 - truffleruby's native and jvm modes are two runtime ARTIFACTS of one
   implementation (they differ in which dependencies they can host, not
   in the language they speak): mode is NOT a selector axis — selection

--- a/docs/spec/schemas/payload-manifest.yaml
+++ b/docs/spec/schemas/payload-manifest.yaml
@@ -164,10 +164,14 @@ grammar:
                 the SAME engine, and the list is never empty (both named
                 manifest errors). An `abi:` in force REQUIRES
                 `implementation:` on that entry and FORBIDS the list form —
-                an ABI is per-implementation by construction (named manifest
-                errors, spec 28 §8). A reader predating schema_minor 7 fails
-                the LIST spelling's parse — the correct refusal (never a
-                guessed entry).
+                an ABI is per-implementation by construction (spec 28 §8).
+                The FORBIDS is a consumer named manifest error; the
+                REQUIRES is an AUTHORING rule enforced at press/publish
+                (tebako#556, spec 18 §3: pre-axis published manifests that
+                declare abi without implementation stay dispatchable
+                through the compat window). A reader predating schema_minor
+                7 fails the LIST spelling's parse — the correct refusal
+                (never a guessed entry).
               fields:
                 engine: {type: string, required: true}
                 constraint: {type: string, required: true, notes: "range for pure-language (\">= 3.3, < 5.0\"); abi-line for native-extension (\"~> 3.3.0\")"}


### PR DESCRIPTION
## What

Fixes the retroactivity of the axis-polish `abi ⇒ implementation` manifest refusal — **release-blocker #556**: that refusal landed in the consumer `PayloadManifest::validate()` via #554 and is contained in no tag; the next tag would have broken dispatch and install of every pre-axis published native payload (metanorma 1.16.9-* — 66 entrypoints with `abi` and no `implementation`; xml2rfc 3.34.0) the moment the shim or installer parsed the store mirror.

Manifest instances carry no `schema_minor`, so a minor-gated refusal is not expressible; per the schema evolution law (spec 18 §3) the rule becomes **producer-strict, consumer-lenient**.

## The split

- `PayloadManifest::from_yaml` stays the **consumer** arm (dispatch / install / spawn / info / check / compose / driver / shim / store) — pre-axis published manifests stay dispatchable through the compat window.
- New `PayloadManifest::validate_authoring` / `from_yaml_authoring` — the **producer** arm: everything `validate()` checks, plus the abi⇒implementation refusal (message names the enforcement point).
- `tebako publish` — the registry-emission gate (`publish.rs:735`, `:803`) — flips to the authoring arm: nothing authoring-dirty becomes resolvable. Every other caller audited and deliberately left consumer (install ×3, compose, check, shim, driver ×2, payload_store, merkle_host, tfs-cli enc ×2, bench, info) — they all touch possibly-old published artifacts.
- The list-form ban (a parse-shape rule) stays a consumer named error.
- spec 28 §8 names the enforcement point; `docs/spec/schemas/payload-manifest.yaml` and the `RuntimeRequirement` rustdoc name the split.

## Tests

- `abi_without_implementation_is_a_named_authoring_error` — retargeted to the authoring arm (was the consumer refusal).
- `pre_axis_abi_without_implementation_stays_dispatchable` — NEW: the same document parses, round-trips, and stays schema-valid through the consumer arm.
- `native_requirement_with_implementation_round_trips` — extended: accepted by both arms.

## Evidence

- `cargo test -p tpkg`: 288 passed, 0 failed (12 suites).
- `cargo test -p tebako-cli publish`: 6/6 ok, crate compiles clean.
- `cargo fmt --check`: clean.

Fixes #556.
