### PR TITLE
resolve: advance the default runtime line to 0.16.22 (the spec-32 grammar)

### DIFF
--- a/crates/tebako-resolve/src/lib.rs
+++ b/crates/tebako-resolve/src/lib.rs
@@ -76,8 +76,13 @@ pub use transport::{HttpTransport, Transport};
 /// `kind: runtime` DEPENDS edge — a pref-less resolution landing on an
 /// older line fails closed at the payload's first dispatch with the
 /// driver's named manifest error, so the default line must never trail
-/// the newest published factory line.
-pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.18";
+/// the newest published factory line. From 0.16.22 the runtimes link
+/// the v2.3.0 driver unit: the grammar also accepts the spec-32
+/// `kind: executable` edge (the xml2rfc leg of metanorma's requires
+/// block) — reproduced against the published 0.16.18 macos-arm64 exe:
+/// "unknown variant `executable` … the payload's self-description
+/// lies".
+pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.22";
 
 /// Fetch `reference` (pin-verified at the fetch boundary) and install it
 /// as `payloads/<name>/<version>.tfs` — or return the existing entry.


### PR DESCRIPTION
Pref-less runtime resolution queries the factory release named by
`DEFAULT_TEBAKO_VERSION`. The 0.16.18 line links the v2.1.0 driver unit,
whose manifest grammar predates spec 32: a payload declaring a
`kind: executable` DEPENDS edge fails closed at first dispatch:

```
tebako-driver: corrupt /__tpkg__/manifest.yaml in the image mounted at '/'
(payload manifest yaml error: requires.[3].kind: unknown variant
`executable`, expected one of `language`, `toolkit`, `data`, `runtime`)
```

Reproduced 2026-09-10 against the published 0.16.18 macos-arm64 runtime
with the CURRENT published metanorma payload (1.16.9-9 — its xml2rfc leg
declares `kind: executable`): fresh-home `tebako install metanorma` +
any shim dispatch dead-ends at the parse. The 0.16.22 line (link unit
v2.3.0 ≥ v2.2.0, where the spec-32 variant landed) parses and runs the
same payload — verified end-to-end by a full signed-CLI smoke: v2.6.0
CLI + shim, fresh home, metanorma compile → semantic XML produced.

Same failure class as the 0.16.9→0.16.18 advance (50a09da5 — `kind:
runtime` then, `kind: executable` now): the default line must never
trail the newest published factory line. The release-process hole that
let v2.6.0 ship with a 9-day-stale line is queued as automation
(roadmap 78 leg 3: factory publish → default-line bump PR fan-out;
roadmap 79: release-time currency gate).

One constant + its comment. Local gates: `cargo test -p tebako-resolve`
85/85, `-p tebako-shim` 131/131, fmt clean, clippy `-D warnings` clean.

Ref: tebako#567 (the sibling fresh-home gap: per-engine runtime index
routing for non-ruby runtimes).
