### PR TITLE
install: payload signer-pin mismatch exits 72 (spec 09 §9 SignerKeyChanged)

### DIFF
--- a/crates/tebako-cli/src/install.rs
+++ b/crates/tebako-cli/src/install.rs
@@ -1850,9 +1850,9 @@ fn verify_signature<T: Transport>(
                     .as_deref()
                     .map_or_else(String::new, |p| format!(" (primary {p})"));
                 return Err(err(
-                    EX_TEBAKO_SIGNATURE,
+                    EX_TEBAKO_TRUST,
                     format!(
-                        "{} is signed by {issuer}{primary_note} but the registry pins {pin} — refusing to install; nothing was cached",
+                        "{} is signed by {issuer}{primary_note} but the registry pins {pin} — the signer key changed (spec 09 §9 SignerKeyChanged); refusing to install; nothing was cached",
                         fetched.origin
                     ),
                 ));

--- a/crates/tebako-cli/tests/install.rs
+++ b/crates/tebako-cli/tests/install.rs
@@ -752,8 +752,9 @@ fn pin_naming_another_primary_is_the_named_mismatch() {
     install::add_registry(&fx.home, &reg_ref).unwrap();
 
     let err = install::install(&fx.home, "app", None, Some(&fx.shim_binary)).unwrap_err();
-    assert_eq!(err.code, 71, "{err:?}");
+    assert_eq!(err.code, 72, "{err:?}");
     assert!(err.message.contains("registry pins"), "{err:?}");
+    assert!(err.message.contains("the signer key changed"), "{err:?}");
     assert!(!fx.payloads_dir().join("app/1.0.tfs").exists());
 }
 


### PR DESCRIPTION
## What

The payload install path's signer-pin mismatch now exits **72** (`SignerKeyChanged`, spec 09 §9) instead of 71, matching the runtime-fetch path shipped in #572 (`resolve.rs`'s "the signer key changed" arm) and the spec's named class:

> A key mismatch fails closed (`SignerKeyChanged`, exit 72) — spec 09 §9

The message gains the same "the signer key changed" phrase the runtime-fetch path uses, so operators see one consistent wording across both fetch families. Nothing else changes: invalid signature stays 71, untrusted key stays 72, the pin still names the primary (subkey issuance resolves through the keyring).

Pre-existing deviation, called out during #572's review and recorded as a follow-up in TODO.roadmap/80 — deliberately its own PR (behavior change on a shipped path), not a ride-along.

## Evidence

- `cargo test -p tebako-cli --test install` — full suite green locally (debug), including:
  - `pin_naming_another_primary_is_the_named_mismatch` — now asserts 72 + "registry pins" + "the signer key changed"
  - `invalid_signature_is_the_named_signature_error` — still 71 (untouched path, re-verified)
- `cargo fmt --check -p tebako-cli` clean.

## Spec

No spec change — this aligns the code TO spec 09 §9's existing rule (the spec already said 72).
