### PR TITLE
spec 09 §4/§5 G1 runtime fetch verification (shim + CLI) + #567 per-engine index routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,13 +413,18 @@ jobs:
         with:
           components: clippy
 
+      # Pure-Rust crates only — this leg provisions no C toolchain.
+      # tebako-shim left this set with G1 (runtime-fetch signature
+      # verification links tebako-signer's vendored rnp/Botan); its
+      # Windows coverage rides the gnu shim leg (the shipped target)
+      # and its lint coverage the workspace clippy on linux/mac.
       - name: cargo test (pure-Rust crates)
         working-directory: tebako-rs
-        run: cargo test -p tebako-bootstrap -p tebako-shim -p tebako-resolve -p tebako-http -p tebako-term -p tebako-json -p tpkg -p tebako-bench
+        run: cargo test -p tebako-bootstrap -p tebako-resolve -p tebako-http -p tebako-term -p tebako-json -p tpkg -p tebako-bench
 
       - name: clippy (pure-Rust crates)
         working-directory: tebako-rs
-        run: cargo clippy -p tebako-bootstrap -p tebako-shim -p tebako-resolve -p tebako-http -p tebako-term -p tebako-json -p tpkg -p tebako-bench --all-targets -- -D warnings
+        run: cargo clippy -p tebako-bootstrap -p tebako-resolve -p tebako-http -p tebako-term -p tebako-json -p tpkg -p tebako-bench --all-targets -- -D warnings
 
   # The bootstrap on the target the release binaries actually ship on
   # (x86_64-pc-windows-gnu, ucrt64 — TODO.prepublish/03). ring does not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,12 +487,15 @@ jobs:
       # ONE toolchain across the ecosystem (the factory's ruby link uses
       # the same ucrt64 gcc); setup-msys2's /usr/bin stays OFF PATH —
       # the script's closed PATH takes Git's coreutils instead.
+      # cmake/ninja/make join the toolchain because G1 links
+      # tebako-signer's vendored rnp into the shim — rnp-src builds
+      # json-c via cmake (the release leg's exact package set).
       - name: Set up MSys2 (ucrt64 toolchain)
         uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: ucrt64
           path-type: minimal
-          install: mingw-w64-ucrt-x86_64-toolchain
+          install: mingw-w64-ucrt-x86_64-toolchain mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-ninja mingw-w64-ucrt-x86_64-make
 
       - uses: dtolnay/rust-toolchain@1.94.1
         with:

--- a/ci/windows-gnu-shim.sh
+++ b/ci/windows-gnu-shim.sh
@@ -4,7 +4,11 @@
 # test run. tebako-resolve rides along: its gix/reqwest TLS stack is
 # provider-split on this target (rustls/aws-lc-rs — ring 0.17 does not
 # compile under mingw; the tebako-http split of commit 8de4335), and this
-# leg is where that stack is proven on the real toolchain.
+# leg is where that stack is proven on the real toolchain. Since G1
+# (runtime-fetch signature verification), tebako-shim also links
+# tebako-signer's vendored rnp/Botan — so this leg carries the same
+# three build provisions as ci/windows-gnu-cli.sh (make shim,
+# BOTAN_CONFIGURE_CC, bindgen header args).
 #
 # Everything the leg needs is HERE, not inline in the workflow YAML —
 # run-blocks get string-edited and break silently; a script is reviewed
@@ -19,6 +23,17 @@ set -euo pipefail
 # (the runner carries several mingw installs and first-DLL-wins
 # resolution is STATUS_ENTRYPOINT_NOT_FOUND at process start).
 export PATH="/d/a/_temp/msys64/ucrt64/bin:/c/Program Files/Git/usr/bin:/c/Program Files/Git/cmd:/c/Users/runneradmin/.cargo/bin:/c/Windows/System32"
+
+# tebako-signer's vendored rnp builds Botan via botan-src, which spawns
+# plain `make` (hardcoded upstream); MSYS2's ucrt64 ships only
+# mingw32-make.exe. Give it a `make` on the closed PATH — a COPY (Git
+# bash "symlinks" are text files to CreateProcess). Fails loudly here if
+# the toolchain ever drops mingw32-make, instead of upstream's cryptic
+# "program not found".
+TOOLSHIM=/d/a/_temp/tebako-toolshim
+mkdir -p "$TOOLSHIM"
+cp "/d/a/_temp/msys64/ucrt64/bin/mingw32-make.exe" "$TOOLSHIM/make.exe"
+export PATH="$TOOLSHIM:$PATH"
 
 # One linker, resolved from the closed PATH above (ucrt64's gcc).
 export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=gcc.exe
@@ -39,6 +54,28 @@ export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(cygpath -w "$WRAP")"
 # violates it; the factory probe proved libmingwex's compat _assert.o
 # then dies on __imp___msvcrt_assert).
 export RUSTFLAGS="-C link-arg=-static-libgcc -C link-arg=-static-libstdc++ -C link-arg=-lmsvcrt"
