### PR TITLE
release: v2.7.0 — the signing-verification line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 members = ["crates/tpkg", "crates/tfs", "crates/sqfs-sys", "crates/tebako-pkg", "crates/tfs-cli", "crates/tebako-bootstrap", "crates/tebako-cli", "crates/tebako-http", "crates/tebako-signer", "crates/tebako-shim", "crates/tebako-json", "crates/tebako-resolve", "crates/tebako-term", "crates/tebako-info", "crates/libtfs-preload", "crates/tebako-driver", "crates/tebako-runtime-launcher", "crates/tebako-arscope", "crates/tebako-bench", "tests/contract"]
 
 [workspace.package]
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 rust-version = "1.79"
 license = "BSD-2-Clause"


### PR DESCRIPTION
## What

Workspace version 2.6.0 → 2.7.0, then tag `v2.7.0` on the merge.

## Why minor

G1 is a new capability: runtime-fetch signature verification with `TEBAKO_REQUIRE_SIGNED=1` fail-closed enforcement (#571 spec, #572 implementation), plus the install signer-pin exit-code consistency fix (#573) and the metanorma registry-grammar routing (#567). New capability, backwards compatible → minor bump.

## Pin sweep

Not needed: intra-workspace pins are caret `^2.x`, which accepts 2.7.0 (the pin-sweep rule is for `^0.x.y` boundary crossings). Verified: no `=2.x` exact pins, no `2.6.0` literals outside the root `Cargo.toml`.

## After merge

Tag `v2.7.0` on the merge sha → `release.yml` builds every platform, signs (OpenPGP + Authenticode + notarize), size-gates, publishes.
