### PR TITLE
spec 09/13: runtime fetch-time signature verification (roadmap 80/G1)

### DIFF
--- a/docs/spec/05-resolution-and-cache.md
+++ b/docs/spec/05-resolution-and-cache.md
@@ -87,8 +87,12 @@ recorded for the failure message.
   An edge no channel answers is a NAMED error enumerating the channels
   tried (never a silent query of a base that hosts no such engine — a
   wrong-line 404 is diagnosed as what it is).
-- Signing of the index itself: spec 09 §5 (signed manifest closes the
-  same-channel-MITM gap).
+- Signing of the index and the artifacts it names: spec 09 §5 (every
+  consumable index form signed — the same-channel-MITM gap closes) and
+  spec 09 §4's runtime-fetch verification point (the per-artifact
+  `signature` check, the unsigned-line semantics, the exit codes). The
+  fetch journal records the verification strength alongside the base and
+  the channel that supplied it.
 
 ## 3. Machine cache layout (`~/.tebako`)
 

--- a/docs/spec/06-launcher-abi.md
+++ b/docs/spec/06-launcher-abi.md
@@ -59,7 +59,8 @@ republish of v1-era runtimes needed.
 4. Resolve the runtime per spec 05 §5 — negotiating the contract version
    (§6) fail-closed before any checksum acceptance.
 5. Image-era: ensure `<asset>.tfs` + trust markers in the cache entry
-   (fetch + verify on miss), install read-only.
+   (fetch + verify on miss — authenticity per spec 09 §4's runtime-fetch
+   point first, then sha256 integrity as today), install read-only.
 6. Exec the handoff. Never returns on success.
 
 ## 4. Exit codes (named, stable)

--- a/docs/spec/09-trust-and-signing.md
+++ b/docs/spec/09-trust-and-signing.md
@@ -5,7 +5,10 @@ part: bootstrap, runtime payloads, data payloads, and release indexes.
 Status: signing machinery SHIPPED (M29 phase 2); the classical root key
 ceremony EXECUTED 2026-09-09 (§7); release signing SHIPPED — the
 finalize job signs every released part and the release indexes behind