+
+# tebako-signer's vendored rnp builds Botan via botan-src: configure.py
+# defaults to MSVC on os=windows and there is no cl on the closed PATH —
+# steer it to the ucrt64 gcc (probe-proven: with the default the
+# configure dies on "Default compiler is msvc but could not find 'cl'").
+export BOTAN_CONFIGURE_CC=gcc
+
+# bindgen (rnp-rs's rnp bindings) drives the runner image's libclang in
+# MSVC mode: with no mingw header dirs on its search path, rnp.h dies on
+# <stdbool.h> (tebako-rs CI run 30714614829). Point clang at the ucrt64
+# headers — the C library's and gcc's own (stdbool.h lives there) — and
+# name the target explicitly. The paths must be WINDOWS-FORM (D:/...):
+# libclang is a native Windows binary — the msys form (/d/a/...) does not
+# resolve for it (openjdk feedstock run 30719756048 proved the msys form
+# a no-op). Fail loudly if the toolchain layout moves.
+UCRT64=/d/a/_temp/msys64/ucrt64
+GCC_INCLUDE=$(echo "$UCRT64"/lib/gcc/x86_64-w64-mingw32/*/include)
+if [ ! -d "$GCC_INCLUDE" ]; then
+  echo "ucrt64 gcc include dir not found under $UCRT64/lib/gcc — toolchain layout changed"
+  exit 1
+fi
+export BINDGEN_EXTRA_CLANG_ARGS="--target=x86_64-w64-mingw32 -isystem $(cygpath -m "$UCRT64/include") -isystem $(cygpath -m "$GCC_INCLUDE")"
 
 TARGET=x86_64-pc-windows-gnu
 

--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -1928,15 +1928,17 @@ fn signature_reference(sig: &SignaturePin, release: &Reference) -> Result<Refere
 }
 
 /// `TEBAKO_REQUIRE_SIGNED` truthiness (mirrors the bootstrap's rule:
-/// set and not "0").
-fn require_signed() -> bool {
+/// set and not "0"). pub(crate): the runtime resolver (resolve.rs)
+/// applies the same rule to the runtime fetch (spec 09 §4 G1).
+pub(crate) fn require_signed() -> bool {
     std::env::var("TEBAKO_REQUIRE_SIGNED").is_ok_and(|v| !v.is_empty() && v != "0")
 }
 
 /// Append one line to the audit journal (<home>/journal.log), mirroring
 /// the bootstrap's convention. Best-effort: journaling never fails the
-/// install.
-fn journal(home: &Path, line: &str) {
+/// install. pub(crate): the runtime resolver journals the runtime
+/// fetch's trust outcomes through the same line (spec 09 §4 G1).
+pub(crate) fn journal(home: &Path, line: &str) {
     use std::io::Write;
     let _ = std::fs::create_dir_all(home);
     let now = std::time::SystemTime::now()

--- a/crates/tebako-cli/src/resolve.rs
+++ b/crates/tebako-cli/src/resolve.rs
@@ -13,6 +13,17 @@
 //! into place with an atomic rename, so partial downloads never poison the
 //! cache.
 //!
+//! G1 (spec 09 §4/§5): the fetch is signature-verified at the index
+//! boundary whenever the release carries detached `.asc` siblings (the
+//! per-package shard's, manifest.json's, or SHA256SUMS.txt's — the first
+//! TRUSTED form wins; a verified form beats an unsigned one regardless of
+//! the index's preference order), and a `signature:` block declared on
+//! the entry or a facet (spec 13 §2a) verifies against the downloaded
+//! bytes BEFORE the sha256 check. An unverifiable fetch is accepted
+//! LOUDLY (stderr + audit journal); TEBAKO_REQUIRE_SIGNED=1 refuses it
+//! (exit 71) before any asset downloads. An invalid signature exits 71;
+//! an untrusted signer or a changed signer key exits 72.
+//!
 //! The gem's BootstrapManager half is ported for the RUST bootstrap only
 //! (spec 19 §4): [`BootstrapResolver`] resolves the per-triplet
 //! tebako-bootstrap published with the product's own releases
@@ -35,6 +46,7 @@ use std::path::{Path, PathBuf};
 use sha2::Digest;
 
 use tebako_pkg::{json_parse, JsonValue};
+use tpkg::runtime_store::EntrySignature;
 
 use crate::error::{packaging_error, TebakoError};
 use crate::fetch::{fetch_bytes, fetch_text, FetchError};
@@ -83,6 +95,11 @@ pub struct IndexEntry {
     pub platform: Option<String>,
     pub filename: String,
     pub sha256: String,
+    /// The entry's declared detached-signature block (spec 13 §2a):
+    /// the signer pin + the `.asc` asset name within the same release.
+    /// Absent on the pre-signing keep-forever line and on any
+    /// SHA256SUMS-derived entry (the sums form carries no signatures).
+    pub signature: Option<EntrySignature>,
     /// The runtime image sibling (item 30b): `<asset>.tfs` from the
     /// manifest's additive `image` key or the SHA256SUMS line.
     pub image: Option<ImageRef>,
@@ -91,23 +108,27 @@ pub struct IndexEntry {
     pub dll: Option<DllRef>,
 }
 
-/// A resolved runtime image reference (filename + expected sha256).
+/// A resolved runtime image reference (filename + expected sha256 +
+/// the declared signature block when the manifest carries one).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImageRef {
     pub filename: String,
     pub sha256: String,
+    pub signature: Option<EntrySignature>,
 }
 
 /// A resolved ruby DLL reference (tebako-runtime-ruby#40): the release
 /// asset (`filename` — unique per leg), the PE name it installs under
 /// (`install_as` — two same-ABI legs share it; the SHA256SUMS index form
 /// carries no PE name, so a sums-derived ref cannot be installed), and the
-/// expected sha256.
+/// expected sha256 (+ the declared signature block when the manifest
+/// carries one — the sums form carries none).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DllRef {
     pub filename: String,
     pub install_as: Option<String>,
     pub sha256: String,
+    pub signature: Option<EntrySignature>,
 }
 
 /// The release index plus its raw card text — the entries and, when the
@@ -115,6 +136,47 @@ pub struct DllRef {
 /// monolithic manifest.json), the card the spec 18 contract gate reads
 /// (tebako#493).
 type IndexAndCard = (Vec<IndexEntry>, Option<String>);
+
+/// Whether the consumed release-index form was signature-verified at the
+/// fetch boundary (spec 09 §4/§5, roadmap 80 G1): the detached `.asc`
+/// sibling of the shard / manifest.json / SHA256SUMS.txt verified
+/// TRUSTED against the keyring (the signer's resolved PRIMARY keyid
+/// rides along for the audit journal), or no form carried a verifiable
+/// signature.
+#[derive(Debug)]
+enum IndexTrust {
+    Unverified,
+    Verified { signer: String },
+}
+
+impl IndexTrust {
+    fn signer(&self) -> Option<&str> {
+        match self {
+            IndexTrust::Unverified => None,
+            IndexTrust::Verified { signer } => Some(signer),
+        }
+    }
+}
+
+/// The fetched release index: the entries, the raw card when the form
+/// was a JSON card (the contract gate reads it), and the form's trust
+/// outcome (G1).
+struct FetchedIndex {
+    entries: Vec<IndexEntry>,
+    card: Option<String>,
+    trust: IndexTrust,
+}
+
+/// One release-index form's parse outcome: the form cannot serve the
+/// request (fall through to the next form — the pre-G1 IndexUnavailable
+/// semantics), or it carries a TORN `signature` block (spec 13 §2a —
+/// FATAL, exit 65: an index lying about its trust anchors never falls
+/// through to an unsigned form, spec 00 §9).
+#[derive(Debug)]
+enum ParseFail {
+    Unavailable(String),
+    Torn(String),
+}
 
 /// The outcome of resolving a runtime: the interpreter plus, when the
 /// release is image-era, its runtime image reference.
@@ -201,40 +263,65 @@ impl Resolver {
                 image: image_marker(),
             });
         }
-        self.with_entry_lock(
-            &dir,
-            &self.entry_ref(ruby_version, platform, tebako_version),
-            || {
-                if !executable.is_file() {
-                    let entry = self.install(&dir, ruby_version, platform, tebako_version)?;
-                    if let Some(image) = entry.image.clone() {
-                        self.install_image(&dir, &image, tebako_version)?;
-                    }
-                    if let Some(dll) = entry.dll.clone() {
-                        self.install_dll(&dir, &dll, tebako_version)?;
-                    }
-                    return Ok(());
+        let entry_ref = self.entry_ref(ruby_version, platform, tebako_version);
+        self.with_entry_lock(&dir, &entry_ref, || {
+            if !executable.is_file() {
+                let (entry, trust, mut signers) =
+                    self.install(&dir, ruby_version, platform, tebako_version)?;
+                if let Some(signer) = trust.signer() {
+                    signers.push(signer.to_string());
                 }
-                // The exe is cached but its image marker is missing (an
-                // entry installed before the image era, or a partial
-                // wipe): backfill the image from the release index so the
-                // entry is complete again.
-                if image_marker().is_none() {
-                    let entry_ref = self.entry_ref(ruby_version, platform, tebako_version);
-                    self.offline_check(&entry_ref, tebako_version)?;
-                    let (index, card) = self.fetch_index(ruby_version, platform, tebako_version)?;
-                    let entry = self.find_entry(&index, ruby_version, platform, tebako_version)?;
-                    contract_gate(&entry_ref, card.as_deref(), &entry.filename)?;
-                    if let Some(image) = entry.image.clone() {
-                        self.install_image(&dir, &image, tebako_version)?;
-                    }
-                    if let Some(dll) = entry.dll.clone() {
-                        self.install_dll(&dir, &dll, tebako_version)?;
-                    }
+                if let Some(image) = entry.image.clone() {
+                    signers.extend(self.install_image(&dir, &image, tebako_version)?);
                 }
-                Ok(())
-            },
-        )?;
+                if let Some(dll) = entry.dll.clone() {
+                    signers.extend(self.install_dll(&dir, &dll, tebako_version)?);
+                }
+                self.journal_verified(&entry_ref, &signers);
+                return Ok(());
+            }
+            // The exe is cached but its image marker is missing (an
+            // entry installed before the image era, or a partial
+            // wipe): backfill the image from the release index so the
+            // entry is complete again.
+            if image_marker().is_none() {
+                self.offline_check(&entry_ref, tebako_version)?;
+                let fetched = self.fetch_index(ruby_version, platform, tebako_version)?;
+                let entry =
+                    self.find_entry(&fetched.entries, ruby_version, platform, tebako_version)?;
+                contract_gate(&entry_ref, fetched.card.as_deref(), &entry.filename)?;
+                if matches!(fetched.trust, IndexTrust::Unverified) {
+                    // The backfill fetches only the facets — the
+                    // unsigned rule keys on THEIR declared
+                    // signatures (the exe is already cached).
+                    let declared = entry
+                        .image
+                        .as_ref()
+                        .and_then(|i| i.signature.as_ref())
+                        .is_some()
+                        || entry
+                            .dll
+                            .as_ref()
+                            .and_then(|d| d.signature.as_ref())
+                            .is_some();
+                    self.unsigned_gate(&entry_ref, declared, crate::install::require_signed())?;
+                }
+                let mut signers: Vec<String> = fetched
+                    .trust
+                    .signer()
+                    .map(|s| s.to_string())
+                    .into_iter()
+                    .collect();
+                if let Some(image) = entry.image.clone() {
+                    signers.extend(self.install_image(&dir, &image, tebako_version)?);
+                }
+                if let Some(dll) = entry.dll.clone() {
+                    signers.extend(self.install_dll(&dir, &dll, tebako_version)?);
+                }
+                self.journal_verified(&entry_ref, &signers);
+            }
+            Ok(())
+        })?;
         // The install placed the exe under the index spelling and the
         // index rode into the entry — the name flows from it now.
         let executable =
@@ -303,52 +390,61 @@ impl Resolver {
         let marker = fs::read_to_string(dir.join(format!("{filename}.sha256"))).ok()?;
         let sha256 = marker.split_whitespace().next()?.to_string();
         if sha256.len() == 64 {
-            Some(ImageRef { filename, sha256 })
+            // The trusted marker proves the sha256 gate passed at install
+            // — the declared-signature check ran then, never per run.
+            Some(ImageRef {
+                filename,
+                sha256,
+                signature: None,
+            })
         } else {
             None
         }
     }
 
     /// Download + verify + install the runtime image (0444 + trusted
-    /// markers), sharing the bootstrap's cache layout (item 30b). Called
-    /// with the entry lock already held.
+    /// markers), sharing the bootstrap's cache layout (item 30b). A
+    /// declared `signature:` block verifies against the downloaded bytes
+    /// BEFORE the sha256 check (G1, spec 09 §4); the verified signer
+    /// rides back for the audit journal. Called with the entry lock
+    /// already held.
     fn install_image(
         &self,
         dir: &Path,
         image: &ImageRef,
         tebako_version: &str,
-    ) -> Result<(), TebakoError> {
+    ) -> Result<Option<String>, TebakoError> {
         let image_path = dir.join(&image.filename);
         let marker = dir.join(format!("{}.sha256", image.filename));
         if image_path.is_file() && marker.is_file() {
-            return Ok(());
+            return Ok(None);
         }
         let url = self.package_url(&image.filename, tebako_version);
         let tmp_dir = self.cache_root.join(TMP_DIR);
         let tmp = tmp_dir.join(format!("{}.{}.part", image.filename, std::process::id()));
-        match fetch_bytes(&url) {
-            Ok(bytes) => {
-                if let Err(e) = crate::fetch::write_tmp(&tmp, &bytes) {
-                    let _ = fs::remove_file(&tmp);
-                    return Err(packaging_error(122, Some(&format!("{e} writing {url}"))));
-                }
-            }
+        let bytes = match fetch_bytes(&url) {
+            Ok(bytes) => bytes,
             Err(FetchError::IndexUnavailable(_)) => {
-                let _ = fs::remove_file(&tmp);
                 return Err(packaging_error(122, Some(&format!("{url}: not found"))));
             }
             Err(e @ FetchError::Throttled { .. }) => {
-                let _ = fs::remove_file(&tmp);
                 return Err(packaging_error(122, Some(&e.to_string())));
             }
             Err(FetchError::DownloadFailed(msg)) => {
-                let _ = fs::remove_file(&tmp);
                 return Err(packaging_error(122, Some(&msg)));
             }
             Err(e) => {
-                let _ = fs::remove_file(&tmp);
                 return Err(packaging_error(122, Some(&e.to_string())));
             }
+        };
+        let signer = image
+            .signature
+            .as_ref()
+            .map(|sig| self.verify_declared(&bytes, &image.filename, sig, tebako_version))
+            .transpose()?;
+        if let Err(e) = crate::fetch::write_tmp(&tmp, &bytes) {
+            let _ = fs::remove_file(&tmp);
+            return Err(packaging_error(122, Some(&format!("{e} writing {url}"))));
         }
         let actual = sha256_file_hex(&tmp)
             .ok_or_else(|| packaging_error(121, Some(&format!("cannot hash {}", tmp.display()))))?;
@@ -374,7 +470,7 @@ impl Resolver {
             format!("{url}\n"),
         )
         .map_err(err)?;
-        Ok(())
+        Ok(signer)
     }
 
     /// Download + verify + install the windows ruby DLL
@@ -382,18 +478,19 @@ impl Resolver {
     /// the PE name the exe and the extension .so's import (never the asset
     /// name: assets are unique per leg, two same-ABI legs share the PE
     /// name) — read-only with `<install_as>.sha256`/`<install_as>.origin`
-    /// trusted markers, the image's exact discipline. A ref without an
-    /// `install_as` (the SHA256SUMS index form carries no PE name) is not
-    /// installable: the dll facet is manifest-keyed. Called with the entry
-    /// lock already held.
+    /// trusted markers, the image's exact discipline (declared signature
+    /// before the sha256 check; the verified signer rides back for the
+    /// audit journal). A ref without an `install_as` (the SHA256SUMS index
+    /// form carries no PE name) is not installable: the dll facet is
+    /// manifest-keyed. Called with the entry lock already held.
     fn install_dll(
         &self,
         dir: &Path,
         dll: &DllRef,
         tebako_version: &str,
-    ) -> Result<(), TebakoError> {
+    ) -> Result<Option<String>, TebakoError> {
         let Some(install_as) = dll.install_as.as_deref() else {
-            return Ok(());
+            return Ok(None);
         };
         // The PE name writes a file into the cache entry — a separator
         // would escape it; refuse by name, never install.
@@ -409,34 +506,34 @@ impl Resolver {
         let dll_path = dir.join(install_as);
         let marker = dir.join(format!("{install_as}.sha256"));
         if dll_path.is_file() && marker.is_file() {
-            return Ok(());
+            return Ok(None);
         }
         let url = self.package_url(&dll.filename, tebako_version);
         let tmp_dir = self.cache_root.join(TMP_DIR);
         let tmp = tmp_dir.join(format!("{}.{}.part", dll.filename, std::process::id()));
-        match fetch_bytes(&url) {
-            Ok(bytes) => {
-                if let Err(e) = crate::fetch::write_tmp(&tmp, &bytes) {
-                    let _ = fs::remove_file(&tmp);
-                    return Err(packaging_error(122, Some(&format!("{e} writing {url}"))));
-                }
-            }
+        let bytes = match fetch_bytes(&url) {
+            Ok(bytes) => bytes,
             Err(FetchError::IndexUnavailable(_)) => {
-                let _ = fs::remove_file(&tmp);
                 return Err(packaging_error(122, Some(&format!("{url}: not found"))));
             }
             Err(e @ FetchError::Throttled { .. }) => {
-                let _ = fs::remove_file(&tmp);
                 return Err(packaging_error(122, Some(&e.to_string())));
             }
             Err(FetchError::DownloadFailed(msg)) => {
-                let _ = fs::remove_file(&tmp);
                 return Err(packaging_error(122, Some(&msg)));
             }
             Err(e) => {
-                let _ = fs::remove_file(&tmp);
                 return Err(packaging_error(122, Some(&e.to_string())));
             }
+        };
+        let signer = dll
+            .signature
+            .as_ref()
+            .map(|sig| self.verify_declared(&bytes, &dll.filename, sig, tebako_version))
+            .transpose()?;
+        if let Err(e) = crate::fetch::write_tmp(&tmp, &bytes) {
+            let _ = fs::remove_file(&tmp);
+            return Err(packaging_error(122, Some(&format!("{e} writing {url}"))));
         }
         let actual = sha256_file_hex(&tmp)
             .ok_or_else(|| packaging_error(121, Some(&format!("cannot hash {}", tmp.display()))))?;
@@ -458,7 +555,7 @@ impl Resolver {
         fs::rename(&tmp, &dll_path).map_err(err)?;
         fs::write(&marker, format!("{expected}  {install_as}\n")).map_err(err)?;
         fs::write(dir.join(format!("{install_as}.origin")), format!("{url}\n")).map_err(err)?;
-        Ok(())
+        Ok(signer)
     }
 
     /// Extract the runtime package's filesystem layout next to the cached
@@ -619,15 +716,42 @@ impl Resolver {
         ruby_version: &str,
         platform: &str,
         tebako_version: &str,
-    ) -> Result<IndexEntry, TebakoError> {
+    ) -> Result<(IndexEntry, IndexTrust, Vec<String>), TebakoError> {
         let entry_ref = self.entry_ref(ruby_version, platform, tebako_version);
         self.offline_check(&entry_ref, tebako_version)?;
-        let (index, card) = self.fetch_index(ruby_version, platform, tebako_version)?;
-        let entry = self.find_entry(&index, ruby_version, platform, tebako_version)?;
+        let fetched = self.fetch_index(ruby_version, platform, tebako_version)?;
+        let entry = self.find_entry(&fetched.entries, ruby_version, platform, tebako_version)?;
         // spec 18 C2: the release card gates BEFORE the runtime download.
-        contract_gate(&entry_ref, card.as_deref(), &entry.filename)?;
+        contract_gate(&entry_ref, fetched.card.as_deref(), &entry.filename)?;
+        // G1 (spec 09 §4): the unsigned rule decides BEFORE any asset
+        // downloads — a declared signature on any artifact this run
+        // installs counts as signed coverage.
+        if matches!(fetched.trust, IndexTrust::Unverified) {
+            let declared = entry.signature.is_some()
+                || entry
+                    .image
+                    .as_ref()
+                    .and_then(|i| i.signature.as_ref())
+                    .is_some()
+                || entry
+                    .dll
+                    .as_ref()
+                    .and_then(|d| d.signature.as_ref())
+                    .is_some();
+            self.unsigned_gate(&entry_ref, declared, crate::install::require_signed())?;
+        }
         let url = self.package_url(&entry.filename, tebako_version);
-        let tmp = self.download(&url, &entry.filename)?;
+        let (tmp, bytes) = self.download(&url, &entry.filename)?;
+        let mut signers = Vec::new();
+        if let Some(sig) = &entry.signature {
+            match self.verify_declared(&bytes, &entry.filename, sig, tebako_version) {
+                Ok(signer) => signers.push(signer),
+                Err(e) => {
+                    let _ = fs::remove_file(&tmp);
+                    return Err(e);
+                }
+            }
+        }
         self.verify(&tmp, entry)?;
         // The exe installs under the index entry's `filename` verbatim
         // (spec 05 §2 SSOT; tebako#456 — the factory publishes windows
@@ -635,13 +759,14 @@ impl Resolver {
         // entry so every consumer flows the spelling from it.
         let executable = dir.join(&entry.filename);
         self.place(&tmp, &executable, entry, &url)?;
-        if let Some(card) = &card {
+        if let Some(card) = &fetched.card {
             let card_path = dir.join("manifest.json");
             fs::write(&card_path, card).map_err(|e| {
                 crate::error::plain_error(format!("{e} installing {}", card_path.display()))
             })?;
         }
-        Ok(entry.clone())
+        let entry = entry.clone();
+        Ok((entry, fetched.trust, signers))
     }
 
     fn offline(&self) -> bool {
@@ -734,12 +859,19 @@ impl Resolver {
     /// The release index plus, when it parsed from a JSON card (the
     /// per-package shard or the monolithic manifest.json), the raw card
     /// text (the spec 18 contract gate reads it ahead of the download —
-    /// no second fetch of the index).
+    /// no second fetch of the index), plus the form's trust outcome.
     ///
-    /// Preference order (tebako#493; spec 05 §2): the per-package shard
-    /// `<stem>.manifest.json` — the sidecar-era authority, one small
-    /// object carrying exactly this triple's entry — then the derived
-    /// monoliths (`manifest.json`, then `SHA256SUMS.txt`). The fallbacks
+    /// G1 (spec 09 §4/§5) runs as a trust scan FIRST
+    /// ([`Self::fetch_verified_index`]): every index form's detached
+    /// `.asc` sibling is probed in the index's preference order and the
+    /// first form whose signature verifies TRUSTED is the consumed form
+    /// — a verified form beats an unsigned one regardless of preference
+    /// order. Only when NO form carries a verifiable signature does the
+    /// legacy chain run (the per-package shard `<stem>.manifest.json` —
+    /// the sidecar-era authority, one small object carrying exactly this
+    /// triple's entry — then the derived monoliths `manifest.json`, then
+    /// `SHA256SUMS.txt`; tebako#493, spec 05 §2), and its outcome is
+    /// Unverified: the caller applies the unsigned rule. The fallbacks
     /// stay forever: pre-shard releases are immutable and remain
     /// installable (invariant 7).
     fn fetch_index(
@@ -747,10 +879,21 @@ impl Resolver {
         ruby_version: &str,
         platform: &str,
         tebako_version: &str,
-    ) -> Result<IndexAndCard, TebakoError> {
+    ) -> Result<FetchedIndex, TebakoError> {
         let mut tried: Vec<String> = Vec::new();
-        if let Some(pair) = self.fetch_shard(ruby_version, platform, tebako_version, &mut tried)? {
-            return Ok(pair);
+        if let Some(verified) =
+            self.fetch_verified_index(ruby_version, platform, tebako_version, &mut tried)?
+        {
+            return Ok(verified);
+        }
+        if let Some((entries, card)) =
+            self.fetch_shard(ruby_version, platform, tebako_version, &mut tried)?
+        {
+            return Ok(FetchedIndex {
+                entries,
+                card,
+                trust: IndexTrust::Unverified,
+            });
         }
         for name in INDEX_FILES {
             let url = self.index_url(name, tebako_version);
@@ -758,18 +901,14 @@ impl Resolver {
                 Ok(body) => match self.parse_index(name, &body, tebako_version) {
                     Ok(entries) => {
                         let card = (*name == "manifest.json").then_some(body);
-                        return Ok((entries, card));
+                        return Ok(FetchedIndex {
+                            entries,
+                            card,
+                            trust: IndexTrust::Unverified,
+                        });
                     }
-                    Err(FetchError::IndexUnavailable(_)) => tried.push(url),
-                    Err(e @ FetchError::Throttled { .. }) => {
-                        return Err(packaging_error(122, Some(&e.to_string())));
-                    }
-                    Err(FetchError::DownloadFailed(msg)) => {
-                        return Err(packaging_error(122, Some(&msg)));
-                    }
-                    Err(e) => {
-                        return Err(packaging_error(122, Some(&e.to_string())));
-                    }
+                    Err(ParseFail::Unavailable(msg)) => tried.push(format!("{url} ({msg})")),
+                    Err(ParseFail::Torn(msg)) => return Err(TebakoError::new(msg, 65)),
                 },
                 Err(FetchError::IndexUnavailable(_)) => tried.push(url),
                 Err(e @ FetchError::Throttled { .. }) => {
@@ -792,12 +931,133 @@ impl Resolver {
         ))
     }
 
+    /// The G1 trust scan (spec 09 §4/§5): each index form's detached
+    /// `.asc` sibling is probed in the index's preference order (the
+    /// per-package shard, then INDEX_FILES); the FIRST form whose
+    /// signature verifies TRUSTED against the keyring is the consumed
+    /// form — entries AND the contract card come from those verified
+    /// bytes. A present `.asc` that does not verify is a hard 71 (the
+    /// signed bytes are corrupt or tampered); one whose signer is not
+    /// in the keyring is a hard 72 (register the publisher's key
+    /// first); neither falls through to an unsigned form. A form
+    /// without an `.asc` is skipped here and left for the legacy chain.
+    /// `Ok(None)` = nothing verifiable.
+    fn fetch_verified_index(
+        &self,
+        ruby_version: &str,
+        platform: &str,
+        tebako_version: &str,
+        tried: &mut Vec<String>,
+    ) -> Result<Option<FetchedIndex>, TebakoError> {
+        let shard =
+            format!("tebako-runtime-{tebako_version}-{ruby_version}-{platform}.manifest.json");
+        let mut forms: Vec<&str> = vec![shard.as_str()];
+        forms.extend(INDEX_FILES);
+        let mut keyring: Option<Vec<u8>> = None;
+        for name in forms {
+            let asc_url = self.index_url(&format!("{name}.asc"), tebako_version);
+            let asc = match fetch_bytes(&asc_url) {
+                Ok(bytes) => bytes,
+                Err(FetchError::IndexUnavailable(_)) => continue,
+                Err(e @ FetchError::Throttled { .. }) => {
+                    return Err(packaging_error(122, Some(&e.to_string())));
+                }
+                Err(FetchError::DownloadFailed(msg)) => {
+                    return Err(packaging_error(122, Some(&msg)));
+                }
+                Err(e) => return Err(packaging_error(122, Some(&e.to_string()))),
+            };
+            let url = self.index_url(name, tebako_version);
+            let body = match fetch_text(&url) {
+                Ok(body) => body,
+                Err(FetchError::IndexUnavailable(_)) => {
+                    tried.push(url);
+                    continue;
+                }
+                Err(e @ FetchError::Throttled { .. }) => {
+                    return Err(packaging_error(122, Some(&e.to_string())));
+                }
+                Err(FetchError::DownloadFailed(msg)) => {
+                    return Err(packaging_error(122, Some(&msg)));
+                }
+                Err(e) => return Err(packaging_error(122, Some(&e.to_string()))),
+            };
+            if keyring.is_none() {
+                keyring = Some(self.keyring()?);
+            }
+            let keyring = keyring.as_deref().expect("built above");
+            let signer = match tebako_signer::verify_detached_full(keyring, body.as_bytes(), &asc) {
+                Ok(tebako_signer::VerifyOutcome::Trusted(signer)) => {
+                    // The signature may issue from a signing subkey —
+                    // the identity that journals is the resolved
+                    // PRIMARY keyid (spec 09 §9).
+                    let signer = signer.to_ascii_lowercase();
+                    tebako_signer::primary_keyid_of(keyring, &signer)
+                        .map_err(|e| TebakoError::new(format!("{name}.asc: {e}"), 71))?
+                        .unwrap_or(signer)
+                }
+                Ok(tebako_signer::VerifyOutcome::Untrusted(keyid)) => {
+                    return Err(TebakoError::new(
+                        format!(
+                            "the {RELEASE_NAME} release index {name} (v{tebako_version}) is signed by {keyid}, which is not in the trusted keyring — register the publisher's key (~/.tebako/keyring/trusted.pgp), then retry; nothing was cached"
+                        ),
+                        72,
+                    ));
+                }
+                Ok(tebako_signer::VerifyOutcome::Invalid(keyid)) => {
+                    return Err(TebakoError::new(
+                        format!(
+                            "the {RELEASE_NAME} release index {name} (v{tebako_version}) carries a signature that does not verify (signer {}) — the index or its signature is corrupt; nothing was cached",
+                            keyid.unwrap_or_else(|| "unknown".to_string())
+                        ),
+                        71,
+                    ));
+                }
+                Err(e) => {
+                    return Err(TebakoError::new(
+                        format!("cannot verify the release index signature {name}.asc: {e}"),
+                        71,
+                    ));
+                }
+            };
+            let parsed: Result<IndexAndCard, ParseFail> = if name == shard.as_str() {
+                self.parse_shard(&body, ruby_version, platform, tebako_version)
+                    .map(|entry| (vec![entry], Some(format!("[{body}]"))))
+            } else {
+                self.parse_index(name, &body, tebako_version)
+                    .map(|entries| (entries, (name == "manifest.json").then_some(body)))
+            };
+            match parsed {
+                Ok((entries, card)) => {
+                    crate::install::journal(
+                        &self.cache_root,
+                        &format!("event=runtime-index-verified form={name} signer={signer}"),
+                    );
+                    return Ok(Some(FetchedIndex {
+                        entries,
+                        card,
+                        trust: IndexTrust::Verified { signer },
+                    }));
+                }
+                // A verified form that cannot serve this request (the
+                // shard declares another triple) falls through like any
+                // unusable form — a later form may still verify.
+                Err(ParseFail::Unavailable(msg)) => {
+                    tried.push(format!("{url} ({msg})"));
+                    continue;
+                }
+                Err(ParseFail::Torn(msg)) => return Err(TebakoError::new(msg, 65)),
+            }
+        }
+        Ok(None)
+    }
+
     fn parse_index(
         &self,
         name: &str,
         body: &str,
         tebako_version: &str,
-    ) -> Result<Vec<IndexEntry>, FetchError> {
+    ) -> Result<Vec<IndexEntry>, ParseFail> {
         if name == "manifest.json" {
             self.parse_manifest(body, tebako_version)
         } else {
@@ -811,25 +1071,26 @@ impl Resolver {
         &self,
         body: &str,
         tebako_version: &str,
-    ) -> Result<Vec<IndexEntry>, FetchError> {
-        let data = json_parse(body).map_err(|_| {
-            FetchError::IndexUnavailable("manifest.json is not valid JSON".to_string())
-        })?;
+    ) -> Result<Vec<IndexEntry>, ParseFail> {
+        let data = json_parse(body)
+            .map_err(|_| ParseFail::Unavailable("manifest.json is not valid JSON".to_string()))?;
         let JsonValue::Array(items) = data else {
-            return Err(FetchError::IndexUnavailable(
+            return Err(ParseFail::Unavailable(
                 "manifest.json is not an array".to_string(),
             ));
         };
-        Ok(items
-            .iter()
-            .filter(|e| {
-                e.find("tebako_version")
-                    .and_then(|v| v.as_string())
-                    .as_deref()
-                    == Some(tebako_version)
-            })
-            .filter_map(entry_from_json)
-            .collect())
+        let mut out = Vec::new();
+        for e in items.iter().filter(|e| {
+            e.find("tebako_version")
+                .and_then(|v| v.as_string())
+                .as_deref()
+                == Some(tebako_version)
+        }) {
+            if let Some(entry) = entry_from_json(e)? {
+                out.push(entry);
+            }
+        }
+        Ok(out)
     }
 
     /// Preference 1 of the sidecar era (tebako#493): the per-package
@@ -874,15 +1135,11 @@ impl Resolver {
                 let card = format!("[{body}]");
                 Ok(Some((vec![entry], Some(card))))
             }
-            Err(FetchError::IndexUnavailable(_)) => {
-                tried.push(url);
+            Err(ParseFail::Unavailable(msg)) => {
+                tried.push(format!("{url} ({msg})"));
                 Ok(None)
             }
-            Err(e @ FetchError::Throttled { .. }) => {
-                Err(packaging_error(122, Some(&e.to_string())))
-            }
-            Err(FetchError::DownloadFailed(msg)) => Err(packaging_error(122, Some(&msg))),
-            Err(e) => Err(packaging_error(122, Some(&e.to_string()))),
+            Err(ParseFail::Torn(msg)) => Err(TebakoError::new(msg, 65)),
         }
     }
 
@@ -898,12 +1155,12 @@ impl Resolver {
         ruby_version: &str,
         platform: &str,
         tebako_version: &str,
-    ) -> Result<IndexEntry, FetchError> {
+    ) -> Result<IndexEntry, ParseFail> {
         let data = json_parse(body).map_err(|_| {
-            FetchError::IndexUnavailable("the package shard is not valid JSON".to_string())
+            ParseFail::Unavailable("the package shard is not valid JSON".to_string())
         })?;
         if !matches!(data, JsonValue::Object(_)) {
-            return Err(FetchError::IndexUnavailable(
+            return Err(ParseFail::Unavailable(
                 "the package shard is not an object".to_string(),
             ));
         }
@@ -912,7 +1169,7 @@ impl Resolver {
             || declares("ruby_version").as_deref() != Some(ruby_version)
             || declares("platform").as_deref() != Some(platform)
         {
-            return Err(FetchError::IndexUnavailable(format!(
+            return Err(ParseFail::Unavailable(format!(
                 "the package shard declares {}/{}/{} — requested {}/{}/{}",
                 declares("tebako_version").as_deref().unwrap_or("?"),
                 declares("ruby_version").as_deref().unwrap_or("?"),
@@ -922,8 +1179,8 @@ impl Resolver {
                 platform
             )));
         }
-        entry_from_json(&data).ok_or_else(|| {
-            FetchError::IndexUnavailable("the package shard carries no filename/sha256".to_string())
+        entry_from_json(&data)?.ok_or_else(|| {
+            ParseFail::Unavailable("the package shard carries no filename/sha256".to_string())
         })
     }
 
@@ -973,6 +1230,7 @@ impl Resolver {
                 platform: Some(platform),
                 filename: file.to_string(),
                 sha256: sha256.to_ascii_lowercase(),
+                signature: None,
                 image: None,
                 dll: None,
             });
@@ -988,6 +1246,7 @@ impl Resolver {
                 entry.image = Some(ImageRef {
                     filename: filename.to_string(),
                     sha256: sha256.to_ascii_lowercase(),
+                    signature: None,
                 });
             }
         }
@@ -1003,13 +1262,17 @@ impl Resolver {
                     filename: filename.to_string(),
                     install_as: None,
                     sha256: sha256.to_ascii_lowercase(),
+                    signature: None,
                 });
             }
         }
         out
     }
 
-    fn download(&self, url: &str, filename: &str) -> Result<PathBuf, TebakoError> {
+    /// Fetch `url` into the store's tmp/ dir; returns the tmp path AND
+    /// the bytes (a declared `signature:` block verifies against the
+    /// bytes in memory — before they are ever re-read from disk).
+    fn download(&self, url: &str, filename: &str) -> Result<(PathBuf, Vec<u8>), TebakoError> {
         let tmp_dir = self.cache_root.join(TMP_DIR);
         fs::create_dir_all(&tmp_dir).map_err(|e| {
             crate::error::plain_error(format!("{e} creating {}", tmp_dir.display()))
@@ -1021,7 +1284,7 @@ impl Resolver {
                     let _ = fs::remove_file(&tmp);
                     return Err(packaging_error(122, Some(&format!("{e} writing {url}"))));
                 }
-                Ok(tmp)
+                Ok((tmp, bytes))
             }
             Err(FetchError::IndexUnavailable(_)) => {
                 let _ = fs::remove_file(&tmp);
@@ -1040,6 +1303,147 @@ impl Resolver {
                 Err(packaging_error(122, Some(&e.to_string())))
             }
         }
+    }
+
+    // ---- trust (spec 09 §4/§5, roadmap 80 G1) ------------------------
+
+    /// The spec 09 §9 zero-interaction keyring: the user's trusted
+    /// keyring plus the embedded tamatebako root (and the
+    /// TEBAKO_TRUSTED_ROOT dev override). Built lazily: an unsigned
+    /// release never touches it.
+    fn keyring(&self) -> Result<Vec<u8>, TebakoError> {
+        tebako_signer::verification_keyring(&self.cache_root).map_err(|e| {
+            TebakoError::new(format!("cannot build the verification keyring: {e}"), 74)
+        })
+    }
+
+    /// Verify one artifact's declared `signature:` block (spec 13 §2a)
+    /// against its downloaded bytes BEFORE the sha256 check: the `.asc`
+    /// fetches from the same release, the signer must be in the keyring
+    /// AND be the pinned key (a signing subkey pins by its resolved
+    /// PRIMARY keyid, spec 09 §9). Returns the primary keyid that
+    /// verified (the audit journal's signer identity).
+    fn verify_declared(
+        &self,
+        bytes: &[u8],
+        asset: &str,
+        sig: &EntrySignature,
+        tebako_version: &str,
+    ) -> Result<String, TebakoError> {
+        // The asc names a sibling asset of the same release — a
+        // separator would escape it; refuse by name, never fetch.
+        if sig.asc.contains('/') || sig.asc.contains('\\') {
+            return Err(TebakoError::new(
+                format!(
+                    "{asset} declares a signature asset (\"{}\") that is not a bare file name",
+                    sig.asc
+                ),
+                65,
+            ));
+        }
+        let asc_url = self.package_url(&sig.asc, tebako_version);
+        let asc = fetch_bytes(&asc_url).map_err(|e| {
+            TebakoError::new(
+                format!("{asset} declares a signature but {asc_url} did not fetch: {e}"),
+                71,
+            )
+        })?;
+        let keyring = self.keyring()?;
+        let issuer = match tebako_signer::verify_detached_full(&keyring, bytes, &asc) {
+            Ok(tebako_signer::VerifyOutcome::Trusted(issuer)) => issuer.to_ascii_lowercase(),
+            Ok(tebako_signer::VerifyOutcome::Untrusted(keyid)) => {
+                return Err(TebakoError::new(
+                    format!(
+                        "{asset} is signed by {keyid}, which is not in the trusted keyring — register the publisher's key (~/.tebako/keyring/trusted.pgp), then retry; nothing was cached"
+                    ),
+                    72,
+                ));
+            }
+            Ok(tebako_signer::VerifyOutcome::Invalid(keyid)) => {
+                return Err(TebakoError::new(
+                    format!(
+                        "{asset} carries a signature that does not verify (signer {}) — the download or its signature is corrupt; nothing was cached",
+                        keyid.unwrap_or_else(|| "unknown".to_string())
+                    ),
+                    71,
+                ));
+            }
+            Err(e) => {
+                return Err(TebakoError::new(
+                    format!("cannot verify the declared signature of {asset}: {e}"),
+                    71,
+                ));
+            }
+        };
+        // The signature may issue from a signing subkey — the identity
+        // the pin names is the resolved PRIMARY keyid (spec 09 §9).
+        let primary = tebako_signer::primary_keyid_of(&keyring, &issuer)
+            .map_err(|e| TebakoError::new(format!("{asset}: {e}"), 71))?;
+        let pin = sig.keyid.to_ascii_lowercase();
+        if issuer != pin && primary.as_deref() != Some(pin.as_str()) {
+            return Err(TebakoError::new(
+                format!(
+                    "{asset} declares signer {pin} but was signed by {issuer} — the signer key changed; nothing was cached"
+                ),
+                72,
+            ));
+        }
+        Ok(primary.unwrap_or(issuer))
+    }
+
+    /// The spec 09 §5 unsigned rule, applied when the release index
+    /// could not be verified and BEFORE any asset downloads: a declared
+    /// signature on any artifact this run installs counts as signed
+    /// coverage; TEBAKO_REQUIRE_SIGNED=1 refuses the unsigned fetch
+    /// (exit 71, nothing cached); otherwise the fetch proceeds LOUDLY
+    /// (stderr + the audit journal).
+    fn unsigned_gate(
+        &self,
+        entry_ref: &str,
+        declared: bool,
+        require_signed: bool,
+    ) -> Result<(), TebakoError> {
+        if declared {
+            return Ok(());
+        }
+        if require_signed {
+            return Err(TebakoError::new(
+                format!(
+                    "{entry_ref} is unsigned — the release index carries no verifiable signature and no artifact declares one — and TEBAKO_REQUIRE_SIGNED=1 is set — refusing to fetch; nothing was cached"
+                ),
+                71,
+            ));
+        }
+        eprintln!(
+            "tebako: warning: {entry_ref} is unsigned (the release carries no verifiable signature) — installing with sha256 verification only; set TEBAKO_REQUIRE_SIGNED=1 to refuse unsigned runtimes"
+        );
+        crate::install::journal(
+            &self.cache_root,
+            &format!(
+                "event=unsigned-runtime-fetch runtime_ref={entry_ref} mirror={}",
+                self.mirror
+            ),
+        );
+        Ok(())
+    }
+
+    /// Journal the verified signers of one runtime fetch (the index
+    /// form's plus every declared artifact's), one deduped line.
+    fn journal_verified(&self, entry_ref: &str, signers: &[String]) {
+        if signers.is_empty() {
+            return;
+        }
+        let mut signers = signers.to_vec();
+        signers.sort();
+        signers.dedup();
+        crate::install::journal(
+            &self.cache_root,
+            &format!(
+                "event=runtime-fetch-verified runtime_ref={entry_ref} mirror={} signer={}",
+                self.mirror,
+                signers.join(",")
+            ),
+        );
     }
 
     // ---- locking ---------------------------------------------------------
@@ -1081,39 +1485,66 @@ impl Resolver {
 /// identity (`filename`, `sha256` — both mandatory, anything less is no
 /// entry) plus the additive facets (the env image; the windows ruby DLL,
 /// tebako-runtime-ruby#40 — absent on every POSIX entry, ignored by
-/// consumers that predate it). Shared by the monolithic manifest's array
-/// items and the per-package shard (tebako#493).
-fn entry_from_json(e: &JsonValue) -> Option<IndexEntry> {
-    let filename = e.find("filename").and_then(|v| v.as_string())?;
-    let sha256 = e
-        .find("sha256")
-        .and_then(|v| v.as_string())?
-        .to_ascii_lowercase();
-    Some(IndexEntry {
+/// consumers that predate it) and the declared signature blocks (spec 13
+/// §2a — a PRESENT but torn block is fatal, never a silent downgrade to
+/// unsigned). Shared by the monolithic manifest's array items and the
+/// per-package shard (tebako#493).
+fn entry_from_json(e: &JsonValue) -> Result<Option<IndexEntry>, ParseFail> {
+    let Some(filename) = e.find("filename").and_then(|v| v.as_string()) else {
+        return Ok(None);
+    };
+    let Some(sha256) = e.find("sha256").and_then(|v| v.as_string()) else {
+        return Ok(None);
+    };
+    let image = match e.find("image") {
+        Some(img) => {
+            let filename = img.find("filename").and_then(|v| v.as_string());
+            let sha256 = img.find("sha256").and_then(|v| v.as_string());
+            match (filename, sha256) {
+                (Some(filename), Some(sha256)) => Some(ImageRef {
+                    filename,
+                    sha256: sha256.to_ascii_lowercase(),
+                    signature: declared_signature(e, Some("image"))?,
+                }),
+                _ => None,
+            }
+        }
+        None => None,
+    };
+    let dll = match e.find("dll") {
+        Some(d) => {
+            let filename = d.find("filename").and_then(|v| v.as_string());
+            let sha256 = d.find("sha256").and_then(|v| v.as_string());
+            match (filename, sha256) {
+                (Some(filename), Some(sha256)) => Some(DllRef {
+                    filename,
+                    install_as: d.find("install_as").and_then(|v| v.as_string()),
+                    sha256: sha256.to_ascii_lowercase(),
+                    signature: declared_signature(e, Some("dll"))?,
+                }),
+                _ => None,
+            }
+        }
+        None => None,
+    };
+    Ok(Some(IndexEntry {
         ruby_version: e.find("ruby_version").and_then(|v| v.as_string()),
         platform: e.find("platform").and_then(|v| v.as_string()),
         filename,
-        sha256,
-        image: e.find("image").and_then(|img| {
-            Some(ImageRef {
-                filename: img.find("filename").and_then(|v| v.as_string())?,
-                sha256: img
-                    .find("sha256")
-                    .and_then(|v| v.as_string())?
-                    .to_ascii_lowercase(),
-            })
-        }),
-        dll: e.find("dll").and_then(|d| {
-            Some(DllRef {
-                filename: d.find("filename").and_then(|v| v.as_string())?,
-                install_as: d.find("install_as").and_then(|v| v.as_string()),
-                sha256: d
-                    .find("sha256")
-                    .and_then(|v| v.as_string())?
-                    .to_ascii_lowercase(),
-            })
-        }),
-    })
+        sha256: sha256.to_ascii_lowercase(),
+        signature: declared_signature(e, None)?,
+        image,
+        dll,
+    }))
+}
+
+/// The declared signature block of one entry facet (spec 13 §2a) — the
+/// tpkg helper's torn-block error is fatal here (`ParseFail::Torn`).
+fn declared_signature(
+    entry: &JsonValue,
+    facet: Option<&str>,
+) -> Result<Option<EntrySignature>, ParseFail> {
+    tpkg::runtime_store::entry_signature(entry, facet).map_err(ParseFail::Torn)
 }
 
 // ---------------------------------------------------------------------
@@ -1878,7 +2309,7 @@ mod tests {
     fn manifest_runtime_rejects_object() {
         let r = Resolver::new();
         let err = r.parse_manifest("{\"assets\":[]}", "0.15.9").unwrap_err();
-        assert!(matches!(err, FetchError::IndexUnavailable(_)));
+        assert!(matches!(err, ParseFail::Unavailable(_)));
     }
 
     #[test]
@@ -2251,17 +2682,17 @@ mod tests {
         let err = r
             .parse_shard("[{}]", "3.3.12", "windows-ucrt64", "0.16.17")
             .unwrap_err();
-        assert!(matches!(err, FetchError::IndexUnavailable(_)));
+        assert!(matches!(err, ParseFail::Unavailable(_)));
         // a triple mismatch cannot serve the request
         let err = r
             .parse_shard(body, "3.4.10", "windows-ucrt64", "0.16.17")
             .unwrap_err();
-        assert!(matches!(err, FetchError::IndexUnavailable(_)));
+        assert!(matches!(err, ParseFail::Unavailable(_)));
         // unparseable
         let err = r
             .parse_shard("{", "3.3.12", "windows-ucrt64", "0.16.17")
             .unwrap_err();
-        assert!(matches!(err, FetchError::IndexUnavailable(_)));
+        assert!(matches!(err, ParseFail::Unavailable(_)));
     }
 
     #[test]
@@ -2686,6 +3117,347 @@ mod tests {
         let r = boot_resolver(&cache, &mirror, false);
         let path = r.resolve("macos-arm64").unwrap();
         assert!(path.is_file());
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    // ---- roadmap 80 G1: the signed runtime fetch (spec 09 §4/§5) -------
+
+    const G1_TAG: &str = "0.16.30";
+    const G1_RUBY: &str = "3.3.12";
+    const G1_PLATFORM: &str = "macos-arm64";
+
+    fn g1_exe() -> String {
+        format!("tebako-runtime-{G1_TAG}-{G1_RUBY}-{G1_PLATFORM}")
+    }
+
+    fn g1_image() -> String {
+        format!("{}.tfs", g1_exe())
+    }
+
+    fn g1_dll() -> String {
+        format!("{}.dll", g1_exe())
+    }
+
+    fn g1_entry_dir(cache: &Path) -> PathBuf {
+        cache
+            .join("runtimes")
+            .join(format!("ruby-{G1_RUBY}-{G1_TAG}-{G1_PLATFORM}"))
+    }
+
+    fn g1_journal(cache: &Path) -> String {
+        fs::read_to_string(cache.join("journal.log")).unwrap_or_default()
+    }
+
+    /// A scratch (cache root, release mirror, press key) triple: the
+    /// exe/image/dll assets at v0.16.30 and a fresh press-local key that
+    /// is NOT yet in the cache's trusted keyring — each test composes
+    /// its own trust shape.
+    fn g1_mirror(tag: &str) -> (PathBuf, PathBuf, tebako_signer::PressKey) {
+        let dir =
+            std::env::temp_dir().join(format!("tebako-resolve-g1-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let cache = dir.join("home");
+        let release = dir.join("mirror").join(format!("v{G1_TAG}"));
+        fs::create_dir_all(&release).unwrap();
+        let key = tebako_signer::press_local_key(&dir.join("press")).unwrap();
+        fs::write(release.join(g1_exe()), b"fake runtime exe\n").unwrap();
+        fs::write(release.join(g1_image()), b"fake env image\n").unwrap();
+        fs::write(release.join(g1_dll()), b"fake ruby dll\n").unwrap();
+        (cache, dir.join("mirror"), key)
+    }
+
+    /// Write one detached `.asc` sibling for a release asset, signed by
+    /// `key` over the asset's CURRENT bytes.
+    fn g1_sign_file(release: &Path, key: &tebako_signer::PressKey, name: &str) {
+        let bytes = fs::read(release.join(name)).unwrap();
+        let asc = tebako_signer::sign_detached(&bytes, &key.secret_key, &key.fingerprint).unwrap();
+        fs::write(release.join(format!("{name}.asc")), asc).unwrap();
+    }
+
+    /// Write the release's era-2 manifest.json (the contract set +
+    /// exe/image/dll facets). `signed` attaches the declared `signature:`
+    /// blocks (spec 13 §2a — entry + image + dll) and writes every
+    /// `<asset>.asc` sibling, all by `key`.
+    fn g1_write_manifest(release: &Path, key: &tebako_signer::PressKey, signed: bool) {
+        let keyid = hex_lower(&key.keyid);
+        let block = |name: &str| -> String {
+            if !signed {
+                return String::new();
+            }
+            g1_sign_file(release, key, name);
+            format!(r#","signature":{{"keyid":"{keyid}","asc":"{name}.asc"}}"#)
+        };
+        let manifest = format!(
+            r#"[{{"tebako_version":"{G1_TAG}","contract_era":2,"contract_version":2,"mount_root":"/__tfs__","ruby_version":"{G1_RUBY}","platform":"{G1_PLATFORM}","filename":"{}","sha256":"{}"{},"image":{{"filename":"{}","sha256":"{}"{}}},"dll":{{"filename":"{}","install_as":"libruby-x.dll","sha256":"{}"{}}}}}]"#,
+            g1_exe(),
+            sha256_file_hex(&release.join(g1_exe())).unwrap(),
+            block(&g1_exe()),
+            g1_image(),
+            sha256_file_hex(&release.join(g1_image())).unwrap(),
+            block(&g1_image()),
+            g1_dll(),
+            sha256_file_hex(&release.join(g1_dll())).unwrap(),
+            block(&g1_dll()),
+        );
+        fs::write(release.join("manifest.json"), manifest).unwrap();
+    }
+
+    #[test]
+    fn g1_signed_release_verifies_and_journals_every_signer() {
+        let (cache, mirror, key) = g1_mirror("happy");
+        let release = mirror.join(format!("v{G1_TAG}"));
+        g1_write_manifest(&release, &key, true);
+        g1_sign_file(&release, &key, "manifest.json");
+        tebako_signer::register_trusted(&cache, &key.public_key).unwrap();
+        let r = dll_resolver(&cache, &mirror);
+        let resolved = r.resolve_runtime(G1_RUBY, G1_PLATFORM, G1_TAG).unwrap();
+        assert!(resolved.executable.is_file());
+        let dir = g1_entry_dir(&cache);
+        assert!(dir.join(g1_image()).is_file());
+        assert!(dir.join("libruby-x.dll").is_file());
+        let journal = g1_journal(&cache);
+        let keyid = hex_lower(&key.keyid);
+        assert!(
+            journal.contains(&format!(
+                "event=runtime-index-verified form=manifest.json signer={keyid}"
+            )),
+            "{journal}"
+        );
+        assert!(
+            journal.contains(&format!(
+                "event=runtime-fetch-verified runtime_ref=ruby@{G1_RUBY} (tebako {G1_TAG}, {G1_PLATFORM})"
+            )),
+            "{journal}"
+        );
+        assert!(journal.contains(&format!("signer={keyid}")), "{journal}");
+        assert!(!journal.contains("unsigned-runtime-fetch"), "{journal}");
+        // a cache hit re-resolves without the mirror (a run is a run)
+        fs::remove_dir_all(&mirror).unwrap();
+        r.resolve_runtime(G1_RUBY, G1_PLATFORM, G1_TAG).unwrap();
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn g1_untrusted_index_signer_is_a_named_72() {
+        let (cache, mirror, key) = g1_mirror("untrusted");
+        let release = mirror.join(format!("v{G1_TAG}"));
+        g1_write_manifest(&release, &key, true);
+        g1_sign_file(&release, &key, "manifest.json");
+        // the signing key is NOT registered — nothing trusts it
+        let r = dll_resolver(&cache, &mirror);
+        let err = r.resolve_runtime(G1_RUBY, G1_PLATFORM, G1_TAG).unwrap_err();
+        assert_eq!(err.code, 72);
+        assert!(
+            err.message.contains("not in the trusted keyring"),
+            "{}",
+            err.message
+        );
+        assert!(
+            err.message.contains(&hex_lower(&key.keyid)),
+            "the untrusted signer is named: {}",
+            err.message
+        );
+        assert!(!g1_entry_dir(&cache).join(g1_exe()).exists());
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn g1_tampered_exe_fails_the_signature_before_the_sha() {
+        let (cache, mirror, key) = g1_mirror("tampered-exe");
+        let release = mirror.join(format!("v{G1_TAG}"));
+        g1_write_manifest(&release, &key, true);
+        g1_sign_file(&release, &key, "manifest.json");
+        tebako_signer::register_trusted(&cache, &key.public_key).unwrap();
+        // tamper the exe AFTER its .asc was written — the manifest's
+        // declared sha now also mismatches, but the signature check runs
+        // FIRST (spec 09 §4)
+        fs::write(release.join(g1_exe()), b"evil exe\n").unwrap();
+        let r = dll_resolver(&cache, &mirror);
+        let err = r.resolve_runtime(G1_RUBY, G1_PLATFORM, G1_TAG).unwrap_err();
+        assert_eq!(err.code, 71);
+        assert!(err.message.contains("does not verify"), "{}", err.message);
+        assert!(!g1_entry_dir(&cache).join(g1_exe()).exists());
+        let journal = g1_journal(&cache);
+        assert!(!journal.contains("runtime-fetch-verified"), "{journal}");
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn g1_a_declared_signature_whose_asc_is_missing_is_a_named_71() {
+        let (cache, mirror, key) = g1_mirror("missing-asc");
+        let release = mirror.join(format!("v{G1_TAG}"));
+        g1_write_manifest(&release, &key, true);
+        g1_sign_file(&release, &key, "manifest.json");
+        tebako_signer::register_trusted(&cache, &key.public_key).unwrap();
+        // the exe's declared .asc vanishes from the release
+        fs::remove_file(release.join(format!("{}.asc", g1_exe()))).unwrap();
+        let r = dll_resolver(&cache, &mirror);
+        let err = r.resolve_runtime(G1_RUBY, G1_PLATFORM, G1_TAG).unwrap_err();
+        assert_eq!(err.code, 71);
+        assert!(err.message.contains("did not fetch"), "{}", err.message);
+        assert!(
+            err.message.contains(&format!("{}.asc", g1_exe())),
+            "the missing asset is named: {}",
+            err.message
+        );
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn g1_a_changed_signer_key_is_a_named_72() {
+        let (cache, mirror, key) = g1_mirror("key-pin");
+        let release = mirror.join(format!("v{G1_TAG}"));
+        g1_write_manifest(&release, &key, true);
+        tebako_signer::register_trusted(&cache, &key.public_key).unwrap();
+        // the manifest's pin no longer names the signing key (the index
+        // itself is honestly re-signed — the LIE is inside the card)
+        let manifest_path = release.join("manifest.json");
+        let pinned = fs::read_to_string(&manifest_path)
+            .unwrap()
+            .replace(&hex_lower(&key.keyid), &"0".repeat(16));
+        fs::write(&manifest_path, pinned).unwrap();
+        g1_sign_file(&release, &key, "manifest.json");
+        let r = dll_resolver(&cache, &mirror);
+        let err = r.resolve_runtime(G1_RUBY, G1_PLATFORM, G1_TAG).unwrap_err();
+        assert_eq!(err.code, 72);
+        assert!(
+            err.message.contains("the signer key changed"),
+            "{}",
+            err.message
+        );
+        assert!(!g1_entry_dir(&cache).join(g1_exe()).exists());
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn g1_an_unsigned_release_installs_loudly() {
+        let (cache, mirror, _key) = g1_mirror("unsigned");
+        let release = mirror.join(format!("v{G1_TAG}"));
+        // no signature blocks, no .asc siblings — the pre-signing shape
+        g1_write_manifest(&release, &_key, false);
+        let r = dll_resolver(&cache, &mirror);
+        let resolved = r.resolve_runtime(G1_RUBY, G1_PLATFORM, G1_TAG).unwrap();
+        assert!(resolved.executable.is_file());
+        let journal = g1_journal(&cache);
+        assert!(
+            journal.contains(&format!(
+                "event=unsigned-runtime-fetch runtime_ref=ruby@{G1_RUBY} (tebako {G1_TAG}, {G1_PLATFORM})"
+            )),
+            "{journal}"
+        );
+        assert!(!journal.contains("runtime-fetch-verified"), "{journal}");
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn g1_unsigned_gate_matrix() {
+        let dir =
+            std::env::temp_dir().join(format!("tebako-resolve-g1-gate-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let r = Resolver {
+            cache_root: dir.join("home"),
+            mirror: "file:///nowhere".to_string(),
+            lock_timeout: LOCK_TIMEOUT,
+        };
+        // a declared signature counts as signed coverage, always
+        r.unsigned_gate("ruby@x", true, true).unwrap();
+        r.unsigned_gate("ruby@x", true, false).unwrap();
+        // unsigned + not required: a loud pass (stderr + the journal)
+        r.unsigned_gate("ruby@x", false, false).unwrap();
+        let journal = g1_journal(&r.cache_root);
+        assert!(
+            journal.contains("event=unsigned-runtime-fetch runtime_ref=ruby@x"),
+            "{journal}"
+        );
+        // unsigned + TEBAKO_REQUIRE_SIGNED: refused before any download
+        let err = r.unsigned_gate("ruby@x", false, true).unwrap_err();
+        assert_eq!(err.code, 71);
+        assert!(
+            err.message.contains("TEBAKO_REQUIRE_SIGNED=1"),
+            "{}",
+            err.message
+        );
+        assert!(
+            err.message.contains("nothing was cached"),
+            "{}",
+            err.message
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn g1_a_tampered_index_is_a_named_71() {
+        let (cache, mirror, key) = g1_mirror("tampered-index");
+        let release = mirror.join(format!("v{G1_TAG}"));
+        g1_write_manifest(&release, &key, true);
+        g1_sign_file(&release, &key, "manifest.json");
+        tebako_signer::register_trusted(&cache, &key.public_key).unwrap();
+        // tamper the index AFTER its .asc was written
+        let manifest_path = release.join("manifest.json");
+        let body = fs::read_to_string(&manifest_path)
+            .unwrap()
+            .replace("3.3.12", "3.3.99");
+        fs::write(&manifest_path, body).unwrap();
+        let r = dll_resolver(&cache, &mirror);
+        let err = r.resolve_runtime(G1_RUBY, G1_PLATFORM, G1_TAG).unwrap_err();
+        assert_eq!(err.code, 71);
+        assert!(err.message.contains("does not verify"), "{}", err.message);
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn g1_a_verified_form_beats_an_unsigned_one_regardless_of_preference() {
+        let (cache, mirror, key) = g1_mirror("verified-wins");
+        let release = mirror.join(format!("v{G1_TAG}"));
+        g1_write_manifest(&release, &key, true);
+        g1_sign_file(&release, &key, "manifest.json");
+        tebako_signer::register_trusted(&cache, &key.public_key).unwrap();
+        // the shard (the preference-1 form) is UNSIGNED and POISONED —
+        // its image sha would fail the install with 121 if it were read
+        let shard = format!(
+            r#"{{"tebako_version":"{G1_TAG}","contract_era":2,"contract_version":2,"mount_root":"/__tfs__","ruby_version":"{G1_RUBY}","platform":"{G1_PLATFORM}","filename":"{}","sha256":"{}","image":{{"filename":"{}","sha256":"{}"}}}}"#,
+            g1_exe(),
+            sha256_file_hex(&release.join(g1_exe())).unwrap(),
+            g1_image(),
+            "f".repeat(64),
+        );
+        fs::write(release.join(format!("{}.manifest.json", g1_exe())), shard).unwrap();
+        let r = dll_resolver(&cache, &mirror);
+        r.resolve_runtime(G1_RUBY, G1_PLATFORM, G1_TAG).unwrap();
+        let journal = g1_journal(&cache);
+        assert!(
+            journal.contains("event=runtime-index-verified form=manifest.json"),
+            "{journal}"
+        );
+        let _ = fs::remove_dir_all(cache.parent().unwrap());
+    }
+
+    #[test]
+    fn g1_a_signed_sums_only_release_still_fails_the_contract_gate() {
+        let (cache, mirror, key) = g1_mirror("sums-only");
+        let release = mirror.join(format!("v{G1_TAG}"));
+        // no manifest.json, no shard — SHA256SUMS.txt carries the entry,
+        // and it IS signed (the verified index form)
+        let sums = format!(
+            "{}  {}\n{}  {}\n",
+            sha256_file_hex(&release.join(g1_exe())).unwrap(),
+            g1_exe(),
+            sha256_file_hex(&release.join(g1_image())).unwrap(),
+            g1_image(),
+        );
+        fs::write(release.join("SHA256SUMS.txt"), sums).unwrap();
+        g1_sign_file(&release, &key, "SHA256SUMS.txt");
+        tebako_signer::register_trusted(&cache, &key.public_key).unwrap();
+        let r = dll_resolver(&cache, &mirror);
+        let err = r.resolve_runtime(G1_RUBY, G1_PLATFORM, G1_TAG).unwrap_err();
+        // the sums form carries no contract card — pre-era, exit 75
+        assert_eq!(err.code, 75);
+        assert!(err.message.contains("pre-era"), "{}", err.message);
+        let journal = g1_journal(&cache);
+        assert!(
+            journal.contains("event=runtime-index-verified form=SHA256SUMS.txt"),
+            "{journal}"
+        );
         let _ = fs::remove_dir_all(cache.parent().unwrap());
     }
 }

--- a/crates/tebako-shim/Cargo.toml
+++ b/crates/tebako-shim/Cargo.toml
@@ -38,6 +38,10 @@ serde_yaml = "0.9"
 # In-process HTTP for runtime downloads (spec 00 invariant 1) — the same
 # crate the bootstrap resolves through.
 tebako-http = { version = "2.0.0", path = "../tebako-http" }
+# Runtime fetch-time OpenPGP verification (spec 09 §4 — roadmap 80's G1):
+# the consumed index form's detached .asc and every declared per-artifact
+# signature verify at download. No size gate here (unlike the bootstrap).
+tebako-signer = { version = "2.0.0", path = "../tebako-signer" }
 libc = "0.2"
 sha2 = "0.10"
 

--- a/crates/tebako-shim/src/config.rs
+++ b/crates/tebako-shim/src/config.rs
@@ -73,6 +73,13 @@ pub struct RuntimePref {
     /// (tebako-resolve::DEFAULT_TEBAKO_VERSION).
     #[serde(default)]
     pub tebako: String,
+    /// The per-engine download base pin (spec 05 §2's channel 1, #567):
+    /// a release download base URL this engine's runtimes resolve from,
+    /// ahead of `TEBAKO_RUNTIME_MIRROR` (a differing mirror value is
+    /// shadowed — loud + journaled). Absent = the rest of the chain
+    /// (mirror env → registry-derived → the ruby default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 pub fn config_path(home: &Path) -> PathBuf {
@@ -609,6 +616,7 @@ mod tests {
         RuntimePref {
             version: version.to_string(),
             tebako: tebako.to_string(),
+            source: None,
         }
     }
 

--- a/crates/tebako-shim/src/lib.rs
+++ b/crates/tebako-shim/src/lib.rs
@@ -22,7 +22,10 @@
 //! Discipline: no async, no clap, no logging framework; hand-rolled argv;
 //! named errors and exit codes (spec 06 §4 reused); cache-install mirrors
 //! the bootstrap's flock / tmp+rename / trust-marker discipline (spec 05
-//! §4) without linking the bootstrap crate (which drags in rnp).
+//! §4). Runtime fetch-time OpenPGP verification (spec 09 §4, roadmap 80's
+//! G1) links tebako-signer directly — the shim carries no size gate, so
+//! unlike the bootstrap it verifies with the full keyring machinery
+//! (trusted keyring + embedded root + `TEBAKO_TRUSTED_ROOT` override).
 //!
 //! The dispatch-time registry-default link resolves EVERY registry form
 //! of spec 04 §2 through tebako-resolve (service contents API, pinned
@@ -64,6 +67,14 @@ pub const EX_USAGE: u8 = 64;
 pub const EX_TEBAKO_MANIFEST: u8 = 65;
 pub const EX_TEBAKO_UNAVAILABLE: u8 = 69;
 pub const EX_TEBAKO_SHA: u8 = 70;
+/// spec 06 §4: an invalid signature on a fetched runtime artifact (or an
+/// unsigned fetch under `TEBAKO_REQUIRE_SIGNED=1`) — spec 09 §4's strict
+/// rule, G1 (roadmap 80).
+pub const EX_TEBAKO_SIGNATURE: u8 = 71;
+/// spec 06 §4: the signer of a fetched runtime artifact is not in the
+/// trusted keyring, or the verified signer is not the key the index
+/// entry / registry pins (spec 09 §4/§9's SignerKeyChanged).
+pub const EX_TEBAKO_TRUST: u8 = 72;
 pub const EX_TEBAKO_IO: u8 = 74;
 /// The runtime release declares a contract this shim does not speak —
 /// or none at all (spec 18 C2/S11/S12): a pre-era release manifest, a

--- a/crates/tebako-shim/src/runtime.rs
+++ b/crates/tebako-shim/src/runtime.rs
@@ -16,8 +16,23 @@
 //! contract refusal; tebako-resolve::contract owns the reader),
 //! manifest.json-primary / SHA256SUMS-fallback checksum extraction,
 //! `TEBAKO_RUNTIME_MIRROR` / `TEBAKO_OFFLINE` — reimplemented
-//! here rather than linked: the bootstrap crate drags in rnp, and the
-//! shim stays pure-Rust + tebako-http.
+//! here rather than linked from the bootstrap crate.
+//!
+//! Two extensions over the bootstrap's path live here:
+//!
+//! - **The per-engine download source chain** (spec 05 §2, tebako#567):
+//!   config `runtimes: {<engine>: {source:}}` → `TEBAKO_RUNTIME_MIRROR` →
+//!   the registered registries' `kind: runtime` entries (the release.ref
+//!   derives the base AND the tag) → the product default (ruby only —
+//!   a non-ruby engine no channel answers is the named error enumerating
+//!   the channels).
+//! - **Fetch-time OpenPGP verification** (spec 09 §4, roadmap 80's G1):
+//!   the consumed index form's detached `.asc` verifies BEFORE its
+//!   digests are trusted; every artifact whose entry DECLARES
+//!   `signature:` (spec 13 §2a) verifies against it. Strict: invalid →
+//!   71, untrusted signer / pin mismatch → 72; an unsigned release is
+//!   first-class (loud + journaled) except under
+//!   `TEBAKO_REQUIRE_SIGNED=1` (71).
 
 use std::io::Read;
 use std::path::Path;
@@ -27,7 +42,8 @@ use tpkg::{RuntimeRequirement, RuntimeRequirements};
 use crate::config::{self, RuntimePref};
 use crate::versions;
 use crate::{
-    fail, Ctx, ShimError, EX_TEBAKO_CONTRACT, EX_TEBAKO_IO, EX_TEBAKO_SHA, EX_TEBAKO_UNAVAILABLE,
+    fail, Ctx, ShimError, EX_TEBAKO_CONTRACT, EX_TEBAKO_IO, EX_TEBAKO_MANIFEST, EX_TEBAKO_SHA,
+    EX_TEBAKO_SIGNATURE, EX_TEBAKO_TRUST, EX_TEBAKO_UNAVAILABLE,
 };
 
 const DEFAULT_RELEASES_BASE: &str =
@@ -39,8 +55,8 @@ const LOCK_POLL_MS: u64 = 200;
 // tpkg (spec 00 §10 — one owner, every consumer flows): the shim's
 // resolution/download layers below build on these re-exports.
 use tpkg::runtime_store::{
-    entry_asset_names, entry_filename, entry_matches, entry_meta, newest_compatible_any,
-    release_index_entry,
+    entry_asset_names, entry_filename, entry_matches, entry_meta, entry_signature,
+    newest_compatible_any, release_index_entry, EntrySignature,
 };
 pub use tpkg::runtime_store::{
     exe_suffix, newest_compatible, platform_string, scan_all_cached, scan_cached, CachedRuntime,
@@ -158,6 +174,7 @@ pub fn resolve_runtime(
             RuntimePref {
                 version: String::new(),
                 tebako: tebako_resolve::DEFAULT_TEBAKO_VERSION.to_string(),
+                source: None,
             },
             true,
         ),
@@ -213,7 +230,12 @@ pub fn resolve_runtime(
     // with nothing satisfiable fails here with the named
     // platform-availability error; anything unreadable leaves the pin
     // the target (all pin-path behaviors unchanged).
-    let target = match index_selected_target(reqs, pref, ctx)? {
+    // The per-engine download source (spec 05 §2's four-channel chain,
+    // tebako#567) — computed once per download, threaded through the
+    // index probe and the fetch. Every download journals the base and the
+    // channel that supplied it.
+    let source = runtime_source(reqs, (!prefless).then_some(pref), &cfg, ctx)?;
+    let target = match index_selected_target(reqs, pref, &source, ctx)? {
         Some(pick) => pick,
         None if !prefless => pref.clone(),
         None => {
@@ -228,7 +250,7 @@ pub fn resolve_runtime(
             );
         }
     };
-    let rt = download_runtime(reqs.engine(), &target, ctx)?;
+    let rt = download_runtime(reqs.engine(), &target, &source, ctx)?;
     // The downloaded runtime's abi line must satisfy the payload too —
     // the release index carries it (abi: None is the compat window).
     // The single-entry native shape keeps its exact named error.
@@ -489,15 +511,19 @@ fn released_versions(text: &str, engine: &str, platform: &str) -> Option<Vec<Rel
 fn index_selected_target(
     reqs: &RuntimeRequirements,
     pref: &RuntimePref,
+    source: &RuntimeSource,
     ctx: &Ctx,
 ) -> Result<Option<RuntimePref>, ShimError> {
     if offline_mode(ctx) {
         return Ok(None);
     }
     let platform = platform_string();
-    let base_raw = releases_base(ctx);
-    let base = skip_file_scheme(&base_raw).to_string();
-    let local = base_is_local(&base_raw);
+    let base = skip_file_scheme(&source.base).to_string();
+    let local = base_is_local(&source.base);
+    // The release tag the URLs ride: the channel-3 registry pin verbatim
+    // (its release.ref names it — the openjdk v2.5.1 shape, where the tag
+    // is NOT the rows' tebako line), else the probed line's `v<tebako>`.
+    let tag = source.tag_for(&pref.tebako);
     let probe = ctx
         .home
         .join("tmp")
@@ -507,9 +533,26 @@ fn index_selected_target(
         // store dirs under the install lock and names the IO failure.
         return Ok(None);
     }
-    let text = fetch_manifest_text(&base, local, &pref.tebako, &probe);
+    let text = fetch_manifest_text(&base, local, &tag, &probe);
     let _ = std::fs::remove_dir_all(&probe);
     let Some(text) = text else {
+        // A registry-pinned tag (channel 3) has no fallback line: the
+        // registry named THIS release — an unreadable index there is the
+        // named error, never a silent drop to the preference's line.
+        if let Some(tag) = &source.tag {
+            return fail(
+                EX_TEBAKO_UNAVAILABLE,
+                format!(
+                    "the registry-derived {} runtime release {} carries no readable release index at {}/{}/manifest.json\n  the registry named this release for \"{}\" — fix the registry entry or pin `runtimes: {{{}: {{source: …}}}}` to override it",
+                    reqs.engine(),
+                    tag,
+                    source.base,
+                    tag,
+                    reqs,
+                    reqs.engine()
+                ),
+            );
+        }
         return Ok(None);
     };
     let Some(released) = released_versions(&text, reqs.engine(), platform) else {
@@ -549,6 +592,7 @@ fn index_selected_target(
                 .tebako_version
                 .clone()
                 .unwrap_or_else(|| pref.tebako.clone()),
+            source: None,
         }));
     }
     let mut known: Vec<&str> = released.iter().map(|e| e.lang_version.as_str()).collect();
@@ -578,11 +622,234 @@ fn offline_mode(ctx: &Ctx) -> bool {
         .is_some_and(|v| !v.is_empty() && v != "0")
 }
 
-fn releases_base(ctx: &Ctx) -> String {
-    ctx.env_get("TEBAKO_RUNTIME_MIRROR")
-        .filter(|v| !v.is_empty())
-        .unwrap_or(DEFAULT_RELEASES_BASE)
-        .to_string()
+/// The per-engine download source (spec 05 §2's chain — tebako#567): the
+/// release download base, the tag the URLs ride, the chain channel that
+/// supplied them (journaled per fetch), and — channel 3 only — the
+/// registry entry's signature pin (spec 09 §9).
+#[derive(Debug)]
+struct RuntimeSource {
+    /// The release download base (`{base}/{tag}/<asset>` URLs).
+    base: String,
+    /// The pinned release tag. `None` = `v<tebako>` of the line being
+    /// read (the factory convention: the probed line for the index, the
+    /// pick's own line for the assets). `Some` pins ONE tag for every
+    /// fetch — channel 3's registry-derived form, where the registry
+    /// names the release and a row's `tebako_version` stays the identity
+    /// line (the openjdk v2.5.1 shape: tag v2.5.1, rows on tebako 2.5.0).
+    tag: Option<String>,
+    /// The chain channel that supplied this source (spec 05 §2's journal
+    /// requirement): `config-source` / `mirror-env` / `registry` /
+    /// `default`.
+    channel: &'static str,
+    /// Channel 3's registry signature pin (spec 09 §9): the PRIMARY keyid
+    /// the verified signer of the index/artifacts must resolve to.
+    signer_pin: Option<String>,
+}
+
+impl RuntimeSource {
+    /// The tag a fetch on tebako line `tebako_line` rides.
+    fn tag_for(&self, tebako_line: &str) -> String {
+        self.tag
+            .clone()
+            .unwrap_or_else(|| format!("v{tebako_line}"))
+    }
+}
+
+/// Append one line to the audit journal (`~/.tebako/journal.log`) —
+/// best-effort, like every journal write: the answer never depends on
+/// the record.
+fn journal(home: &Path, line: &str) {
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(home.join("journal.log"))
+    {
+        use std::io::Write as _;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let _ = f.write_all(format!("{now} {line}\n").as_bytes());
+    }
+}
+
+/// `TEBAKO_REQUIRE_SIGNED=1` (spec 09 §4): set, non-empty, not "0".
+fn require_signed(ctx: &Ctx) -> bool {
+    ctx.env_get("TEBAKO_REQUIRE_SIGNED")
+        .is_some_and(|v| !v.is_empty() && v != "0")
+}
+
+/// The per-engine download-source chain (spec 05 §2, tebako#567) — first
+/// hit wins:
+///
+/// 1. the config pin's `source:` (a differing `TEBAKO_RUNTIME_MIRROR` is
+///    shadowed — loud + journaled);
+/// 2. `TEBAKO_RUNTIME_MIRROR` (the operator's global override);
+/// 3. the registered registries' `kind: runtime` entries whose `engine`
+///    (+ `implementation` when the edge names one) matches, with a
+///    version satisfying the edge — the base AND the tag derive from
+///    that version's `release.ref` (the zero-config path);
+/// 4. the product default — the ruby factory, RUBY ONLY: a non-ruby
+///    engine no channel answers is the named error enumerating the
+///    channels (the #567 closeout).
+fn runtime_source(
+    reqs: &RuntimeRequirements,
+    config_pref: Option<&RuntimePref>,
+    cfg: &config::UserConfig,
+    ctx: &Ctx,
+) -> Result<RuntimeSource, ShimError> {
+    let engine = reqs.engine();
+    let mirror = ctx
+        .env_get("TEBAKO_RUNTIME_MIRROR")
+        .filter(|v| !v.is_empty());
+    // Channel 1: the config pin's declared source.
+    if let Some(base) = config_pref.and_then(|p| p.source.as_deref()) {
+        if let Some(mirror) = mirror.filter(|m| *m != base) {
+            // The pin shadows the operator's mirror for this engine —
+            // never silently (spec 05 §2).
+            eprintln!(
+                "tebako-shim: warning: the {engine} runtime source: pin ({base}) shadows TEBAKO_RUNTIME_MIRROR ({mirror}) for this engine"
+            );
+            journal(
+                &ctx.home,
+                &format!(
+                    "event=runtime-source-shadow engine={engine} source={base} shadowed_mirror={mirror}"
+                ),
+            );
+        }
+        return Ok(RuntimeSource {
+            base: base.to_string(),
+            tag: None,
+            channel: "config-source",
+            signer_pin: None,
+        });
+    }
+    // Channel 2: the operator's global mirror.
+    if let Some(mirror) = mirror {
+        return Ok(RuntimeSource {
+            base: mirror.to_string(),
+            tag: None,
+            channel: "mirror-env",
+            signer_pin: None,
+        });
+    }
+    // Channel 3: the registered registries (the zero-config path).
+    if let Some(source) = registry_derived_source(reqs, cfg, ctx) {
+        return Ok(source);
+    }
+    // Channel 4: the product default — the ruby factory hosts ruby only.
+    if engine == "ruby" {
+        return Ok(RuntimeSource {
+            base: DEFAULT_RELEASES_BASE.to_string(),
+            tag: None,
+            channel: "default",
+            signer_pin: None,
+        });
+    }
+    fail(
+        EX_TEBAKO_UNAVAILABLE,
+        format!(
+            "no download source for {engine} runtimes — every channel of the per-engine chain (spec 05 §2) came up empty:\n  1. config.yaml `runtimes: {{{engine}: {{source: …}}}}` — not set\n  2. TEBAKO_RUNTIME_MIRROR — not set\n  3. the registered registries — none lists a `kind: runtime` entry for engine \"{engine}\" with a version satisfying \"{reqs}\"\n  4. the product default — hosts ruby runtimes only\n  register the registry that publishes the {engine} runtime (`tebako add-registry`), or pin a source"
+        ),
+    )
+}
+
+/// Channel 3: the registry-derived source. Scans the configured
+/// registries IN ORDER; the first `kind: runtime` entry matching the
+/// engine (+ the edge's implementation when named) with a version
+/// satisfying the requirement answers — the base + tag derive from that
+/// version's `release.ref`. Only GitHub service refs derive a
+/// `{base}/{tag}` download root (the runtime fetch grammar); other ref
+/// classes skip with a journal note. A registry that does not resolve is
+/// journaled and skipped — it cannot answer, and a later channel still
+/// can (the failure is named in the no-channel error's enumeration).
+fn registry_derived_source(
+    reqs: &RuntimeRequirements,
+    cfg: &config::UserConfig,
+    ctx: &Ctx,
+) -> Option<RuntimeSource> {
+    let engine = reqs.engine();
+    let implementation = reqs
+        .entries()
+        .iter()
+        .find_map(|r| r.implementation.as_deref());
+    for reg_ref in &cfg.registries {
+        let registry = match crate::regcache::registry_for(&ctx.home, reg_ref, ctx) {
+            Ok(r) => r,
+            Err(e) => {
+                journal(
+                    &ctx.home,
+                    &format!(
+                        "event=runtime-source-registry-error engine={engine} registry={reg_ref} error={e:?}"
+                    ),
+                );
+                continue;
+            }
+        };
+        for entry in registry.runtime_entries(engine, implementation) {
+            // The newest registry version satisfying ANY entry of the
+            // `any_of` requirement answers where this engine lives.
+            let pick = entry
+                .versions
+                .iter()
+                .filter(|v| {
+                    reqs.entries()
+                        .iter()
+                        .any(|r| versions::from_validated(&r.constraint).matches(&v.version))
+                })
+                .max_by(|a, b| versions::compare(&a.version, &b.version));
+            let Some(version) = pick else { continue };
+            let derived = match tebako_resolve::Reference::parse(&version.release.r#ref) {
+                Ok(tebako_resolve::Reference::Service {
+                    service: tebako_resolve::Service::Github,
+                    owner,
+                    repo,
+                    version: tag,
+                    ..
+                }) => Some(RuntimeSource {
+                    base: format!("https://github.com/{owner}/{repo}/releases/download"),
+                    tag: Some(tag),
+                    channel: "registry",
+                    signer_pin: version.signature.as_ref().map(|s| s.keyid.clone()),
+                }),
+                // A non-GitHub release.ref cannot spell the `{base}/{tag}`
+                // download root the runtime fetch rides — journaled, never
+                // guessed.
+                Ok(other) => {
+                    journal(
+                        &ctx.home,
+                        &format!(
+                            "event=runtime-source-registry-skip engine={engine} registry={reg_ref} entry={} version={} reason=release-ref-class-{}-not-a-download-base",
+                            entry.name,
+                            version.version,
+                            match &other {
+                                tebako_resolve::Reference::Service { service, .. } =>
+                                    service.name(),
+                                tebako_resolve::Reference::Git { .. } => "git",
+                                tebako_resolve::Reference::Https { .. } => "https",
+                                tebako_resolve::Reference::File { .. } => "file",
+                            }
+                        ),
+                    );
+                    None
+                }
+                Err(e) => {
+                    journal(
+                        &ctx.home,
+                        &format!(
+                            "event=runtime-source-registry-skip engine={engine} registry={reg_ref} entry={} version={} reason=bad-release-ref error={e}",
+                            entry.name, version.version
+                        ),
+                    );
+                    None
+                }
+            };
+            if derived.is_some() {
+                return derived;
+            }
+        }
+    }
+    None
 }
 
 fn base_is_local(base: &str) -> bool {
@@ -863,17 +1130,13 @@ fn sha_from_sums(text: &str, asset: &str) -> Result<String, ()> {
     Err(())
 }
 
-/// Fetch the release index (`manifest.json`) into the tmp staging dir
-/// and return its text. `None` when it does not exist or does not read —
-/// the caller decides what that means (spec 18: the pre-era signal).
-fn fetch_manifest_text(base: &str, local: bool, abi: &str, tmp_dir: &Path) -> Option<String> {
+/// Fetch the release index (`manifest.json`) at release tag `tag` into
+/// the tmp staging dir and return its text. `None` when it does not
+/// exist or does not read — the caller decides what that means (spec 18:
+/// the pre-era signal).
+fn fetch_manifest_text(base: &str, local: bool, tag: &str, tmp_dir: &Path) -> Option<String> {
     let manifest_tmp = tmp_dir.join("manifest.json");
-    fetch_url(
-        &format!("{base}/v{abi}/manifest.json"),
-        local,
-        &manifest_tmp,
-    )
-    .ok()?;
+    fetch_url(&format!("{base}/{tag}/manifest.json"), local, &manifest_tmp).ok()?;
     std::fs::read_to_string(&manifest_tmp).ok()
 }
 
@@ -908,23 +1171,72 @@ fn contract_gate(
     }
 }
 
-/// The expected checksum for an asset: manifest.json primary,
-/// SHA256SUMS.txt fallback (the bootstrap's exact order). Returns the
-/// optional sha plus the two diagnostic indices so the caller names the
-/// failure itself — an absent entry is data, not an error (the v1-era
-/// image rule needs it). `manifest_text` is the already-fetched release
-/// index when the caller holds it (the contract gate reads it first);
-/// `None` fetches it here.
+/// Which release-index form the G1 verification (spec 09 §4) trusted for
+/// this fetch — the digests come from THAT form and no other (an
+/// unverified form's digests are never consulted once a form verified).
+enum IndexTrust {
+    /// No form carried a verifiable signature — the pre-signing
+    /// keep-forever line: manifest primary, SHA256SUMS fallback (the
+    /// behavior that predates G1), the unsigned rule applies.
+    Unverified,
+    /// manifest.json verified (the signer's resolved PRIMARY keyid).
+    VerifiedManifest(String),
+    /// Only SHA256SUMS.txt verified — digests from it; the contract card
+    /// has no trusted carrier (the caller refuses 75).
+    VerifiedSums {
+        text: String,
+        #[allow(dead_code)]
+        signer: String,
+    },
+}
+
+impl IndexTrust {
+    /// The verified signer (resolved PRIMARY keyid), when any form
+    /// verified.
+    fn signer(&self) -> Option<&str> {
+        match self {
+            IndexTrust::Unverified => None,
+            IndexTrust::VerifiedManifest(signer) => Some(signer),
+            IndexTrust::VerifiedSums { signer, .. } => Some(signer),
+        }
+    }
+}
+
+/// The expected checksum for an asset: the VERIFIED index form's digests
+/// when a form verified (spec 09 §4 — never an unverified fallback);
+/// otherwise manifest.json primary, SHA256SUMS.txt fallback (the
+/// bootstrap's exact order). Returns the optional sha plus the two
+/// diagnostic indices so the caller names the failure itself — an absent
+/// entry is data, not an error (the v1-era image rule needs it).
+/// `manifest_text` is the already-fetched release index when the caller
+/// holds it (the contract gate reads it first); `None` fetches it here
+/// (unverified chain only).
 #[allow(clippy::too_many_arguments)]
 fn expected_checksum(
     base: &str,
     local: bool,
-    abi: &str,
+    tag: &str,
     asset: &str,
     tmp_dir: &Path,
     manifest_text: Option<&str>,
+    trust: &IndexTrust,
 ) -> Result<(Option<String>, (usize, usize)), ShimError> {
-    let sums_url = format!("{base}/v{abi}/SHA256SUMS.txt");
+    // The verified chains read the consumed form's digests and nothing
+    // else — an unverified form is never consulted once a form verified.
+    match trust {
+        IndexTrust::VerifiedManifest(_) => {
+            let expected = manifest_text.and_then(|t| sha_from_manifest(t, asset).ok());
+            let diag = if expected.is_some() { 4 } else { 3 };
+            return Ok((expected, (diag, 0)));
+        }
+        IndexTrust::VerifiedSums { text, .. } => {
+            let expected = sha_from_sums(text, asset).ok();
+            let diag = if expected.is_some() { 4 } else { 3 };
+            return Ok((expected, (0, diag)));
+        }
+        IndexTrust::Unverified => {}
+    }
+    let sums_url = format!("{base}/{tag}/SHA256SUMS.txt");
     let mut expected = None;
     let mut diag_manifest = 1;
     let owned_text;
@@ -935,13 +1247,7 @@ fn expected_checksum(
         }
         None => {
             let manifest_tmp = tmp_dir.join("manifest.json");
-            if fetch_url(
-                &format!("{base}/v{abi}/manifest.json"),
-                local,
-                &manifest_tmp,
-            )
-            .is_ok()
-            {
+            if fetch_url(&format!("{base}/{tag}/manifest.json"), local, &manifest_tmp).is_ok() {
                 diag_manifest = 2;
                 owned_text = std::fs::read_to_string(&manifest_tmp).ok();
                 if owned_text.is_some() {
@@ -977,17 +1283,226 @@ fn expected_checksum(
     Ok((expected, (diag_manifest, diag_sums)))
 }
 
-/// Download + verify + atomically install one asset into an entry staging
-/// dir. Returns the verified sha256.
-fn install_asset(
-    url: &str,
+/// The G1 fetch-time verification context (spec 09 §4): the keyring this
+/// fetch verifies against — the user's trusted keyring + the embedded
+/// first-party root + the `TEBAKO_TRUSTED_ROOT` dev override (the CLI's
+/// payload-install keyring, mirrored key-for-key) — plus the channel-3
+/// registry signature pin (spec 09 §9) when the source came from a
+/// registry.
+struct FetchTrust {
+    keyring: Vec<u8>,
+    signer_pin: Option<String>,
+}
+
+impl FetchTrust {
+    fn build(source: &RuntimeSource, ctx: &Ctx) -> Result<FetchTrust, ShimError> {
+        let mut keyring = tebako_signer::trusted_keyring_bytes(&ctx.home).map_err(|e| {
+            ShimError::new(
+                EX_TEBAKO_IO,
+                format!("cannot read the trusted keyring: {e}"),
+            )
+        })?;
+        let root = tebako_signer::dearmor_bytes(tebako_signer::ROOT_PUBLIC_KEY.as_bytes())
+            .map_err(|e| {
+                ShimError::new(
+                    EX_TEBAKO_IO,
+                    format!("the embedded root key does not dearmor: {e}"),
+                )
+            })?;
+        keyring.extend_from_slice(&root);
+        if let Some(extra) = tebako_signer::trusted_root_override_key(
+            ctx.env_get("TEBAKO_TRUSTED_ROOT").map(str::to_string),
+        ) {
+            keyring.extend_from_slice(&extra);
+        }
+        Ok(FetchTrust {
+            keyring,
+            signer_pin: source.signer_pin.clone(),
+        })
+    }
+
+    /// Verify one detached-signature pair (spec 09 §4's strict rule):
+    /// Invalid → 71; Untrusted (the signer is not in the trusted
+    /// keyring) → 72; Trusted → the declared keyid (the entry's
+    /// `signature.keyid`, the PRIMARY per spec 13 §2a) and the channel-3
+    /// registry pin re-assert — a mismatch is SignerKeyChanged, 72.
+    /// Returns the resolved PRIMARY keyid of the verified signer.
+    fn verify_detached(
+        &self,
+        what: &str,
+        bytes: &[u8],
+        asc: &[u8],
+        declared_keyid: Option<&str>,
+    ) -> Result<String, ShimError> {
+        let outcome =
+            tebako_signer::verify_detached_full(&self.keyring, bytes, asc).map_err(|e| {
+                ShimError::new(
+                    EX_TEBAKO_SIGNATURE,
+                    format!("cannot verify the signature on {what}: {e}"),
+                )
+            })?;
+        let issuer = match outcome {
+            tebako_signer::VerifyOutcome::Trusted(keyid) => keyid,
+            tebako_signer::VerifyOutcome::Untrusted(keyid) => {
+                return fail(
+                    EX_TEBAKO_TRUST,
+                    format!(
+                        "{what} is signed by {keyid}, which is not in the trusted keyring — refusing to install or execute\n  if you trust this signer, register its public key with `tebako key import`"
+                    ),
+                );
+            }
+            tebako_signer::VerifyOutcome::Invalid(keyid) => {
+                return fail(
+                    EX_TEBAKO_SIGNATURE,
+                    format!(
+                        "invalid signature on {what}{} — refusing to install or execute\n  the download was deleted; the cache was not touched",
+                        keyid.map(|k| format!(" (issuer {k})")).unwrap_or_default()
+                    ),
+                );
+            }
+        };
+        let primary = tebako_signer::primary_keyid_of(&self.keyring, &issuer)
+            .map_err(|e| {
+                ShimError::new(
+                    EX_TEBAKO_SIGNATURE,
+                    format!("cannot resolve the signer of {what}: {e}"),
+                )
+            })?
+            .unwrap_or_else(|| issuer.clone());
+        // The entry pin (spec 13 §2a) and the channel-3 registry pin
+        // (spec 09 §9) both name PRIMARY keyids; a signature issuing
+        // from a signing SUBKEY resolves to its primary before the
+        // compare.
+        for (pin, origin) in [
+            (declared_keyid, "the release index entry declares"),
+            (self.signer_pin.as_deref(), "the registry pins"),
+        ] {
+            if let Some(want) = pin {
+                let want = want.to_lowercase();
+                if issuer != want && primary != want {
+                    return fail(
+                        EX_TEBAKO_TRUST,
+                        format!(
+                            "{what} is signed by {primary}, but {origin} {want} — the signer key changed (spec 09 §9); refusing to install or execute"
+                        ),
+                    );
+                }
+            }
+        }
+        Ok(primary)
+    }
+
+    /// The per-artifact leg (spec 09 §4): fetch the declared `.asc` (a
+    /// DECLARED asc that does not fetch → 71) and verify the downloaded
+    /// bytes BEFORE the sha256 check. Returns the verified signer's
+    /// resolved PRIMARY keyid.
+    fn verify_asset(
+        &self,
+        dir_url: &str,
+        local: bool,
+        tmp_dir: &Path,
+        asset_path: &Path,
+        asset: &str,
+        declared: &EntrySignature,
+    ) -> Result<String, ShimError> {
+        // The asc names an exact asset within the same release — a bare
+        // file name, never a path (spec 13 §2a).
+        if declared.asc.contains('/') || declared.asc.contains('\\') {
+            return fail(
+                EX_TEBAKO_MANIFEST,
+                format!(
+                    "the release index's signature.asc for {asset} (\"{}\") is not a bare asset name — the release is malformed",
+                    declared.asc
+                ),
+            );
+        }
+        let asc_url = format!("{dir_url}/{}", declared.asc);
+        let asc_tmp = tmp_dir.join(&declared.asc);
+        if fetch_url(&asc_url, local, &asc_tmp).is_err() {
+            return fail(
+                EX_TEBAKO_SIGNATURE,
+                format!(
+                    "the release index declares signature \"{}\" for {asset} but it did not fetch from {asc_url} — a declared signature that does not fetch is refused (spec 09 §4)",
+                    declared.asc
+                ),
+            );
+        }
+        let asc = std::fs::read(&asc_tmp).map_err(|e| {
+            ShimError::new(
+                EX_TEBAKO_IO,
+                format!(
+                    "cannot read the fetched signature {}: {e}",
+                    asc_tmp.display()
+                ),
+            )
+        })?;
+        let bytes = std::fs::read(asset_path).map_err(|e| {
+            ShimError::new(
+                EX_TEBAKO_IO,
+                format!("cannot read the downloaded {}: {e}", asset_path.display()),
+            )
+        })?;
+        self.verify_detached(asset, &bytes, &asc, Some(&declared.keyid))
+    }
+}
+
+/// The index-trust resolution (spec 09 §4): probe the path's index forms
+/// in preference order (manifest.json → SHA256SUMS.txt); the FIRST form
+/// whose detached `.asc` verifies is the consumed form — its digests
+/// alone are trusted from that point. A present asc that verifies
+/// Invalid → 71, a signer outside the trusted keyring → 72 (strict); an
+/// ABSENT asc moves to the next form — the unsigned rule decides after.
+fn verify_index(
+    trust: &FetchTrust,
+    base: &str,
     local: bool,
-    asset: &str,
+    tag: &str,
+    manifest_text: &str,
+    tmp_dir: &Path,
+) -> Result<IndexTrust, ShimError> {
+    let fetch_opt = |name: &str| -> Option<Vec<u8>> {
+        let tmp = tmp_dir.join(name);
+        fetch_url(&format!("{base}/{tag}/{name}"), local, &tmp).ok()?;
+        std::fs::read(&tmp).ok()
+    };
+    if let Some(asc) = fetch_opt("manifest.json.asc") {
+        let signer =
+            trust.verify_detached("manifest.json", manifest_text.as_bytes(), &asc, None)?;
+        return Ok(IndexTrust::VerifiedManifest(signer));
+    }
+    if let Some(asc) = fetch_opt("SHA256SUMS.txt.asc") {
+        // A dangling asc over an unfetchable body is not a verified form
+        // — the unsigned rule decides.
+        let Some(sums) = fetch_opt("SHA256SUMS.txt").and_then(|b| String::from_utf8(b).ok()) else {
+            return Ok(IndexTrust::Unverified);
+        };
+        let signer = trust.verify_detached("SHA256SUMS.txt", sums.as_bytes(), &asc, None)?;
+        return Ok(IndexTrust::VerifiedSums { text: sums, signer });
+    }
+    Ok(IndexTrust::Unverified)
+}
+
+/// Download + verify + atomically install one asset into an entry staging
+/// dir. The spec 09 §4 order: the DECLARED signature verifies first
+/// (invalid → 71, untrusted signer / pin mismatch → 72), then the sha256
+/// (70). `fetch_name` is the release-asset spelling (the URL's last
+/// segment); `install_name` the name it stages under (the windows dll
+/// facet's PE name — everywhere else the two are one). Returns the
+/// verified sha256 plus the verified signer's PRIMARY keyid when a
+/// signature was declared and verified.
+#[allow(clippy::too_many_arguments)]
+fn install_asset(
+    dir_url: &str,
+    local: bool,
+    fetch_name: &str,
+    install_name: &str,
     tmp_dir: &Path,
     expected: &str,
-) -> Result<String, ShimError> {
-    let tmp_asset = tmp_dir.join(asset);
-    if fetch_url(url, local, &tmp_asset).is_err() {
+    sig: Option<(&EntrySignature, &FetchTrust)>,
+) -> Result<(String, Option<String>), ShimError> {
+    let url = format!("{dir_url}/{fetch_name}");
+    let tmp_asset = tmp_dir.join(install_name);
+    if fetch_url(&url, local, &tmp_asset).is_err() {
         return fail(
             EX_TEBAKO_UNAVAILABLE,
             format!(
@@ -995,6 +1510,12 @@ fn install_asset(
             ),
         );
     }
+    let signer = match sig {
+        Some((declared, trust)) => {
+            Some(trust.verify_asset(dir_url, local, tmp_dir, &tmp_asset, fetch_name, declared)?)
+        }
+        None => None,
+    };
     let actual = sha256_file_hex(&tmp_asset).map_err(|e| {
         ShimError::new(
             EX_TEBAKO_IO,
@@ -1006,12 +1527,12 @@ fn install_asset(
         return fail(
             EX_TEBAKO_SHA,
             format!(
-                "SHA256 mismatch for downloaded runtime {asset} — refusing to install or execute\n  expected: {} (from the release index)\n  actual:   {actual}\n  the download was deleted; the cache was not touched",
+                "SHA256 mismatch for downloaded runtime {fetch_name} — refusing to install or execute\n  expected: {} (from the release index)\n  actual:   {actual}\n  the download was deleted; the cache was not touched",
                 expected.to_lowercase()
             ),
         );
     }
-    Ok(actual)
+    Ok((actual, signer))
 }
 
 /// What the staging step produced: a fresh install (the staged names)
@@ -1037,6 +1558,7 @@ enum StageOutcome {
 fn download_runtime(
     engine: &str,
     pref: &RuntimePref,
+    source: &RuntimeSource,
     ctx: &Ctx,
 ) -> Result<CachedRuntime, ShimError> {
     let platform = platform_string();
@@ -1070,9 +1592,13 @@ fn download_runtime(
         });
     }
 
-    let base_raw = releases_base(ctx);
-    let base = skip_file_scheme(&base_raw).to_string();
-    let local = base_is_local(&base_raw);
+    let base = skip_file_scheme(&source.base).to_string();
+    let local = base_is_local(&source.base);
+    // The release tag every fetch of this download rides (spec 05 §2):
+    // channel 3 pins the registry-named tag; the other channels ride the
+    // pick's own tebako line (the factory's `v<tebako>` convention).
+    let tag = source.tag_for(&pref.tebako);
+    let dir_url = format!("{base}/{tag}");
 
     if offline_mode(ctx) {
         return fail(
@@ -1151,8 +1677,8 @@ fn download_runtime(
         // a contract refusal never downloads a byte of the runtime. No
         // readable manifest is the same pre-era signal (no old-path
         // readers; the SHA256SUMS fallback covers checksums only).
-        let manifest_url = format!("{base}/v{}/manifest.json", pref.tebako);
-        let manifest_text = fetch_manifest_text(&base, local, &pref.tebako, &tmp_dir).ok_or_else(|| {
+        let manifest_url = format!("{dir_url}/manifest.json");
+        let manifest_text = fetch_manifest_text(&base, local, &tag, &tmp_dir).ok_or_else(|| {
             ShimError::new(
                 EX_TEBAKO_CONTRACT,
                 format!(
@@ -1180,6 +1706,69 @@ fn download_runtime(
         if file_exists(&entry_dir.join(&asset)) {
             return Ok(StageOutcome::Raced { asset, image_asset });
         }
+
+        // G1 (spec 09 §4): the consumed index form's detached signature
+        // verifies BEFORE its digests are trusted — and before any asset
+        // byte downloads.
+        let trust = FetchTrust::build(source, ctx)?;
+        let index_trust = verify_index(&trust, &base, local, &tag, &manifest_text, &tmp_dir)?;
+
+        // The declared per-artifact signatures (spec 13 §2a): a PRESENT
+        // but torn block is the named error — never a silent downgrade
+        // to the unsigned rule.
+        let declared_sig = |facet: Option<&str>| -> Result<Option<EntrySignature>, ShimError> {
+            entry_match
+                .map(|e| entry_signature(e, facet))
+                .transpose()
+                .map(Option::flatten)
+                .map_err(|m| {
+                    ShimError::new(
+                        EX_TEBAKO_MANIFEST,
+                        format!("runtime \"{runtime_ref}\": the release index's {m}"),
+                    )
+                })
+        };
+        let exe_sig = declared_sig(None)?;
+        let image_sig = declared_sig(Some("image"))?;
+        let dll_sig = declared_sig(Some("dll"))?;
+
+        // The unsigned rule (spec 09 §4): no verified index form AND no
+        // declared per-artifact signature — the pre-signing keep-forever
+        // line. Loud + journaled on EVERY fetch; refused (71) under
+        // TEBAKO_REQUIRE_SIGNED=1 — before a byte of the runtime moves.
+        let any_declared = exe_sig.is_some() || image_sig.is_some() || dll_sig.is_some();
+        if index_trust.signer().is_none() && !any_declared {
+            if require_signed(ctx) {
+                return fail(
+                    EX_TEBAKO_SIGNATURE,
+                    format!(
+                        "runtime \"{runtime_ref}\" is unsigned — no signed release index form and no declared per-artifact signature — and TEBAKO_REQUIRE_SIGNED=1 is set: refusing to install or execute\n  unset TEBAKO_REQUIRE_SIGNED to accept the unsigned fetch (it is journaled), or pin a signed runtime release"
+                    ),
+                );
+            }
+            eprintln!(
+                "tebako-shim: warning: runtime \"{runtime_ref}\" is unsigned — no verifiable signature on the release; the sha256 digest is the only integrity anchor (spec 09 §4's pre-signing keep-forever line)"
+            );
+            journal(
+                &ctx.home,
+                &format!(
+                    "event=unsigned-runtime-fetch runtime_ref={runtime_ref} base={} channel={}",
+                    source.base, source.channel
+                ),
+            );
+        }
+
+        // The contract card rides the CONSUMED index form: a sums-only
+        // verified fetch has no trusted card carrier — the spec 18 C2
+        // refusal (75), never a card read from an unverified manifest.
+        if matches!(index_trust, IndexTrust::VerifiedSums { .. }) {
+            return fail(
+                EX_TEBAKO_CONTRACT,
+                format!(
+                    "runtime \"{runtime_ref}\": only SHA256SUMS.txt verified — manifest.json is unsigned, so no trusted release contract card exists — refusing to install or execute (spec 09 §4 + spec 18 C2)\n  a spec-conformant factory signs every index form (spec 13 §2a); report the release"
+                ),
+            );
+        }
         contract_gate(
             &runtime_ref,
             &manifest_text,
@@ -1191,14 +1780,14 @@ fn download_runtime(
         )?;
 
         // executable
-        let exe_url = format!("{base}/v{}/{asset}", pref.tebako);
         let (exe_sha, (diag_m, diag_s)) = expected_checksum(
             &base,
             local,
-            &pref.tebako,
+            &tag,
             &asset,
             &tmp_dir,
             Some(&manifest_text),
+            &index_trust,
         )?;
         const DIAG: [&str; 5] = [
             "not tried",
@@ -1211,12 +1800,26 @@ fn download_runtime(
             ShimError::new(
                 EX_TEBAKO_UNAVAILABLE,
                 format!(
-                    "no checksum for {asset} in the release\n  tried: {base}/v{abi}/manifest.json ({})\n         {base}/v{abi}/SHA256SUMS.txt ({})",
-                    DIAG[diag_m], DIAG[diag_s], abi = pref.tebako
+                    "no checksum for {asset} in the release\n  tried: {dir_url}/manifest.json ({})\n         {dir_url}/SHA256SUMS.txt ({})",
+                    DIAG[diag_m], DIAG[diag_s]
                 ),
             )
         })?;
-        let actual = install_asset(&exe_url, local, &asset, &tmp_dir, &expected)?;
+        let mut signers: Vec<String> = index_trust
+            .signer()
+            .map(str::to_string)
+            .into_iter()
+            .collect();
+        let (actual, exe_signer) = install_asset(
+            &dir_url,
+            local,
+            &asset,
+            &asset,
+            &tmp_dir,
+            &expected,
+            exe_sig.as_ref().map(|s| (s, &trust)),
+        )?;
+        signers.extend(exe_signer);
         make_executable(&tmp_dir.join(&asset));
         // image-era runtime image: same mirror/offline/verify rules —
         // when the release index carries it. The image is optional only
@@ -1237,15 +1840,23 @@ fn download_runtime(
         let (image_sha, _) = expected_checksum(
             &base,
             local,
-            &pref.tebako,
+            &tag,
             &image_asset,
             &tmp_dir,
             Some(&manifest_text),
+            &index_trust,
         )?;
         let has_image = if let Some(image_expected) = image_sha {
-            let image_url = format!("{base}/v{}/{image_asset}", pref.tebako);
-            let image_actual =
-                install_asset(&image_url, local, &image_asset, &tmp_dir, &image_expected)?;
+            let (image_actual, image_signer) = install_asset(
+                &dir_url,
+                local,
+                &image_asset,
+                &image_asset,
+                &tmp_dir,
+                &image_expected,
+                image_sig.as_ref().map(|s| (s, &trust)),
+            )?;
+            signers.extend(image_signer);
             make_readonly(&tmp_dir.join(&image_asset));
             let _ = std::fs::write(
                 tmp_dir.join(format!("{image_asset}.sha256")),
@@ -1253,7 +1864,7 @@ fn download_runtime(
             );
             let _ = std::fs::write(
                 tmp_dir.join(format!("{image_asset}.origin")),
-                format!("runtime_ref={runtime_ref}\nurl={image_url}\nsha256={image_actual}\n"),
+                format!("runtime_ref={runtime_ref}\nurl={dir_url}/{image_asset}\nsha256={image_actual}\n"),
             );
             true
         } else {
@@ -1278,8 +1889,16 @@ fn download_runtime(
                     ),
                 );
             }
-            let dll_url = format!("{base}/v{}/{dll_asset}", pref.tebako);
-            let dll_actual = install_asset(&dll_url, local, &install_as, &tmp_dir, &dll_expected)?;
+            let (dll_actual, dll_signer) = install_asset(
+                &dir_url,
+                local,
+                &dll_asset,
+                &install_as,
+                &tmp_dir,
+                &dll_expected,
+                dll_sig.as_ref().map(|s| (s, &trust)),
+            )?;
+            signers.extend(dll_signer);
             make_readonly(&tmp_dir.join(&install_as));
             let _ = std::fs::write(
                 tmp_dir.join(format!("{install_as}.sha256")),
@@ -1287,14 +1906,29 @@ fn download_runtime(
             );
             let _ = std::fs::write(
                 tmp_dir.join(format!("{install_as}.origin")),
-                format!("runtime_ref={runtime_ref}\nurl={dll_url}\nsha256={dll_actual}\n"),
+                format!("runtime_ref={runtime_ref}\nurl={dir_url}/{dll_asset}\nsha256={dll_actual}\n"),
             );
         }
         let _ = std::fs::write(tmp_dir.join("sha256"), format!("{actual}  {asset}\n"));
         let _ = std::fs::write(
             tmp_dir.join("origin"),
-            format!("runtime_ref={runtime_ref}\nurl={exe_url}\nsha256={actual}\n"),
+            format!("runtime_ref={runtime_ref}\nurl={dir_url}/{asset}\nsha256={actual}\n"),
         );
+        // spec 05 §2's journal rule: every download records the base, the
+        // channel that supplied it, and the verification strength.
+        if !signers.is_empty() {
+            signers.sort();
+            signers.dedup();
+            journal(
+                &ctx.home,
+                &format!(
+                    "event=runtime-fetch-verified runtime_ref={runtime_ref} base={} channel={} signer={}",
+                    source.base,
+                    source.channel,
+                    signers.join(",")
+                ),
+            );
+        }
         Ok(StageOutcome::Installed {
             has_image,
             asset,
@@ -1367,5 +2001,279 @@ fn download_runtime(
             lock_release(lock);
             Err(e)
         }
+    }
+}
+
+// ---------------------------------------------------------------------
+// unit tests: the per-engine download-source chain (spec 05 §2, #567)
+// ---------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::UserConfig;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_home(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "tebako-shim-runtime-test-{tag}-{}-{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::SeqCst)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn test_ctx(home: &Path) -> Ctx {
+        Ctx {
+            home: home.to_path_buf(),
+            cwd: home.to_path_buf(),
+            env: std::collections::BTreeMap::new(),
+        }
+    }
+
+    fn reqs(engine: &str, constraint: &str) -> RuntimeRequirements {
+        RuntimeRequirements::one(RuntimeRequirement {
+            engine: engine.to_string(),
+            constraint: tpkg::Constraint::new(constraint).unwrap(),
+            implementation: None,
+            abi: None,
+        })
+    }
+
+    fn pref(version: &str, tebako: &str, source: Option<&str>) -> RuntimePref {
+        RuntimePref {
+            version: version.to_string(),
+            tebako: tebako.to_string(),
+            source: source.map(str::to_string),
+        }
+    }
+
+    /// Write a registry file and return its `file://` ref.
+    fn registry_ref(home: &Path, name: &str, yaml: &str) -> String {
+        let path = home.join(name);
+        std::fs::write(&path, yaml).unwrap();
+        tebako_http::file_url(&path)
+    }
+
+    const OPENJDK_REGISTRY: &str = r#"
+schema_version: 1
+payloads:
+  - name: tebako-runtime-openjdk
+    kind: runtime
+    engine: java
+    implementation: temurin
+    versions:
+      - version: '21.0.11'
+        platforms: universal
+        release: {ref: 'tfs:github:tamatebako/tebako-runtime-openjdk:v2.5.0'}
+      - version: '21.0.12'
+        platforms: universal
+        release: {ref: 'tfs:github:tamatebako/tebako-runtime-openjdk:v2.5.1'}
+        signature: {keyid: 'efc3c250f7862a48', asc: 'openjdk-21.0.12-universal.tfs.asc'}
+"#;
+
+    #[test]
+    fn config_source_wins_and_shadows_a_differing_mirror() {
+        let home = temp_home("chain-source");
+        let mut ctx = test_ctx(&home);
+        ctx.env.insert(
+            "TEBAKO_RUNTIME_MIRROR".to_string(),
+            "https://mirror.invalid/releases".to_string(),
+        );
+        let p = pref(
+            "21.0.12",
+            "2.5.0",
+            Some("https://pinned.example.com/releases"),
+        );
+        let cfg = UserConfig::default();
+        let source = runtime_source(&reqs("java", ">= 21"), Some(&p), &cfg, &ctx).unwrap();
+        assert_eq!(source.base, "https://pinned.example.com/releases");
+        assert_eq!(source.channel, "config-source");
+        assert_eq!(source.tag, None, "a bare base pin rides the tebako line");
+        let journal = std::fs::read_to_string(home.join("journal.log")).unwrap();
+        assert!(
+            journal.contains("event=runtime-source-shadow engine=java"),
+            "{journal}"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn the_mirror_env_is_channel_2() {
+        let home = temp_home("chain-mirror");
+        let mut ctx = test_ctx(&home);
+        ctx.env.insert(
+            "TEBAKO_RUNTIME_MIRROR".to_string(),
+            "https://mirror.invalid/releases".to_string(),
+        );
+        let p = pref("21.0.12", "2.5.0", None);
+        let cfg = UserConfig::default();
+        let source = runtime_source(&reqs("java", ">= 21"), Some(&p), &cfg, &ctx).unwrap();
+        assert_eq!(source.base, "https://mirror.invalid/releases");
+        assert_eq!(source.channel, "mirror-env");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn the_registry_channel_derives_base_tag_and_pin() {
+        // The golden openjdk v2.5.1 shape: the registry version's
+        // release.ref names the TAG (v2.5.1) while the rows ride their
+        // own tebako line (2.5.0) — the tag is decoupled from the
+        // identity line.
+        let home = temp_home("chain-registry");
+        let ctx = test_ctx(&home);
+        let reg = registry_ref(&home, "tpkg-registry.yaml", OPENJDK_REGISTRY);
+        let cfg = UserConfig {
+            registries: vec![reg],
+            ..UserConfig::default()
+        };
+        let source = runtime_source(&reqs("java", ">= 21"), None, &cfg, &ctx).unwrap();
+        assert_eq!(source.channel, "registry");
+        assert_eq!(
+            source.base,
+            "https://github.com/tamatebako/tebako-runtime-openjdk/releases/download"
+        );
+        assert_eq!(
+            source.tag.as_deref(),
+            Some("v2.5.1"),
+            "the newest SATISFYING version's tag"
+        );
+        assert_eq!(source.signer_pin.as_deref(), Some("efc3c250f7862a48"));
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn the_registry_channel_matches_the_constraint_and_the_implementation() {
+        let home = temp_home("chain-registry-match");
+        let ctx = test_ctx(&home);
+        let reg = registry_ref(&home, "tpkg-registry.yaml", OPENJDK_REGISTRY);
+        let cfg = UserConfig {
+            registries: vec![reg],
+            ..UserConfig::default()
+        };
+        // A constraint no registry version satisfies: the channel does
+        // not answer (the named no-channel error for a non-ruby engine).
+        let err = runtime_source(&reqs("java", ">= 25"), None, &cfg, &ctx).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_UNAVAILABLE);
+        assert!(err.message.contains("no download source"), "{err:?}");
+        // An implementation the registry entry does not carry: same.
+        let req = RuntimeRequirements::one(RuntimeRequirement {
+            engine: "java".to_string(),
+            constraint: tpkg::Constraint::new(">= 21").unwrap(),
+            implementation: Some("graalvm".to_string()),
+            abi: None,
+        });
+        let err = runtime_source(&req, None, &cfg, &ctx).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_UNAVAILABLE);
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn an_engine_less_runtime_entry_stays_invisible_to_the_chain() {
+        // The openjdk golden gap: a `kind: runtime` entry without the
+        // payload-level `engine:` key is pre-discovery legacy — resolvable
+        // by name, never an edge answer.
+        let home = temp_home("chain-engineless");
+        let ctx = test_ctx(&home);
+        let reg = registry_ref(
+            &home,
+            "tpkg-registry.yaml",
+            r#"
+schema_version: 1
+payloads:
+  - name: tebako-runtime-openjdk
+    kind: runtime
+    versions:
+      - version: '21.0.12'
+        platforms: universal
+        release: {ref: 'tfs:github:tamatebako/tebako-runtime-openjdk:v2.5.1'}
+"#,
+        );
+        let cfg = UserConfig {
+            registries: vec![reg],
+            ..UserConfig::default()
+        };
+        let err = runtime_source(&reqs("java", ">= 21"), None, &cfg, &ctx).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_UNAVAILABLE);
+        assert!(err.message.contains("kind: runtime"), "{err:?}");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn a_non_github_release_ref_is_journaled_and_skipped() {
+        let home = temp_home("chain-nongithub");
+        let ctx = test_ctx(&home);
+        let reg = registry_ref(
+            &home,
+            "tpkg-registry.yaml",
+            r#"
+schema_version: 1
+payloads:
+  - name: tebako-runtime-python
+    kind: runtime
+    engine: python
+    versions:
+      - version: '3.13.5'
+        platforms: universal
+        release: {ref: 'tfs:gitlab:acme/tebako-runtime-python:v0.3.0'}
+"#,
+        );
+        let cfg = UserConfig {
+            registries: vec![reg],
+            ..UserConfig::default()
+        };
+        let err = runtime_source(&reqs("python", ">= 3.13"), None, &cfg, &ctx).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_UNAVAILABLE);
+        let journal = std::fs::read_to_string(home.join("journal.log")).unwrap();
+        assert!(
+            journal.contains("event=runtime-source-registry-skip engine=python"),
+            "{journal}"
+        );
+        assert!(journal.contains("gitlab"), "{journal}");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn the_default_channel_serves_ruby_only() {
+        let home = temp_home("chain-default");
+        let ctx = test_ctx(&home);
+        let cfg = UserConfig::default();
+        let source = runtime_source(&reqs("ruby", ">= 3.3"), None, &cfg, &ctx).unwrap();
+        assert_eq!(source.channel, "default");
+        assert_eq!(source.base, DEFAULT_RELEASES_BASE);
+        assert_eq!(source.tag, None);
+        let err = runtime_source(&reqs("java", ">= 21"), None, &cfg, &ctx).unwrap_err();
+        assert_eq!(err.code, EX_TEBAKO_UNAVAILABLE);
+        for channel in [
+            "source:",
+            "TEBAKO_RUNTIME_MIRROR",
+            "kind: runtime",
+            "hosts ruby runtimes only",
+        ] {
+            assert!(err.message.contains(channel), "{channel} — {err:?}");
+        }
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn tag_for_rides_the_line_unless_pinned() {
+        let unpinned = RuntimeSource {
+            base: "https://x".to_string(),
+            tag: None,
+            channel: "default",
+            signer_pin: None,
+        };
+        assert_eq!(unpinned.tag_for("0.16.22"), "v0.16.22");
+        let pinned = RuntimeSource {
+            base: "https://x".to_string(),
+            tag: Some("v2.5.1".to_string()),
+            channel: "registry",
+            signer_pin: None,
+        };
+        assert_eq!(pinned.tag_for("2.5.0"), "v2.5.1");
     }
 }

--- a/crates/tebako-shim/tests/runtime_trust.rs
+++ b/crates/tebako-shim/tests/runtime_trust.rs
@@ -1,0 +1,516 @@
+//! Runtime fetch-time OpenPGP verification (spec 09 §4 — roadmap 80's G1)
+//! and the per-engine download-source chain (spec 05 §2 — tebako#567).
+//!
+//! Fixtures are file:// release mirrors signed by a throwaway
+//! `press_local_key`; trust is registered in the test home's keyring —
+//! the exact shape the production path consumes.
+
+mod common;
+
+use std::path::Path;
+
+use common::*;
+use tebako_shim::runtime::{self, RuntimeResolution};
+use tpkg::{Constraint, RuntimeRequirement, RuntimeRequirements};
+
+fn req_engine(engine: &str, constraint: &str) -> RuntimeRequirements {
+    RuntimeRequirements::one(RuntimeRequirement {
+        engine: engine.to_string(),
+        constraint: Constraint::new(constraint).expect("test constraint parses"),
+        implementation: None,
+        abi: None,
+    })
+}
+
+fn ready(res: RuntimeResolution) -> runtime::CachedRuntime {
+    match res {
+        RuntimeResolution::Ready(rt) => *rt,
+        RuntimeResolution::Zero => panic!("expected a resolved runtime"),
+    }
+}
+
+/// A file:// release mirror in the factory's locked shape (spec 13 §2a),
+/// signed per spec 09 §5's finalize pass when `key` is Some: the index
+/// entry declares `signature` blocks for the exe and the image, and
+/// `manifest.json.asc` + the per-asset ascs sit beside their bodies.
+/// `tag` is the release directory — decoupled from the rows' tebako line
+/// (the openjdk v2.5.1 shape). Returns the release directory.
+#[allow(clippy::too_many_arguments)]
+fn write_signed_release(
+    root: &Path,
+    engine: &str,
+    lv: &str,
+    tebako: &str,
+    tag: &str,
+    key: Option<&tebako_signer::PressKey>,
+    declared_keyid: Option<&str>,
+) -> std::path::PathBuf {
+    let platform = platform();
+    let dir = root.join(tag);
+    std::fs::create_dir_all(&dir).expect("mirror dir");
+    let asset_base = format!("tebako-runtime-{tebako}-{lv}-{platform}");
+    let exe_name = format!("{asset_base}{}", tebako_shim::runtime::exe_suffix());
+    let image_name = format!("{asset_base}.tfs");
+    let exe_bytes = format!("signed runtime exe {lv}\n");
+    let image_bytes = format!("signed runtime image {lv}\n");
+    std::fs::write(dir.join(&exe_name), &exe_bytes).expect("exe");
+    std::fs::write(dir.join(&image_name), &image_bytes).expect("image");
+    let declared = key.map(|k| {
+        declared_keyid
+            .map(str::to_string)
+            .unwrap_or_else(|| tebako_signer::hex_lower(&k.keyid))
+    });
+    let signature_block = |asc: &str| match &declared {
+        Some(keyid) => format!(", \"signature\": {{\"keyid\": \"{keyid}\", \"asc\": \"{asc}\"}}"),
+        None => String::new(),
+    };
+    let manifest = format!(
+        "[{{\"tebako_version\": \"{tebako}\", \"contract_era\": 2, \"contract_version\": 2, \"mount_root\": \"/__tfs__\", \"{engine}_version\": \"{lv}\", \"platform\": \"{platform}\", \"filename\": \"{exe_name}\", \"sha256\": \"{}\"{}, \"image\": {{\"filename\": \"{image_name}\", \"sha256\": \"{}\"{}}}}}]\n",
+        sha256_hex(exe_bytes.as_bytes()),
+        signature_block(&format!("{exe_name}.asc")),
+        sha256_hex(image_bytes.as_bytes()),
+        signature_block(&format!("{image_name}.asc")),
+    );
+    std::fs::write(dir.join("manifest.json"), &manifest).expect("manifest.json");
+    if let Some(k) = key {
+        let sign = |data: &[u8]| {
+            tebako_signer::sign_detached(data, &k.secret_key, &k.fingerprint).expect("sign")
+        };
+        std::fs::write(dir.join("manifest.json.asc"), sign(manifest.as_bytes())).expect("asc");
+        std::fs::write(
+            dir.join(format!("{exe_name}.asc")),
+            sign(exe_bytes.as_bytes()),
+        )
+        .expect("exe asc");
+        std::fs::write(
+            dir.join(format!("{image_name}.asc")),
+            sign(image_bytes.as_bytes()),
+        )
+        .expect("image asc");
+    }
+    dir
+}
+
+fn journal_text(home: &Path) -> String {
+    std::fs::read_to_string(home.join("journal.log")).unwrap_or_default()
+}
+
+#[test]
+fn a_signed_release_verifies_and_journals_the_strength() {
+    let tmp = TempDir::new("g1-signed");
+    let home = tmp.path().join("home");
+    let factory = tmp.path().join("factory");
+    let key = tebako_signer::press_local_key(&factory).expect("factory key");
+    // The consumer trusts the factory key (TOFU registration).
+    tebako_signer::register_trusted(&home, &key.public_key).expect("trust");
+    let mirror = tmp.path().join("mirror");
+    write_signed_release(
+        &mirror,
+        "ruby",
+        "4.0.6",
+        "0.16.0",
+        "v0.16.0",
+        Some(&key),
+        None,
+    );
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    // Fail-closed mode on: a signed release must sail through it.
+    ctx.env.insert("TEBAKO_REQUIRE_SIGNED".into(), "1".into());
+
+    let rt =
+        ready(runtime::resolve_runtime(Some(&req_engine("ruby", ">= 3.3")), true, &ctx).unwrap());
+    assert_eq!(rt.lang_version, "4.0.6");
+    assert!(rt.exe.is_file());
+    assert!(rt.image.is_some());
+    let journal = journal_text(&home);
+    let line = journal
+        .lines()
+        .find(|l| l.contains("event=runtime-fetch-verified"))
+        .unwrap_or_else(|| panic!("no verified-fetch journal line in {journal}"));
+    assert!(line.contains("channel=mirror-env"), "{line}");
+    assert!(
+        line.contains(&format!("signer={}", tebako_signer::hex_lower(&key.keyid))),
+        "{line} names the verified signer"
+    );
+    assert!(
+        !journal.contains("event=unsigned-runtime-fetch"),
+        "{journal}"
+    );
+}
+
+#[test]
+fn an_untrusted_signer_is_exit_72() {
+    let tmp = TempDir::new("g1-untrusted");
+    let home = tmp.path().join("home");
+    let factory = tmp.path().join("factory");
+    // Signed — but the consumer's keyring never learned the key.
+    let key = tebako_signer::press_local_key(&factory).expect("factory key");
+    let mirror = tmp.path().join("mirror");
+    write_signed_release(
+        &mirror,
+        "ruby",
+        "4.0.6",
+        "0.16.0",
+        "v0.16.0",
+        Some(&key),
+        None,
+    );
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    let err =
+        runtime::resolve_runtime(Some(&req_engine("ruby", ">= 3.3")), true, &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_TRUST, "{}", err.message);
+    assert!(
+        err.message.contains("not in the trusted keyring"),
+        "{}",
+        err.message
+    );
+    assert!(
+        !home
+            .join("runtimes")
+            .join(format!("ruby-4.0.6-0.16.0-{}", platform()))
+            .exists(),
+        "a refused runtime entered the cache"
+    );
+}
+
+#[test]
+fn a_tampered_artifact_is_exit_71_before_the_checksum() {
+    let tmp = TempDir::new("g1-tampered");
+    let home = tmp.path().join("home");
+    let factory = tmp.path().join("factory");
+    let key = tebako_signer::press_local_key(&factory).expect("factory key");
+    tebako_signer::register_trusted(&home, &key.public_key).expect("trust");
+    let mirror = tmp.path().join("mirror");
+    let dir = write_signed_release(
+        &mirror,
+        "ruby",
+        "4.0.6",
+        "0.16.0",
+        "v0.16.0",
+        Some(&key),
+        None,
+    );
+    // Tamper the exe AFTER signing: the declared asc no longer matches.
+    let exe = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .find(|n| n.starts_with("tebako-runtime-") && !n.ends_with(".tfs") && !n.ends_with(".asc"))
+        .expect("exe asset");
+    std::fs::write(dir.join(&exe), b"evicted bytes\n").unwrap();
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    let err =
+        runtime::resolve_runtime(Some(&req_engine("ruby", ">= 3.3")), true, &ctx).unwrap_err();
+    assert_eq!(
+        err.code,
+        tebako_shim::EX_TEBAKO_SIGNATURE,
+        "{}",
+        err.message
+    );
+    assert!(err.message.contains("invalid signature"), "{}", err.message);
+}
+
+#[test]
+fn a_declared_signature_that_does_not_fetch_is_exit_71() {
+    let tmp = TempDir::new("g1-missing-asc");
+    let home = tmp.path().join("home");
+    let factory = tmp.path().join("factory");
+    let key = tebako_signer::press_local_key(&factory).expect("factory key");
+    tebako_signer::register_trusted(&home, &key.public_key).expect("trust");
+    let mirror = tmp.path().join("mirror");
+    let dir = write_signed_release(
+        &mirror,
+        "ruby",
+        "4.0.6",
+        "0.16.0",
+        "v0.16.0",
+        Some(&key),
+        None,
+    );
+    // The entry declares the exe's asc; the release does not carry it.
+    let asc = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .find(|n| n.starts_with("tebako-runtime-") && n.ends_with(".asc") && !n.contains("tfs"))
+        .expect("exe asc");
+    std::fs::remove_file(dir.join(&asc)).unwrap();
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    let err =
+        runtime::resolve_runtime(Some(&req_engine("ruby", ">= 3.3")), true, &ctx).unwrap_err();
+    assert_eq!(
+        err.code,
+        tebako_shim::EX_TEBAKO_SIGNATURE,
+        "{}",
+        err.message
+    );
+    assert!(err.message.contains("did not fetch"), "{}", err.message);
+}
+
+#[test]
+fn a_signer_key_mismatch_against_the_declared_keyid_is_exit_72() {
+    let tmp = TempDir::new("g1-keyid-mismatch");
+    let home = tmp.path().join("home");
+    let factory = tmp.path().join("factory");
+    let key = tebako_signer::press_local_key(&factory).expect("factory key");
+    tebako_signer::register_trusted(&home, &key.public_key).expect("trust");
+    let mirror = tmp.path().join("mirror");
+    // The entry pins a DIFFERENT primary than the one that signed —
+    // spec 09 §9's SignerKeyChanged.
+    write_signed_release(
+        &mirror,
+        "ruby",
+        "4.0.6",
+        "0.16.0",
+        "v0.16.0",
+        Some(&key),
+        Some("0000000000000000"),
+    );
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    let err =
+        runtime::resolve_runtime(Some(&req_engine("ruby", ">= 3.3")), true, &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_TRUST, "{}", err.message);
+    assert!(
+        err.message.contains("signer key changed"),
+        "{}",
+        err.message
+    );
+}
+
+#[test]
+fn an_unsigned_release_warns_journals_and_installs() {
+    let tmp = TempDir::new("g1-unsigned");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    write_signed_release(&mirror, "ruby", "4.0.6", "0.16.0", "v0.16.0", None, None);
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    let rt =
+        ready(runtime::resolve_runtime(Some(&req_engine("ruby", ">= 3.3")), true, &ctx).unwrap());
+    assert_eq!(rt.lang_version, "4.0.6");
+    let journal = journal_text(&home);
+    let line = journal
+        .lines()
+        .find(|l| l.contains("event=unsigned-runtime-fetch"))
+        .unwrap_or_else(|| panic!("no unsigned-fetch journal line in {journal}"));
+    assert!(line.contains("channel=mirror-env"), "{line}");
+}
+
+#[test]
+fn an_unsigned_release_under_require_signed_is_exit_71() {
+    let tmp = TempDir::new("g1-unsigned-strict");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    write_signed_release(&mirror, "ruby", "4.0.6", "0.16.0", "v0.16.0", None, None);
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    ctx.env.insert("TEBAKO_REQUIRE_SIGNED".into(), "1".into());
+    let err =
+        runtime::resolve_runtime(Some(&req_engine("ruby", ">= 3.3")), true, &ctx).unwrap_err();
+    assert_eq!(
+        err.code,
+        tebako_shim::EX_TEBAKO_SIGNATURE,
+        "{}",
+        err.message
+    );
+    assert!(
+        err.message.contains("TEBAKO_REQUIRE_SIGNED"),
+        "{}",
+        err.message
+    );
+    assert!(
+        !home
+            .join("runtimes")
+            .join(format!("ruby-4.0.6-0.16.0-{}", platform()))
+            .exists(),
+        "a refused runtime entered the cache"
+    );
+}
+
+#[test]
+fn a_sums_only_signed_release_has_no_trusted_contract_card() {
+    // Only SHA256SUMS.txt verifies: its digests are trustworthy, but the
+    // contract card's carrier (manifest.json) is unsigned — the spec 18
+    // C2 refusal (75), never a card read from an unverified form.
+    let tmp = TempDir::new("g1-sums-only");
+    let home = tmp.path().join("home");
+    let factory = tmp.path().join("factory");
+    let key = tebako_signer::press_local_key(&factory).expect("factory key");
+    tebako_signer::register_trusted(&home, &key.public_key).expect("trust");
+    let mirror = tmp.path().join("mirror");
+    let dir = write_signed_release(
+        &mirror,
+        "ruby",
+        "4.0.6",
+        "0.16.0",
+        "v0.16.0",
+        Some(&key),
+        None,
+    );
+    // Drop the manifest's asc; sign a SHA256SUMS.txt instead.
+    std::fs::remove_file(dir.join("manifest.json.asc")).unwrap();
+    let mut sums = String::new();
+    for entry in std::fs::read_dir(&dir).unwrap().flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.ends_with(".asc") || name == "manifest.json" || name == "SHA256SUMS.txt" {
+            continue;
+        }
+        let bytes = std::fs::read(entry.path()).unwrap();
+        sums.push_str(&format!("{}  {name}\n", sha256_hex(&bytes)));
+    }
+    std::fs::write(dir.join("SHA256SUMS.txt"), &sums).unwrap();
+    let asc = tebako_signer::sign_detached(sums.as_bytes(), &key.secret_key, &key.fingerprint)
+        .expect("sign sums");
+    std::fs::write(dir.join("SHA256SUMS.txt.asc"), asc).unwrap();
+    write_config(
+        &home,
+        "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n",
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+    let err =
+        runtime::resolve_runtime(Some(&req_engine("ruby", ">= 3.3")), true, &ctx).unwrap_err();
+    assert_eq!(err.code, tebako_shim::EX_TEBAKO_CONTRACT, "{}", err.message);
+    assert!(
+        err.message.contains("SHA256SUMS.txt verified"),
+        "{}",
+        err.message
+    );
+}
+
+#[test]
+fn the_config_source_pin_shadows_the_mirror_loudly() {
+    // spec 05 §2 channel 1: `source:` wins; a differing
+    // TEBAKO_RUNTIME_MIRROR is shadowed — loud + journaled.
+    let tmp = TempDir::new("567-source-pin");
+    let home = tmp.path().join("home");
+    let factory = tmp.path().join("factory");
+    let key = tebako_signer::press_local_key(&factory).expect("factory key");
+    tebako_signer::register_trusted(&home, &key.public_key).expect("trust");
+    let pinned = tmp.path().join("pinned");
+    write_signed_release(
+        &pinned,
+        "ruby",
+        "4.0.6",
+        "0.16.0",
+        "v0.16.0",
+        Some(&key),
+        None,
+    );
+    let shadowed = tmp.path().join("shadowed");
+    std::fs::create_dir_all(&shadowed).unwrap(); // empty — consulting it fails
+    let pinned_url = tebako_http::file_url(&pinned);
+    write_config(
+        &home,
+        &format!(
+            "runtimes:\n  ruby:\n    version: 4.0.6\n    tebako: 0.16.0\n    source: \"{pinned_url}\"\n"
+        ),
+    );
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&shadowed),
+    );
+    let rt =
+        ready(runtime::resolve_runtime(Some(&req_engine("ruby", ">= 3.3")), true, &ctx).unwrap());
+    assert_eq!(
+        rt.lang_version, "4.0.6",
+        "the config source served, not the (empty) mirror"
+    );
+    let journal = journal_text(&home);
+    let line = journal
+        .lines()
+        .find(|l| l.contains("event=runtime-source-shadow"))
+        .unwrap_or_else(|| panic!("no shadowing journal line in {journal}"));
+    assert!(line.contains("engine=ruby"), "{line}");
+    let verified = journal
+        .lines()
+        .find(|l| l.contains("event=runtime-fetch-verified"))
+        .unwrap_or_else(|| panic!("no verified-fetch journal line in {journal}"));
+    assert!(verified.contains("channel=config-source"), "{verified}");
+}
+
+#[test]
+fn a_non_ruby_engine_no_channel_answers_is_the_named_error() {
+    // tebako#567's closeout: no config source, no mirror, no registry,
+    // and the default hosts ruby only — the error enumerates the chain.
+    let tmp = TempDir::new("567-no-channel");
+    let home = tmp.path().join("home");
+    let err = runtime::resolve_runtime(
+        Some(&req_engine("java", ">= 21")),
+        true,
+        &ctx(&home, tmp.path()),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.code,
+        tebako_shim::EX_TEBAKO_UNAVAILABLE,
+        "{}",
+        err.message
+    );
+    for channel in [
+        "runtimes: {java: {source:",
+        "TEBAKO_RUNTIME_MIRROR",
+        "kind: runtime",
+        "hosts ruby runtimes only",
+    ] {
+        assert!(err.message.contains(channel), "{channel} — {}", err.message);
+    }
+}

--- a/crates/tpkg/src/runtime_store.rs
+++ b/crates/tpkg/src/runtime_store.rs
@@ -133,6 +133,53 @@ pub fn entry_filename(entry: &tebako_json::Value, facet: Option<&str>) -> Option
         .filter(|s| !s.is_empty())
 }
 
+/// The parsed `signature` block of a release-index entry (spec 13 §2a):
+/// the signing key's PRIMARY keyid (16 lowercase hex — spec 09 §9's
+/// identity-not-instrument rule) + the exact `.asc` asset name within the
+/// same release.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntrySignature {
+    pub keyid: String,
+    pub asc: String,
+}
+
+/// The `signature` block of the entry itself (`facet: None`) or of a
+/// facet object (`image` / `dll`). `Ok(None)` = the key is absent — the
+/// pre-signing keep-forever line (spec 13 §2a). A PRESENT but torn block
+/// (not a map, empty/absent `keyid` or `asc`) is the named error: an
+/// index the fetch path already trusted is lying about its trust anchors
+/// — never a silent downgrade to the unsigned rule (spec 00 §9).
+pub fn entry_signature(
+    entry: &tebako_json::Value,
+    facet: Option<&str>,
+) -> Result<Option<EntrySignature>, String> {
+    let node = match facet {
+        Some(f) => entry.find(f),
+        None => Some(entry),
+    };
+    let Some(node) = node else { return Ok(None) };
+    let Some(sig) = node.find("signature") else {
+        return Ok(None);
+    };
+    let where_ = match facet {
+        Some(f) => format!("the entry's {f}.signature"),
+        None => "the entry's signature".to_string(),
+    };
+    if !matches!(sig, tebako_json::Value::Object(_)) {
+        return Err(format!("{where_} must be a map (spec 13 §2a)"));
+    }
+    let field = |name: &str| -> Result<String, String> {
+        sig.find(name)
+            .and_then(|v| v.as_string())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| format!("{where_} lacks a usable {name} (spec 13 §2a)"))
+    };
+    Ok(Some(EntrySignature {
+        keyid: field("keyid")?,
+        asc: field("asc")?,
+    }))
+}
+
 /// The exe / env-image names for a cache entry: flow the cached release
 /// index verbatim when it names this identity, else the synthesized
 /// fallback (`{name}.exe` on windows, `{name}` on posix — spec 05 §2's
@@ -1193,6 +1240,62 @@ mod tests {
         assert_eq!(entry_contract_version(&dir3, "never-released"), None);
         assert_eq!(entry_contract_version(&tmp.join("runtimes"), &exe3), None);
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // -----------------------------------------------------------------
+    // spec 13 §2a: the per-artifact signature block
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn entry_signature_reads_the_entry_and_facet_blocks() {
+        let parsed = tebako_json::parse(
+            r#"[{"filename": "exe",
+                 "signature": {"keyid": "efc3c250f7862a48", "asc": "exe.asc"},
+                 "image": {"filename": "img.tfs",
+                            "signature": {"keyid": "efc3c250f7862a48", "asc": "img.tfs.asc"}},
+                 "dll": {"filename": "d.dll"}}]"#,
+        )
+        .unwrap();
+        let tebako_json::Value::Array(entries) = &parsed else {
+            panic!("an array parses");
+        };
+        let entry = &entries[0];
+        let exe_sig = entry_signature(entry, None).unwrap().expect("declared");
+        assert_eq!(exe_sig.keyid, "efc3c250f7862a48");
+        assert_eq!(exe_sig.asc, "exe.asc");
+        let img_sig = entry_signature(entry, Some("image"))
+            .unwrap()
+            .expect("declared");
+        assert_eq!(img_sig.asc, "img.tfs.asc");
+        // Absent key (entry-level on a facet, whole entry without it):
+        // the pre-signing keep-forever line — Ok(None), never an error.
+        assert_eq!(entry_signature(entry, Some("dll")).unwrap(), None);
+        let bare = tebako_json::parse(r#"[{"filename": "old-exe"}]"#).unwrap();
+        let tebako_json::Value::Array(entries) = &bare else {
+            panic!("an array parses");
+        };
+        assert_eq!(entry_signature(&entries[0], None).unwrap(), None);
+        assert_eq!(entry_signature(&entries[0], Some("image")).unwrap(), None);
+    }
+
+    #[test]
+    fn entry_signature_torn_blocks_are_named_errors() {
+        let parsed = tebako_json::parse(
+            r#"[{"filename": "exe", "signature": "garbage"},
+                 {"filename": "exe2", "signature": {"keyid": "efc3c250f7862a48"}},
+                 {"filename": "exe3", "image": {"signature": {"keyid": "", "asc": "x.asc"}}}]"#,
+        )
+        .unwrap();
+        let tebako_json::Value::Array(entries) = &parsed else {
+            panic!("an array parses");
+        };
+        let err = entry_signature(&entries[0], None).unwrap_err();
+        assert!(err.contains("must be a map"), "{err}");
+        let err = entry_signature(&entries[1], None).unwrap_err();
+        assert!(err.contains("asc"), "{err}");
+        let err = entry_signature(&entries[2], Some("image")).unwrap_err();
+        assert!(err.contains("image.signature"), "{err}");
+        assert!(err.contains("keyid"), "{err}");
     }
 
     // -----------------------------------------------------------------

--- a/docs/spec/05-resolution-and-cache.md
+++ b/docs/spec/05-resolution-and-cache.md
@@ -62,9 +62,10 @@ recorded for the failure message.
   (coreutils `<sha>  <file>` — the store marker's exact shape). The
   sidecar is the per-asset pin; the shard's sha fields are re-anchored
   to the served bytes at publish time.
-- **The download base is PER-ENGINE** (the chain below is PLANNED —
-  TODO.v2-1/30; today a single base serves all engines, with
-  `TEBAKO_RUNTIME_MIRROR` as the only override). First hit wins, and
+- **The download base is PER-ENGINE** (the chain below is SHIPPED in
+  tebako-shim's dispatch-time fetch — tebako#567; the CLI's press-time
+  resolver and the bootstrap consult `TEBAKO_RUNTIME_MIRROR` + the
+  default base only). First hit wins, and
   every download journals the base AND the channel that supplied it:
   1. `runtimes: {<engine>: {source: <base>}}` — the authored config pin
      (spec 07 §0; most specific: an operator who pins an engine's

--- a/docs/spec/07-shims-and-dispatch.md
+++ b/docs/spec/07-shims-and-dispatch.md
@@ -35,7 +35,8 @@ in `config.yaml` as the exact ref).
   `[payload@]version`), `registries:` (spec 04 refs), `runtimes:`
   (engine → `{version, tebako, source?}` runtime preference; `source:`
   pins the engine's download base — spec 05 §2's per-engine chain,
-  PLANNED TODO.v2-1/30). The shim never writes this file — except
+  SHIPPED in the shim's dispatch-time fetch, tebako#567). The shim never
+  writes this file — except
   through `tebako-shim use`, the explicit verb (tmp + rename, the same
   discipline as `add-registry`; a structural edit that preserves keys,
   not comments).

--- a/docs/spec/09-trust-and-signing.md
+++ b/docs/spec/09-trust-and-signing.md
@@ -7,8 +7,12 @@ ceremony EXECUTED 2026-09-09 (§7); release signing SHIPPED — the
 finalize job signs every released part and the release indexes behind
 `TEBAKO_RELEASE_SIGNING_ENABLED` (§6). Runtime FETCH-TIME verification
 (§4's resolve-path point, §5's signed index forms, spec 13 §2a's
-per-artifact `signature`) is PLANNED — roadmap 80/G1: until it lands,
-runtime release signatures are out-of-band only.
+per-artifact `signature`) is SHIPPED in the CLI's press-time resolver
+and the shim's dispatch-time fetch (roadmap 80/G1, tebako#567's chain);
+the bootstrap's first-run runtime download is the remaining leg
+(PLANNED — until it lands, the bootstrap verifies sha256 only and never
+reads `signature` declarations: the pre-G1 behavior, landing together
+with the `openpgp-verify` capability flip of the rollout note below).
 
 > **Rollout phase — unverified-first (roadmap 72).** The shipped
 > tebako-bootstrap is built WITHOUT OpenPGP verification (the
@@ -95,9 +99,10 @@ tebako validates below it — see spec 12 §5.
 - **Install time:** registry-pinned payload signatures verify against the
   trusted keyring PLUS the embedded root public key — a tamatebako-signed
   payload verifies Trusted on a fresh machine, no registration step.
-- **Runtime fetch (resolve time — tebako-resolve, the one code path
-  behind the shim's dispatch, the CLI's install/press, and the
-  bootstrap's runtime download; PLANNED — roadmap 80/G1):** the resolver
+- **Runtime fetch (resolve time — the per-binary fetch paths: the
+  shim's dispatch-time download and the CLI's press-time resolver SHIPPED
+  (roadmap 80/G1); the bootstrap's runtime download is the remaining
+  leg, PLANNED):** the resolver
   verifies the consumed index form's detached signature (§5) BEFORE
   trusting its digests, then verifies each fetched artifact whose entry
   declares `signature` (spec 13 §2a) — always strict: an invalid


### PR DESCRIPTION
## DRAFT — do not merge (owner rule: production moves only on explicit go-ahead)

Implements the code side of the spec amendment merged as #571 (`bf8beca5`):

- **G1 — runtime fetch-time signature verification** (spec 09 §4/§5, spec 13 §2a's per-artifact `signature:` blocks) in the two runtime-fetch paths that ship with OpenPGP verification today: the **shim's dispatch-time fetch** and the **CLI's press-time resolver** (`tebako press` / `tebako cache` flows).
- **#567 — per-engine runtime index routing**: spec 05 §2's four-channel download-base chain, **shim only** (the CLI resolver and the bootstrap stay on `TEBAKO_RUNTIME_MIRROR` + the product default — the spec now says so).

### What lands, per crate

**`tpkg`** — `runtime_store::entry_signature(entry, facet)`: the ONE parser of a release-index entry's declared `signature: {keyid, asc}` block (entry level, or the `image` / `dll` facet). Absent = pre-signing keep-forever line (`Ok(None)`); present-but-torn = the named error, never a silent downgrade to unsigned (spec 00 §9).

**`tebako-shim`** (dispatch-time fetch):
- The release index's `.asc` siblings are probed before any digest is trusted (`manifest.json.asc`, then `SHA256SUMS.txt.asc`); a TRUSTED form is consumed, an untrusted signer is exit 72, an invalid signature exit 71.
- Declared per-artifact `signature:` blocks verify against the downloaded bytes BEFORE the sha256 check; the signer pins by resolved PRIMARY keyid (a signing subkey pins by its primary, spec 09 §9).
- The unsigned rule (spec 09 §5): an unverifiable fetch proceeds LOUDLY (stderr + `event=unsigned-runtime-fetch` in the audit journal); `TEBAKO_REQUIRE_SIGNED=1` refuses (exit 71) before any asset downloads.
- **#567**: `runtime_source()` resolves the download base through the spec 05 §2 chain — 1. config `runtimes: {<engine>: {source:}}` pin (a differing mirror env is journaled as shadowed), 2. `TEBAKO_RUNTIME_MIRROR`, 3. registry-derived from a matching `kind: runtime` entry (with the entry's signer pin), 4. the product default base. An engine no channel answers is a named error enumerating the channels tried. Every fetch journals the base AND the channel that supplied it.

**`tebako-cli`** (press-time fetch — `crates/tebako-cli/src/resolve.rs`):
- The spec 09 §5 trust scan runs FIRST (`fetch_verified_index`): every consumable index form's detached `.asc` is probed in preference order (the per-package shard `<stem>.manifest.json`, `manifest.json`, `SHA256SUMS.txt`); the first TRUSTED form is the consumed form — **a verified form beats an unsigned one regardless of the index's preference order**. Only when no form carries a verifiable signature does the legacy shard → monolith chain run, marked `IndexTrust::Unverified`.
- `verify_declared`: each artifact's declared `signature:` block (exe, env image, windows dll) verifies against the downloaded bytes BEFORE the sha256 check. The `.asc` must be a bare asset name of the same release (a separator is exit 65, never fetched).
- The unsigned gate applies BEFORE any asset downloads when the index is unverified; a declared signature on any artifact the run installs counts as signed coverage.
- Journal: `event=runtime-index-verified form=<name> signer=<primary-keyid>` at the index boundary; `event=runtime-fetch-verified runtime_ref=… mirror=… signer=…` (deduped) per resolved runtime; `event=unsigned-runtime-fetch runtime_ref=… mirror=…` for the loud-unsigned path.
- `install.rs`: `require_signed` / `journal` flip to `pub(crate)` so the resolver shares the exact rules — no second copy (spec 00 §10).

### Exit-code matrix (spec 09 §4)

| Situation | CLI (press) | shim (dispatch) |
|---|---|---|
| Index `.asc` invalid / tampered | 71 | 71 |
| Index signer not in keyring | 72 | 72 |
| Declared artifact `.asc` invalid | 71 | 71 |
| Declared artifact `.asc` does not fetch | 71 | 71 |
| Declared artifact signer untrusted | 72 | 72 |
| Signer key ≠ declared pin (pin by primary) | **72** | 72 |
| Torn `signature:` block (spec 13 §2a) | 65 | 65 |
| Unsigned + `TEBAKO_REQUIRE_SIGNED=1` | 71 (before any download) | 71 |
| Unsigned, no requirement | loud warning + journal, sha256 as today | loud warning + journal, sha256 as today |

Divergence to note: the payload-install path (`install.rs`) uses **71** for a signer-pin mismatch; the runtime-fetch paths use **72** (the signer key CHANGED is a trust-identity failure, same class as an untrusted signer). Flagging for review — easy to align either way.

### What deliberately does NOT change

- **`tebako-resolve`'s `cache.rs` stays sha256-only.** It is the *payload* cache; payload signature verification already lives in `install.rs::verify_signature`, which runs BEFORE `cache.install` — authenticity is the caller's job, the cache enforces the digest anchor. G1 concerns the *runtime* fetch paths, which live in the shim (`runtime.rs`), the CLI (`resolve.rs`), and the bootstrap (`lib.rs`) — the first two are this PR.
- **The bootstrap's first-run runtime download is the remaining leg** (named PLANNED in spec 09's header + §4 bullet here). The shipped bootstrap builds WITHOUT `openpgp-verify` (roadmap 72 rollout: verification returns via the tebako-crypto payload); its G1 leg — the feature-on verify plus the compiled-out loud-UNVERIFIED arm mirroring spec 06 §3 — lands with that capability flip. Until then it verifies sha256 only and never reads `signature:` declarations (the pre-G1 behavior).
- The CLI's *bootstrap* store (`BootstrapResolver`, spec 19 §4 — the tebako-bootstrap asset fetch from the product's own releases) stays sha256-only in this PR; G1's scope is the runtime fetch.

### Test evidence (all debug; `cargo test --release` never run locally per repo rule)

- `tpkg`: 173 lib tests + all integration suites ok — incl. the 2 new `entry_signature` tests (facet/absent/torn).
- `tebako-shim`: lib 20 + dispatch 36 + manage 18 + regcache 7 + resolve 19 + runtime 32 + shell 7 ok; the new `tests/runtime_trust.rs` (10 tests) covers the signed happy path, untrusted signer (72), tampered exe (71), missing asc (71), pin mismatch (72), unsigned+REQUIRE_SIGNED (71), unsigned loud-pass, verified-manifest-beats-unsigned-sums, config-source pinning with shadow journal, and the no-channel-answers named error.
- `tebako-cli`: lib 163 ok — 40 `resolve::` tests incl. **10 new G1 tests**: signed happy path (journal asserts), untrusted index signer (72), tampered exe (71, signature checked BEFORE sha), missing declared asc (71), changed signer key (72), unsigned installs loudly (+ journal), pure `unsigned_gate` matrix, tampered index (71), verified-manifest beats a POISONED unsigned shard (preference rule), signed-sums-only release still hits the contract gate (75). `tests/cli_e2e.rs` 14/14 ok against the REAL releases (the unsigned ruby 0.16.22 line installs with the loud warning — live proof the pre-signing keep-forever line is untouched), plus all 16 other integration suites green.
- Full matrix run on the final tree: **837 tests, 0 failures**, across tpkg (lib + 10 integration suites), tebako-signer, tebako-resolve, tebako-shim (lib + 8 suites), tebako-cli (lib + 16 suites); cli_e2e (14) separately.
- Golden fixture: the openjdk feedstock's published `v2.5.1` `manifest.json.asc` / `SHA256SUMS.txt.asc` verify VALIDSIG against the embedded tamatebako root — issued by the release signing subkey `7a437d7382a3cf5a`, whose primary is the root `efc3c250f7862a48` (the spec 09 §9 primary-vs-subkey rule is why verification resolves the primary before pinning).
- `cargo fmt --check` clean on tpkg / tebako-shim / tebako-cli; `cargo clippy` on the touched crates shows only two pre-existing warnings (`info.rs` sort_by, `trace/mod.rs` collapsible_match — present on `bf8beca5` too, verified by stash).
