### PR TITLE
ci: sign + notarize the macOS release legs behind APPLE_SIGNING_ENABLED (spec 31 §8.3)

### DIFF
--- a/.github/workflows/lib/stage.sh
+++ b/.github/workflows/lib/stage.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # stage.sh — stage the six release binaries for one platform, strip
-# them, publish the size table, gate the bootstrap size, and write the
-# sha/size fragments the finalize job merges into SHA256SUMS +
-# manifest.json.
+# them, sign them (macOS only, spec 31 §5: BEFORE the digests below —
+# sign-then-hash is mandatory), publish the size table, gate the
+# bootstrap size, and write the sha/size fragments the finalize job
+# merges into SHA256SUMS + manifest.json.
 #
 # Required env: VERSION (release version, tag minus v), PLATFORM (the
 # tebako platform id, e.g. macos-arm64). Optional: TARGET (defaults to
@@ -45,6 +46,10 @@ for tool in $TOOLS; do
   cp "$src" "$dest"
   if [ "$(uname -s)" = "Darwin" ]; then
     strip -S "$dest" 2>/dev/null || true
+    # Spec 31 §5: sign the final bytes BEFORE the sha256 fragment is
+    # written below — SHA256SUMS/sidecars must anchor the SIGNED bytes.
+    # Loud no-op when the leg's enablement gate is disarmed.
+    bash ci/macos-sign-one.sh "$dest"
   else
     strip "$dest" 2>/dev/null || true
   fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,14 @@
 # signatures slot in later (item 29 phase 2) by signing SHA256SUMS and
 # uploading .asc files — no restructuring.
 #
+# macOS signing (spec 31 §5): the macOS legs codesign (Developer ID
+# Application, hardened runtime) the staged binaries BEFORE their sha256
+# fragments are written, then notarize + quarantine-mark them so the leg's
+# own ship gate is the Gatekeeper exec canary. The legs run unsigned BY
+# DESIGN (spec 00 invariant 7) unless the repo variable
+# APPLE_SIGNING_ENABLED=true arms the gate; armed + a missing APPLE_*
+# secret is a fast named failure, never a partial release.
+#
 # Windows (ucrt64) ships from the `windows` job (the five binaries,
 # platform id windows-ucrt64 per the spec 03 §3 axis) and the
 # `windows-link-unit` job (the factory's staticlib input).
@@ -240,15 +248,46 @@ jobs:
             -p tebako-runtime-launcher \
             -p tfs -p tebako-driver -p libtfs-preload
 
-      - name: Stage, strip, size-gate
+      # Spec 31 §5: arm Apple signing when the repo variable
+      # APPLE_SIGNING_ENABLED=true is set (unsigned stays first-class
+      # otherwise — the stage/notarize steps below then no-op/skip).
+      - name: Set up Apple signing (spec 31 enablement gate)
+        working-directory: tebako-rs
+        env:
+          APPLE_SIGNING_ENABLED: ${{ vars.APPLE_SIGNING_ENABLED }}
+          APPLE_DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
+          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: bash ci/macos-sign-setup.sh
+
+      - name: Stage, strip, sign, size-gate
         working-directory: tebako-rs
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
           PLATFORM: ${{ matrix.platform }}
+          # For macos-sign-one.sh's TeamIdentifier assert (armed legs).
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: bash .github/workflows/lib/stage.sh
 
