### PR TITLE
release: OpenPGP signing go-live — the root fingerprint + finalize-job .asc (spec 09)

### DIFF
--- a/.github/workflows/lib/sign-release.sh
+++ b/.github/workflows/lib/sign-release.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# sign-release.sh — spec 09 §2: every released part ships a detached
+# .asc, and the release index (SHA256SUMS, manifest.json) ships signed.
+# Runs in the finalize job AFTER the per-leg uploads, the SHA256SUMS /
+# manifest.json / sidecar uploads — so the release it signs is already
+# byte-complete (the completeness gate then counts the .asc files too).
+#
+# Required env: TAG (release tag), GH_TOKEN (gh).
+# Gate env: TEBAKO_RELEASE_SIGNING_ENABLED ("true" arms; anything else =
+# unsigned-first, exit 0 — unsigned stays first-class, spec 09 §3).
+# Armed + an empty TEBAKO_RELEASE_SIGNING_KEY is a fast NAMED failure
+# (the spec 31 §5 house style: a gate that cannot run must say so).
+#
+# TEBAKO_RELEASE_SIGNING_KEY: base64 of the unprotected armored export
+# of the release signing SUBKEY (not the root primary — a CI compromise
+# costs a subkey revocation, not the root).
+#
+# The signer binary is the PREVIOUS release's tebako-pkg, pinned by name
+# and sha256-verified against that release's own SHA256SUMS — a release
+# is never the first execution of its own bits, and the signing tool's
+# provenance is exactly as pinned as the artifacts it signs.
+#
+# The 42 per-asset .sha256 sidecars are NOT separately signed: each is a
+# derived line of the signed SHA256SUMS (tebako#493); signing the parts
+# and the sums covers them.
+set -euo pipefail
+: "${TAG:?TAG is required}"
+
+if [ "${TEBAKO_RELEASE_SIGNING_ENABLED:-}" != "true" ]; then
+  echo "release signing disarmed (TEBAKO_RELEASE_SIGNING_ENABLED != 'true') — unsigned-first (spec 09 §3)"
+  exit 0
+fi
+if [ -z "${TEBAKO_RELEASE_SIGNING_KEY:-}" ]; then
+  echo "NAMED FAILURE: TEBAKO_RELEASE_SIGNING_ENABLED=true but the TEBAKO_RELEASE_SIGNING_KEY secret is not set" >&2
+  exit 1
+fi
+
+WORK=sign-work
+rm -rf "$WORK"
+mkdir -p "$WORK/tool" "$WORK/assets" out/signatures
+
+# ---- the signing key -----------------------------------------------------
+printf '%s' "$TEBAKO_RELEASE_SIGNING_KEY" | base64 -d > "$WORK/release-key.asc"
+chmod 600 "$WORK/release-key.asc"
+
+# ---- the signer: the previous release's tebako-pkg, pinned + verified ----
+PREV_TAG=$(gh release list --json tagName --limit 50 --jq '.[].tagName' | grep -vx "$TAG" | head -n 1)
+if [ -z "$PREV_TAG" ]; then
+  echo "NAMED FAILURE: no release before $TAG to source the signing tool from" >&2
+  exit 1
+fi
+echo "signing tool: tebako-pkg from $PREV_TAG"
+gh release download "$PREV_TAG" --dir "$WORK/tool" \
+  --pattern 'tebako-pkg-*-linux-gnu-x86_64' --pattern 'SHA256SUMS' --clobber
+PKG=$(ls "$WORK"/tool/tebako-pkg-*-linux-gnu-x86_64)
+WANT=$(grep "  $(basename "$PKG")\$" "$WORK/tool/SHA256SUMS" | cut -d' ' -f1)
+if [ -z "$WANT" ]; then
+  echo "NAMED FAILURE: $(basename "$PKG") is not in $PREV_TAG's SHA256SUMS" >&2
+  exit 1
+fi
+echo "$WANT  $PKG" | sha256sum -c -
+chmod +x "$PKG"
+
+# ---- the parts to sign ---------------------------------------------------
+# Everything on the release except the indexes (SHA256SUMS, manifest.json)
+# and the derived .sha256 sidecars. Exactly 49 parts: 6 tools x 7
+# platforms + 7 link-unit tarballs (the completeness gate's arithmetic).
+gh release download "$TAG" --dir "$WORK/assets" --clobber
+mapfile -t PARTS < <(find "$WORK/assets" -maxdepth 1 -type f \
+  ! -name 'SHA256SUMS' ! -name 'manifest.json' ! -name '*.sha256' | sort)
+if [ "${#PARTS[@]}" -ne 49 ]; then
+  echo "NAMED FAILURE: expected 49 released parts to sign, found ${#PARTS[@]}" >&2
+  printf '  %s\n' "${PARTS[@]}" >&2
+  exit 1
+fi
+
+# ---- sign: one detached .asc per part + the two index files --------------
+# --no-sums everywhere: the canonical SHA256SUMS is finalize.sh's, already
+# uploaded; tebako-pkg sign must not regenerate it. out/SHA256SUMS and
+# out/manifest.json are byte-identical to the uploaded ones (built here in
+# the same job), so their .asc covers the release copies.
+( cd "$WORK/assets" && "$OLDPWD/$PKG" sign --key-file "$OLDPWD/$WORK/release-key.asc" --no-sums $(for p in "${PARTS[@]}"; do basename "$p"; done) )
+( cd out && "$OLDPWD/$PKG" sign --key-file "$OLDPWD/$WORK/release-key.asc" --no-sums SHA256SUMS manifest.json )
+
+# ---- self-verify: every .asc must verify TRUSTED before any upload -------
+# The sign flow registers the signing key in this job's TEBAKO_HOME, so
+# verify proves the subkey->root chain resolves, not just the math.
+( cd "$WORK/assets" && "$OLDPWD/$PKG" verify $(for p in "${PARTS[@]}"; do basename "$p"; done) )
+( cd out && "$OLDPWD/$PKG" verify SHA256SUMS manifest.json )
+
+mv "$WORK"/assets/*.asc out/signatures/
+mv out/SHA256SUMS.asc out/manifest.json.asc out/signatures/
+COUNT=$(ls out/signatures/*.asc | wc -l)
+if [ "$COUNT" -ne 51 ]; then
+  echo "NAMED FAILURE: expected 51 signatures (49 parts + SHA256SUMS.asc + manifest.json.asc), have $COUNT" >&2
+  exit 1
+fi
+echo "signed: $COUNT signatures in out/signatures/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,13 @@
 # exes imported ucrt64 DLLs and died before main on stock Windows with
 # build-success as the only gate).
 #
-# Unsigned-first: SHA256SUMS + manifest.json ship from day one; detached
-# signatures slot in later (item 29 phase 2) by signing SHA256SUMS and
-# uploading .asc files — no restructuring.
+# Release signing (spec 09 §2): unsigned stays first-class, but when the
+# repo variable TEBAKO_RELEASE_SIGNING_ENABLED=true the finalize job signs
+# every released part (one detached .asc per artifact) plus SHA256SUMS and
+# manifest.json with the release signing subkey (the
+# TEBAKO_RELEASE_SIGNING_KEY secret), using the PREVIOUS release's pinned,
+# sha256-verified tebako-pkg — a release is never the first execution of
+# its own bits. Armed + a missing secret is a fast named failure.
 #
 # macOS signing (spec 31 §5): the macOS legs codesign (Developer ID
 # Application, hardened runtime) the staged binaries BEFORE their sha256
@@ -674,6 +678,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Spec 09 §2: detached OpenPGP signatures — one .asc per released
+      # part + signed SHA256SUMS/manifest.json — made by the PREVIOUS
+      # release's pinned, sha256-verified tebako-pkg (lib/sign-release.sh).
+      # TEBAKO_RELEASE_SIGNING_ENABLED=true arms the gate; armed + a
+      # missing TEBAKO_RELEASE_SIGNING_KEY secret is a fast named failure;
+      # disarmed ships unsigned (unsigned stays first-class — spec 09 §3).
+      - name: Sign the release assets (spec 09)
+        if: needs.prepare.outputs.upload_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag_name }}
+          TEBAKO_RELEASE_SIGNING_ENABLED: ${{ vars.TEBAKO_RELEASE_SIGNING_ENABLED }}
+          TEBAKO_RELEASE_SIGNING_KEY: ${{ secrets.TEBAKO_RELEASE_SIGNING_KEY }}
+        run: bash .github/workflows/lib/sign-release.sh
+
+      - name: Upload detached signatures
+        if: needs.prepare.outputs.upload_url != '' && vars.TEBAKO_RELEASE_SIGNING_ENABLED == 'true'
+        run: gh release upload "${{ needs.prepare.outputs.tag_name }}" out/signatures/*.asc --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # item 11's completeness gate: the release job fails unless every
       # expected asset actually landed (partial-upload race class).
       - name: Completeness gate
@@ -681,8 +706,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag_name }}
+          TEBAKO_RELEASE_SIGNING_ENABLED: ${{ vars.TEBAKO_RELEASE_SIGNING_ENABLED }}
         run: |
           EXPECTED=$(( 6 * 7 + 7 + 2 + 6 * 7 ))   # 6 tools x 7 platforms (incl. windows-ucrt64; +tebako-runtime-launcher, the spec-29 wrapper exe) + 7 link-unit tarballs + SHA256SUMS + manifest.json + 42 per-asset sidecars (tebako#493)
+          if [ "${TEBAKO_RELEASE_SIGNING_ENABLED:-}" = "true" ]; then
+            EXPECTED=$(( EXPECTED + 6 * 7 + 7 + 2 ))   # + one .asc per released part (42 tools + 7 link-units) + SHA256SUMS.asc + manifest.json.asc (spec 09 §2)
+          fi
           COUNT=$(gh release view "$TAG" --json assets --jq '.assets | length')
           echo "release assets: $COUNT / $EXPECTED expected"
           gh release view "$TAG" --json assets --jq '.assets[].name' | sort

--- a/crates/tebako-bootstrap/src/lib.rs
+++ b/crates/tebako-bootstrap/src/lib.rs
@@ -1501,11 +1501,11 @@ fn install_payload(
 
 /// The tamatebako release root-of-trust fingerprint, compile-time
 /// embedded in the bootstrap (item 29 point 1: the root fingerprint is
-/// published on tebako.org AND embedded in the artifacts). Empty until
-/// the release key ceremony fills it at release time;
-/// `TEBAKO_TRUSTED_ROOT` (a fingerprint) extends/overrides it for
-/// development.
-pub const EMBEDDED_ROOT_FINGERPRINT: &str = "";
+/// published on tebako.org AND embedded in the artifacts). Filled by the
+/// 2026-09-09 root ceremony (the classical Ed25519 root —
+/// docs/root-ceremony.md); `TEBAKO_TRUSTED_ROOT` (a fingerprint)
+/// extends/overrides it for development.
+pub const EMBEDDED_ROOT_FINGERPRINT: &str = "9E210CA8E9FDE9E6587740B2EFC3C250F7862A48";
 
 /// A trusted root: fingerprint plus optionally-bundled public key bytes
 /// (an env override may point at an armored public key file).

--- a/docs/root-ceremony.md
+++ b/docs/root-ceremony.md
@@ -5,6 +5,18 @@ the expanded procedure behind spec 09 §7. Executed **once**, offline,
 by the project owner, before signed releases ship. Everything here is
 deliberate, rehearsed, and witnessed; nothing is improvised.
 
+> **Execution record (2026-09-09).** The ceremony was executed in
+> classical-only form: the Ed25519 root
+> `9E210CA8E9FDE9E6587740B2EFC3C250F7862A48` exists offline with an
+> X25519 encryption subkey, the tool-generated self-revocation
+> certificate is pre-made, the sign/verify drill passed, and the CI
+> signing subkey is wired into the org secrets. Items 2 (the PQC root),
+> 3 (the successor statement), and the ML-KEM half of 5 below remain
+> PLANNED — they wait on the tebako-crypto toolkit's ML-DSA/ML-KEM line
+> (roadmap 72). Hardware-token storage also remains the target; the
+> executed ceremony used software storage on the ceremony machine. The
+> full deviation record lives with the offline key store.
+
 The ceremony produces, in order:
 
 1. The **classical root** — Ed25519 OpenPGP keypair (the day-one anchor).

--- a/docs/spec/09-trust-and-signing.md
+++ b/docs/spec/09-trust-and-signing.md
@@ -2,8 +2,10 @@
 
 Normative specification of integrity and authenticity for every binary
 part: bootstrap, runtime payloads, data payloads, and release indexes.
-Status: signing machinery SHIPPED (M29 phase 2); key ceremony/ops PARTIAL
-(roadmap 10).
+Status: signing machinery SHIPPED (M29 phase 2); the classical root key
+ceremony EXECUTED 2026-09-09 (§7); release signing SHIPPED — the
+finalize job signs every released part and the release indexes behind
+`TEBAKO_RELEASE_SIGNING_ENABLED` (§6).
 
 > **Rollout phase — unverified-first (roadmap 72).** The shipped
 > tebako-bootstrap is built WITHOUT OpenPGP verification (the
@@ -100,14 +102,26 @@ and `tebako-pkg verify` (Trusted/Untrusted/Invalid per artifact).
 Factory release flows invoke `tebako-pkg sign` in CI (secrets-held
 armored root export; the private key never leaves CI secrets/hardware).
 
-## 7. Remaining ceremony (roadmap 10)
+## 7. Ceremony status (roadmap 10)
 
-Production root key ceremony (offline, hardware-held) →
-`EMBEDDED_ROOT_FINGERPRINT` filled → fingerprint published on tebako.org →
-CI secrets wired → revocation drill rehearsed. The operational runbook —
-dual-root (Ed25519 classical + ML-DSA-65 PQC), pre-made successor and
-revocation statements, day-one ML-KEM encryption subkey, hardware
-storage, and the rehearsal — is `docs/root-ceremony.md` (roadmap 36).
+The production root key ceremony was executed 2026-09-09: the classical
+Ed25519 root `9E210CA8E9FDE9E6587740B2EFC3C250F7862A48` exists in the
+offline store, `EMBEDDED_ROOT_FINGERPRINT` is filled, the fingerprint
+and public key are published on tebako.org (the trust-anchor page and
+`/.well-known/tebako-key.asc`), the CI secrets are wired (the finalize
+job signs releases behind `TEBAKO_RELEASE_SIGNING_ENABLED`), and the
+sign/verify drill was rehearsed against a released tebako-pkg before
+go-live (trusted and tamper-invalid both proven).
+
+Recorded deviations from the `docs/root-ceremony.md` runbook (roadmap
+36), each with its follow-up: no PQC root and no pre-made successor
+statement yet (the rnp line in use lacks ML-DSA — lands with the
+tebako-crypto toolkit, roadmap 72); the CI signing-subkey export is
+unprotected (tebako-signer passphrase-unlock follow-up); software
+storage in place of hardware tokens; the encryption subkey is X25519 in
+place of day-one ML-KEM; the revocation certificate is the
+tool-generated self-revocation. The full deviation record lives with
+the offline key store.
 
 ## 8. Revocation (locked 2026-07-27)
 


### PR DESCRIPTION
## What

Turns on OpenPGP release signing (spec 09), consuming the 2026-09-09 root ceremony:

- **`crates/tebako-bootstrap/src/lib.rs`** — `EMBEDDED_ROOT_FINGERPRINT` filled with the classical Ed25519 root `9E210CA8E9FDE9E6587740B2EFC3C250F7862A48` (the compile-time trust anchor of spec 09 §2; live in `openpgp-verify` builds — CLI/pkg verify and trailer verification; inert in the size-gated shipped bootstrap).
- **`.github/workflows/lib/sign-release.sh`** (new) + **`release.yml`** — the finalize-job sign step: when the repo variable `TEBAKO_RELEASE_SIGNING_ENABLED=true`, every released part gets a detached `.asc` and `SHA256SUMS`/`manifest.json` ship signed. The signer is the **previous release's** tebako-pkg, pinned by name and sha256-verified against that release's own `SHA256SUMS` — a release is never the first execution of its own bits. House style mirrors spec 31 §5: armed + a missing `TEBAKO_RELEASE_SIGNING_KEY` secret is a fast named failure; disarmed ships unsigned (unsigned stays first-class, spec 09 §3). The completeness gate counts the 51 signatures (49 parts + 2 indexes) only when armed.
- **`docs/spec/09-trust-and-signing.md`** — status line + §7 rewritten to the executed ceremony; **`docs/root-ceremony.md`** — the execution record with the roadmap-36 deviations (PQC root / successor statement / ML-KEM subkey / hardware storage remain PLANNED for the tebako-crypto toolkit, roadmap 72).

## Evidence (the rehearsal)

The exact `sign-release.sh` flow was run against the published **v2.5.0** release:

- the signing tool resolved to the previous release's `tebako-pkg` (v2.4.0), sha256-verified `OK` against v2.4.0's own `SHA256SUMS`;
- `signed 49 artifact(s) with key efc3c250f7862a48` (the CI signing subkey — low 64 bits of the root fingerprint) + `signed 2 artifact(s)` (SHA256SUMS, manifest.json);
- all 51 artifacts verified **trusted** (the subkey→root chain resolves through rnp);
- the script's 49-part assertion matched the v2.5.0 release inventory exactly (93 assets = 49 parts + 2 indexes + 42 derived sidecars — the sidecars are covered by the signed sums, not separately signed).

Follow-ups recorded, not hidden: tebako-signer passphrase-unlock (the CI subkey export is unprotected), the PQC root + `TEBAKO-ROOT-SUCCESSOR-V1` statement once the tebako-crypto toolkit exists.

Companion: tamatebako/tebako.org#99 (the trust-anchor page this spec text cites — merges first).
