### PR TITLE
ci: sha-pin the Windows signing actions (spec 34 §8.2 proof)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -965,7 +965,7 @@ jobs:
       # × the windows-signing environment this job runs in.
       - name: Azure login (OIDC, spec 34 §5)
         if: steps.signgate.outputs.armed == 'true'
-        uses: azure/login@v2 # TODO(sha-pin): pin on first armed run
+        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2 (sha-pinned 2026-09-11; proven on armed dry-run 34490242097)
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -978,7 +978,7 @@ jobs:
       # this action's @v1 (deviation from the spec's draft shape).
       - name: Sign the staged PE artifacts (spec 34 §5)
         if: steps.signgate.outputs.armed == 'true'
-        uses: Azure/artifact-signing-action@v1 # TODO(sha-pin): pin on first armed run
+        uses: Azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # v1 (sha-pinned 2026-09-11; proven on armed dry-run 34490242097)
         with:
           endpoint: ${{ vars.AZURE_ENDPOINT }}
           signing-account-name: ${{ vars.AZURE_SIGNING_ACCOUNT_NAME }}


### PR DESCRIPTION
## What

Pin the two Windows-signing actions to the exact SHAs the first armed run resolved, removing the `TODO(sha-pin)` markers:

- `azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6` (v2)
- `Azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16` (v1)

## Evidence (armed dry-run 34490242097, 2026-09-10)

- azure/login OIDC succeeded on the **immutable subject** `repo:tamatebako@87628837/tebako@387117246:environment:windows-signing` (post GitHub-side `use_immutable_subject` opt-in; the Entra credential carries the same string).
- `Azure/artifact-signing-action@v1` resolved to SHA `b443cf8e…` (the run's "Download action repository" line) and signed the staged PE set; signtool verify + the §1.3 re-hash over the signed bytes passed; the run finished green.

Gate-off parity is unchanged (the pin touches only the `uses:` lines; the steps remain `if: steps.signgate.outputs.armed == 'true'`).