+      # Notarize the SIGNED staged binaries and quarantine-mark every one:
+      # the ship gate right after then smokes them under the exact
+      # Gatekeeper path a user's download takes (bare Mach-O keeps an
+      # online ticket — stapling/spctl are bundle-only by design).
+      - name: Notarize the staged binaries (spec 31)
+        if: vars.APPLE_SIGNING_ENABLED == 'true'
+        working-directory: tebako-rs
+        env:
+          APPLE_ASC_KEY_P8: ${{ secrets.APPLE_ASC_KEY_P8 }}
+          APPLE_ASC_KEY_ID: ${{ secrets.APPLE_ASC_KEY_ID }}
+          APPLE_ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: bash ci/macos-notarize.sh out/*-"$VERSION-$PLATFORM"
+
       # The ship gate BEFORE any upload: bare-launch smoke (plain run on
-      # the runner) + the otool -L whitelist (/usr/lib + /System only).
+      # the runner — with the notarized binaries' quarantine marks in
+      # place when the spec 31 gate is armed) + the otool -L whitelist
+      # (/usr/lib + /System only).
       - name: Ship gate (bare-launch smoke + dylib audit)
         working-directory: tebako-rs
         env:

--- a/ci/macos-notarize.sh
+++ b/ci/macos-notarize.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# macos-notarize.sh — notarize the leg's staged (already signed)
+# binaries and leave each one quarantine-marked, so the leg's OWN ship
+# gate then smokes every binary under the exact Gatekeeper path a user's
+# download takes (spec 31 §6.3). Bare CLI Mach-O: stapling is
+# unsupported and spctl rejects standalone tools BY DESIGN — Apple keeps
+# an ONLINE ticket (Gatekeeper resolves it at first exec), so the
+# documented verification is codesign's notarization check; the
+# quarantine mark + the standard ship gate is the exec canary (a
+# notarization that only partially landed fails THIS leg, never a user
+# box). The workflow skips this step entirely when the spec 31 gate is
+# disarmed (if: vars.APPLE_SIGNING_ENABLED == 'true').
+#
+# Required env: APPLE_ASC_KEY_P8, APPLE_ASC_KEY_ID, APPLE_ASC_ISSUER_ID,
+# RUNNER_TEMP.
+# Usage: macos-notarize.sh <binary> [<binary> ...]
+set -euo pipefail
+[ "$#" -ge 1 ] || { echo "usage: $0 <binary> [<binary> ...]" >&2; exit 64; }
+
+work="$RUNNER_TEMP/tebako-notarize"
+mkdir -p "$work"
+printf '%s' "$APPLE_ASC_KEY_P8" > "$work/AuthKey.p8"
+# -j: archive the bare file names, not the out/ path prefix.
+zip -q -j "$work/binaries.zip" "$@"
+xcrun notarytool submit "$work/binaries.zip" --key "$work/AuthKey.p8" \
+  --key-id "$APPLE_ASC_KEY_ID" --issuer "$APPLE_ASC_ISSUER_ID" \
+  --wait --timeout 20m | tee "$work/notary.txt"
+grep -q 'status: Accepted' "$work/notary.txt" || {
+  xcrun notarytool log "$(grep -m1 -oE '[0-9a-f-]{36}' "$work/notary.txt")" \
+    --key "$work/AuthKey.p8" --key-id "$APPLE_ASC_KEY_ID" --issuer "$APPLE_ASC_ISSUER_ID" 2>&1 | tail -20
+  echo "::error::notarytool did not Accept the submission"; exit 1; }
+
+for bin in "$@"; do
+  codesign --verify --strict --check-notarization -R=notarized "$bin"
+  xattr -w com.apple.quarantine '0081;00000000;Safari;' "$bin"
+done
+echo "notarized + quarantine-marked: $# binaries (the ship gate is the exec canary)"

--- a/ci/macos-sign-one.sh
+++ b/ci/macos-sign-one.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# macos-sign-one.sh — sign ONE staged binary with the Developer ID
+# identity the setup step armed (spec 31 §5). Hardened runtime, no
+# entitlements: the product tools JIT nothing and dlopen no materialized
+# code (the runtime exe's entitlement pair is the factory's profile,
+# spec 31 §3/§5). Gate disarmed → loud unsigned no-op (spec 00
+# invariant 7). The TeamIdentifier is asserted against APPLE_TEAM_ID
+# when present — a wrong-cert signature fails HERE, not on a user box.
+#
+# Usage: macos-sign-one.sh <binary>
+set -euo pipefail
+bin="$1"
+if [ -z "${CODESIGN_HASH:-}" ]; then
+  echo "unsigned: $(basename "$bin") (spec 31 gate disarmed — invariant 7)"
+  exit 0
+fi
+codesign --force --options runtime --timestamp \
+  --keychain "${CODESIGN_KEYCHAIN:?setup step did not export CODESIGN_KEYCHAIN}" \
+  --sign "$CODESIGN_HASH" "$bin"
+codesign --verify --strict --verbose=1 "$bin"
+if [ -n "${APPLE_TEAM_ID:-}" ]; then
+  codesign -dvv "$bin" 2>&1 | grep -q "TeamIdentifier=$APPLE_TEAM_ID" \
+    || { echo "::error::$(basename "$bin"): TeamIdentifier is not $APPLE_TEAM_ID — signed by an unexpected identity"; exit 1; }
+fi
+echo "signed: $(basename "$bin") (hardened runtime)"

--- a/ci/macos-sign-setup.sh
+++ b/ci/macos-sign-setup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# macos-sign-setup.sh — the spec 31 §5 enablement gate for the macOS
+# release legs. The repo variable APPLE_SIGNING_ENABLED=true arms
+# signing; anything else ships unsigned BY DESIGN (spec 00 invariant 7:
+# unsigned stays first-class) and this step is a loud notice. Armed but
+# a secret unresolved is a FAST named failure — never a partial release
+# (a leg that hashes unsigned bytes while its siblings sign is the
+# partial-release class; sign-then-hash is mandatory).
+#
+# Armed, this creates the throwaway signing keychain, imports the
+# Developer ID Application identity, and exports for the leg's later
+# steps (via GITHUB_ENV):
+#   CODESIGN_HASH     — the cert SHA-1. Sign by hash, NEVER by name: a
+#                       duplicate identity in any search-listed keychain
+#                       makes name resolution ambiguous (proven locally
+#                       and in the spec-31 sign-probe).
+#   CODESIGN_KEYCHAIN — the keychain path codesign searches.
+#
+# Required env when armed: APPLE_DEVELOPER_ID_P12 (base64),
+# APPLE_DEVELOPER_ID_P12_PASSWORD, APPLE_TEAM_ID. Runner env:
+# APPLE_SIGNING_ENABLED (from vars.), RUNNER_TEMP, GITHUB_ENV.
+set -euo pipefail
+
+if [ "${APPLE_SIGNING_ENABLED:-false}" != "true" ]; then
+  echo "::notice::spec 31: APPLE_SIGNING_ENABLED != true — this leg ships UNSIGNED (spec 00 invariant 7)"
+  exit 0
+fi
+
+missing=""
+for v in APPLE_DEVELOPER_ID_P12 APPLE_DEVELOPER_ID_P12_PASSWORD APPLE_TEAM_ID; do
+  [ -n "${!v:-}" ] || missing="$missing $v"
+done
+if [ -n "$missing" ]; then
+  echo "::error::APPLE_SIGNING_ENABLED=true but unset:$missing — spec 31 §5: fast failure, never a partial release"
+  exit 1
+fi
+
+work="$RUNNER_TEMP/tebako-sign"
+mkdir -p "$work"
+printf '%s' "$APPLE_DEVELOPER_ID_P12" | base64 -d > "$work/devid.p12"
+KC="$work/sign.keychain"
+security create-keychain -p sign-kc-pass "$KC"
+security unlock-keychain -p sign-kc-pass "$KC"
+# codesign resolves identities through the user search list — a freshly
+# created keychain is not on it (the sign-probe's attempt-2 "item could
+# not be found" lesson).
+security list-keychains -d user -s "$KC" $(security list-keychains -d user | tr -d '"')
+security import "$work/devid.p12" -k "$KC" -P "$APPLE_DEVELOPER_ID_P12_PASSWORD" \
+  -T /usr/bin/codesign -T /usr/bin/security
+security set-key-partition-list -S apple-tool:,apple: -k sign-kc-pass "$KC" >/dev/null
+
+HASH=$(security find-identity -v -p codesigning "$KC" | awk '/Developer ID Application/ {print $2; exit}')
+[ -n "$HASH" ] || { echo "::error::no Developer ID Application identity in the p12"; exit 1; }
+echo "CODESIGN_HASH=$HASH" >> "$GITHUB_ENV"
+echo "CODESIGN_KEYCHAIN=$KC" >> "$GITHUB_ENV"
+echo "spec 31: signing armed — Developer ID Application cert ${HASH:0:10}… (keychain $KC)"

--- a/docs/spec/31-macos-signing-notarization.md
+++ b/docs/spec/31-macos-signing-notarization.md
@@ -1,7 +1,10 @@
 # Spec 31 — macOS signing and notarization
 
-**Status: PLANNED (drafted 2026-09-04; implementation lands per §8's
-order).** Amends spec 03 §2 (the L1 manifest gains the `signing:` block),
+**Status: PARTIAL — §5's org pipelines (tebako release legs + factory
+runtime leg, gated on `APPLE_SIGNING_ENABLED`) and the §6.3 probe-proven
+notarization gate landed 2026-09-09; §2–§4 (the tpkg `signing:` block,
+press entitlement merge, the publisher pipeline) remain PLANNED
+(drafted 2026-09-04).** Amends spec 03 §2 (the L1 manifest gains the `signing:` block),
 spec 23 §2 (a second non-host sibling declaration) and §4 (press merges
 the entitlement union). No wire-format change; no trailer change; no
 change to spec 09's trust layer — Apple signing and tebako payload
@@ -178,9 +181,19 @@ zip <stitched exe> && xcrun notarytool submit <zip> \
 2. **The JIT canary** — with `allow-jit` merged, `RUBY_YJIT_ENABLE=1
    <signed runtime> -e 'abort unless RubyVM::YJIT.enabled?'` passes on
    arm64 (TODO.yjit/01's phase-0 probe, re-run against the signed exe).
-3. **The notarization gate** — `spctl -a -vv -t execute <exe>` and
-   `xcrun stapler validate <zip>` (where stapled) pass in the release
-   workflow before SHA256SUMS is computed.
+3. **The notarization gate** — for bare CLI Mach-Os, `codesign --verify
+   --strict --check-notarization -R=notarized <exe>` plus a
+   quarantine-xattr exec canary (each notarized binary is left marked
+   `com.apple.quarantine`, so the leg's own ship gate / boot smoke runs
+   it under Gatekeeper's exact download path) pass in the release
+   workflow before SHA256SUMS is computed. `spctl -a -vv -t execute` is
+   NOT the gate for standalone executables: it is bundle-oriented and
+   rejects bare CLI Mach-Os BY DESIGN ("the code is valid but does not
+   seem to be an app") regardless of notarization state — proven by the
+   spec-31 sign-probe (tebako#522, run 34319254822). Stapling likewise
+   exists only for pkg/dmg containers: `xcrun stapler validate` applies
+   where a stapled container ships, never to a bare exe (its ticket is
+   online-only, resolved by Gatekeeper at first exec).
 4. **Press validation** — `--platform macos-*` with a runtime slice and
    no `disable-library-validation` in the merged set after derivation is
    unreachable (§3 derives it); an unknown entitlement id fails the


### PR DESCRIPTION
## Spec 31 §8.3 — sign + notarize the macOS release legs

Lands the tebako-org half of spec 31 §5 for the product's own macOS artifacts, behind the spec's gate. **No behavior change unless the repo variable `APPLE_SIGNING_ENABLED=true` is set** (it is set now — the proof run below exercises the armed path; without it every leg ships unsigned by design, spec 00 invariant 7).

### The per-leg sequence (sign-then-hash is mandatory — spec 31 §5)

1. **Setup / gate** (`ci/macos-sign-setup.sh`, new): `APPLE_SIGNING_ENABLED != true` → loud unsigned notice, nothing else happens. Armed + any `APPLE_*` secret unresolved → **fast named failure** (never a partial release). Armed → throwaway keychain (added to the user search list — the sign-probe's attempt-2 lesson), p12 import, partition list, export `CODESIGN_HASH` (the cert SHA-1 — sign by hash, never by name) + `CODESIGN_KEYCHAIN`.
2. **Stage signs before hashing** (`stage.sh` + `ci/macos-sign-one.sh`, new): each staged binary is codesigned (`--options runtime --timestamp`, no entitlements — the product tools JIT nothing) **before** its sha256 fragment is written, so `SHA256SUMS`/sidecars anchor the final signed bytes. `TeamIdentifier` asserted against `APPLE_TEAM_ID`.
3. **Notarize** (`ci/macos-notarize.sh`, new; step gated on the repo variable): zip → `notarytool submit --wait` → `codesign --verify --check-notarization -R=notarized` per binary → every binary left **quarantine-marked**, so the leg's own ship gate (unchanged) smokes them under Gatekeeper's exact download path. Bare Mach-O keeps an online ticket — stapling and `spctl` are bundle-only by design (probe evidence).

### Spec correction in the same PR

§6.3 previously required `spctl -a -vv -t execute` — the sign-probe (run 34319254822, tebako#522) proved `spctl` rejects bare CLI Mach-Os by design regardless of notarization. §6.3 now names the probe-proven verification; the status line records §5 landed, §2–§4 (the `signing:` manifest block + press entitlement merge — the publisher/packed-mn path) still PLANNED.

### Proof

- `release.yml` `workflow_dispatch` on this branch, gate armed: run **34331284651** — both macOS legs sign, notarize, and pass the ship gate under the quarantine xattr (results linked before merge).
- Pre-merge CI (ci.yml) is unaffected: release-only files + docs.

Factory half (runtime exe with the `disable-library-validation` + `allow-jit` pair): tebako-runtime-ruby PR, spec 31 §8.4 — chained separately (one PR per repo).
