### PR TITLE
chore: canonical openjdk refs in fixtures/comments after the org transfer + rename

### DIFF
--- a/.github/workflows/lib/stage.sh
+++ b/.github/workflows/lib/stage.sh
@@ -25,7 +25,7 @@ SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/null}"
 # table — this script must also run under bash 3.2 / POSIX sh, which
 # have no `declare -A`). tebako-shim is the dispatcher (TODO.testing/07).
 # tebako-runtime-launcher is the spec-29 wrapper exe (the repacked-
-# runtime ship form — tebako-packages/openjdk#23's download).
+# runtime ship form — tamatebako/tebako-runtime-openjdk#23's download).
 TOOLS="tebako-bootstrap tfs tebako-pkg tebako tebako-shim tebako-runtime-launcher"
 
 mkdir -p out "fragments/frag-$PLATFORM"

--- a/crates/tebako-pkg/tests/info.rs
+++ b/crates/tebako-pkg/tests/info.rs
@@ -1165,7 +1165,7 @@ const SPAWNED_LOCK_YAML: &str = "lock:\n\
      \x20     carry: false\n\
      \x20     exe: {sha256: \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}\n\
      \x20     image: {sha256: \"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}\n\
-     \x20     source: \"https://github.com/tebako-packages/openjdk/releases/download\"\n";
+     \x20     source: \"https://github.com/tamatebako/tebako-runtime-openjdk/releases/download\"\n";
 
 fn bundle_spawned_app(w: &TempDir, home: &Path, pm_yaml: &str) -> PathBuf {
     let app = mk_image_files(

--- a/crates/tpkg/src/package.rs
+++ b/crates/tpkg/src/package.rs
@@ -1270,7 +1270,7 @@ mod tests {
                 sha('b'),
             )])),
             source: Some(
-                "tfs:github:tebako-packages/openjdk-feedstock:21.0.5#openjdk-21.0.5-macos-arm64.tfs"
+                "tfs:github:tamatebako/tebako-runtime-openjdk:21.0.5#openjdk-21.0.5-macos-arm64.tfs"
                     .to_string(),
             ),
         }
@@ -1346,7 +1346,7 @@ mod tests {
             },
             dll: None,
             source: Some(
-                "tfs:github:tebako-packages/openjdk:2.1.5#tebako-runtime-2.1.5-21.0.12-macos-arm64.tfs"
+                "tfs:github:tamatebako/tebako-runtime-openjdk:2.1.5#tebako-runtime-2.1.5-21.0.12-macos-arm64.tfs"
                     .to_string(),
             ),
         }


### PR DESCRIPTION
## What

Canonical-reference sweep after the 2026-09-10 org transfer (`tebako-packages/openjdk` → `tamatebako/openjdk`; runtime feedstocks live in the tamatebako org — the boundary is the artifact's role).

- `crates/tpkg/src/package.rs` — two test-fixture ref strings (one still named the even-older `openjdk-feedstock`)
- `crates/tebako-pkg/tests/info.rs` — the spawned-runtime lock fixture's `source:` URL
- `.github/workflows/lib/stage.sh` — a comment pointer to openjdk#23

All are synthetic fixtures/comments — no live fetch paths (the resolver hits whatever the registry declares; registries were swept in the feedstock PRs: tamatebako/openjdk#34, jruby#2, truffleruby#6).

## Gates

- `cargo test -p tpkg`: 171/171
- `cargo test -p tebako-pkg --test info`: 28/28