-`TEBAKO_RELEASE_SIGNING_ENABLED` (§6).
+`TEBAKO_RELEASE_SIGNING_ENABLED` (§6). Runtime FETCH-TIME verification
+(§4's resolve-path point, §5's signed index forms, spec 13 §2a's
+per-artifact `signature`) is PLANNED — roadmap 80/G1: until it lands,
+runtime release signatures are out-of-band only.
 
 > **Rollout phase — unverified-first (roadmap 72).** The shipped
 > tebako-bootstrap is built WITHOUT OpenPGP verification (the
@@ -92,6 +95,28 @@ tebako validates below it — see spec 12 §5.
 - **Install time:** registry-pinned payload signatures verify against the
   trusted keyring PLUS the embedded root public key — a tamatebako-signed
   payload verifies Trusted on a fresh machine, no registration step.
+- **Runtime fetch (resolve time — tebako-resolve, the one code path
+  behind the shim's dispatch, the CLI's install/press, and the
+  bootstrap's runtime download; PLANNED — roadmap 80/G1):** the resolver
+  verifies the consumed index form's detached signature (§5) BEFORE
+  trusting its digests, then verifies each fetched artifact whose entry
+  declares `signature` (spec 13 §2a) — always strict: an invalid
+  signature → exit 71; a signer keyid whose primary is not in the
+  trusted keyring → exit 72; a declared `.asc` that does not fetch →
+  exit 71 (a signing declaration without its signature asset is an
+  invalid signing state, never a skip). The sha256 check then runs as
+  today (exit 70). An entry with NO signature anywhere (a pre-signing
+  release line — those releases are keep-forever, spec 13 §8) is
+  accepted with a loud stderr warning + audit journal
+  (`event=unsigned-runtime-fetch`) on every fetch — the download moment
+  IS the trust decision here (§9's two-models rule) — and refused with
+  exit 71 under `TEBAKO_REQUIRE_SIGNED=1`. A bootstrap built without
+  `openpgp-verify` treats declared runtime signatures exactly as it
+  treats signed trailers (spec 06 §3): loud UNVERIFIED warning +
+  journal, sha256 enforced as integrity-only, exit 71 under
+  `TEBAKO_REQUIRE_SIGNED=1` naming the missing capability. The store
+  markers keep their spec 05 §4 semantics — verification happens at
+  fetch/install, never per run.
 - **First run:** the loader verifies the trailer signature against the
   keyring, then each slot's sha256 before mounting/extracting (streaming,
   one pass at install time; the trust-anchor marker avoids re-hashing
@@ -102,9 +127,25 @@ tebako validates below it — see spec 12 §5.
 
 ## 5. Release index authentication
 
-`manifest.json` is signed (detached `.asc`); resolvers verify the index
-signature before trusting its hashes — closing the gap where a MITM swaps
-both package and unsigned manifest. Same keyring, same verify path.
+Every index form a resolver can consume ships a detached `.asc` from the
+factory's release key, and the resolver verifies the signature of the
+form it consumed BEFORE trusting its hashes — closing the gap where a
+MITM swaps both package and unsigned manifest. Same keyring, same verify
+path. Per runtime factory release (spec 13 §2a): each per-package shard
+`<stem>.manifest.json` ships `<stem>.manifest.json.asc` (the sidecar-era
+authority is signed first), the derived monoliths ship
+`manifest.json.asc` and `SHA256SUMS.txt.asc`, and every payload asset
+(the interpreter exe, the env image, a windows dll) ships its own
+`<asset>.asc`. The entry's `signature: {keyid, asc}` fields name the
+per-artifact sidecars — the same SSOT rule as `filename`: the factory
+declares the spellings, consumers flow them verbatim and never
+synthesize. `keyid` names the signer's PRIMARY keyid (§9's
+primary-vs-subkey rule). All of it is additive: pre-signing releases
+carry none of it and stay installable under §4's unsigned-fetch rule
+(keep-forever, spec 13 §8); a release that declares a `signature` for an
+artifact MUST ship that `.asc` — a declaration without its signature
+asset is an invalid signing state (§4: exit 71 at fetch, and the
+factory's publish fails before that, spec 13 §2a).
 
 ## 6. Tooling
 
@@ -218,6 +259,13 @@ issuer is reported alongside for transparency).
 - Payload slices: signed trailer verified against the author's pinned
   key; per-slot digests chain off it (§4).
 - Runtime slices (tamatebako): the embedded root — nothing to register.
+- Runtime slices (third-party — discovered through a registry's
+  `kind: runtime` entry, spec 05 §2's registry-derived base): the
+  publishing registry's pinned key — the channel that supplied the
+  download base also anchors the key, so a third-party runtime adds no
+  ceremony past the add-registry TOFU. The entry's `signature.keyid`
+  must resolve to that pinned primary (mismatch → `SignerKeyChanged`,
+  exit 72).
 - Third-party fat/slim binaries: verified at install/import against the
   pinned author key (the same verify path); the author may ALSO
   OS-codesign with their own Developer ID — Apple/Microsoft gates then

--- a/docs/spec/13-factories-and-releases.md
+++ b/docs/spec/13-factories-and-releases.md
@@ -54,13 +54,20 @@ publish invocation writes ONLY its own payload assets plus the metadata
 that describes them — the per-asset `<asset>.sha256` sidecar (coreutils
 `<sha>  <file>`, hashed from the local bytes) and the per-package
 `<stem>.manifest.json` shard (the entry below, served standalone, every
-sha field re-anchored to the served bytes). The monoliths
-(`manifest.json`, `SHA256SUMS.txt`) and the release notes are DERIVED
-conveniences written by a single finalize pass from the release's own
-shards plus the asset listing's server-computed digests — never a job's
-local merge (the 2026-08-29 incident: four platform jobs racing the two
-shared monoliths wedged an asset name server-side). Payload assets stay
-byte-immutable; metadata is derivable and converges (digest-match skip,
+sha field re-anchored to the served bytes; on signing-enabled lines the
+shard also declares each artifact's `signature` block — the `.asc`
+spellings are the factory's to declare, written at publish). The
+monoliths (`manifest.json`, `SHA256SUMS.txt`) and the release notes are
+DERIVED conveniences written by a single finalize pass from the
+release's own shards plus the asset listing's server-computed digests —
+never a job's local merge (the 2026-08-29 incident: four platform jobs
+racing the two shared monoliths wedged an asset name server-side). The
+finalize pass also signs (spec 09 §5, behind the signing flag): every
+payload asset's `<asset>.asc`, every shard's `<stem>.manifest.json.asc`,
+and the monoliths' `manifest.json.asc` / `SHA256SUMS.txt.asc` — a
+signature the shard declares but the finalize pass does not produce
+fails the release, never ships. Payload assets stay byte-immutable;
+metadata is derivable and converges (digest-match skip,
 loud replace on drift). Sidecars and shards are the authority; the
 resolver reads them first (spec 05 §2).
 
@@ -73,7 +80,10 @@ resolver reads them first (spec 05 §2).
   "filename": "tebako-runtime-0.16.0-3.3.7-macos-arm64",
   "sha256": "…", "size_bytes": 38683544,
   "abi": "arm64-darwin-23",
-  "image": {"filename": "….tfs", "sha256": "…", "size_bytes": 7658081}
+  "signature": {"keyid": "efc3c250f7862a48",
+                "asc": "tebako-runtime-0.16.0-3.3.7-macos-arm64.asc"},
+  "image": {"filename": "….tfs", "sha256": "…", "size_bytes": 7658081,
+            "signature": {"keyid": "efc3c250f7862a48", "asc": "….tfs.asc"}}
 }
 ```
 
@@ -85,6 +95,18 @@ resolver reads them first (spec 05 §2).
 - The image nests under `image` (name + sha + size); the exe's own
   digest is the entry's `sha256`. `contract_version` negotiates the
   launcher semantics (spec 17).
+- `signature` (additive, opt-in per artifact — spec 09 §5): the exe
+  carries the entry-level `signature`, the env image `image.signature`,
+  a windows `dll` its own — each `{keyid, asc}` mirroring the registry
+  model (spec 04 §2): `keyid` the signer's 16-lowercase-hex PRIMARY
+  keyid (spec 09 §9's primary-vs-subkey rule), `asc` the detached
+  sidecar's exact asset name within the same release (declared by the
+  factory, flowed verbatim — consumers never synthesize it, exactly like
+  `filename`). Absent marks a pre-signing release line — keep-forever
+  (§8), installable under spec 09 §4's unsigned-fetch rule. Present ⇒
+  the named `.asc` exists in the same release: a declaration without its
+  signature asset is an invalid signing state (spec 09 §4 — exit 71 at
+  fetch, and the publish fails before that, above).
 
 ## 3. Drift loop (SHIPPED pending PR merge: ruby#41, runtime-ruby#17)
 


### PR DESCRIPTION
## Summary

Docs-only spec amendment — the spec-side leg of **roadmap 80 / gap G1** (the runtime fetch path is sha256-only today, so signed runtime releases are out-of-band until the resolver verifies in-band). Spec first per spec 14; the resolve + bootstrap implementation rides with #567's per-engine download-base chain (the same `tebako-resolve` code path) as a follow-up PR.

No code changes; no behavior changes.

## What changes

- **spec 09 §4** — new verification point **Runtime fetch (resolve time)**, the one `tebako-resolve` code path behind shim dispatch, CLI install/press, and the bootstrap's runtime download:
  - the consumed index form's detached signature verifies BEFORE its digests are trusted;
  - each artifact whose entry declares `signature` verifies strict: invalid → exit 71, unknown primary keyid → exit 72, declared-but-missing `.asc` → exit 71 (never a skip);
  - unsigned pre-signing release lines stay first-class (keep-forever, spec 13 §8): loud warning + `event=unsigned-runtime-fetch` journal per fetch, exit 71 under `TEBAKO_REQUIRE_SIGNED=1`;
  - an `openpgp-verify`-off bootstrap mirrors spec 06 §3's trailer rule (loud UNVERIFIED + journal; REQUIRE_SIGNED fails closed naming the missing capability);
  - store markers unchanged: verify at fetch/install, never per run.
- **spec 09 §5** — release index authentication extended to the shard era: `<stem>.manifest.json.asc`, `manifest.json.asc`, `SHA256SUMS.txt.asc`, and per-asset `<asset>.asc`; the entry's `signature: {keyid, asc}` names the sidecars (factory declares, consumers flow — the `filename` SSOT rule); `keyid` is the PRIMARY per §9's subkey rule.
- **spec 09 §9** — per-artifact-class list gains third-party runtime slices: verified against the publishing registry's pinned key (the channel that supplied the download base anchors the key); mismatch → `SignerKeyChanged` (72).
- **spec 13 §2a** — the release-index entry gains additive per-artifact `signature` blocks (exe / `image` / `dll`), example uses the real root's primary keyid; publish shape: shards declare the `.asc` names, the finalize pass signs assets + shards + monoliths, a declared-but-unproduced signature fails the release.
- **spec 05 §2 / spec 06 §3** — cross-refs; the fetch journal records the verification strength alongside the download base and channel.

## Not in this PR

- tebako#567 per-engine routing needs **no** spec amendment — spec 05 §2's four-channel chain, spec 07 §0's `source:` key, and spec 30 §1's edge download rule already carry it (PLANNED). Implementation-only, same code path as G1.
- The resolve/bootstrap implementation of this spec (roadmap 80 leg 1) and the rt-ruby signed re-cut that gives it a golden (trr#154 armed) land separately.

Refs: roadmap 80 (TODO.roadmap/80-trust-plane-completion.md, gap G1), tebako#567, trr#154.
