### PR TITLE
release: v2.6.0 — workspace version bump (2.5.0 → 2.6.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-runtime-launcher", "crates/tebako-arscope", "crates/tebako-bench", "tests/contract"]
 
 [workspace.package]
-version = "2.5.0"
+version = "2.6.0"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"


### PR DESCRIPTION
## release: v2.6.0 — workspace version bump (2.5.0 → 2.6.0)

One line: `[workspace.package] version` in the root `Cargo.toml`. Bump
shape mirrors the v2.5.0 bump (38298a47 — same single line); the
intra-workspace pins stay at ^2.0.0, which accepts 2.6.0 — not
boundary-crossing, no pin moves.

Carries to release:

- **PR #564 (spec 09 §9)** — the embedded tamatebako root public key +
  primary-keyid signature pins: zero-interaction first-party
  verification of signed payloads (`tebako install` of a signed
  feedstock verifies Trusted with no key registration), plus the
  tebako-pkg verify usage-string fix and the lead-position `--version`
  fix.

This is the release the Q10 live-fire runs against: signed
hello 2.12.2 (tebako-packages/hello run 34449022753, six `.asc`
assets, registry keyid `efc3c250f7862a48`) installing under
`TEBAKO_REQUIRE_SIGNED=1` with zero key registration.
