### PR TITLE
tpkg: the plain-wins rule for variant-suffixed versions (roadmap 88)

### DIFF
--- a/crates/tebako-shim/tests/runtime.rs
+++ b/crates/tebako-shim/tests/runtime.rs
@@ -134,6 +134,28 @@ fn no_preference_downloads_the_index_pick_on_the_default_line() {
 }
 
 #[test]
+fn the_index_pick_prefers_the_plain_twin_over_a_variant_suffix() {
+    // spec 05 §5's plain-wins rule (roadmap 88): an index carrying
+    // plain + variant twins of one version resolves the open constraint
+    // to the PLAIN — a factory's `-jit` build never silently outranks
+    // its plain twin (the metanorma 1.16.9-11 publish failure).
+    let tmp = TempDir::new("plain-wins-index-pick");
+    let home = tmp.path().join("home");
+    let mirror = tmp.path().join("mirror");
+    let line = tebako_resolve::DEFAULT_TEBAKO_VERSION;
+    write_release_index(&mirror, line, &["3.13.15", "3.13.15-jit"]);
+    let mut ctx = ctx(&home, tmp.path());
+    ctx.env.insert(
+        "TEBAKO_RUNTIME_MIRROR".into(),
+        tebako_http::file_url(&mirror),
+    );
+
+    let rt = ready(runtime::resolve_runtime(Some(&req("~> 3.13.0")), true, &ctx).unwrap());
+    assert_eq!(rt.lang_version, "3.13.15");
+    assert!(rt.exe.is_file());
+}
+
+#[test]
 fn no_preference_and_an_index_without_a_satisfier_is_the_platform_error() {
     let tmp = TempDir::new("prefless-unsatisfiable");
     let home = tmp.path().join("home");

--- a/crates/tpkg/src/versions.rs
+++ b/crates/tpkg/src/versions.rs
@@ -262,7 +262,7 @@ mod tests {
         assert!(c.matches("3.13.15-jit"));
         assert!(!c.matches("3.14.0"));
         // …but the max pick among satisfiers is the plain twin.
-        let vs = vec!["3.13.15-jit".to_string(), "3.13.15".to_string()];
+        let vs = ["3.13.15-jit".to_string(), "3.13.15".to_string()];
         let pick = vs
             .iter()
             .filter(|v| c.matches(v))

--- a/crates/tpkg/src/versions.rs
+++ b/crates/tpkg/src/versions.rs
@@ -9,9 +9,20 @@
 //!   `~> 3.3.0` means `>= 3.3.0, < 3.4`; `~> 3.3` means `>= 3.3, < 4`).
 //!
 //! Hand-rolled (no semver crate): the loaders keep bootstrap size
-//! discipline. Versions are dot-separated components; numeric components
-//! compare numerically, anything else lexicographically, missing
-//! components are zero.
+//! discipline. Versions are dot-separated components; missing components
+//! are zero. Within one component (spec 05 §5's ordering rule): a leading
+//! numeric prefix compares numerically (`1.10 > 1.9`); at an equal prefix
+//! a PLAIN component ranks ABOVE a suffixed one (`3.13.15 > 3.13.15-jit`
+//! — semver's release > prerelease rule, so a factory's build variant
+//! never silently outranks its plain twin in a newest-satisfying pick);
+//! two suffixes order lexicographically; a component without a numeric
+//! prefix falls back to whole-component string order. Constraint MATCHING
+//! is unaffected by the ordering rule: a variant version still satisfies
+//! an open constraint (a platform where ONLY the variant exists still
+//! resolves) — it just never wins a max pick against the plain twin. A
+//! variant is SELECTED through the pin surface (config `version:`, the
+//! registry default), which names versions exactly; the constraint
+//! grammar itself (spec 03) admits only plain dot-decimal clauses.
 //!
 //! Constraint GRAMMAR is not re-implemented here: [`Constraint`] (the
 //! manifest model) validates at parse (spec 03 — the unified model), and
@@ -33,14 +44,35 @@ fn components(v: &str) -> Vec<&str> {
     v.split('.').collect()
 }
 
+/// Split a component into its leading numeric prefix and the optional
+/// non-numeric suffix (`15-jit` → `(15, Some("-jit"))`, `15` →
+/// `(15, None)`). A component with no leading digit (or a prefix too big
+/// for u64) has no numeric prefix and falls back to string order.
+fn numeric_prefix(c: &str) -> Option<(u64, Option<&str>)> {
+    let digits = c.bytes().take_while(|b| b.is_ascii_digit()).count();
+    if digits == 0 {
+        return None;
+    }
+    let (num, rest) = c.split_at(digits);
+    let n = num.parse::<u64>().ok()?;
+    Some((n, if rest.is_empty() { None } else { Some(rest) }))
+}
+
 fn compare_component(a: &str, b: &str) -> Ordering {
-    match (a.parse::<u64>(), b.parse::<u64>()) {
-        (Ok(x), Ok(y)) => x.cmp(&y),
+    match (numeric_prefix(a), numeric_prefix(b)) {
+        (Some((x, sx)), Some((y, sy))) => x.cmp(&y).then_with(|| match (sx, sy) {
+            (None, None) => Ordering::Equal,
+            // The plain-wins rule (spec 05 §5): release > prerelease.
+            (None, Some(_)) => Ordering::Greater,
+            (Some(_), None) => Ordering::Less,
+            (Some(s), Some(t)) => s.cmp(t),
+        }),
         _ => a.cmp(b),
     }
 }
 
-/// Compare two dotted versions (`1.2` == `1.2.0`, `1.10` > `1.9`).
+/// Compare two dotted versions (`1.2` == `1.2.0`, `1.10` > `1.9`,
+/// `3.13.15` > `3.13.15-jit` — the plain-wins rule, spec 05 §5).
 pub fn compare(a: &str, b: &str) -> Ordering {
     let (ca, cb) = (components(a), components(b));
     for i in 0..ca.len().max(cb.len()) {
@@ -194,6 +226,53 @@ mod tests {
         assert_eq!(compare("1.10", "1.9"), Ordering::Greater);
         assert!(compare("3.3.5", "3.4.0") == Ordering::Less);
         assert_eq!(compare("4.0.6", "4.0.6"), Ordering::Equal);
+    }
+
+    #[test]
+    fn plain_wins_over_a_variant_suffix() {
+        // spec 05 §5: at an equal numeric prefix, plain ranks ABOVE
+        // suffixed (semver's release > prerelease rule) — a factory's
+        // build variant never outranks its plain twin in a max pick.
+        assert_eq!(compare("3.13.15", "3.13.15-jit"), Ordering::Greater);
+        assert_eq!(compare("3.13.15-jit", "3.13.15"), Ordering::Less);
+        assert_eq!(compare("3.13.15-jit", "3.13.15-jit"), Ordering::Equal);
+        // two suffixes order lexicographically
+        assert_eq!(compare("3.13.15-a", "3.13.15-jit"), Ordering::Less);
+        // numeric dominance is unchanged across the suffix boundary
+        assert_eq!(compare("3.13.16-jit", "3.13.15"), Ordering::Greater);
+        assert_eq!(compare("3.13.15-jit", "3.13.16"), Ordering::Less);
+        assert_eq!(compare("1.10", "1.9"), Ordering::Greater);
+        // a component with no numeric prefix keeps whole-string order
+        assert_eq!(compare("1.2.rc1", "1.2.rc2"), Ordering::Less);
+        // and the max pick over twins lands on the plain
+        let vs = vec![
+            "3.13.15-jit".to_string(),
+            "3.13.15".to_string(),
+            "3.13.9".to_string(),
+        ];
+        assert_eq!(newest(&vs).as_deref(), Some("3.13.15"));
+    }
+
+    #[test]
+    fn variant_matching_is_unchanged_only_the_pick_changes() {
+        // An open constraint still MATCHES the variant (a platform where
+        // only the variant exists still resolves)…
+        let c = parse_constraint("~> 3.13.0").unwrap();
+        assert!(c.matches("3.13.15"));
+        assert!(c.matches("3.13.15-jit"));
+        assert!(!c.matches("3.14.0"));
+        // …but the max pick among satisfiers is the plain twin.
+        let vs = vec!["3.13.15-jit".to_string(), "3.13.15".to_string()];
+        let pick = vs
+            .iter()
+            .filter(|v| c.matches(v))
+            .max_by(|a, b| compare(a, b));
+        assert_eq!(pick.map(String::as_str), Some("3.13.15"));
+        // The constraint grammar (spec 03) admits only plain dot-decimal
+        // clauses — a suffixed pin is a named parse error there; variant
+        // selection rides the pin surface (config `version:`, registry
+        // default), which names versions exactly and never compares.
+        assert!(parse_constraint("= 3.13.15-jit").is_err());
     }
 
     #[test]

--- a/docs/spec/05-resolution-and-cache.md
+++ b/docs/spec/05-resolution-and-cache.md
@@ -223,6 +223,24 @@ their platform string as the per-package `abi` key in the release index
 eligible (the compat window — a payload's abi check never fails against
 an unknown line).
 
+**Version ordering (the plain-wins rule — the single owner is
+`tpkg::versions::compare`; every consumer flows it).** Versions are
+dot-separated components, missing components zero. Within one component:
+a leading numeric prefix compares numerically (`1.10 > 1.9`); at an
+equal prefix a PLAIN component ranks ABOVE a suffixed one
+(`3.13.15 > 3.13.15-jit` — semver's release > prerelease rule), so a
+factory's build variant (a `-jit`, `-debug`, … line) never silently
+outranks its plain twin in a newest-satisfying pick; two suffixes order
+lexicographically; a component without a numeric prefix falls back to
+whole-component string order. Constraint MATCHING is unaffected: a
+variant version still satisfies an open constraint, so a platform where
+ONLY the variant exists still resolves — the variant simply never wins
+a max pick against the plain twin. A variant is SELECTED through the pin
+surface (the config `version:` pin, the registry default), which names
+versions exactly and never compares; the constraint grammar itself
+(spec 03) admits only plain dot-decimal clauses, so a suffixed clause
+stays a named parse error.
+
 **The implementation axis (spec 28 §8):** `engine` names the LANGUAGE —
 mri, jruby and truffleruby are all `engine: ruby`, told apart by the
 runtime's `provides.implementation`. A requirement WITHOUT


### PR DESCRIPTION
## Summary

Roadmap 88 — the plain-wins rule for variant-suffixed versions. `tpkg::versions::compare` (the single owner of the spec 05 §5 ordering) ranked a variant-suffixed component ABOVE its plain twin (`"15-jit" > "15"` via the string fallback), so every newest-satisfying pick whose constraint spans both silently delivered the variant. Live-fired in the metanorma 1.16.9-11 tag publish (run 34686659995): the xml2rfc edge's `~> 3.13.0` picked python `3.13.15-jit` over the pinned `3.13.15`.

## The rule (spec 05 §5 amendment, in this PR)

Within one dotted component:

1. Split into numeric prefix + optional non-numeric suffix (`15-jit` → `(15, "-jit")`; `15` → `(15, none)`).
2. Prefixes differ → numeric order (unchanged: `1.10 > 1.9`).
3. Prefixes equal → **plain ranks ABOVE suffixed** (semver's release > prerelease rule); two suffixes order lexicographically.
4. Either side without a numeric prefix → whole-component string order (unchanged fallback).

Constraint MATCHING is unchanged: a variant still satisfies an open constraint (a platform where ONLY the variant exists still resolves) — it simply never wins a max pick against the plain twin. Variant SELECTION rides the pin surface (config `version:`, registry default), which names versions exactly and never compares; the constraint grammar (spec 03) admits only plain dot-decimal clauses, so a suffixed clause stays a named parse error.

## Blast radius

Every consumer is a "newest satisfying" pick and the rule is coherent for each: `tebako-shim` runtime.rs (the index pick) + dispatch.rs (newest installed payload satisfying a dep), `tpkg::runtime_store::newest_compatible` (the cached pick), `tebako-cli` check/compose/install. The dual-line payloads (`1.16.9` vs `1.16.9-ruby4.0`) are unaffected — the registry's explicit `default:` governs the unpinned pick; the rule removes a latent hazard there.

## Tests

- Unit (`tpkg::versions`): plain > suffixed at equal prefix; suffix-vs-suffix lexicographic; numeric dominance unchanged; `1.2 == 1.2.0` unchanged; `~> 3.13.0` matches BOTH `3.13.15` and `3.13.15-jit` but the max pick is `3.13.15`; a suffixed constraint clause is a named parse error.
- Regression (`tebako-shim/tests/runtime.rs`): a release index carrying plain + jit twins resolves `~> 3.13.0` to the PLAIN — red against the pre-fix comparator, green with it (verified both ways locally).

## Notes

Stacked on #578 (one-PR-per-repo: this branch's base is that PR's head; retargets to main on its merge).

🤖 Generated with [Kimi Code](https://github.com/tamatebako/tebako)
