### PR TITLE
spec 17 §2.3 + 22 §4: the trust bridge (roadmap 81, PLANNED)

### DIFF
--- a/docs/spec/17-runtime-driver-contract.md
+++ b/docs/spec/17-runtime-driver-contract.md
@@ -228,6 +228,52 @@ option processing reads it at boot (`RUBY_YJIT_ENABLE`, `PYTHON_JIT`,
   and each key's provenance layer render through the spec 15 §4
   surface; no per-run journal entry exists in this phase.
 
+### 2.3 The trust bridge (roadmap 81, PLANNED)
+
+The loader plane's network configuration (spec 04's `network:` grammar —
+the single resolution owner) already trusts the enterprise proxy story
+for its OWN fetches: `tls_roots: platform` / `TEBAKO_TLS_PLATFORM_ROOTS`
+(the OS store, where the GPO/MDM-pushed proxy CA lives) and additive
+`extra_ca:` / `TEBAKO_EXTRA_CA` (org PEMs parsed into the bundled
+roots). This subsection is the bridge that makes the RUNTIME's TLS
+stacks follow the same resolution — one config, every plane; the
+canonical runtime images stay pristine (trust material flows at run
+time, never a per-org rebuild).
+
+- **The wire.** The dispatcher (shim / bootstrap) resolves netconfig
+  ONCE per process and conveys the verdict to the driver by exporting
+  `TEBAKO_TLS_PLATFORM_ROOTS` / `TEBAKO_EXTRA_CA` into the handoff env —
+  env inheritance is the wire (spec 00 §10: no second hand-written
+  copy, no second config read in the driver).
+- **The PEM planes (ruby / python / everything openssl- or
+  curl-fashioned).** When either var is in force, the driver's cert
+  convention (§2's `SSL_CERT_FILE` row, spec 22 §4) materializes a
+  MERGED bundle instead of the image's bare `cert.pem`: the image roots
+  + the enumerated platform store (rustls-native-certs; the driver is
+  not size-gated) in platform mode, or the image roots + the parsed
+  `extra_ca` PEMs in additive mode. The merged bundle lives under the
+  same resources cache with the same digest discipline (spec 22 §4's
+  write-once + per-boot rehash), content-keyed by the merge inputs.
+  Precedence is the §2 row's unchanged: a user's real host-path
+  `SSL_CERT_FILE` always wins; the stale in-VFS spelling is still
+  rewritten. Platform + additive simultaneously is the netconfig
+  layer's named error, never the driver's.
+- **The java plane.** The JVM is a spawned child (spec 30), not a
+  driver boot — its bridge rides the §2.2 interp_env chain on the
+  dispatcher side: in platform mode on windows the chain additively
+  appends `-Djavax.net.ssl.trustStoreType=Windows-ROOT` to
+  `JAVA_TOOL_OPTIONS` (the JVM trusts the OS store natively; additive
+  merge, never a stomp). The `extra_ca`-on-java shape (a materialized
+  PKCS12 truststore + `-Djavax.net.ssl.trustStore`) is the open
+  sub-item of roadmap 81 — until it lands, `extra_ca` with a spawned
+  java edge in force yields a loud journal line naming the gap, never
+  a silent partial-trust boot.
+- **Fail closed.** A malformed `extra_ca` PEM, an unenumerable
+  platform store, or an unwritable merge destination is a named boot
+  error (65 class) — never a silent fall back to the image bundle
+  alone, which would surface as inscrutable TLS errors deep in the
+  payload. There is no verify-off spelling.
+
 ## 3. File IO semantics
 
 The runtime's IO MUST route mounted paths through the TFS layer

--- a/docs/spec/22-runtime-native-interposition.md
+++ b/docs/spec/22-runtime-native-interposition.md
@@ -781,7 +781,13 @@ env-surface exception is the cert convention (`ssl/cert.pem`): the
 driver — the single owner of where the materialized copy landed —
 exports `SSL_CERT_FILE` at boot per spec 17 §2's table (an image-side
 default pointing at the in-VFS spelling is unreadable by libcrypto's
-native CRT IO on the store-less boot, the #437 failure).
+native CRT IO on the store-less boot, the #437 failure). When the
+handoff env carries the loader's network resolution
+(`TEBAKO_TLS_PLATFORM_ROOTS` / `TEBAKO_EXTRA_CA`), the materialized
+cert is the MERGED bundle of spec 17 §2.3 (image roots + platform
+store or extra PEMs) — a derived resource under this section's same
+write-once / per-boot-rehash discipline, content-keyed by the merge
+inputs.
 
 **Rule R3.** Materialization is whole-file, read-only, and verified.
 The mechanics (locked):


### PR DESCRIPTION
## What

Spec-first for roadmap 81 (metanorma-iho#531 — enterprise MITM proxy trust). No code changes; the new subsection is marked **PLANNED**.

- **spec 17 §2.3 (new): the trust bridge.** The loader plane already resolves the proxy grammar (`network:` `tls_roots: platform` / `extra_ca`, shipped with TODO.v2-1/33). This pins how the runtime's TLS stacks follow that ONE resolution:
  - the dispatcher conveys the verdict by env (`TEBAKO_TLS_PLATFORM_ROOTS` / `TEBAKO_EXTRA_CA`) — spec 00 §10, no second config read in the driver;
  - the driver's cert convention materializes a **merged bundle** (image roots + enumerated platform store via rustls-native-certs, or + parsed extra PEMs), same precedence as the §2 `SSL_CERT_FILE` row (the user's own host path always wins);
  - the java plane rides the §2.2 interp_env chain: `-Djavax.net.ssl.trustStoreType=Windows-ROOT` in platform mode on windows (the JVM trusts the OS store natively). The `extra_ca`-on-java PKCS12 shape is the named open sub-item;
  - fail closed on malformed PEMs / unenumerable stores — never a silent partial-trust boot; no verify-off spelling.
- **spec 22 §4:** cross-ref — the merged bundle is a derived resource under the cert convention's write-once / per-boot-rehash discipline, content-keyed by the merge inputs.

The hard constraint (owner, roadmap 81): the canonical runtime images stay pristine — trust material flows at run time through config only, never a per-org runtime rebuild.

Refs: TODO.roadmap/81-enterprise-proxy-trust.md, metanorma-iho#531.
