### PR TITLE
press: auto-compose the lock's spawned[] rows (spec 23 §13.6, specs 30/32)

### DIFF
--- a/crates/tebako-cli/src/compose.rs
+++ b/crates/tebako-cli/src/compose.rs
@@ -400,8 +400,8 @@ pub fn resolve_closure<T: Transport>(
                 // spec 32 §1: the executable edge's MOUNT axis co-mounts
                 // the provider payload like toolkit/data (below); an
                 // expose-only edge is NEVER co-mounted — it rides the
-                // embedded manifest verbatim and the lock's hand-authored
-                // spawned[] rows (the spec 30 §1 posture).
+                // spawn walk's lock.spawned[] row (spec 23 §13.6,
+                // src/spawn.rs).
                 if let tpkg::Requirement::Executable {
                     name,
                     payload,
@@ -436,9 +436,8 @@ pub fn resolve_closure<T: Transport>(
                 let (name, constraint, mount) = match requirement {
                     // The runtime axes: the composition's runtime: row
                     // owns the language edge; a spawned-runtime edge
-                    // (spec 30) is NEVER co-mounted — it rides the
-                    // embedded manifest verbatim and resolves at
-                    // dispatch/spawn, not at compose.
+                    // (spec 30) is NEVER co-mounted — the spawn walk
+                    // (spec 23 §13.6, src/spawn.rs) composes its lock row.
                     tpkg::Requirement::Language { .. } | tpkg::Requirement::Runtime { .. } => {
                         continue
                     }
@@ -494,7 +493,9 @@ pub fn resolve_closure<T: Transport>(
 /// matches the capability against `entrypoints[]` of versions satisfying
 /// the edge's constraint. Zero providers is the named not-found; more
 /// than one is AmbiguousProvider — pin the provider with `payload:`.
-fn compose_capability_provider<T: Transport>(
+/// `pub(crate)`: the spawn walk (spec 23 §13.6) resolves the same answer
+/// for the lock's payload rows.
+pub(crate) fn compose_capability_provider<T: Transport>(
     home: &Path,
     fetcher: &Fetcher<T>,
     consumer: &str,

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -81,6 +81,7 @@ pub mod run;
 pub mod runner;
 pub mod scenario;
 pub mod sdk;
+pub mod spawn;
 pub mod strip;
 pub mod suite;
 pub mod trace;
@@ -278,6 +279,15 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
     // exactly what press tested (spec 23 §4).
     let mut compose_slices: Vec<compose::ComposeSlice> = Vec::new();
     let mut runtime_carried = opts.mode == PressMode::Fat;
+    // The spawn walk's (preset, home) inputs (spec 23 §13.6): the compose
+    // document's resolved pair when one drives the press; else the
+    // --mode-derived preset and a lazily resolved store home (a spawn-less
+    // plain press never pays for it).
+    let mut spawn_preset = match opts.mode {
+        PressMode::Fat => tpkg::ComposePreset::SelfContained,
+        _ => tpkg::ComposePreset::SharedRuntime,
+    };
+    let mut spawn_home: Option<PathBuf> = None;
     if let Some(doc) = &compose_doc {
         let mut doc = doc.clone();
         let preset = if opts.mode_explicit {
@@ -306,6 +316,8 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
             .runtime
             .carry
             .unwrap_or_else(|| preset.default_carry(true));
+        spawn_preset = preset;
+        spawn_home = Some(home);
     }
 
     let mut images: Vec<(PathBuf, String, u32)> = vec![(
@@ -422,18 +434,30 @@ pub fn press(opts: &PressOptions) -> Result<PathBuf, TebakoError> {
             source: Some(s.source.clone()),
         });
     }
+    // The lock's spawned rows (spec 23 §13.6, spec 30 §2, spec 32 §6):
+    // press walks the app image's L1 `requires:` — every kind: runtime
+    // edge and every expose-carrying kind: executable edge — resolves
+    // each exactly as managed dispatch would, and pins the carried bytes
+    // (the slots follow the app/slice/carried-runtime slots in walk
+    // order). A spawn-less app image composes no rows and never resolves
+    // the store home; `tebako-pkg validate` cross-checks the mirror.
+    let spawn = spawn::resolve_spawned_edges(
+        || match spawn_home {
+            Some(home) => Ok(home),
+            None => compose::tebako_home(),
+        },
+        &tebako_resolve::Fetcher::new(),
+        &app_image,
+        &stem,
+        spawn_preset,
+        install::host_platform()?,
+        images.len() as u32,
+    )?;
+    images.extend(spawn.images);
     let lock = tpkg::PackageLock {
         runtime: Some(lock_runtime),
         slices: lock_slices,
-        // The D2 press does not yet mirror the app payload's L1
-        // `requires[].kind: runtime` (spec 30 §1) or expose-carrying
-        // `requires[].kind: executable` (spec 32 §6) edges into lock
-        // rows — packages declaring spawned edges hand-author the lock's
-        // `spawned[]` block (packed-mn) and `tebako-pkg validate`
-        // cross-checks the mirror (both row shapes). Auto-mirroring
-        // (press-time runtime/payload resolution for the pick + pins) is
-        // the follow-up.
-        spawned: Vec::new(),
+        spawned: spawn.rows,
     };
 
     let mut runtime_ref = format!("ruby@{ruby_ver};tebako={}", opts.tebako_version);

--- a/crates/tebako-cli/src/spawn.rs
+++ b/crates/tebako-cli/src/spawn.rs
@@ -1,0 +1,747 @@
+//! The press-time spawned-edge walk (spec 23 §13.6, spec 30 §2, spec 32
+//! §6): `tebako press` reads the app image's L1 `requires:` and composes
+//! the lock's `spawned[]` rows itself — one row per `kind: runtime` edge
+//! (spec 30) and per expose-carrying `kind: executable` edge (spec 32),
+//! in manifest order — resolving each edge exactly as managed dispatch
+//! would (the runtime pair through the machine runtime store, the
+//! provider payload through the registered registries into the payload
+//! cache) and pinning the carried bytes' digests into the row.
+//!
+//! Press is NOT install: the resolved bytes land in the trust-anchored
+//! caches, but no mirrors, shims, or materialized trees are written —
+//! those are the install verb's surface (spec 07 §2). `carry` rides the
+//! preset's defaults; a row the preset leaves SHARED splits by kind: a
+//! shared runtime row is a named press error (press resolves runtimes
+//! through the machine store and records no replayable `source:` — the
+//! error advises `--mode=self-contained`; the hand-authored `spawned[]`
+//! block stays the escape hatch, spec 23 §13.6), while a shared payload
+//! row records its registry `source:` (no current preset produces one).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use tebako_resolve::registry::RegistryPlatforms;
+use tebako_resolve::{Fetcher, PayloadCache, ResolveError, Transport};
+use tpkg::{ComposePreset, Platform};
+
+use crate::compose;
+use crate::error::TebakoError;
+use crate::image_manifest;
+use crate::install;
+
+// The spec 06 §4 named set (the codes compose.rs/install.rs already own;
+// the spawn walk's errors are manifest/resolution failures of the same
+// family).
+const EX_TEBAKO_MANIFEST: i32 = 65;
+const EX_TEBAKO_SHA: i32 = 70;
+const EX_TEBAKO_IO: i32 = 74;
+
+fn err(message: impl Into<String>) -> TebakoError {
+    TebakoError::new(message, EX_TEBAKO_MANIFEST)
+}
+
+/// The walk's product: the lock's `spawned[]` rows (in the app
+/// manifest's `requires:` order) plus the carried bytes as press image
+/// specs (`(path, mount, format_id)` — the mount is always "", a carried
+/// spawned artifact is never mounted; its slot is the spec's index in
+/// press's image list).
+#[derive(Debug, Default)]
+pub struct SpawnedPlan {
+    pub rows: Vec<tpkg::LockedSpawned>,
+    pub images: Vec<(PathBuf, String, u32)>,
+}
+
+/// One spawn-bearing edge of the app manifest (the walk's unit).
+enum SpawnEdge<'m> {
+    /// A `kind: runtime` edge (spec 30 §1) — the row mirrors the edge
+    /// whether or not it exposes names.
+    Runtime {
+        engine: &'m str,
+        implementation: Option<&'m str>,
+        constraint: &'m tpkg::Constraint,
+        expose: &'m [String],
+    },
+    /// An expose-carrying `kind: executable` edge (spec 32 §1/§6).
+    Executable {
+        name: &'m str,
+        payload: Option<&'m str>,
+        constraint: &'m tpkg::Constraint,
+        expose: &'m [String],
+    },
+}
+
+/// Compose the lock's `spawned[]` rows for one press (spec 23 §13.6).
+/// `home` is LAZY: a spawn-less app image (no embedded manifest, or no
+/// spawn-bearing edges) composes no rows and never resolves the store
+/// home — the plain press's shape is unchanged. `first_slot` is the
+/// image-list index the walk's carried slots continue from (the app,
+/// the carried compose slices, and the carried runtime pair sit below
+/// it).
+pub fn resolve_spawned_edges<H, T>(
+    home: H,
+    fetcher: &Fetcher<T>,
+    app_image: &Path,
+    app_name: &str,
+    preset: ComposePreset,
+    host: Platform,
+    first_slot: u32,
+) -> Result<SpawnedPlan, TebakoError>
+where
+    H: FnOnce() -> Result<PathBuf, TebakoError>,
+    T: Transport,
+{
+    let Some(text) = image_manifest::read_embedded_manifest(app_image)? else {
+        return Ok(SpawnedPlan::default());
+    };
+    let manifest = tpkg::PayloadManifest::from_yaml(&text).map_err(|e| {
+        err(format!(
+            "the embedded manifest of {} does not parse: {e}",
+            app_image.display()
+        ))
+    })?;
+
+    let mut edges: Vec<SpawnEdge> = Vec::new();
+    for requirement in &manifest.requires {
+        match requirement {
+            tpkg::Requirement::Runtime {
+                engine,
+                implementation,
+                constraint,
+                expose,
+            } => {
+                // The lock's own validator refuses two rows for one
+                // engine+implementation — press refuses to compose them
+                // first, naming the edges.
+                if edges.iter().any(|e| {
+                    matches!(e, SpawnEdge::Runtime { engine: e2, implementation: i2, .. }
+                        if *e2 == engine && *i2 == implementation.as_deref())
+                }) {
+                    return Err(err(format!(
+                        "the app payload declares two spawned runtime edges on engine '{engine}'{} — one lock.spawned[] row per engine+implementation (spec 23 §13.6)",
+                        implementation
+                            .as_deref()
+                            .map(|i| format!(" (implementation '{i}')"))
+                            .unwrap_or_default()
+                    )));
+                }
+                edges.push(SpawnEdge::Runtime {
+                    engine,
+                    implementation: implementation.as_deref(),
+                    constraint,
+                    expose,
+                });
+            }
+            tpkg::Requirement::Executable {
+                name,
+                payload,
+                constraint,
+                expose,
+                ..
+            } if !expose.is_empty() => {
+                edges.push(SpawnEdge::Executable {
+                    name,
+                    payload: payload.as_deref(),
+                    constraint,
+                    expose,
+                });
+            }
+            _ => {}
+        }
+    }
+    if edges.is_empty() {
+        return Ok(SpawnedPlan::default());
+    }
+
+    // The expose × own-entrypoint collision refusal (spec 30 §3, spec 32
+    // §1) is the manifest validator's — `PayloadManifest::from_yaml`
+    // already refused a colliding expose list above; the walk never sees
+    // one.
+
+    let home = home()?;
+    let ctx = tebako_shim::Ctx {
+        home: home.clone(),
+        cwd: std::env::current_dir().map_err(|e| TebakoError::new(e.to_string(), EX_TEBAKO_IO))?,
+        env: std::env::vars().collect(),
+    };
+
+    let mut plan = SpawnedPlan::default();
+    let mut next_slot = first_slot;
+    // One row per provider payload (the lock's validator refuses two) —
+    // checked AFTER provider resolution: two edges naming different
+    // capabilities may still resolve to the one provider.
+    let mut seen_providers: Vec<(String, String)> = Vec::new();
+    for edge in &edges {
+        match edge {
+            SpawnEdge::Runtime {
+                engine,
+                implementation,
+                constraint,
+                expose,
+            } => {
+                let row = spawned_runtime_row(
+                    &ctx,
+                    engine,
+                    *implementation,
+                    constraint,
+                    expose,
+                    preset,
+                    &mut plan,
+                    &mut next_slot,
+                )?;
+                plan.rows.push(tpkg::LockedSpawned::Runtime(row));
+            }
+            SpawnEdge::Executable {
+                name,
+                payload,
+                constraint,
+                expose,
+            } => {
+                let provider = match payload {
+                    Some(p) => p.to_string(),
+                    None => compose::compose_capability_provider(
+                        &home, fetcher, app_name, name, constraint,
+                    )?,
+                };
+                if let Some((first, _)) = seen_providers.iter().find(|(_, p)| p == &provider) {
+                    return Err(err(format!(
+                        "the executable edges \"{first}\" and \"{name}\" both resolve to the provider payload '{provider}' — one lock.spawned[] row per provider payload (spec 23 §13.6); merge the expose lists into one edge"
+                    )));
+                }
+                seen_providers.push((name.to_string(), provider.clone()));
+                let row = spawned_payload_row(
+                    &home,
+                    &ctx,
+                    fetcher,
+                    &manifest,
+                    name,
+                    &provider,
+                    constraint,
+                    expose,
+                    preset,
+                    host,
+                    &mut plan,
+                    &mut next_slot,
+                )?;
+                plan.rows.push(tpkg::LockedSpawned::Payload(row));
+            }
+        }
+    }
+    Ok(plan)
+}
+
+/// The shared-runtime row refusal (spec 23 §13.6): press resolves
+/// spawned runtimes through the machine store and records no replayable
+/// `source:`, so a shared row could not reproduce on another machine.
+fn gate_carried_runtime(what: &str, preset: ComposePreset) -> Result<(), TebakoError> {
+    if preset.default_carry(true) {
+        return Ok(());
+    }
+    Err(err(format!(
+        "{what} rides the shared-runtime preset, but press resolves spawned runtimes through the machine store and a shared row would record no replayable `source:` (spec 23 §13.6) — press --mode=self-contained to carry the pair, or hand-author the lock's spawned[] row"
+    )))
+}
+
+/// The expose cross-check against the runtime image's OWN embedded
+/// manifest (spec 30 §2's install-time class, mirrored at press — the
+/// shim layer deliberately cannot read images; press can).
+fn check_expose_against_runtime(
+    engine: &str,
+    rt: &tpkg::runtime_store::CachedRuntime,
+    expose: &[String],
+) -> Result<(), TebakoError> {
+    if expose.is_empty() {
+        return Ok(());
+    }
+    let image = rt.image.as_ref().ok_or_else(|| {
+        err(format!(
+            "the cached {engine} runtime {} (tebako {}) carries no verified env image — the expose list cannot be verified",
+            rt.lang_version, rt.tebako_version
+        ))
+    })?;
+    let text = image_manifest::read_embedded_manifest(image)?.ok_or_else(|| {
+        err(format!(
+            "the {engine} runtime image {} carries no embedded manifest — the expose list cannot be verified",
+            image.display()
+        ))
+    })?;
+    let manifest = tpkg::PayloadManifest::from_yaml(&text).map_err(|e| {
+        err(format!(
+            "the embedded manifest of {} does not parse: {e}",
+            image.display()
+        ))
+    })?;
+    let tpkg::Provides::Runtime(provides) = &manifest.provides else {
+        return Err(err(format!(
+            "{} is not a runtime payload — a spawn edge can only expose a runtime's entrypoints",
+            image.display()
+        )));
+    };
+    for name in expose {
+        if !provides.entrypoints.iter().any(|e| &e.name == name) {
+            return Err(err(format!(
+                "expose: the {engine} runtime {} declares no entrypoint \"{name}\" (declared: {}) — fix the payload's expose list or the runtime's spawn surface",
+                rt.lang_version,
+                provides
+                    .entrypoints
+                    .iter()
+                    .map(|e| e.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Compose one §13.6 runtime row (spec 30 §2): the edge resolved through
+/// the machine store (download allowed — the same posture as install's
+/// pre-staging), the expose list cross-checked, the pair carried with
+/// its digest pins.
+#[allow(clippy::too_many_arguments)]
+fn spawned_runtime_row(
+    ctx: &tebako_shim::Ctx,
+    engine: &str,
+    implementation: Option<&str>,
+    constraint: &tpkg::Constraint,
+    expose: &[String],
+    preset: ComposePreset,
+    plan: &mut SpawnedPlan,
+    next_slot: &mut u32,
+) -> Result<tpkg::LockedSpawnedRuntime, TebakoError> {
+    let rt =
+        tebako_shim::runtime::resolve_runtime_edge(engine, implementation, constraint, true, ctx)
+            .map_err(install::map_shim)?;
+    check_expose_against_runtime(engine, &rt, expose)?;
+    gate_carried_runtime(
+        &format!(
+            "the app payload's spawned runtime edge on engine '{engine}' ({})",
+            constraint.as_str()
+        ),
+        preset,
+    )?;
+    carried_runtime_row(
+        &rt,
+        engine,
+        implementation,
+        constraint,
+        expose.to_vec(),
+        plan,
+        next_slot,
+    )
+}
+
+/// Assemble one carried §13.6 runtime row from a resolved store entry:
+/// hash-pins the exe + env image (+ the windows dll facet when the
+/// cached release index declares one — tebako-runtime-ruby#40) and
+/// stages the bytes as slots in press's image list, exe first, then the
+/// image, then the dll (the packed-mn oracle's slot order).
+fn carried_runtime_row(
+    rt: &tpkg::runtime_store::CachedRuntime,
+    engine: &str,
+    implementation: Option<&str>,
+    constraint: &tpkg::Constraint,
+    expose: Vec<String>,
+    plan: &mut SpawnedPlan,
+    next_slot: &mut u32,
+) -> Result<tpkg::LockedSpawnedRuntime, TebakoError> {
+    let hash = |path: &Path| -> Result<String, TebakoError> {
+        crate::resolve::sha256_file_hex(path).ok_or_else(|| {
+            TebakoError::new(
+                format!(
+                    "cannot hash the spawned runtime artifact {}",
+                    path.display()
+                ),
+                EX_TEBAKO_IO,
+            )
+        })
+    };
+    let exe_sha = hash(&rt.exe)?;
+    let exe_slot = *next_slot;
+    *next_slot += 1;
+    plan.images
+        .push((rt.exe.clone(), String::new(), tpkg::TPKG_FORMAT_AUTO));
+    let image = rt.image.clone().ok_or_else(|| {
+        err(format!(
+            "the cached {engine} runtime {} (tebako {}) carries no verified env image — a spawned row needs the pair",
+            rt.lang_version, rt.tebako_version
+        ))
+    })?;
+    let image_sha = hash(&image)?;
+    let image_slot = *next_slot;
+    *next_slot += 1;
+    plan.images
+        .push((image, String::new(), tpkg::TPKG_FORMAT_DWARFS));
+    // The dll facet rides the cached index mirror's grammar (tpkg owns
+    // it); a carried-staged cache entry holds no index and records none.
+    let exe_name = rt
+        .exe
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let dll = match tpkg::runtime_store::entry_dll(&rt.dir, &exe_name) {
+        Some(d) => {
+            let dll_path = rt.dir.join(&d.install_as);
+            if !dll_path.is_file() {
+                return Err(err(format!(
+                    "the cached {engine} runtime entry {} is corrupt: its release index declares the dll facet \"{}\" (install_as \"{}\") but the store holds no such file",
+                    rt.dir.display(),
+                    d.filename,
+                    d.install_as
+                )));
+            }
+            let dll_sha = hash(&dll_path)?;
+            if dll_sha != d.sha256 {
+                return Err(TebakoError::new(
+                    format!(
+                        "the cached {engine} runtime dll {} hashes to {dll_sha} but the release index pins {} — the store entry is damaged; reinstall the runtime",
+                        dll_path.display(),
+                        d.sha256
+                    ),
+                    EX_TEBAKO_SHA,
+                ));
+            }
+            let slot = *next_slot;
+            *next_slot += 1;
+            plan.images
+                .push((dll_path, String::new(), tpkg::TPKG_FORMAT_AUTO));
+            Some(tpkg::LockedSpawnedArtifact {
+                slot: Some(slot),
+                sha256: tpkg::DigestPin::One(d.sha256),
+                install_as: Some(d.install_as),
+            })
+        }
+        None => None,
+    };
+    Ok(tpkg::LockedSpawnedRuntime {
+        engine: engine.to_string(),
+        implementation: implementation.map(str::to_string),
+        constraint: constraint.clone(),
+        expose,
+        version: rt.lang_version.clone(),
+        tebako: rt.tebako_version.clone(),
+        carry: true,
+        exe: tpkg::LockedSpawnedArtifact {
+            slot: Some(exe_slot),
+            sha256: tpkg::DigestPin::One(exe_sha),
+            install_as: None,
+        },
+        image: tpkg::LockedSpawnedArtifact {
+            slot: Some(image_slot),
+            sha256: tpkg::DigestPin::One(image_sha),
+            install_as: None,
+        },
+        dll,
+        source: None,
+    })
+}
+
+/// Compose one §13.6 payload row (spec 32 §6): the provider payload
+/// resolved through the registries into the payload cache (the compose
+/// closure's fetch → verify → cache tail), the expose list cross-checked
+/// against the provider's embedded manifest, and the provider's OWN
+/// `kind: language` edge resolved as the nested runtime row (its
+/// constraint mirrored verbatim, its expose empty).
+#[allow(clippy::too_many_arguments)]
+fn spawned_payload_row<T: Transport>(
+    home: &Path,
+    ctx: &tebako_shim::Ctx,
+    fetcher: &Fetcher<T>,
+    app: &tpkg::PayloadManifest,
+    edge_name: &str,
+    provider: &str,
+    constraint: &tpkg::Constraint,
+    expose: &[String],
+    preset: ComposePreset,
+    host: Platform,
+    plan: &mut SpawnedPlan,
+    next_slot: &mut u32,
+) -> Result<tpkg::LockedSpawnedPayload, TebakoError> {
+    let consumer = format!("{} {}", app.identity.name, app.identity.version);
+
+    // Registry resolution (the compose closure's tail): one registry
+    // carrying the provider, the newest satisfying version, fetched +
+    // verified + cached. Press is not install — no mirrors, no shims.
+    let mut found = install::find_in_registries(home, fetcher, provider)?;
+    let (reg_ref, registry_payload) = match found.len() {
+        0 => {
+            return Err(err(format!(
+                "{consumer} requires executable {edge_name} but its provider payload '{provider}' is not carried by any registered registry — register one with: tebako add-registry <ref>"
+            )));
+        }
+        1 => found.pop().expect("len == 1 checked"),
+        n => {
+            return Err(err(format!(
+                "{consumer} requires executable {edge_name} and its provider payload '{provider}' is listed by {n} registered registries (AmbiguousRegistries):\n{}\n  narrow it with an explicit registry set",
+                found
+                    .iter()
+                    .map(|(r, _)| format!("    - {r}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )));
+        }
+    };
+    let eval = tpkg::versions::from_validated(constraint);
+    let version = registry_payload
+        .versions
+        .iter()
+        .map(|v| v.version.as_str())
+        .filter(|v| eval.matches(v))
+        .max_by(|a, b| tpkg::versions::compare(a, b))
+        .map(str::to_string)
+        .ok_or_else(|| {
+            err(format!(
+                "{consumer} requires executable {edge_name} but no published version of '{provider}' satisfies '{}' (available: {})",
+                constraint.as_str(),
+                registry_payload
+                    .versions
+                    .iter()
+                    .map(|v| v.version.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))
+        })?;
+    let entry = registry_payload.version(&version).expect("selected above");
+    let install_plan =
+        install::plan_from_registry_entry(&reg_ref, &registry_payload, Some(&version), Some(host))?;
+    let cache = PayloadCache::with_root(home);
+    let cached = match cache
+        .get(&install_plan.name, &install_plan.version)
+        .map_err(install::map_resolve)?
+    {
+        Some(cached) => cached,
+        None => {
+            if tebako_resolve::cache::offline() {
+                return Err(install::map_resolve(ResolveError::Offline {
+                    what: format!("payload {}@{}", install_plan.name, install_plan.version),
+                }));
+            }
+            let fetched = fetcher
+                .fetch(&install_plan.reference)
+                .map_err(install::map_resolve)?;
+            let (cached, _status) = cache
+                .install(
+                    &install_plan.name,
+                    &install_plan.version,
+                    install_plan.expected_sha256.as_deref(),
+                    || Ok(fetched),
+                )
+                .map_err(install::map_resolve)?;
+            cached
+        }
+    };
+
+    // The lock's pin (spec 23 §13.3): the single universal digest, or the
+    // host triplet's row — press verifies the host's bytes.
+    let pin = match &entry.platforms {
+        RegistryPlatforms::Universal => tpkg::DigestPin::One(cached.sha256.clone()),
+        RegistryPlatforms::PerTriplet(_) => tpkg::DigestPin::PerTriplet(BTreeMap::from([(
+            host.release_asset_name().to_string(),
+            cached.sha256.clone(),
+        )])),
+    };
+
+    // The provider's embedded manifest (tier 1, authoritative) drives the
+    // expose cross-check and the nested runtime pick; the identity
+    // cross-check is the compose closure's (the registry must agree with
+    // the bytes it names).
+    let text = image_manifest::read_embedded_manifest(&cached.path)?.ok_or_else(|| {
+        err(format!(
+            "the spawned provider image {} carries no embedded manifest — the expose list cannot be verified",
+            cached.path.display()
+        ))
+    })?;
+    let provider_manifest = tpkg::PayloadManifest::from_yaml(&text).map_err(|e| {
+        err(format!(
+            "the embedded manifest of {} does not parse: {e}",
+            cached.path.display()
+        ))
+    })?;
+    if provider_manifest.identity.name != install_plan.name
+        || provider_manifest.identity.version != install_plan.version
+    {
+        return Err(err(format!(
+            "the embedded manifest declares {} {} but the spawned edge resolved {} {} — the registry entry is inconsistent with the payload it names",
+            provider_manifest.identity.name,
+            provider_manifest.identity.version,
+            install_plan.name,
+            install_plan.version
+        )));
+    }
+
+    // The expose cross-check (spec 32 §6/§7 — install's mirror-check
+    // class, reading the provider's embedded manifest): each exposed name
+    // must resolve to a declared entrypoint CARRYING a runtime
+    // requirement (a runtime-less entry has no spawn form — spec 32
+    // §0/§1). A toolkit executable and a runtime's own entrypoint are
+    // runtime-less by construction.
+    enum Found<'p> {
+        Entrypoint(&'p tpkg::Entrypoint),
+        RuntimeLess,
+        Undeclared,
+    }
+    let find = |exposed: &str| -> Found {
+        match &provider_manifest.provides {
+            tpkg::Provides::App(app) => match app.entrypoints.iter().find(|e| e.name == exposed) {
+                Some(ep) => Found::Entrypoint(ep),
+                None => Found::Undeclared,
+            },
+            tpkg::Provides::Runtime(r) => match r.entrypoints.iter().find(|e| e.name == exposed) {
+                Some(ep) => Found::Entrypoint(ep),
+                None => Found::Undeclared,
+            },
+            tpkg::Provides::Toolkit(t) => {
+                if t.executables.iter().any(|e| e.name == exposed) {
+                    Found::RuntimeLess
+                } else {
+                    Found::Undeclared
+                }
+            }
+            _ => Found::Undeclared,
+        }
+    };
+    let declared: Vec<&str> = match &provider_manifest.provides {
+        tpkg::Provides::App(app) => app.entrypoints.iter().map(|e| e.name.as_str()).collect(),
+        tpkg::Provides::Runtime(r) => r.entrypoints.iter().map(|e| e.name.as_str()).collect(),
+        tpkg::Provides::Toolkit(t) => t.executables.iter().map(|e| e.name.as_str()).collect(),
+        _ => Vec::new(),
+    };
+    let mut exposed_eps: Vec<&tpkg::Entrypoint> = Vec::new();
+    for exposed in expose {
+        let ep = match find(exposed) {
+            Found::Entrypoint(ep) => ep,
+            Found::RuntimeLess => {
+                return Err(err(format!(
+                    "{consumer} requires executable {edge_name}: the provider's entrypoint \"{exposed}\" carries no runtime_requirement — a runtime-less entry has no spawn form, its surface is the exec tier (spec 32 §0/§1)"
+                )));
+            }
+            Found::Undeclared => {
+                return Err(err(format!(
+                    "{consumer} requires executable {edge_name} and exposes \"{exposed}\" but the provider payload {provider} {version} declares no such entrypoint (declared: {}) — fix the expose list or the provider's manifest (spec 32 §7)",
+                    declared.join(", ")
+                )));
+            }
+        };
+        if ep.runtime_requirement.is_none() {
+            return Err(err(format!(
+                "{consumer} requires executable {edge_name}: the provider's entrypoint \"{exposed}\" carries no runtime_requirement — a runtime-less entry has no spawn form, its surface is the exec tier (spec 32 §0/§1)"
+            )));
+        }
+        exposed_eps.push(ep);
+    }
+
+    // One nested runtime per row: every exposed entrypoint must agree on
+    // the engine, and on the implementation axis of its first
+    // requirement entry (spec 28 §8's pre-stage convention).
+    let first_reqs = exposed_eps[0]
+        .runtime_requirement
+        .as_ref()
+        .expect("checked above");
+    let engine = first_reqs.engine().to_string();
+    let implementation = first_reqs.entries()[0].implementation.clone();
+    for ep in &exposed_eps[1..] {
+        let reqs = ep.runtime_requirement.as_ref().expect("checked above");
+        if reqs.engine() != engine {
+            return Err(err(format!(
+                "the provider payload {provider} {version}'s exposed entrypoints disagree on the runtime engine ({engine} vs {}) — one spawned row carries one nested runtime (spec 32 §6); split the expose list across edges",
+                reqs.engine()
+            )));
+        }
+        if reqs.entries()[0].implementation != implementation {
+            return Err(err(format!(
+                "the provider payload {provider} {version}'s exposed entrypoints disagree on the runtime implementation — one spawned row carries one nested runtime (spec 32 §6); split the expose list across edges"
+            )));
+        }
+    }
+
+    // The nested row's constraint mirrors the provider's OWN
+    // kind: language edge for the engine, verbatim (spec 32 §6 — the
+    // validate cross-check asserts it against the provider's L1 edge).
+    let language = provider_manifest
+        .requires
+        .iter()
+        .find_map(|r| match r {
+            tpkg::Requirement::Language { engine: e, constraint } if *e == engine => {
+                Some(constraint)
+            }
+            _ => None,
+        })
+        .ok_or_else(|| {
+            err(format!(
+                "the provider payload {provider} {version} declares no kind: language edge for engine '{engine}' — the spawned row's nested runtime constraint has no source (spec 32 §6)"
+            ))
+        })?;
+
+    let rt = tebako_shim::runtime::resolve_runtime_edge(
+        &engine,
+        implementation.as_deref(),
+        language,
+        true,
+        ctx,
+    )
+    .map_err(install::map_shim)?;
+    for ep in &exposed_eps {
+        let reqs = ep.runtime_requirement.as_ref().expect("checked above");
+        if !reqs
+            .entries()
+            .iter()
+            .any(|r| tpkg::runtime_store::entry_matches(&rt, r))
+        {
+            return Err(err(format!(
+                "the nested runtime pick ({engine} {} / tebako {}) satisfies the provider's language edge but not the exposed entrypoint \"{}\"'s runtime_requirement ({reqs}) — pin a tighter kind: language edge in the provider's manifest",
+                rt.lang_version, rt.tebako_version, ep.name
+            )));
+        }
+    }
+
+    gate_carried_runtime(
+        &format!("the spawned payload provider '{provider}'s nested {engine} runtime"),
+        preset,
+    )?;
+
+    // Slot order (the packed-mn oracle): the provider image first, then
+    // the nested pair (exe, image, dll).
+    let image_carry = preset.default_carry(false);
+    let image_artifact = if image_carry {
+        let slot = *next_slot;
+        *next_slot += 1;
+        plan.images
+            .push((cached.path.clone(), String::new(), tpkg::TPKG_FORMAT_AUTO));
+        tpkg::LockedSpawnedArtifact {
+            slot: Some(slot),
+            sha256: pin,
+            install_as: None,
+        }
+    } else {
+        // No current preset produces a shared payload row (the image
+        // carries under both) — the shape stays expressible: the pin
+        // stands and `source:` records the fetch coordinates.
+        tpkg::LockedSpawnedArtifact {
+            slot: None,
+            sha256: pin,
+            install_as: None,
+        }
+    };
+    let nested = carried_runtime_row(
+        &rt,
+        &engine,
+        implementation.as_deref(),
+        language,
+        Vec::new(),
+        plan,
+        next_slot,
+    )?;
+    Ok(tpkg::LockedSpawnedPayload {
+        payload: provider.to_string(),
+        constraint: constraint.clone(),
+        expose: expose.to_vec(),
+        version: install_plan.version.clone(),
+        carry: image_carry,
+        image: image_artifact,
+        runtime: nested,
+        source: if image_carry {
+            None
+        } else {
+            Some(install_plan.reference.to_string())
+        },
+    })
+}

--- a/crates/tebako-cli/tests/compose_press.rs
+++ b/crates/tebako-cli/tests/compose_press.rs
@@ -721,7 +721,8 @@ fn resolve_closure_executable_capability_scan_matches_the_entrypoint_mirror() {
 fn resolve_closure_executable_expose_only_is_never_co_mounted() {
     // spec 32 §1: the expose axis is a SPAWN surface — no mount, no
     // closure slice; the edge rides the embedded manifest into the lock's
-    // hand-authored spawned[] rows (the spec 30 §1 posture).
+    // spawned[] rows (the press's spawn walk composes them, spec 23
+    // §13.6).
     let fx = Fixture::new("execexpose");
     let a_image = image(
         "app",

--- a/crates/tebako-cli/tests/spawn_press.rs
+++ b/crates/tebako-cli/tests/spawn_press.rs
@@ -1,0 +1,676 @@
+//! The press-time spawned-edge walk (spec 23 §13.6, spec 30 §2, spec 32
+//! §6): `spawn::resolve_spawned_edges` composes the lock's `spawned[]`
+//! rows from the app image's L1 `requires:` — runtime rows off the
+//! machine store's cached runtimes, payload rows off `file://` fixture
+//! registries. Everything runs against temp homes — no network, no env
+//! mutation.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use tebako_cli::error::TebakoError;
+use tebako_cli::spawn::{self, SpawnedPlan};
+use tebako_resolve::{sha256_hex, Fetcher};
+use tpkg::Platform;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("tebako-cli-spawn-{tag}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A temp TEBAKO_HOME plus a mirror dir holding payload/registry files.
+struct Fixture {
+    dir: PathBuf,
+    home: PathBuf,
+    mirror: PathBuf,
+}
+
+impl Fixture {
+    fn new(tag: &str) -> Fixture {
+        let dir = scratch(tag);
+        let home = dir.join("home");
+        let mirror = dir.join("mirror");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&mirror).unwrap();
+        Fixture { dir, home, mirror }
+    }
+
+    /// Write a mirror file and answer its file:// reference.
+    fn mirror_file(&self, file: &str, bytes: &[u8]) -> String {
+        fs::write(self.mirror.join(file), bytes).unwrap();
+        tebako_http::file_url(&self.mirror.join(file))
+    }
+
+    /// The registered-registries config carrying exactly the given refs.
+    fn register(&self, registries: &[String]) {
+        let mut yaml = String::from("registries:\n");
+        for r in registries {
+            yaml.push_str(&format!("  - {r}\n"));
+        }
+        fs::write(self.home.join("config.yaml"), yaml).unwrap();
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn sha(byte: u8) -> String {
+    String::from(char::from(byte)).repeat(64)
+}
+
+fn zip_image_with_manifest(manifest_yaml: &str) -> Vec<u8> {
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let options = zip::write::SimpleFileOptions::default();
+    writer
+        .start_file("__tpkg__/manifest.yaml", options)
+        .unwrap();
+    writer.write_all(manifest_yaml.as_bytes()).unwrap();
+    writer.start_file("app/bin/app", options).unwrap();
+    writer.write_all(b"#!/bin/sh\n").unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+/// The app image under press: a kind: app manifest whose own entrypoint
+/// is `mn`, carrying the given `requires:` block verbatim.
+fn app_image_with_requires(requires: &str) -> Vec<u8> {
+    let manifest = format!(
+        "identity:\n  schema_version: 1\n  kind: app\n  name: mn\n  version: \"1.0\"\n  producer: {{tool: tebako, tool_version: 0.15.9}}\n  created: \"2026-09-12T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{}\"\n    blob_sha256: \"{}\"\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n  entrypoints:\n    - name: mn\n      path: /app/bin/mn\n      runtime_requirement: {{engine: ruby, constraint: \">= 3.3, < 5.0\"}}\n  platforms: universal\n  capabilities: {{exec: true, read: true}}\nrequires:\n{requires}",
+        sha(b'a'),
+        sha(b'b')
+    );
+    zip_image_with_manifest(&manifest)
+}
+
+/// A manifest-less image (the pre-era plain press shape).
+fn manifestless_image() -> Vec<u8> {
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let options = zip::write::SimpleFileOptions::default();
+    writer.start_file("app/bin/app", options).unwrap();
+    writer.write_all(b"#!/bin/sh\n").unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+/// A cached java runtime store entry (spec 05 §3's grammar) whose env
+/// image is a real zip image carrying a kind: runtime manifest with the
+/// given spawn entrypoints; `index` is the cached release-index mirror
+/// (manifest.json) when the entry carries one. Returns (exe, image).
+fn cached_java_runtime(
+    fx: &Fixture,
+    entrypoints: &[&str],
+    index: Option<String>,
+) -> (PathBuf, PathBuf) {
+    cached_runtime(fx, "java", "21.0.8", "0.3.0", entrypoints, index)
+}
+
+fn cached_ruby_runtime(fx: &Fixture) -> (PathBuf, PathBuf) {
+    cached_runtime(fx, "ruby", "3.4.2", "0.3.0", &["ruby"], None)
+}
+
+fn cached_runtime(
+    fx: &Fixture,
+    engine: &str,
+    lv: &str,
+    ver: &str,
+    entrypoints: &[&str],
+    index: Option<String>,
+) -> (PathBuf, PathBuf) {
+    let platform = tebako_shim::runtime::platform_string();
+    let dir = fx
+        .home
+        .join("runtimes")
+        .join(format!("{engine}-{lv}-{ver}-{platform}"));
+    fs::create_dir_all(&dir).unwrap();
+    let exe_name = format!(
+        "tebako-runtime-{ver}-{lv}-{platform}{}",
+        tebako_shim::runtime::exe_suffix()
+    );
+    let exe = dir.join(&exe_name);
+    fs::write(&exe, format!("fake {engine} runtime exe\n")).unwrap();
+    let eps: String = entrypoints
+        .iter()
+        .map(|e| format!("    - {{name: {e}, path: /bin/{e}}}\n"))
+        .collect();
+    let manifest = format!(
+        "identity:\n  schema_version: 1\n  kind: runtime\n  name: tebako-runtime-{engine}\n  version: \"{lv}\"\n  producer: {{tool: tebako, tool_version: 0.15.9}}\n  created: \"2026-09-12T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{}\"\n    blob_sha256: \"{}\"\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n  provides: {{engine: {engine}, version: \"{lv}\", abi_line: \"21\", platform: aarch64-macos}}\n  built_from: {{src_sha256: {}, patch_set: v1}}\n  entrypoints:\n{eps}  capabilities: {{exec: true, read: true, runtime: true}}\n",
+        sha(b'a'),
+        sha(b'b'),
+        sha(b'c')
+    );
+    let image_bytes = zip_image_with_manifest(&manifest);
+    let image_name = format!("tebako-runtime-{ver}-{lv}-{platform}.tfs");
+    let image = dir.join(&image_name);
+    fs::write(&image, &image_bytes).unwrap();
+    fs::write(
+        dir.join(format!("{image_name}.sha256")),
+        format!("{}  {image_name}\n", sha256_hex(&image_bytes)),
+    )
+    .unwrap();
+    if let Some(index) = index {
+        fs::write(dir.join("manifest.json"), index).unwrap();
+    }
+    (exe, image)
+}
+
+/// The provider app image (spec 32): a kind: app manifest whose
+/// entrypoint carries a runtime_requirement, plus — when given — the
+/// `kind: language` edge the nested runtime row mirrors.
+fn provider_image(name: &str, version: &str, entrypoint: &str, language: Option<&str>) -> Vec<u8> {
+    let requires = match language {
+        Some(constraint) => format!(
+            "requires:\n  - kind: language\n    engine: ruby\n    constraint: \"{constraint}\"\n"
+        ),
+        None => String::new(),
+    };
+    let manifest = format!(
+        "identity:\n  schema_version: 1\n  kind: app\n  name: {name}\n  version: \"{version}\"\n  producer: {{tool: tebako, tool_version: 0.15.9}}\n  created: \"2026-09-12T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{}\"\n    blob_sha256: \"{}\"\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n  entrypoints:\n    - name: {entrypoint}\n      path: /app/bin/{entrypoint}\n      runtime_requirement: {{engine: ruby, constraint: \">= 3.3, < 5.0\"}}\n  platforms: universal\n  capabilities: {{exec: true, read: true}}\n{requires}",
+        sha(b'a'),
+        sha(b'b')
+    );
+    zip_image_with_manifest(&manifest)
+}
+
+/// A provider whose entrypoint is runtime-less (the exec tier — no
+/// spawn form, spec 32 §0/§1).
+fn runtime_less_provider_image(name: &str, version: &str, entrypoint: &str) -> Vec<u8> {
+    let manifest = format!(
+        "identity:\n  schema_version: 1\n  kind: app\n  name: {name}\n  version: \"{version}\"\n  producer: {{tool: tebako, tool_version: 0.15.9}}\n  created: \"2026-09-12T00:00:00Z\"\n  digest:\n    tree_hash: \"sha256:{}\"\n    blob_sha256: \"{}\"\n  signing: {{state: unsigned}}\n  encryption: {{state: none}}\nprovides:\n  entrypoints:\n    - name: {entrypoint}\n      path: /app/bin/{entrypoint}\n  platforms: universal\n  capabilities: {{exec: true, read: true}}\n",
+        sha(b'a'),
+        sha(b'b')
+    );
+    zip_image_with_manifest(&manifest)
+}
+
+/// The provider's registry document (entrypoints mirrored, universal).
+fn provider_registry_yaml(
+    name: &str,
+    version: &str,
+    payload_ref: &str,
+    entrypoint: &str,
+) -> String {
+    format!(
+        "schema_version: 1\npayloads:\n  - name: {name}\n    kind: app\n    versions:\n      - version: {version}\n        platforms: universal\n        release: {{ref: {payload_ref}}}\n        runtime_requirement: {{engine: ruby, constraint: \">= 3.1\"}}\n        entrypoints: [{entrypoint}]\n    default: {version}\n"
+    )
+}
+
+/// Write the app image into the fixture and answer its path.
+fn app_image(fx: &Fixture, bytes: &[u8]) -> PathBuf {
+    let path = fx.dir.join("app.tfs");
+    fs::write(&path, bytes).unwrap();
+    path
+}
+
+/// The walk against the fixture home, self-contained, first slot 1.
+fn walk(fx: &Fixture, app: &Path) -> Result<SpawnedPlan, TebakoError> {
+    spawn::resolve_spawned_edges(
+        || Ok(fx.home.clone()),
+        &Fetcher::new(),
+        app,
+        "mn",
+        tpkg::ComposePreset::SelfContained,
+        Platform::host(),
+        1,
+    )
+}
+
+// ---------------------------------------------------------------------
+// the runtime edge (spec 30 §2 / spec 23 §13.6)
+// ---------------------------------------------------------------------
+
+#[test]
+fn runtime_edge_composes_the_carried_row_field_by_field() {
+    let fx = Fixture::new("rt-row");
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: runtime\n    engine: java\n    constraint: \">= 21, < 26\"\n    expose: [java]\n",
+        ),
+    );
+    let (exe, image) = cached_java_runtime(&fx, &["java", "keytool"], None);
+
+    let plan = walk(&fx, &app).unwrap();
+
+    assert_eq!(plan.rows.len(), 1);
+    let tpkg::LockedSpawned::Runtime(row) = &plan.rows[0] else {
+        panic!("a runtime row: {:?}", plan.rows[0]);
+    };
+    // the L1 edge mirrored verbatim
+    assert_eq!(row.engine, "java");
+    assert_eq!(row.implementation, None);
+    assert_eq!(row.constraint.as_str(), ">= 21, < 26");
+    assert_eq!(row.expose, vec!["java".to_string()]);
+    // the press-time pick
+    assert_eq!(row.version, "21.0.8");
+    assert_eq!(row.tebako, "0.3.0");
+    // carried, with the store bytes' pins; source is the shared-row key
+    assert!(row.carry);
+    assert_eq!(row.source, None);
+    assert_eq!(row.exe.slot, Some(1));
+    assert_eq!(
+        row.exe.sha256,
+        tpkg::DigestPin::One(sha256_hex(&fs::read(&exe).unwrap()))
+    );
+    assert_eq!(row.exe.install_as, None);
+    assert_eq!(row.image.slot, Some(2));
+    assert_eq!(
+        row.image.sha256,
+        tpkg::DigestPin::One(sha256_hex(&fs::read(&image).unwrap()))
+    );
+    assert_eq!(row.dll, None);
+    // the carried bytes join the press image list: exe AUTO, image
+    // DWARFS, both with the empty mount (a carried spawned artifact is
+    // never mounted)
+    assert_eq!(
+        plan.images,
+        vec![
+            (exe, String::new(), tpkg::TPKG_FORMAT_AUTO),
+            (image, String::new(), tpkg::TPKG_FORMAT_DWARFS),
+        ]
+    );
+}
+
+#[test]
+fn runtime_edge_without_expose_still_composes_a_row() {
+    // The row mirrors the edge whether or not it exposes names (the
+    // validate reverse check requires a row for EVERY runtime edge).
+    let fx = Fixture::new("rt-noexpose");
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: runtime\n    engine: java\n    constraint: \">= 21\"\n",
+        ),
+    );
+    cached_java_runtime(&fx, &["java"], None);
+
+    let plan = walk(&fx, &app).unwrap();
+
+    assert_eq!(plan.rows.len(), 1);
+    let tpkg::LockedSpawned::Runtime(row) = &plan.rows[0] else {
+        panic!("a runtime row: {:?}", plan.rows[0]);
+    };
+    assert_eq!(row.expose, Vec::<String>::new());
+    assert!(row.carry);
+    assert_eq!(row.exe.slot, Some(1));
+    assert_eq!(row.image.slot, Some(2));
+    assert_eq!(plan.images.len(), 2);
+}
+
+#[test]
+fn runtime_edge_expose_outside_the_spawn_surface_is_a_named_error() {
+    let fx = Fixture::new("rt-badexpose");
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: runtime\n    engine: java\n    constraint: \">= 21\"\n    expose: [javac]\n",
+        ),
+    );
+    cached_java_runtime(&fx, &["java"], None);
+
+    let err = walk(&fx, &app).unwrap_err();
+    assert_eq!(err.code, 65);
+    assert!(
+        err.message.contains("declares no entrypoint \"javac\""),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn expose_colliding_with_the_apps_own_entrypoint_is_a_named_error() {
+    // spec 30 §3 / spec 32 §1: an exposed name never collides with the
+    // app payload's own entries — the MANIFEST VALIDATOR owns the refusal
+    // (the app's own entrypoint here is "mn"); the walk surfaces it as
+    // the named manifest error at parse.
+    let fx = Fixture::new("collision");
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: runtime\n    engine: java\n    constraint: \">= 21\"\n    expose: [mn]\n",
+        ),
+    );
+    cached_java_runtime(&fx, &["mn"], None);
+
+    let err = walk(&fx, &app).unwrap_err();
+    assert_eq!(err.code, 65);
+    assert!(
+        err.message
+            .contains("collides with the payload's own entrypoint name"),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn duplicate_runtime_edges_are_a_named_error() {
+    let fx = Fixture::new("rt-dup");
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: runtime\n    engine: java\n    constraint: \">= 21\"\n  - kind: runtime\n    engine: java\n    constraint: \">= 21\"\n",
+        ),
+    );
+    cached_java_runtime(&fx, &["java"], None);
+
+    let err = walk(&fx, &app).unwrap_err();
+    assert_eq!(err.code, 65);
+    assert!(
+        err.message
+            .contains("one lock.spawned[] row per engine+implementation"),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn shared_runtime_preset_refuses_the_spawned_runtime_row() {
+    // spec 23 §13.6: press resolves spawned runtimes through the machine
+    // store and records no replayable `source:` — the shared row is the
+    // named error advising --mode=self-contained.
+    let fx = Fixture::new("rt-shared");
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: runtime\n    engine: java\n    constraint: \">= 21\"\n",
+        ),
+    );
+    cached_java_runtime(&fx, &["java"], None);
+
+    let err = spawn::resolve_spawned_edges(
+        || Ok(fx.home.clone()),
+        &Fetcher::new(),
+        &app,
+        "mn",
+        tpkg::ComposePreset::SharedRuntime,
+        Platform::host(),
+        1,
+    )
+    .unwrap_err();
+    assert_eq!(err.code, 65);
+    assert!(err.message.contains("--mode=self-contained"), "{err:?}");
+}
+
+#[test]
+fn the_dll_facet_rides_the_carried_row() {
+    // tebako-runtime-ruby#40: the cached release index declares the dll
+    // facet; the store staged it under install_as; the row pins it as the
+    // pair's third slot.
+    let fx = Fixture::new("rt-dll");
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: runtime\n    engine: java\n    constraint: \">= 21\"\n",
+        ),
+    );
+    let platform = tebako_shim::runtime::platform_string();
+    let exe_name = format!(
+        "tebako-runtime-0.3.0-21.0.8-{platform}{}",
+        tebako_shim::runtime::exe_suffix()
+    );
+    let dll_bytes = b"fake jvm dll\n";
+    let index = format!(
+        "[{{\"filename\": \"{exe_name}\", \"dll\": {{\"filename\": \"jvm-assets.dll\", \"install_as\": \"jvm.dll\", \"sha256\": \"{}\"}}}}]",
+        sha256_hex(dll_bytes)
+    );
+    let (exe, image) = cached_java_runtime(&fx, &["java"], Some(index));
+    let dll_path = exe.parent().unwrap().join("jvm.dll");
+    fs::write(&dll_path, dll_bytes).unwrap();
+
+    let plan = walk(&fx, &app).unwrap();
+
+    let tpkg::LockedSpawned::Runtime(row) = &plan.rows[0] else {
+        panic!("a runtime row: {:?}", plan.rows[0]);
+    };
+    let dll = row.dll.as_ref().expect("the dll facet rides the row");
+    assert_eq!(dll.slot, Some(3));
+    assert_eq!(dll.install_as, Some("jvm.dll".to_string()));
+    assert_eq!(dll.sha256, tpkg::DigestPin::One(sha256_hex(dll_bytes)));
+    assert_eq!(
+        plan.images,
+        vec![
+            (exe, String::new(), tpkg::TPKG_FORMAT_AUTO),
+            (image, String::new(), tpkg::TPKG_FORMAT_DWARFS),
+            (dll_path, String::new(), tpkg::TPKG_FORMAT_AUTO),
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------
+// the payload edge (spec 32 §6 / spec 23 §13.6)
+// ---------------------------------------------------------------------
+
+/// The pinned payload-edge fixture: the provider registered at 3.2.1,
+/// the ruby runtime cached for the nested row. Returns the provider
+/// image bytes (the pin's expectation).
+fn payload_fixture(fx: &Fixture) -> Vec<u8> {
+    let provider_bytes = provider_image("xml2rfc", "3.2.1", "xml2rfc", Some("~> 3.4"));
+    let provider_ref = fx.mirror_file("xml2rfc-3.2.1.tfs", &provider_bytes);
+    let registry_ref = fx.mirror_file(
+        "xml2rfc-registry.yaml",
+        provider_registry_yaml("xml2rfc", "3.2.1", &provider_ref, "xml2rfc").as_bytes(),
+    );
+    fx.register(&[registry_ref]);
+    cached_ruby_runtime(fx);
+    provider_bytes
+}
+
+#[test]
+fn payload_edge_composes_the_carried_row_field_by_field() {
+    let fx = Fixture::new("payload-row");
+    let provider_bytes = payload_fixture(&fx);
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: executable\n    name: xml2rfc\n    payload: xml2rfc\n    constraint: \">= 3.0\"\n    expose: [xml2rfc]\n",
+        ),
+    );
+
+    let plan = walk(&fx, &app).unwrap();
+
+    assert_eq!(plan.rows.len(), 1);
+    let tpkg::LockedSpawned::Payload(row) = &plan.rows[0] else {
+        panic!("a payload row: {:?}", plan.rows[0]);
+    };
+    // the L1 edge mirrored verbatim (the resolved provider name)
+    assert_eq!(row.payload, "xml2rfc");
+    assert_eq!(row.constraint.as_str(), ">= 3.0");
+    assert_eq!(row.expose, vec!["xml2rfc".to_string()]);
+    // the press-time pick; carried with the pin; no source on a carried row
+    assert_eq!(row.version, "3.2.1");
+    assert!(row.carry);
+    assert_eq!(row.source, None);
+    assert_eq!(row.image.slot, Some(1));
+    assert_eq!(
+        row.image.sha256,
+        tpkg::DigestPin::One(sha256_hex(&provider_bytes))
+    );
+    // the nested runtime row: the provider's OWN language edge mirrored
+    // verbatim (NOT the entrypoint's runtime_requirement), expose empty
+    let rt = &row.runtime;
+    assert_eq!(rt.engine, "ruby");
+    assert_eq!(rt.implementation, None);
+    assert_eq!(rt.constraint.as_str(), "~> 3.4");
+    assert_eq!(rt.expose, Vec::<String>::new());
+    assert_eq!(rt.version, "3.4.2");
+    assert_eq!(rt.tebako, "0.3.0");
+    assert!(rt.carry);
+    assert_eq!(rt.source, None);
+    assert_eq!(rt.exe.slot, Some(2));
+    assert_eq!(rt.image.slot, Some(3));
+    assert_eq!(rt.dll, None);
+    // slot order: the provider image, then the nested exe, then the
+    // nested image — all empty-mounted
+    let paths: Vec<&Path> = plan.images.iter().map(|(p, _, _)| p.as_path()).collect();
+    assert!(
+        paths[0].ends_with("payloads/xml2rfc/3.2.1.tfs"),
+        "{paths:?}"
+    );
+    assert!(
+        paths[1]
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("tebako-runtime-0.3.0-3.4.2-"),
+        "{paths:?}"
+    );
+    assert!(
+        paths[2].extension().is_some_and(|e| e == "tfs"),
+        "{paths:?}"
+    );
+    assert_eq!(plan.images[0].2, tpkg::TPKG_FORMAT_AUTO);
+    assert_eq!(plan.images[1].2, tpkg::TPKG_FORMAT_AUTO);
+    assert_eq!(plan.images[2].2, tpkg::TPKG_FORMAT_DWARFS);
+    assert!(plan.images.iter().all(|(_, mount, _)| mount.is_empty()));
+}
+
+#[test]
+fn payload_edge_capability_scan_resolves_the_unpinned_provider() {
+    // spec 32 §1 / spec 03 §8 at press: no `payload:` pin — the
+    // registered registries' entrypoint scan answers the provider.
+    let fx = Fixture::new("payload-scan");
+    let provider_bytes = provider_image("xml2rfc-pkg", "3.2.1", "xml2rfc", Some("~> 3.4"));
+    let provider_ref = fx.mirror_file("xml2rfc-pkg-3.2.1.tfs", &provider_bytes);
+    let registry_ref = fx.mirror_file(
+        "xml2rfc-registry.yaml",
+        provider_registry_yaml("xml2rfc-pkg", "3.2.1", &provider_ref, "xml2rfc").as_bytes(),
+    );
+    fx.register(&[registry_ref]);
+    cached_ruby_runtime(&fx);
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: executable\n    name: xml2rfc\n    constraint: \">= 3.0\"\n    expose: [xml2rfc]\n",
+        ),
+    );
+
+    let plan = walk(&fx, &app).unwrap();
+
+    assert_eq!(plan.rows.len(), 1);
+    let tpkg::LockedSpawned::Payload(row) = &plan.rows[0] else {
+        panic!("a payload row: {:?}", plan.rows[0]);
+    };
+    assert_eq!(row.payload, "xml2rfc-pkg");
+    assert_eq!(row.version, "3.2.1");
+    assert_eq!(
+        row.image.sha256,
+        tpkg::DigestPin::One(sha256_hex(&provider_bytes))
+    );
+}
+
+#[test]
+fn payload_edge_exposing_a_runtime_less_entrypoint_is_a_named_error() {
+    // spec 32 §0/§1: the exec tier has no spawn form.
+    let fx = Fixture::new("payload-runtmeless");
+    let provider_bytes = runtime_less_provider_image("xml2rfc", "3.2.1", "xml2rfc");
+    let provider_ref = fx.mirror_file("xml2rfc-3.2.1.tfs", &provider_bytes);
+    let registry_ref = fx.mirror_file(
+        "xml2rfc-registry.yaml",
+        provider_registry_yaml("xml2rfc", "3.2.1", &provider_ref, "xml2rfc").as_bytes(),
+    );
+    fx.register(&[registry_ref]);
+    cached_ruby_runtime(&fx);
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: executable\n    name: xml2rfc\n    payload: xml2rfc\n    constraint: \">= 3.0\"\n    expose: [xml2rfc]\n",
+        ),
+    );
+
+    let err = walk(&fx, &app).unwrap_err();
+    assert_eq!(err.code, 65);
+    assert!(err.message.contains("no spawn form"), "{err:?}");
+}
+
+#[test]
+fn payload_edge_provider_without_a_language_edge_is_a_named_error() {
+    // spec 32 §6: the nested row's constraint mirrors the provider's OWN
+    // kind: language edge — absent, the row has no source.
+    let fx = Fixture::new("payload-nolang");
+    let provider_bytes = provider_image("xml2rfc", "3.2.1", "xml2rfc", None);
+    let provider_ref = fx.mirror_file("xml2rfc-3.2.1.tfs", &provider_bytes);
+    let registry_ref = fx.mirror_file(
+        "xml2rfc-registry.yaml",
+        provider_registry_yaml("xml2rfc", "3.2.1", &provider_ref, "xml2rfc").as_bytes(),
+    );
+    fx.register(&[registry_ref]);
+    cached_ruby_runtime(&fx);
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: executable\n    name: xml2rfc\n    payload: xml2rfc\n    constraint: \">= 3.0\"\n    expose: [xml2rfc]\n",
+        ),
+    );
+
+    let err = walk(&fx, &app).unwrap_err();
+    assert_eq!(err.code, 65);
+    assert!(err.message.contains("no kind: language edge"), "{err:?}");
+}
+
+#[test]
+fn two_edges_resolving_to_one_provider_are_a_named_error() {
+    let fx = Fixture::new("payload-dup");
+    let _ = payload_fixture(&fx);
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: executable\n    name: xml2rfc\n    payload: xml2rfc\n    constraint: \">= 3.0\"\n    expose: [xml2rfc]\n  - kind: executable\n    name: rfc2html\n    payload: xml2rfc\n    constraint: \">= 3.0\"\n    expose: [rfc2html]\n",
+        ),
+    );
+
+    let err = walk(&fx, &app).unwrap_err();
+    assert_eq!(err.code, 65);
+    assert!(
+        err.message
+            .contains("one lock.spawned[] row per provider payload"),
+        "{err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// the negative space: no spawn edges, no work
+// ---------------------------------------------------------------------
+
+#[test]
+fn app_image_without_a_manifest_composes_no_rows() {
+    let fx = Fixture::new("no-manifest");
+    let app = app_image(&fx, &manifestless_image());
+
+    // The home closure must never fire for a spawn-less press.
+    let plan = spawn::resolve_spawned_edges(
+        || -> Result<PathBuf, TebakoError> { panic!("home must stay unresolved") },
+        &Fetcher::new(),
+        &app,
+        "mn",
+        tpkg::ComposePreset::SelfContained,
+        Platform::host(),
+        1,
+    )
+    .unwrap();
+    assert!(plan.rows.is_empty());
+    assert!(plan.images.is_empty());
+}
+
+#[test]
+fn toolkit_only_requires_compose_no_rows() {
+    let fx = Fixture::new("toolkit-only");
+    let app = app_image(
+        &fx,
+        &app_image_with_requires(
+            "  - kind: toolkit\n    name: openjdk\n    constraint: \">= 21\"\n    mount: /opt/openjdk\n",
+        ),
+    );
+
+    let plan = spawn::resolve_spawned_edges(
+        || -> Result<PathBuf, TebakoError> { panic!("home must stay unresolved") },
+        &Fetcher::new(),
+        &app,
+        "mn",
+        tpkg::ComposePreset::SelfContained,
+        Platform::host(),
+        1,
+    )
+    .unwrap();
+    assert!(plan.rows.is_empty());
+    assert!(plan.images.is_empty());
+}

--- a/crates/tebako-info/src/verify.rs
+++ b/crates/tebako-info/src/verify.rs
@@ -343,7 +343,8 @@ pub fn verify_package(
     // claims as `exe`/`dll` carry RAW BYTES (a wrapper exe / a PE dll —
     // never an image): no mount, no manifest check (spec 23 §13.6,
     // spec 30 §2). The byte identity rides the trailer slot digest
-    // (check 2) and the lock's digest pin.
+    // (check 2) and the lock's digest pin, verified against the slot
+    // bytes by section 6's spawned[] digest checks.
     let pm_result = trailer.package_manifest();
     let raw_slots: std::collections::BTreeSet<usize> = match &pm_result {
         Ok(Some(pm)) => pm
@@ -378,7 +379,7 @@ pub fn verify_package(
         if raw_slots.contains(&slot.index) {
             checks.push(Check::skip(
                 name,
-                "spawned runtime artifact (raw bytes — never mounted; the trailer digest and the lock pin carry its identity)",
+                "spawned runtime artifact (raw bytes — never mounted; the lock pin is verified against the slot bytes by the spawned[] digest checks)",
             ));
             continue;
         }
@@ -446,7 +447,7 @@ pub fn verify_package(
         Ok(None) => {}
         Ok(Some(pm)) => {
             entry_checks(binary, &pm, &inspection, &mut checks)?;
-            spawned_checks(&pm, &inspection, &mut checks);
+            spawned_checks(binary, &pm, &inspection, &mut checks)?;
         }
     }
 
@@ -591,6 +592,131 @@ fn entry_checks(
     Ok(())
 }
 
+/// The spawned-edge checks of [`verify_package`] (spec 30 §2, spec 32
+/// §6, spec 23 §13.6): the MIRROR cross-check ([`spawned_mirror_checks`]
+/// — one check per L2 lock row plus one per unmirrored L1 edge) plus the
+/// DIGEST pins ([`spawned_artifact_digests`] — every carried artifact's
+/// lock pin verified against its slot's bytes; the digest checks are
+/// independent of the app payload's L1 usability and run either way).
+fn spawned_checks(
+    binary: &Path,
+    pm: &tpkg::PackageManifest,
+    inspection: &PackageInspection,
+    checks: &mut Vec<Check>,
+) -> Result<(), InfoError> {
+    spawned_mirror_checks(pm, inspection, checks);
+    let rows: &[tpkg::LockedSpawned] = match pm.lock.as_ref() {
+        Some(lock) => &lock.spawned,
+        None => &[],
+    };
+    for row in rows {
+        match row {
+            tpkg::LockedSpawned::Runtime(rt) => {
+                spawned_runtime_digests(
+                    binary,
+                    inspection,
+                    checks,
+                    &format!("spawned[{}]", rt.engine),
+                    rt,
+                )?;
+            }
+            tpkg::LockedSpawned::Payload(p) => {
+                spawned_artifact_digests(
+                    binary,
+                    inspection,
+                    checks,
+                    &format!("spawned[{}]", p.payload),
+                    vec![("image", &p.image)],
+                )?;
+                spawned_runtime_digests(
+                    binary,
+                    inspection,
+                    checks,
+                    &format!("spawned[{}].runtime", p.payload),
+                    &p.runtime,
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The per-runtime-row digest checks (spec 23 §13.6): exe + image + the
+/// windows dll facet when the row carries one.
+fn spawned_runtime_digests(
+    binary: &Path,
+    inspection: &PackageInspection,
+    checks: &mut Vec<Check>,
+    label: &str,
+    row: &tpkg::LockedSpawnedRuntime,
+) -> Result<(), InfoError> {
+    let mut facets: Vec<(&str, &tpkg::LockedSpawnedArtifact)> =
+        vec![("exe", &row.exe), ("image", &row.image)];
+    if let Some(dll) = &row.dll {
+        facets.push(("dll", dll));
+    }
+    spawned_artifact_digests(binary, inspection, checks, label, facets)
+}
+
+/// The lock pin of each carried spawned artifact against its slot's
+/// bytes (spec 23 §13.6's pin rule over §13.3's coverage rule), one
+/// check per artifact named `<label>.<facet> digest`. A shared artifact
+/// (no slot) is dispatch-resolved and emits no check; a per-triplet pin
+/// not covering the host skips LOUD (the host's bytes stay unchecked).
+fn spawned_artifact_digests(
+    binary: &Path,
+    inspection: &PackageInspection,
+    checks: &mut Vec<Check>,
+    label: &str,
+    artifacts: Vec<(&str, &tpkg::LockedSpawnedArtifact)>,
+) -> Result<(), InfoError> {
+    let host = tpkg::Platform::host();
+    for (facet, artifact) in artifacts {
+        let name = format!("{label}.{facet} digest");
+        let Some(slot) = artifact.slot else {
+            continue;
+        };
+        let Some(s) = inspection.slots.get(slot as usize) else {
+            checks.push(Check::fail(
+                name,
+                format!(
+                    "names slot {slot} but the package carries {} slot(s)",
+                    inspection.slots.len()
+                ),
+                exit_code::MALFORMED,
+            ));
+            continue;
+        };
+        let Some(want) = artifact.sha256.for_host(host) else {
+            checks.push(Check::skip(
+                name,
+                format!(
+                    "the lock pin covers no {} row — the host's slot bytes are unchecked (spec 23 §13.3)",
+                    host.release_asset_name()
+                ),
+            ));
+            continue;
+        };
+        let actual = hex(&sha256_region(binary, s.offset, s.size)?);
+        if actual == want {
+            checks.push(Check::pass(
+                name,
+                format!("the lock pin matches the slot {slot} bytes"),
+            ));
+        } else {
+            checks.push(Check::fail(
+                name,
+                format!(
+                    "the lock pin {}… != the slot {slot} bytes {actual}",
+                    &want[..8.min(want.len())]
+                ),
+                exit_code::DIGEST,
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// The spawned-edge cross-check of [`verify_package`] (spec 30 §2, spec
 /// 32 §6, spec 23 §13.6; one check per L2 lock row plus one per
 /// unmirrored L1 edge, named `spawned[<engine|payload>]`). The lock's
@@ -608,7 +734,7 @@ fn entry_checks(
 /// skip-loud otherwise. The mirror source is the PRIMARY entry's slot
 /// image; a package whose app slot carries no usable L1 manifest skips —
 /// pre-manifest packages stay valid (the entry cross-check's rule).
-fn spawned_checks(
+fn spawned_mirror_checks(
     pm: &tpkg::PackageManifest,
     inspection: &PackageInspection,
     checks: &mut Vec<Check>,

--- a/crates/tebako-pkg/tests/info.rs
+++ b/crates/tebako-pkg/tests/info.rs
@@ -1243,56 +1243,135 @@ fn validate_spawned_mirror_mismatches_are_65() {
 }
 
 /// The CARRIED spawned-runtime layout (packed-mn's 4-slot shape, spec 30
-/// §1/§2): slot 1 is the RAW wrapper exe — never an image. validate must
-/// skip its manifest check (the packed-mn#254 gate failure: slot[1]
-/// manifest FAILED with "cannot mount the image (errno 22)").
-#[test]
-fn validate_spawned_carried_raw_exe_slot_skips_the_manifest_check() {
+/// §1/§2): slot 1 is the RAW wrapper exe — never an image, slot 2 the env
+/// image. `exe_pin`/`image_pin` override the lock's DigestPin YAML
+/// fragments (a quoted digest or a per-triplet map); `None` pins the real
+/// sha256 of the carried bytes.
+fn bundle_spawned_carried_runtime(
+    w: &TempDir,
+    home: &Path,
+    exe_pin: Option<String>,
+    image_pin: Option<String>,
+) -> PathBuf {
     use sha2::{Digest, Sha256};
     let sha256_hex = |p: &Path| format!("{:x}", Sha256::digest(std::fs::read(p).unwrap()));
 
-    let w = TempDir::new("psp-raw");
-    let home = test_home("psp-raw");
     let app = mk_image_files(
-        &w,
+        w,
         "spawned.tfs",
         Some(SPAWNED_APP_MANIFEST),
         &[("probe", b"#!/bin/sh\n")],
     );
     let exe = w.0.join("java-exe");
     std::fs::write(&exe, b"\x7fELF raw wrapper bytes - never an image").unwrap();
-    let env = mk_image(&w, "java-env.tfs", None);
+    let env = mk_image(w, "java-env.tfs", None);
+    let exe_pin = exe_pin.unwrap_or_else(|| format!("\"{}\"", sha256_hex(&exe)));
+    let image_pin = image_pin.unwrap_or_else(|| format!("\"{}\"", sha256_hex(&env)));
 
     let pm_yaml = spawned_pm(&format!(
-        "lock:\n  spawned:\n   - engine: java\n     constraint: \">= 21, < 26\"\n     expose: [java]\n     version: \"21.0.12\"\n     tebako: \"2.1.6\"\n     carry: true\n     exe: {{slot: 1, sha256: \"{}\"}}\n     image: {{slot: 2, sha256: \"{}\"}}\n",
-        sha256_hex(&exe),
-        sha256_hex(&env)
+        "lock:\n  spawned:\n   - engine: java\n     constraint: \">= 21, < 26\"\n     expose: [java]\n     version: \"21.0.12\"\n     tebako: \"2.1.6\"\n     carry: true\n     exe: {{slot: 1, sha256: {exe_pin}}}\n     image: {{slot: 2, sha256: {image_pin}}}\n"
     ));
-    let pm = pm_file(&w, &pm_yaml);
+    let pm = pm_file(w, &pm_yaml);
     let pkg =
         w.0.join(format!("pkg-{}", COUNTER.fetch_add(1, Ordering::Relaxed)));
     bundle(
-        &home,
-        &w,
+        home,
+        w,
         &["--package-manifest", pm.to_str().unwrap(), "--exact-mounts"],
         &[&app, &exe, &env],
         &pkg,
     );
+    pkg
+}
+
+/// validate must skip the RAW exe slot's manifest check (the
+/// packed-mn#254 gate failure: slot[1] manifest FAILED with "cannot
+/// mount the image (errno 22)") and verify the lock's digest pins
+/// against the slot bytes (spec 23 §13.6).
+#[test]
+fn validate_spawned_carried_raw_exe_slot_skips_the_manifest_check() {
+    let w = TempDir::new("psp-raw");
+    let home = test_home("psp-raw");
+    let pkg = bundle_spawned_carried_runtime(&w, &home, None, None);
 
     let (rc, out, _) = run(&["validate", pkg.to_str().unwrap()], &w.0, &home);
     assert_eq!(rc, 70, "{out}"); // slot 0 digest agreement, see above
     assert!(
         out.contains(
-            "  slot[1] manifest: skip — spawned runtime artifact (raw bytes — never mounted; the trailer digest and the lock pin carry its identity)\n"
+            "  slot[1] manifest: skip — spawned runtime artifact (raw bytes — never mounted; the lock pin is verified against the slot bytes by the spawned[] digest checks)\n"
         ),
         "{out}"
     );
     assert!(!out.contains("slot[1] manifest: FAILED"), "{out}");
+    // The lock pins verify against the slot bytes.
+    assert!(
+        out.contains("  spawned[java].exe digest: ok — the lock pin matches the slot 1 bytes\n"),
+        "{out}"
+    );
+    assert!(
+        out.contains("  spawned[java].image digest: ok — the lock pin matches the slot 2 bytes\n"),
+        "{out}"
+    );
     // The lock row still mirrors the L1 edge — the cross-check stands.
     assert!(
         out.contains(
             "  spawned[java]: ok — mirrors the L1 edge; the locked version 21.0.12 satisfies \">= 21, < 26\"\n"
         ),
+        "{out}"
+    );
+}
+
+/// A carried artifact whose lock pin disagrees with the slot bytes fails
+/// DIGEST (spec 23 §13.6's pin rule over §13.3's coverage rule) — named
+/// per facet.
+#[test]
+fn validate_spawned_carried_exe_pin_mismatch_is_70() {
+    let w = TempDir::new("psp-flip");
+    let home = test_home("psp-flip");
+    let pkg =
+        bundle_spawned_carried_runtime(&w, &home, Some(format!("\"{}\"", "a".repeat(64))), None);
+
+    let (rc, out, _) = run(&["validate", pkg.to_str().unwrap()], &w.0, &home);
+    assert_eq!(rc, 70, "{out}");
+    assert!(
+        out.contains(
+            "  spawned[java].exe digest: FAILED — the lock pin aaaaaaaa… != the slot 1 bytes "
+        ),
+        "{out}"
+    );
+    // The image facet's pin still verifies.
+    assert!(
+        out.contains("  spawned[java].image digest: ok — the lock pin matches the slot 2 bytes\n"),
+        "{out}"
+    );
+}
+
+/// A per-triplet pin that covers no host row skips LOUD — the host's
+/// slot bytes stay unchecked, never silently passed (spec 23 §13.3).
+#[test]
+fn validate_spawned_carried_per_triplet_pin_without_the_host_row_skips_loud() {
+    let w = TempDir::new("psp-tri");
+    let home = test_home("psp-tri");
+    let other = tpkg::Platform::ALL
+        .iter()
+        .copied()
+        .find(|p| *p != tpkg::Platform::host())
+        .unwrap();
+    let exe_pin = format!("{{{}: \"{}\"}}", other.release_asset_name(), "b".repeat(64));
+    let pkg = bundle_spawned_carried_runtime(&w, &home, Some(exe_pin), None);
+
+    let (rc, out, _) = run(&["validate", pkg.to_str().unwrap()], &w.0, &home);
+    assert_eq!(rc, 70, "{out}"); // slot 0 digest agreement, see above
+    assert!(
+        out.contains(&format!(
+            "  spawned[java].exe digest: skip — the lock pin covers no {} row — the host's slot bytes are unchecked (spec 23 §13.3)\n",
+            tpkg::Platform::host().release_asset_name()
+        )),
+        "{out}"
+    );
+    // The image facet's host-covering pin still verifies.
+    assert!(
+        out.contains("  spawned[java].image digest: ok — the lock pin matches the slot 2 bytes\n"),
         "{out}"
     );
 }
@@ -1501,7 +1580,26 @@ fn validate_spawned32_carried_provider_image_cross_checks_the_nested_runtime() {
     // the nested runtime's RAW exe slot skips the manifest check
     assert!(
         out.contains(
-            "  slot[2] manifest: skip — spawned runtime artifact (raw bytes — never mounted; the trailer digest and the lock pin carry its identity)\n"
+            "  slot[2] manifest: skip — spawned runtime artifact (raw bytes — never mounted; the lock pin is verified against the slot bytes by the spawned[] digest checks)\n"
+        ),
+        "{out}"
+    );
+    // The carried artifacts' lock pins verify against the slot bytes.
+    assert!(
+        out.contains(
+            "  spawned[xml2rfc].image digest: ok — the lock pin matches the slot 1 bytes\n"
+        ),
+        "{out}"
+    );
+    assert!(
+        out.contains(
+            "  spawned[xml2rfc].runtime.exe digest: ok — the lock pin matches the slot 2 bytes\n"
+        ),
+        "{out}"
+    );
+    assert!(
+        out.contains(
+            "  spawned[xml2rfc].runtime.image digest: ok — the lock pin matches the slot 3 bytes\n"
         ),
         "{out}"
     );

--- a/crates/tebako-shim/src/runtime.rs
+++ b/crates/tebako-shim/src/runtime.rs
@@ -55,8 +55,8 @@ const LOCK_POLL_MS: u64 = 200;
 // tpkg (spec 00 §10 — one owner, every consumer flows): the shim's
 // resolution/download layers below build on these re-exports.
 use tpkg::runtime_store::{
-    entry_asset_names, entry_filename, entry_matches, entry_meta, entry_signature,
-    newest_compatible_any, release_index_entry, EntrySignature,
+    entry_asset_names, entry_dll_from_index, entry_filename, entry_matches, entry_meta,
+    entry_signature, newest_compatible_any, release_index_entry, EntrySignature,
 };
 pub use tpkg::runtime_store::{
     exe_suffix, newest_compatible, platform_string, scan_all_cached, scan_cached, CachedRuntime,
@@ -1084,34 +1084,13 @@ fn sha_from_manifest(text: &str, asset: &str) -> Result<String, ()> {
     Err(())
 }
 
-/// The release manifest's ruby DLL facet for the exe entry `asset`
-/// (tebako-runtime-ruby#40 — the additive `dll` key, windows packages
-/// only): `(dll asset filename, install_as, sha256)`. `None` when the
-/// entry carries no `dll` key (every POSIX entry) or the key is
-/// incomplete — the facet is manifest-keyed: the PE name (`install_as`)
-/// exists only there, never derived (the factory's
-/// RubyVersion#msys_dll_name is its single owner).
-fn dll_from_manifest(text: &str, asset: &str) -> Option<(String, String, String)> {
-    let parsed = tebako_json::parse(text).ok()?;
-    let tebako_json::Value::Array(entries) = &parsed else {
-        return None;
-    };
-    entries.iter().find_map(|entry| {
-        if entry
-            .find("filename")
-            .and_then(|f| f.as_string())
-            .as_deref()
-            != Some(asset)
-        {
-            return None;
-        }
-        let dll = entry.find("dll")?;
-        let filename = dll.find("filename").and_then(|v| v.as_string())?;
-        let install_as = dll.find("install_as").and_then(|v| v.as_string())?;
-        let sha256 = dll.find("sha256").and_then(|v| v.as_string())?;
-        Some((filename, install_as, sha256))
-    })
-}
+// The release manifest's ruby DLL facet (tebako-runtime-ruby#40 — the
+// additive `dll` key, windows packages only) is parsed in tpkg
+// (`runtime_store::entry_dll_from_index`, the single grammar owner): the
+// shim reads it at download, the press's spawned-row walk from the
+// cached index. The PE name (`install_as`) exists only in the manifest,
+// never derived (the factory's RubyVersion#msys_dll_name is its single
+// owner).
 
 /// SHA256SUMS.txt fallback: "<64hex><spaces>[*]<filename>" per line.
 #[allow(clippy::result_unit_err)]
@@ -1879,8 +1858,12 @@ fn download_runtime(
         // gate (the exe entry governs its additive facets); a
         // contract-complete entry with no `dll` key installs the exe
         // alone (every POSIX release).
-        if let Some((dll_asset, install_as, dll_expected)) = dll_from_manifest(&manifest_text, &asset)
-        {
+        if let Some(dll_facet) = entry_dll_from_index(&manifest_text, &asset) {
+            let tpkg::runtime_store::EntryDll {
+                filename: dll_asset,
+                install_as,
+                sha256: dll_expected,
+            } = dll_facet;
             if install_as.contains('/') || install_as.contains('\\') {
                 return fail(
                     EX_TEBAKO_UNAVAILABLE,

--- a/crates/tpkg/src/runtime_store.rs
+++ b/crates/tpkg/src/runtime_store.rs
@@ -259,6 +259,62 @@ pub fn entry_contract_version(entry_dir: &Path, exe_name: &str) -> Option<String
 }
 
 // ---------------------------------------------------------------------
+// the windows dll facet (tebako-runtime-ruby#40) — one grammar, read here
+// ---------------------------------------------------------------------
+
+/// The release index's `dll` facet of the exe entry `exe_name`
+/// (tebako-runtime-ruby#40 — the additive `dll` key, windows packages
+/// only): the dll asset's `filename`, the bare PE name it installs under
+/// next to the exe (`install_as` — the factory's RubyVersion#msys_dll_name
+/// is its single owner; never derived), and the pinned `sha256`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntryDll {
+    pub filename: String,
+    pub install_as: String,
+    pub sha256: String,
+}
+
+/// Parse the `dll` facet out of a release-index text for the exe entry
+/// `exe_name`. `None` when the entry carries no `dll` key (every POSIX
+/// entry) or the key is incomplete — the facet is manifest-keyed.
+pub fn entry_dll_from_index(text: &str, exe_name: &str) -> Option<EntryDll> {
+    let parsed = tebako_json::parse(text).ok()?;
+    let tebako_json::Value::Array(entries) = &parsed else {
+        return None;
+    };
+    entries.iter().find_map(|entry| {
+        if entry
+            .find("filename")
+            .and_then(|f| f.as_string())
+            .as_deref()
+            != Some(exe_name)
+        {
+            return None;
+        }
+        let dll = entry.find("dll")?;
+        let filename = dll.find("filename").and_then(|v| v.as_string())?;
+        let install_as = dll.find("install_as").and_then(|v| v.as_string())?;
+        let sha256 = dll.find("sha256").and_then(|v| v.as_string())?;
+        Some(EntryDll {
+            filename,
+            install_as,
+            sha256,
+        })
+    })
+}
+
+/// The cached entry's dll facet (`<entry_dir>/manifest.json` + the exe
+/// entry's `dll` key); `None` when the entry has no cached index mirror,
+/// no entry for the exe, or no complete facet. A carried-staged cache
+/// entry (spec 23 §13.6's lock install) carries no index, so its dll
+/// records nowhere — the press that carried it already pinned the bytes
+/// in the lock row.
+pub fn entry_dll(entry_dir: &Path, exe_name: &str) -> Option<EntryDll> {
+    let text = std::fs::read_to_string(entry_dir.join("manifest.json")).ok()?;
+    entry_dll_from_index(&text, exe_name)
+}
+
+// ---------------------------------------------------------------------
 // spec 33 §1: the on_runtime release-index mirror
 // ---------------------------------------------------------------------
 
@@ -1464,5 +1520,71 @@ mod tests {
         let err = on_runtime_mirror(&dir3, &exe).unwrap_err();
         assert!(err.contains("constraint"), "{err}");
         let _ = std::fs::remove_dir_all(&tmp3);
+    }
+
+    // -----------------------------------------------------------------
+    // the windows dll facet grammar (tebako-runtime-ruby#40)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn entry_dll_from_index_reads_the_complete_facet_only() {
+        let index = r#"[
+            {"filename": "exe-a", "dll": {"filename": "ruby340.dll",
+                "install_as": "x64-ucrt-ruby340.dll",
+                "sha256": "aa"}},
+            {"filename": "exe-b", "dll": {"filename": "d.dll", "install_as": "d.dll"}},
+            {"filename": "exe-c"}
+        ]"#;
+        let dll = entry_dll_from_index(index, "exe-a").expect("the full facet reads");
+        assert_eq!(
+            dll,
+            EntryDll {
+                filename: "ruby340.dll".to_string(),
+                install_as: "x64-ucrt-ruby340.dll".to_string(),
+                sha256: "aa".to_string(),
+            }
+        );
+        // An incomplete facet (no sha256) and an entry without the key
+        // both read as None — never a guessed half-facet.
+        assert_eq!(entry_dll_from_index(index, "exe-b"), None);
+        assert_eq!(entry_dll_from_index(index, "exe-c"), None);
+        assert_eq!(entry_dll_from_index(index, "exe-never-released"), None);
+        assert_eq!(entry_dll_from_index("not json", "exe-a"), None);
+    }
+
+    #[test]
+    fn entry_dll_reads_the_cached_index_mirror() {
+        let tmp = std::env::temp_dir().join(format!(
+            "tpkg-entry-dll-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+        ));
+        let platform = platform_string();
+        let exe = entry_exe_name("4.0.6", "0.16.6", platform);
+        fixture_entry(
+            &tmp,
+            "4.0.6",
+            "0.16.6",
+            true,
+            Some(format!(
+                "{{\"filename\": \"{exe}\", \"dll\": {{\"filename\": \"ruby406.dll\", \"install_as\": \"x64-ucrt-ruby406.dll\", \"sha256\": \"bb\"}}}}"
+            )),
+        );
+        let dir = tmp
+            .join("runtimes")
+            .join(format!("java-4.0.6-0.16.6-{platform}"));
+        let dll = entry_dll(&dir, &exe).expect("the mirror's facet reads");
+        assert_eq!(dll.install_as, "x64-ucrt-ruby406.dll");
+        assert_eq!(dll.sha256, "bb");
+        // No cached index (the carried-staged entry): no dll recorded.
+        fixture_entry(&tmp, "4.0.5", "0.16.6", true, None);
+        let staged = tmp
+            .join("runtimes")
+            .join(format!("java-4.0.5-0.16.6-{platform}"));
+        let staged_exe = entry_exe_name("4.0.5", "0.16.6", platform);
+        assert_eq!(entry_dll(&staged, &staged_exe), None);
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/docs/spec/23-declarative-composition.md
+++ b/docs/spec/23-declarative-composition.md
@@ -11,8 +11,14 @@ replayed under deny with zero hand edits and zero unexpected denials.
 spectrum: per-slice `carry`, the `self-contained`/`shared-runtime`
 presets, and the `platforms:` coverage assertion. The lock substrate
 (§4's rows, §13.1's carry verdicts, `claimed_slots`, shared-slice
-resolution, lazy-seed) is IMPLEMENTED; §13.6's spawned-runtime rows land
-with the standalone-dispatch PR (spec 30 §2's bootstrap half).**
+resolution, lazy-seed) is IMPLEMENTED; §13.6's spawned rows are
+IMPLEMENTED too (2026-09-12): `tebako press` auto-composes them from
+the app image's L1 edges (spec 30's `kind: runtime` and spec 32's
+expose-carrying `kind: executable`) on both press paths, with the
+expose/collision/duplicate checks named in §13.6; `tebako-pkg validate`
+cross-checks the mirror and pins the carried slot bytes. Hand-authoring
+the `spawned[]` block (packed-mn) stays legal — the schema and the
+loader semantics are untouched.**
 
 A tebako run is a composition of one runtime (exe + env image) and N
 payload slices, executed under one host-access policy. This spec makes
@@ -572,6 +578,33 @@ lock:
       # the digest pins stand, per §13.3's universal-or-triplet-map
       # shape.
 ```
+
+**Press composes the rows (implemented 2026-09-12, tebako-cli's
+press).** `tebako press` walks the app image's L1 `requires:` — every
+`kind: runtime` edge (spec 30), and every `kind: executable` edge with
+a non-empty `expose:` (spec 32) — in manifest order, resolves each
+edge exactly as managed dispatch would (spec 05 §5's chain at press
+time: the runtime pair through the machine runtime store with download
+allowed, the provider payload through the registries into the payload
+cache), and emits one `spawned[]` row per edge, slots assigned in walk
+order after the app/slice/carried-runtime slots. The walk refuses, with
+a named press error: an exposed name the depended image's own manifest
+does not declare (the expose check of spec 30 §2 / spec 32 §6); an
+exposed name colliding with the app payload's own entrypoints
+(spec 30 §3 / spec 32 §1 — the L1 manifest validator owns the refusal;
+the walk's parse surfaces it); two edges resolving to the same row target
+(the same engine+implementation, or the same provider payload); a
+`kind: executable` edge whose exposed entrypoints are runtime-less
+(spec 32 §0 — the exec tier has no spawn form) or whose provider
+carries no language edge for the nested runtime pick. `carry` rides the
+preset's defaults (§13.2), exactly like the slice rows. A row the
+preset leaves SHARED splits by kind: a shared RUNTIME row is a named
+press error — press resolves runtimes through the machine store and
+records no replayable `source:`, so the row would not reproduce on
+another machine; the error advises `--mode=self-contained` (hand-author
+the row when a shared spawned runtime is genuinely wanted — the packed-mn
+channel). A shared PAYLOAD row records its registry `source:` and stays
+expressible, though no current preset produces one.
 
 Run time reads ONE block: the loader resolves each row into the store's
 `runtimes/` area — carried → slot extract + digest-verify + install;

--- a/docs/spec/30-runtime-spawned-dependency.md
+++ b/docs/spec/30-runtime-spawned-dependency.md
@@ -4,7 +4,8 @@
 `tpkg` (the `kind: runtime` edge + schema_minor 4 + the runtime-store
 scan), `tebako-shim` (dispatch-time edge resolution + the
 `TEBAKO_SPAWN_LOCK` export), `tebako-cli` (install/compose arms + the
-expose shim registration), `tebako-info` (render arms),
+expose shim registration + the press-time `spawned[]` row composition),
+`tebako-info` (render arms),
 `tebako-driver` (the spawn map, the plan FFI, the PATH launchers, the
 jail union)).** Amends spec 03 §2.3 (DEPENDS
 gains the kind-runtime edge), spec 07 §1/§2 (the spawn surface and shim

--- a/docs/spec/32-spawned-payload-dependency.md
+++ b/docs/spec/32-spawned-payload-dependency.md
@@ -7,7 +7,8 @@ edge resolution + the spawn-lock payload rows),
 `tebako-driver` (the payload-spawn plan composition + the hereditary
 jail ceiling), `tebako-bootstrap` (the lock's spawned payload-row
 resolution), `tebako-cli` (install/compose arms + the expose shim
-registration + the tightening export), `tebako-pkg`/`tebako-info` (the
+registration + the tightening export + the press-time `spawned[]` row
+composition), `tebako-pkg`/`tebako-info` (the
 press-time two-level cross-checks + the render arms)).** Amends spec 03 §8 (the
 `kind: executable` edge gains the `expose:` spawn form), spec 23 §13.6
 (the lock's `spawned[]` rows gain the payload row), spec 30 §0 (the


### PR DESCRIPTION
## What

`tebako press` gains the spawn-closure walk ("fat++", roadmap 84): the app image's L1 `requires:` — every `kind: runtime` edge (spec 30) and every expose-carrying `kind: executable` edge (spec 32) — resolves at press time exactly as managed dispatch would, and each edge lands as a lock `spawned[]` row with the mirrored constraint/expose, the resolved version pair, the carry verdict from the preset's defaults, and the digest pins. Carried rows pack the runtime pair (exe + env image, +dll on windows) or the provider image as slots in walk order after the app/slice/carried-runtime slots.

Hand-authoring the `spawned[]` block (packed-mn) stays legal — schema and loader semantics untouched.

## Semantics (recorded in the spec 23 §13.6 amendment)

- **Shared runtime row = named press error (exit 65)** — press resolves spawned runtimes through the machine store and records no replayable `source:`; the error advises `--mode=self-contained`, and the hand-authored block stays the escape hatch. A shared *payload* row records its registry `source:` and stays expressible.
- **Carried rows record `source: None`** — the packed-mn oracle's shape.
- **Expose × own-entrypoint collision refusal** stays owned by tpkg's `PayloadManifest::from_yaml` validator (spec 30 §3); the walk surfaces it at parse.
- **`carry` rides the preset's defaults** (Fat/`--self-contained` → SelfContained; else SharedRuntime).
- **Lazy home**: a spawn-less app image composes no rows and never resolves the store home — plain press is byte-identical in behavior.
- **dll facet (windows)**: `tpkg::runtime_store` gains `EntryDll`/`entry_dll_from_index`/`entry_dll` (the tebako-runtime-ruby#40 grammar); tebako-shim's private copy is deleted (spec 00 §10 — one grammar owner).

## tebako-info verify — digest gap closed

Every carried spawned artifact's lock pin verifies against its slot's bytes (`spawned[<engine>].exe|image|dll`, `spawned[<payload>].image`, `spawned[<payload>].runtime.<facet>`); slot OOB → 65; mismatch → 70; a per-triplet pin covering no host row skips loud (§13.3).

## Evidence

- `cargo test -p tpkg -p tebako-cli -p tebako-info -p tebako-shim -p tebako-pkg` (debug, standard vcpkg env): **60 suites, 857 passed, 0 failed** — incl. 14 new `spawn_press.rs` tests, 2 new tpkg `entry_dll` tests, 2 new `tebako-pkg/tests/info.rs` validate tests. `cli_e2e` green (needs `cargo build -p tebako-bootstrap` first — pre-existing harness precondition).
- `cargo clippy --workspace --all-targets -- -D warnings` on the CI-pinned **1.94.1** toolchain: zero warnings. (Two pre-existing 1.98-only lints in untouched files left alone.)
- Row-shape oracle: packed-mn's hand-authored lock (`package/package-manifest.yaml:164-195`).

## Deviations (deliberate)

1. dll detection only for index-carrying store entries (carried-staged entries hold no `manifest.json`) — documented on `entry_dll`.
2. `lock.slices[]` pin coverage unchanged (separate concern).
3. press e2e with a spawn-bearing app not exercised — walk is unit-tested (same posture as `resolve_closure`); `cli_e2e` proves plain press unchanged.
