### PR TITLE
spec: the interp_env channel (tebako#559)

### DIFF
--- a/docs/spec/03-payload-manifest.md
+++ b/docs/spec/03-payload-manifest.md
@@ -273,6 +273,40 @@ the engine, the three moments, SKIP/FAIL discipline — are spec 26; the
 grammar is registered in
 `docs/spec/schemas/payload-manifest.yaml`.
 
+### 2.7 INTERP ENV (`interp_env:`, additive — schema_minor 8) — PLANNED (tebako#559)
+
+```yaml
+interp_env:
+  RUBY_YJIT_ENABLE: "1"          # interpreter-option defaults, literal strings
+  RUBY_GC_HEAP_FREE_SLOTS: "500000"
+```
+
+A top-level map (any kind may declare; old readers ignore it under the
+unknown-field rule) carrying **interpreter-option defaults the slice
+author owns**: what options the interpreter starts with is a
+packaging-time decision (the runtime/payload slice developer's), with
+the local user always able to override. The dispatcher exports each
+merged key into the runtime process's environment at dispatch, so the
+interpreter reads it at its own boot (ruby's `RUBY_YJIT_ENABLE`, python's
+`PYTHON_JIT`, the JVM family's option vars — the channel is generic, never
+a ruby wart).
+
+MECE against the existing env surfaces: `provides.env:` (runtime kind)
+is the runtime's COMPOSED process-env defaults (path-class included,
+spec 07 §9); `interp_env:` is the per-slice interpreter-OPTION channel —
+scalar only, never path-class, never a `TEBAKO_*` control var (those are
+dispatcher/driver-owned; both violations are named manifest errors).
+Values are literal strings: no expansion, no execution, no references —
+additive and declarative by construction; a malformed block is a named
+validation error at press / `tfs validate` (exit 65), never discovered
+at run time.
+
+The composition chain and the override order live in spec 07 §9; the
+driver-side application rule in spec 17 §2.2; the audit surface in
+spec 15 §4. A declaration is a DEFAULT, never a requirement: a
+pre-minor-8 consumer ignores the key and ships the interpreter's
+built-in behavior.
+
 ## 3. Platform axis (locked, vcpkg-triplet form)
 
 `platforms` is EITHER `"universal"` (pure-ruby/data) OR an explicit list:
@@ -325,6 +359,9 @@ entries:                          # one per invocable command (N=1 for simple ap
     slot: 0                       # which payload image
     entrypoint: metanorma         # which PROVIDES entrypoint inside it
     runtime_ref: ruby@3.4.2;tebako=0.15.9   # per-entry — suites/multi-runtime
+    interp_env: {RUBY_YJIT_ENABLE: "1"}     # PLANNED (tebako#559): the press-time
+                                  # composition of slot 0's L1 interp_env,
+                                  # packager-refined (spec 07 §9's chain)
   - name: mn2pdf
     slot: 1
     entrypoint: mn2pdf
@@ -358,6 +395,18 @@ lock:                             # the press-time composition lock (spec 23 §4
   validate` (tebako#494). Two entries MAY share one slot — same image,
   different in-image entrypoints: the multi-command single-payload form
   (one app slice carrying several CLIs, e.g. metanorma + fontist).
+- `entries[].interp_env` (PLANNED, tebako#559 — §2.7's L2 face): the
+  press-time COMPOSITION of the slot payload's L1 `interp_env` with the
+  packager's refinement (a packager key wins over the same L1 key; L1
+  keys pass through untouched otherwise). The mirror exists because the
+  size-gated bootstrap reads no image bytes: the standalone dispatcher
+  consumes exactly this block, never the in-image L1. `tebako-pkg
+  validate` cross-checks the composition against the slot's L1 (every
+  L1 key present with its declared or the refined value; a dropped L1
+  key is a named validation error, the tebako#494 class) — the block is
+  a faithful mirror plus declared overrides, never an independent
+  authority. Managed dispatch (registry payloads, no L2) reads the
+  store's L1 manifest mirror instead (spec 07 §9's chain).
 - v1-era packages without the block behave exactly as today (stub.rb /
   local conventions); the block is additive.
 - `mounts` is optional; a slot without a `mounts` row mounts

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -191,7 +191,10 @@ per declared entrypoint name — never as re-exec wrappers.
 
 - User config: `~/.tebako/config.yaml` (YAML — the locked convention;
   supersedes the earlier `config.json` note). Contents: defaults,
-  registries, runtime preferences.
+  registries, runtime preferences. (PLANNED — tebako#559: a per-tool
+  `env:` map, store-config schema minor 3 — the user-config layer of
+  the §9.1 interp_env chain, set by hand or by `tebako-shim env`; never
+  written implicitly by a dispatch.)
 - Project pins: `.tebako-tools.yaml` at any directory — the dispatcher
   walks up from cwd; nearest wins.
 
@@ -406,3 +409,36 @@ app) composes by RULE, never by accident:
   host vars pass through unless the jail says otherwise.
 - Per-entrypoint overrides (suite entries, spec 03 §6) apply last for
   that entry only.
+
+### 9.1 The interp_env chain (PLANNED — tebako#559; spec 03 §2.7)
+
+Interpreter-option defaults compose by their own chain, parallel to the
+rules above and NEVER through the M7 scrub (interp_env keys are
+interpreter options, not rubygems semantics — they are never scrubbed).
+Per dispatched entry, per declared key, FIRST SET wins, highest layer
+first:
+
+1. **User process env** — the operator's invocation environment. A key
+   already set there is the user's explicit choice: it always wins and
+   is never rewritten.
+2. **User config** — `~/.tebako/config.yaml`'s per-tool `env:` map
+   (spec 07 §4; store-config schema minor 3): the operator's standing
+   local policy for one tool.
+3. **Package manifest** — `entries[].interp_env` (spec 03 §6), the
+   standalone/package form only: the packager's press-time refinement
+   (already composed with the slice's L1 declarations by the press).
+   Managed dispatch has no L2 — this layer is absent there by
+   construction.
+4. **Payload manifest** — the slice author's L1 `interp_env:` (spec 03
+   §2.7), read from the store's manifest mirror in managed dispatch.
+5. **Interpreter built-in** — what the interpreter does when nothing
+   declares the key (the declaration is a default, never a
+   requirement).
+
+The dispatcher computes the effective map at dispatch and exports each
+winning key that is NOT already in the process env (layer 1's win is
+passive: the variable is simply there). No key is ever scrubbed,
+rewritten, or guessed; an unset-declared key stays unset (never a
+synthesized "0"). The effective map and each key's provenance layer are
+reportable through the spec 15 §4 surface — resolution is auditable,
+never silent.

--- a/docs/spec/15-info-command.md
+++ b/docs/spec/15-info-command.md
@@ -132,6 +132,11 @@ Two verbs on the product CLI (both SHIPPED; `--json` on every view,
     versions, default).
   - `shims` — each registered command's dispatch preview: the payload,
     version, and runtime it would run today (read-only resolution).
+    (PLANNED — tebako#559: the preview gains the effective interp_env
+    map — every declared interpreter-option key with its winning value
+    and its provenance layer: `env` / `config` / `package` / `payload`
+    / `built-in`, the spec 07 §9.1 chain rendered; a key no layer
+    declares renders `built-in` with no value.)
   - `registries` — registered registries and their dispatch-cache
     freshness (fresh/stale/missing/local).
   - `store` — disk usage by section (runtimes/payloads/shims/tmp/…).

--- a/docs/spec/17-runtime-driver-contract.md
+++ b/docs/spec/17-runtime-driver-contract.md
@@ -200,6 +200,34 @@ mount      = "/" *path-char              ; a VFS-absolute mount point
   over the env image at the runtime root never reached spawned
   children).
 
+### 2.2 Interpreter-option env (`interp_env`, PLANNED — tebako#559)
+
+The spec 07 §9.1 chain's product is ordinary process env, not a driver
+wire var: the dispatcher (the shim in managed mode, the bootstrap in
+standalone) computes the effective interpreter-option map and exports
+each winning key BEFORE the exec/handoff, so the interpreter's own
+option processing reads it at boot (`RUBY_YJIT_ENABLE`, `PYTHON_JIT`,
+`JAVA_TOOL_OPTIONS`, …). Consequences on this contract:
+
+- **The driver applies nothing and never touches these vars.** They are
+  not `TEBAKO_*` control vars, not in the M7 scrub list, and not
+  rewritten by any boot pass — a value the driver finds set is the
+  chain's outcome by construction.
+- **Boot order is safe by construction:** the driver's boot exports
+  (the §2 table's own vars) and the materialization passes all run
+  before the interpreter initializes, and none of them name an
+  interp_env key (the manifest grammar forbids `TEBAKO_*` there — spec
+  03 §2.7).
+- **Spawned children (specs 30/32)** inherit the parent process's
+  environ, so a spawned entrypoint sees the parent's effective map. A
+  spawned PROVIDER's own L1 `interp_env` does NOT apply on that path in
+  this phase (the driver merges nothing) — that axis is a later
+  amendment; a payload needing it is dispatched through the shim, which
+  runs the full §9.1 chain.
+- The auditability requirement is served at dispatch: the effective map
+  and each key's provenance layer render through the spec 15 §4
+  surface; no per-run journal entry exists in this phase.
+
 ## 3. File IO semantics
 
 The runtime's IO MUST route mounted paths through the TFS layer

--- a/docs/spec/schemas/payload-manifest.yaml
+++ b/docs/spec/schemas/payload-manifest.yaml
@@ -18,7 +18,7 @@
 
 schema: payload-manifest
 schema_version: 1 # MAJOR — breaking changes only
-schema_minor: 7 # MINOR — additive changes only (1: materialize, 2: library_aliases, 3: checks, 4: requires kind runtime, 5: requires kind executable + expose, 6: on_runtime, 7: language_version on runtime provides + the runtime_requirement any_of list form and its implementation key)
+schema_minor: 8 # MINOR — additive changes only (1: materialize, 2: library_aliases, 3: checks, 4: requires kind runtime, 5: requires kind executable + expose, 6: on_runtime, 7: language_version on runtime provides + the runtime_requirement any_of list form and its implementation key, 8: interp_env)
 status: normative
 owner: crates/tpkg (the model) in tamatebako/tebako
 edge: C7 (driver → payload images), C10 (executable payload → runtime), C11 (feature payload → consumers)
@@ -362,6 +362,31 @@ grammar:
       A malformed block is a named error at press/`tfs validate` (exit
       65), never discovered at run time (spec 26 §7). Old readers ignore
       the key (unknown-field rule).
+  interp_env:
+    type: map of ENV key → string value
+    required: false
+    since: schema_minor 8
+    key: "[A-Z_][A-Z0-9_]* — the shell-safe env-name grammar; a key outside it is a named manifest error at press/`tfs validate` (exit 65)"
+    notes: >-
+      tebako#559 (PLANNED) — INTERPRETER-OPTION defaults owned by the
+      slice author (RUBY_YJIT_ENABLE, PYTHON_JIT, JAVA_TOOL_OPTIONS, …):
+      values the dispatcher exports into the runtime process at dispatch
+      so the interpreter reads them at its own boot. MECE against
+      provides' `env:` (the runtime kind's composed process-env
+      defaults): interp_env is the per-SLICE packaging-time channel
+      subject to the spec 07 §9 five-layer chain (user env > user config
+      > package manifest > payload manifest > interpreter built-in);
+      it is NEVER path-class (path composition stays spec 07 §9's rule
+      on `env:`) and never carries the TEBAKO_* control namespace (those
+      vars are dispatcher/driver-owned — a TEBAKO_* key here is a named
+      manifest error). Values are literal strings: no expansion, no
+      command execution, no reference grammar — additive and declarative
+      by construction. A malformed block (non-string value, empty key)
+      is a named manifest error at press/`tfs validate` (exit 65),
+      never discovered at run time. Old readers ignore the key
+      (unknown-field rule): a pre-minor-8 dispatcher simply ships the
+      interpreter's built-in default — the declaration is a default,
+      never a requirement.
 
 refusals:
   - case: identity.schema_version missing

--- a/docs/spec/schemas/store-config.yaml
+++ b/docs/spec/schemas/store-config.yaml
@@ -16,7 +16,7 @@
 
 schema: store-config
 schema_version: 1 # MAJOR — breaking changes only
-schema_minor: 2 # MINOR — additive changes only (1: runtimes.*.source; 2: defaults/runtimes accept the [payload@]version qualified grammar — tebako-shim use writes them)
+schema_minor: 3 # MINOR — additive changes only (1: runtimes.*.source; 2: defaults/runtimes accept the [payload@]version qualified grammar — tebako-shim use writes them; 3: env per-tool interpreter-option maps — tebako#559)
 status: normative
 owner: crates/tebako-shim (the config model of record) in tamatebako/tebako
 edge: C13 (everything local → store)
@@ -87,6 +87,20 @@ grammar:
       source (MINOR 1, PLANNED — TODO.v2-1/30) = the per-engine download
       base override (https or file://), the first channel of spec 05 §2's
       per-engine base chain; absent → the chain's lower channels answer.
+  env:
+    type: map(command name → map(ENV key → string value))
+    required: false
+    notes: >-
+      MINOR 3 (PLANNED — tebako#559): the operator's standing per-tool
+      interpreter-option policy — layer 2 of the spec 07 §9.1 interp_env
+      chain (user env > this map > package manifest > payload manifest >
+      interpreter built-in). Keyed by command name, the same axis
+      `defaults:` uses (a k/v SETTINGS map, not multiplicity data);
+      inner keys obey the spec 03 §2.7 grammar ([A-Z_][A-Z0-9_]*, never
+      TEBAKO_*; an offending key is the NAMED grammar error at READ,
+      never a silent skip). Written by hand or by `tebako-shim env
+      <tool> KEY=VALUE` / `--unset`; a dispatch NEVER writes it
+      implicitly.
 
 store_layout_marker:
   path: ~/.tebako/layout-version


### PR DESCRIPTION
spec: the interp_env channel (tebako#559) — payload minor 8, store-config minor 3

Payload-declared interpreter-option defaults with local override, spec-first
per the issue's acceptance order:

- spec 03 §2.7 (PLANNED): the L1 interp_env map — the slice author's
  interpreter-option defaults (RUBY_YJIT_ENABLE / PYTHON_JIT / JVM opts),
  literal strings, additive+declarative, never TEBAKO_*, never path-class
  (MECE vs provides' env:), named manifest errors at press/validate.
  payload-manifest schema_minor 8.
- spec 03 §6: entries[].interp_env — the press-time composition of the
  slot's L1 map with the packager's refinement (the bootstrap reads no
  image bytes; L2 mirrors L1 + declared overrides, validate
  cross-checks, the tebako#494 class).
- spec 07 §9.1 (PLANNED): the five-layer chain — user env > user config
  > package manifest > payload manifest > interpreter built-in; first
  set wins, nothing scrubbed or synthesized; §4 notes the config layer.
- store-config schema_minor 3: the per-tool env: map (layer 2), written
  by hand or tebako-shim env, never implicitly by a dispatch.
- spec 17 §2.2 (PLANNED): the driver applies nothing — the dispatcher
  exports the effective map as ordinary process env before handoff;
  spawned children inherit the parent's environ (the provider-side
  interp_env on spawn paths is a documented later axis).
- spec 15 §4 (PLANNED): tebako info shims renders the effective map with
  per-key provenance (env/config/package/payload/built-in).

All additions marked PLANNED; no code in this PR. Refs #559.
