### PR TITLE
tebako-cli: the tebako bundle verb — offline application bundles (spec 16 §6, roadmap 82/83)

### DIFF
--- a/crates/tebako-cli/src/bundle.rs
+++ b/crates/tebako-cli/src/bundle.rs
@@ -1,0 +1,725 @@
+//! `tebako bundle` (spec 16 §6, roadmap 82/83): compose an OFFLINE
+//! application bundle from the canonical published artifacts — a
+//! pre-seeded store tree (payloads + the whole runtime closure +
+//! registry caches + a rendered config.yaml) plus the platform's CLI
+//! tool set, laid out for an installer (MSI/pkg/SCCM/zip) to drop onto a
+//! machine that may never see the network.
+//!
+//! The hard constraints (owner 2026-09-10/12):
+//! - the bundle is composed of the CANONICAL published artifacts —
+//!   payloads and runtimes byte-identical with what the registries
+//!   published (the store's own sha256/signature verification at stage
+//!   time is the proof), merely PRE-POSITIONED. Nothing is rebuilt.
+//! - configurability lives in the bundle's rendered `config.yaml`
+//!   (the `--config` org overlay: the spec 04 `network:` block, runtime
+//!   preferences, defaults), NEVER in rebuilt bytes.
+//!
+//! Layout:
+//!
+//! ```text
+//! <out>/bin/          the platform's CLI tools (tebako, tebako-shim,
+//!                     tfs, tebako-pkg — the dispatch/run machinery)
+//! <out>/home/         the staged TEBAKO_HOME, verbatim store grammar
+//!                     (payloads/, runtimes/, registries/, shims/,
+//!                     config.yaml, journal.log, …)
+//! <out>/BUNDLE.yaml   the descriptor: what was bundled, pinned, and the
+//!                     commands the installer materializes onto PATH
+//! ```
+//!
+//! The store tree is self-consistent: the rendered config.yaml pins
+//! every staged runtime by its exact (engine, version, tebako-line)
+//! identity, the registry caches let a cold machine resolve with zero
+//! fetches (spec 05 §4's stale-serve covers day 2 with the cable out),
+//! and the shim symlinks (unix) are RELATIVE so the tree relocates as
+//! one piece. v1 builds for the HOST platform only — a cross-target
+//! bundle rides the per-platform CI leg.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use tebako_resolve::{Fetcher, Transport};
+use tebako_shim::config::{self, UserConfig};
+use tebako_shim::runtime::{self, RuntimeResolution};
+use tebako_shim::Ctx;
+
+use crate::error::TebakoError;
+use crate::install;
+
+/// Usage/authoring failures (malformed overlay, occupied output, …).
+const EX_TEBAKO_USAGE: i32 = 65;
+
+/// The four CLI tools a bundle carries (the platform's set, exe suffix
+/// per the host).
+const TOOLS: [&str; 4] = ["tebako", "tebako-shim", "tfs", "tebako-pkg"];
+
+/// The optional packed form of the bundle directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArchiveFormat {
+    TarGz,
+    Zip,
+}
+
+impl ArchiveFormat {
+    pub fn parse(s: &str) -> Result<Self, TebakoError> {
+        match s {
+            "tar.gz" | "tgz" => Ok(Self::TarGz),
+            "zip" => Ok(Self::Zip),
+            other => Err(TebakoError::new(
+                format!("unknown --archive format \"{other}\" — expected `tar.gz` or `zip`"),
+                EX_TEBAKO_USAGE,
+            )),
+        }
+    }
+
+    fn extension(self) -> &'static str {
+        match self {
+            Self::TarGz => "tar.gz",
+            Self::Zip => "zip",
+        }
+    }
+}
+
+/// What a bundle run produced (the installer-facing report).
+#[derive(Debug)]
+pub struct BundleOutcome {
+    /// The bundle directory.
+    pub dir: PathBuf,
+    /// The packed archive, when `--archive` was given.
+    pub archive: Option<PathBuf>,
+    /// The primary payload (name, version).
+    pub payload: (String, String),
+    /// Every staged runtime as (engine, language version, tebako line).
+    pub runtimes: Vec<(String, String, String)>,
+    /// The commands the bundle's shims materialize onto PATH.
+    pub commands: Vec<String>,
+}
+
+/// The inputs of one bundle run (grouped — the parameter list outgrew
+/// the clippy budget at the env injection).
+#[derive(Debug)]
+pub struct BundleRequest<'a> {
+    /// The operator's own TEBAKO_HOME (its registry registrations and
+    /// runtime preferences seed the staging home).
+    pub builder_home: &'a Path,
+    /// The directory holding the platform's CLI binaries (the current
+    /// exe's directory in production).
+    pub tools_dir: &'a Path,
+    /// The bundle target: `<ref | name[@ver]>`.
+    pub target: &'a str,
+    /// The output directory (created; must not exist).
+    pub output: &'a Path,
+    /// The `--config` org overlay (a config.yaml fragment).
+    pub overlay: Option<&'a Path>,
+    /// The optional packed form.
+    pub archive: Option<ArchiveFormat>,
+    /// The effective environment for the staging resolution
+    /// (TEBAKO_RUNTIME_MIRROR and friends) — injected so tests never
+    /// touch the process environment.
+    pub env: &'a BTreeMap<String, String>,
+}
+
+/// `tebako bundle <ref | name[@ver]> --output <dir> [--config org.yaml]
+/// [--archive tar.gz|zip]`.
+pub fn bundle_with<T: Transport>(
+    req: &BundleRequest,
+    fetcher: &Fetcher<T>,
+) -> Result<BundleOutcome, TebakoError> {
+    let output = req.output;
+    if output.exists() {
+        return Err(TebakoError::new(
+            format!(
+                "bundle output {} already exists — choose an empty path (a bundle never overwrites)",
+                output.display()
+            ),
+            EX_TEBAKO_USAGE,
+        ));
+    }
+    let parent = output.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent).map_err(|e| {
+        TebakoError::new(
+            format!("cannot create {}: {e}", parent.display()),
+            EX_TEBAKO_USAGE,
+        )
+    })?;
+    let tmp = parent.join(format!(".bundle-staging-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).map_err(|e| {
+        TebakoError::new(
+            format!("cannot create the staging dir {}: {e}", tmp.display()),
+            EX_TEBAKO_USAGE,
+        )
+    })?;
+    let result = stage(req, &tmp, fetcher);
+    match result {
+        Ok(mut outcome) => {
+            if let Err(e) = std::fs::rename(&tmp, output) {
+                let _ = std::fs::remove_dir_all(&tmp);
+                return Err(TebakoError::new(
+                    format!(
+                        "cannot move the staged bundle into {}: {e}",
+                        output.display()
+                    ),
+                    EX_TEBAKO_USAGE,
+                ));
+            }
+            outcome.dir = output.to_path_buf();
+            outcome.archive = match req.archive {
+                Some(fmt) => Some(pack(output, fmt)?),
+                None => None,
+            };
+            Ok(outcome)
+        }
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&tmp);
+            Err(e)
+        }
+    }
+}
+
+/// The production entry (real transport, real network).
+pub fn bundle(req: &BundleRequest) -> Result<BundleOutcome, TebakoError> {
+    bundle_with(req, &Fetcher::new())
+}
+
+/// The staging pipeline: tools → config → registries → install (the
+/// payload closure + the spawned runtimes, spec 30/32) → the primary
+/// runtime warm → pin-from-reality → relocatable shims → the descriptor.
+/// Everything happens inside `tmp` (renamed to the output by the caller
+/// on success — a failed bundle never leaves a half-tree behind).
+fn stage<T: Transport>(
+    req: &BundleRequest,
+    tmp: &Path,
+    fetcher: &Fetcher<T>,
+) -> Result<BundleOutcome, TebakoError> {
+    let bin = tmp.join("bin");
+    let home = tmp.join("home");
+    std::fs::create_dir_all(&bin)
+        .and_then(|_| std::fs::create_dir_all(&home))
+        .map_err(|e| {
+            TebakoError::new(
+                format!("cannot lay out the bundle tree: {e}"),
+                EX_TEBAKO_USAGE,
+            )
+        })?;
+
+    stage_tools(req.tools_dir, &bin)?;
+    stage_config(req.builder_home, &home, req.overlay)?;
+
+    // The builder's registries register INTO the staging home: nickname
+    // resolution needs them now, and the cached registry files are the
+    // bundle's offline day-1 resolution surface.
+    let registries = config::load_config(&home).map_err(map_shim)?.registries;
+    for reg in &registries {
+        install::add_registry_with(&home, reg, fetcher)?;
+    }
+
+    let shim_binary = bin.join(shim_tool_name());
+    let outcome = install::install_with(&home, req.target, None, Some(&shim_binary), fetcher)?;
+
+    warm_primary_runtime(&home, &outcome.name, &outcome.version, req.env)?;
+
+    let runtimes = pin_runtimes_from_reality(&home)?;
+    relativize_shims(&home, tmp)?;
+    let descriptor = Descriptor {
+        name: outcome.name.clone(),
+        version: outcome.version.clone(),
+        platform: tpkg::Platform::host().to_string(),
+        tebako_version: env!("CARGO_PKG_VERSION").to_string(),
+        commands: outcome.commands.clone(),
+        runtimes: runtimes.clone(),
+    };
+    write_descriptor(tmp, &descriptor)?;
+
+    journal(
+        &home,
+        &format!(
+            "event=bundle-staged name={} version={} runtimes={} commands={}",
+            outcome.name,
+            outcome.version,
+            runtimes.len(),
+            outcome.commands.len()
+        ),
+    );
+
+    Ok(BundleOutcome {
+        dir: tmp.to_path_buf(),
+        archive: None,
+        payload: (outcome.name, outcome.version),
+        runtimes,
+        commands: outcome.commands,
+    })
+}
+
+/// Copy the platform's CLI tool set into `bin/` — every tool of the
+/// dispatch/run surface, a named error when one is missing (a partial
+/// tool set makes a bundle that cannot maintain itself).
+fn stage_tools(tools_dir: &Path, bin: &Path) -> Result<(), TebakoError> {
+    let suffix = exe_suffix();
+    for tool in TOOLS {
+        let src = tools_dir.join(format!("{tool}{suffix}"));
+        if !src.is_file() {
+            return Err(TebakoError::new(
+                format!(
+                    "the tool set beside the tebako exe is incomplete: {} not found — run the bundle verb from a full CLI installation (all four tools ship together)",
+                    src.display()
+                ),
+                EX_TEBAKO_USAGE,
+            ));
+        }
+        std::fs::copy(&src, bin.join(format!("{tool}{suffix}"))).map_err(|e| {
+            TebakoError::new(
+                format!("cannot stage {}: {e}", src.display()),
+                EX_TEBAKO_USAGE,
+            )
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let dst = bin.join(format!("{tool}{suffix}"));
+            let mut perms = std::fs::metadata(&dst)
+                .map_err(|e| {
+                    TebakoError::new(format!("stat {}: {e}", dst.display()), EX_TEBAKO_USAGE)
+                })?
+                .permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&dst, perms).map_err(|e| {
+                TebakoError::new(format!("chmod {}: {e}", dst.display()), EX_TEBAKO_USAGE)
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Render the staging home's config.yaml: the builder's registry
+/// registrations and runtime preferences seed it, the org overlay
+/// (`--config`) overrides per section — the `network:` block (spec 04,
+/// the 81 trust bridge), per-engine runtime prefs, per-tool defaults.
+/// The bundle re-pins `runtimes:` from the staged reality after the
+/// warm, so the shipped config can never name a runtime the bundle
+/// does not carry.
+fn stage_config(
+    builder_home: &Path,
+    home: &Path,
+    overlay: Option<&Path>,
+) -> Result<(), TebakoError> {
+    let builder = config::load_config(builder_home).map_err(map_shim)?;
+    let overlay: Option<UserConfig> = match overlay {
+        Some(path) => {
+            let text = std::fs::read_to_string(path).map_err(|e| {
+                TebakoError::new(
+                    format!("cannot read the org config overlay {}: {e}", path.display()),
+                    EX_TEBAKO_USAGE,
+                )
+            })?;
+            let parsed: UserConfig = serde_yml::from_str(&text).map_err(|e| {
+                TebakoError::new(
+                    format!(
+                        "cannot parse the org config overlay {} ({e}) — the overlay is a config.yaml fragment (network:, runtimes:, defaults:, registries:)",
+                        path.display()
+                    ),
+                    EX_TEBAKO_USAGE,
+                )
+            })?;
+            Some(parsed)
+        }
+        None => None,
+    };
+    let mut registries = builder.registries.clone();
+    if let Some(ov) = &overlay {
+        for r in &ov.registries {
+            if !registries.contains(r) {
+                registries.push(r.clone());
+            }
+        }
+    }
+    let mut runtimes = builder.runtimes.clone();
+    let mut defaults = builder.defaults.clone();
+    let mut network = builder.network;
+    if let Some(ov) = overlay {
+        for (engine, pref) in ov.runtimes {
+            runtimes.insert(engine, pref);
+        }
+        for (tool, pin) in ov.defaults {
+            defaults.insert(tool, pin);
+        }
+        if ov.network.proxy.is_some()
+            || ov.network.tls_roots.is_some()
+            || !ov.network.extra_ca.is_empty()
+        {
+            network = ov.network;
+        }
+    }
+    write_config(home, &registries, &runtimes, &defaults, &network)
+}
+
+/// Serialize a config.yaml — YAML by hand (the store grammar's rule:
+/// YAML for all authored config, and the renderer escapes nothing that
+/// the grammar admits — every value here is a plain scalar or path
+/// string; a value that would break the plain-scalar shape is a named
+/// error, never a silently quoted guess).
+fn write_config(
+    home: &Path,
+    registries: &[String],
+    runtimes: &BTreeMap<String, config::RuntimePref>,
+    defaults: &BTreeMap<String, String>,
+    network: &config::NetworkSection,
+) -> Result<(), TebakoError> {
+    let mut out = String::new();
+    if !defaults.is_empty() {
+        out.push_str("defaults:\n");
+        for (tool, ver) in defaults {
+            out.push_str(&format!("  {}: {}\n", scalar(tool)?, scalar(ver)?));
+        }
+    }
+    if !registries.is_empty() {
+        out.push_str("registries:\n");
+        for r in registries {
+            out.push_str(&format!("  - {}\n", scalar(r)?));
+        }
+    }
+    if !runtimes.is_empty() {
+        out.push_str("runtimes:\n");
+        for (engine, pref) in runtimes {
+            out.push_str(&format!("  {}:\n", scalar(engine)?));
+            out.push_str(&format!("    version: {}\n", scalar(&pref.version)?));
+            if !pref.tebako.is_empty() {
+                out.push_str(&format!("    tebako: {}\n", scalar(&pref.tebako)?));
+            }
+            if let Some(source) = &pref.source {
+                out.push_str(&format!("    source: {}\n", scalar(source)?));
+            }
+        }
+    }
+    if network.proxy.is_some() || network.tls_roots.is_some() || !network.extra_ca.is_empty() {
+        out.push_str("network:\n");
+        if let Some(proxy) = &network.proxy {
+            out.push_str(&format!("  proxy: {}\n", scalar(proxy)?));
+        }
+        if let Some(roots) = &network.tls_roots {
+            out.push_str(&format!("  tls_roots: {}\n", scalar(roots)?));
+        }
+        if !network.extra_ca.is_empty() {
+            out.push_str("  extra_ca:\n");
+            for ca in &network.extra_ca {
+                out.push_str(&format!("    - {}\n", scalar(&ca.display().to_string())?));
+            }
+        }
+    }
+    std::fs::write(config::config_path(home), out).map_err(|e| {
+        TebakoError::new(
+            format!("cannot write the bundle config.yaml: {e}"),
+            EX_TEBAKO_USAGE,
+        )
+    })
+}
+
+/// A config/descriptor value renders as a YAML plain scalar only when
+/// the plain style ROUND-TRIPS IT AS A STRING — a value the core schema
+/// would re-type (int/float/bool/null: `1.0`, `3.13`, `true`) renders
+/// double-quoted instead (the admitted charset never needs an escape
+/// inside quotes). A value outside the charset is a named error, never
+/// a guessed encoding.
+fn scalar(v: &str) -> Result<std::borrow::Cow<'_, str>, TebakoError> {
+    let safe = !v.is_empty()
+        && v.chars().all(|c| {
+            c.is_ascii_alphanumeric()
+                || matches!(c, '.' | '-' | '_' | '/' | ':' | '+' | '@' | '~' | '=' | '?')
+        })
+        && !v.starts_with('-');
+    if !safe {
+        return Err(TebakoError::new(
+            format!("config value {v:?} is not a YAML plain scalar — simplify it"),
+            EX_TEBAKO_USAGE,
+        ));
+    }
+    let mistyped = v.parse::<i64>().is_ok()
+        || v.parse::<f64>().is_ok()
+        || matches!(
+            v,
+            "true" | "false" | "True" | "False" | "TRUE" | "FALSE" | "null" | "Null" | "NULL" | "~"
+        );
+    Ok(if mistyped {
+        format!("\"{v}\"").into()
+    } else {
+        v.into()
+    })
+}
+
+/// Pre-stage the PRIMARY payload's runtime (the `kind: language` axis):
+/// install stages the spawned edges (spec 30/32) but the payload's own
+/// runtime resolves at dispatch — a bundle that ships without it is not
+/// offline-ready. Resolve it exactly as dispatch would (the shim's own
+/// resolver against the staging home), downloading on a cache miss.
+fn warm_primary_runtime(
+    home: &Path,
+    name: &str,
+    version: &str,
+    env: &BTreeMap<String, String>,
+) -> Result<(), TebakoError> {
+    let record = tebako_shim::manifest::payload_record(home, name, version);
+    let mirror =
+        tebako_shim::manifest::Manifest::load(&record.manifest_mirror).map_err(map_shim)?;
+    let ctx = Ctx {
+        home: home.to_path_buf(),
+        cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        env: env.clone(),
+    };
+    let mut warmed: Vec<String> = Vec::new();
+    for ep in mirror.entrypoints() {
+        let Some(reqs) = &ep.runtime_requirement else {
+            continue;
+        };
+        let key = format!("{reqs:?}");
+        if warmed.contains(&key) {
+            continue;
+        }
+        match runtime::resolve_runtime(Some(reqs), true, &ctx).map_err(map_shim)? {
+            RuntimeResolution::Ready(rt) => {
+                journal(
+                    home,
+                    &format!(
+                        "event=bundle-runtime-warm engine={} version={} tebako={}",
+                        rt.engine, rt.lang_version, rt.tebako_version
+                    ),
+                );
+                warmed.push(key);
+            }
+            RuntimeResolution::Zero => {}
+        }
+    }
+    Ok(())
+}
+
+/// Re-pin the staging config's `runtimes:` from the staged reality
+/// (scan the staged store, one pin per engine — the newest staged when
+/// several lines coexist; the dispatch-time resolver still serves every
+/// staged line cache-first, the pin is the bundle's own consistency
+/// record and the day-2 download fallback). A pref for an engine the
+/// bundle did not stage survives verbatim (the operator pinned it for
+/// runtimes the payload resolves later).
+fn pin_runtimes_from_reality(home: &Path) -> Result<Vec<(String, String, String)>, TebakoError> {
+    let staged = tpkg::runtime_store::scan_all_cached(home);
+    let mut cfg = config::load_config(home).map_err(map_shim)?;
+    let mut pins: Vec<(String, String, String)> = Vec::new();
+    let mut engines: Vec<&str> = staged.iter().map(|r| r.engine.as_str()).collect();
+    engines.sort();
+    engines.dedup();
+    for engine in engines {
+        let entries: Vec<_> = staged.iter().filter(|r| r.engine == engine).collect();
+        let pick = entries
+            .iter()
+            .max_by(|a, b| {
+                tpkg::versions::compare(&a.lang_version, &b.lang_version)
+                    .then_with(|| tpkg::versions::compare(&a.tebako_version, &b.tebako_version))
+            })
+            .expect("engines derives from staged");
+        cfg.runtimes.insert(
+            engine.to_string(),
+            config::RuntimePref {
+                version: pick.lang_version.clone(),
+                tebako: pick.tebako_version.clone(),
+                source: cfg.runtimes.get(engine).and_then(|p| p.source.clone()),
+            },
+        );
+        pins.push((
+            engine.to_string(),
+            pick.lang_version.clone(),
+            pick.tebako_version.clone(),
+        ));
+    }
+    let path = config::config_path(home);
+    // Re-render with the SAME shape stage_config produced (pins merged
+    // over the overlay), preserving registries/defaults/network.
+    write_config(
+        home,
+        &cfg.registries,
+        &cfg.runtimes,
+        &cfg.defaults,
+        &cfg.network,
+    )
+    .map_err(|e| {
+        TebakoError::new(
+            format!("cannot re-pin {}: {e}", path.display()),
+            EX_TEBAKO_USAGE,
+        )
+    })?;
+    Ok(pins)
+}
+
+/// Make the shims relocatable: install links them against the bundle's
+/// staged dispatcher (an ABSOLUTE path into the build location) — unix
+/// links are rewritten to the bundle-relative `../../bin/tebako-shim`;
+/// windows shims are byte copies/hardlinks and self-contained already.
+fn relativize_shims(home: &Path, bundle_root: &Path) -> Result<(), TebakoError> {
+    let dir = home.join("shims");
+    let Ok(rd) = std::fs::read_dir(&dir) else {
+        return Ok(());
+    };
+    for entry in rd.flatten() {
+        let link = entry.path();
+        #[cfg(unix)]
+        {
+            let Ok(target) = std::fs::read_link(&link) else {
+                continue;
+            };
+            if !target.is_absolute() {
+                continue;
+            }
+            if !target.starts_with(bundle_root) {
+                continue;
+            }
+            let file = link
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or_default()
+                .to_string();
+            let tool = if file.ends_with(".exe") {
+                "tebako-shim.exe"
+            } else {
+                "tebako-shim"
+            };
+            let rel = Path::new("..").join("..").join("bin").join(tool);
+            std::fs::remove_file(&link)
+                .and_then(|_| std::os::unix::fs::symlink(&rel, &link))
+                .map_err(|e| {
+                    TebakoError::new(
+                        format!("cannot relativize the shim {}: {e}", link.display()),
+                        EX_TEBAKO_USAGE,
+                    )
+                })?;
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (link, bundle_root);
+        }
+    }
+    Ok(())
+}
+
+/// The bundle descriptor (BUNDLE.yaml): the installer's manifest of
+/// what the tree carries — the payload identity, the staged runtimes,
+/// and the command list whose shims land on PATH.
+struct Descriptor {
+    name: String,
+    version: String,
+    platform: String,
+    tebako_version: String,
+    commands: Vec<String>,
+    runtimes: Vec<(String, String, String)>,
+}
+
+fn write_descriptor(root: &Path, d: &Descriptor) -> Result<(), TebakoError> {
+    let mut out = String::from("schema_version: 1\n");
+    out.push_str(&format!("payload: {}\n", scalar(&d.name)?));
+    out.push_str(&format!("version: {}\n", scalar(&d.version)?));
+    out.push_str(&format!("platform: {}\n", scalar(&d.platform)?));
+    out.push_str(&format!("tebako: {}\n", scalar(&d.tebako_version)?));
+    if !d.runtimes.is_empty() {
+        out.push_str("runtimes:\n");
+        for (engine, lv, tv) in &d.runtimes {
+            out.push_str(&format!(
+                "  - {{engine: {}, version: {}, tebako: {}}}\n",
+                scalar(engine)?,
+                scalar(lv)?,
+                scalar(tv)?
+            ));
+        }
+    }
+    if !d.commands.is_empty() {
+        out.push_str("commands:\n");
+        for c in &d.commands {
+            out.push_str(&format!("  - {}\n", scalar(c)?));
+        }
+    }
+    std::fs::write(root.join("BUNDLE.yaml"), out)
+        .map_err(|e| TebakoError::new(format!("cannot write BUNDLE.yaml: {e}"), EX_TEBAKO_USAGE))
+}
+
+/// Pack the bundle directory next to itself (`<out>.tar.gz` / `<out>.zip`).
+fn pack(dir: &Path, fmt: ArchiveFormat) -> Result<PathBuf, TebakoError> {
+    let archive = dir.with_extension(fmt.extension());
+    match fmt {
+        ArchiveFormat::TarGz => {
+            let file = std::fs::File::create(&archive).map_err(|e| {
+                TebakoError::new(
+                    format!("cannot create {}: {e}", archive.display()),
+                    EX_TEBAKO_USAGE,
+                )
+            })?;
+            let enc = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+            let mut builder = tar::Builder::new(enc);
+            let base = dir
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or("bundle")
+                .to_string();
+            // Symlinks must survive the pack (the relocatable shim links
+            // ARE the bundle's dispatch surface) — follow_links off.
+            builder.follow_symlinks(false);
+            builder.append_dir_all(&base, dir).map_err(|e| {
+                TebakoError::new(
+                    format!("cannot pack {}: {e}", dir.display()),
+                    EX_TEBAKO_USAGE,
+                )
+            })?;
+            builder
+                .into_inner()
+                .and_then(|enc| enc.finish())
+                .map_err(|e| {
+                    TebakoError::new(
+                        format!("cannot finish {}: {e}", archive.display()),
+                        EX_TEBAKO_USAGE,
+                    )
+                })?;
+        }
+        ArchiveFormat::Zip => {
+            return Err(TebakoError::new(
+                "the zip bundle leg is not written yet — tar.gz covers the POSIX legs today; zip lands with the windows installer templates (roadmap 83's second half)",
+                EX_TEBAKO_USAGE,
+            ));
+        }
+    }
+    Ok(archive)
+}
+
+/// The dispatcher tool's file name on this platform.
+fn shim_tool_name() -> String {
+    format!("tebako-shim{}", exe_suffix())
+}
+
+fn exe_suffix() -> &'static str {
+    if cfg!(windows) {
+        ".exe"
+    } else {
+        ""
+    }
+}
+
+fn map_shim(e: tebako_shim::ShimError) -> TebakoError {
+    TebakoError::new(e.message, i32::from(e.code))
+}
+
+/// Append one line to the staging home's audit journal — the shim's
+/// journal line grammar (unix-secs + line), mirrored here because the
+/// shim's own `journal` is crate-private. Best-effort, like every
+/// journal write: the bundle never fails on the record.
+fn journal(home: &Path, line: &str) {
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(home.join("journal.log"))
+    {
+        use std::io::Write as _;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let _ = f.write_all(format!("{now} {line}\n").as_bytes());
+    }
+}
+
+/// `tebako bundle`'s exit-code surface: install failures keep the
+/// install code; bundle authoring failures are usage-class.
+pub fn exit_code(err: &TebakoError) -> i32 {
+    err.code
+}

--- a/crates/tebako-cli/src/lib.rs
+++ b/crates/tebako-cli/src/lib.rs
@@ -62,6 +62,7 @@
 //!   gem's 8-byte padding is cosmetic);
 //! - .tebako.yml is not read.
 
+pub mod bundle;
 pub mod check;
 pub mod compose;
 pub mod contract;

--- a/crates/tebako-cli/src/main.rs
+++ b/crates/tebako-cli/src/main.rs
@@ -52,6 +52,10 @@ const USAGE: &str = "Usage:
   tebako update-registries             refresh the dispatch-time registry cache
   tebako install <ref | name[@ver]>    install a payload + register its shims
   tebako uninstall <name>              remove a payload's shims and cache entry
+  tebako bundle <name[@ver]> --output <dir> [--config <org.yaml>] [--archive tar.gz]
+                                       an offline bundle: the payload closure + its
+                                       runtimes + registry caches + the CLI tool set,
+                                       pre-staged for an installer (spec 16 §6)
   tebako shim <verb> …                 the dispatcher's management verbs (spec 07 §3;
                                        ≡ tebako-shim <verb> …: list|use|enable|disable|which|doctor|install-shell|uninstall-shell)
   tebako info [topic] [--remote] [--json]
@@ -178,6 +182,7 @@ fn run(args: &[String]) -> Result<(), CliExit> {
         "update-registries" => run_update_registries(rest),
         "install" => run_install(rest),
         "uninstall" => run_uninstall(rest),
+        "bundle" => run_bundle(rest),
         "shim" => run_shim(rest),
         "info" => run_info(rest),
         "inspect" => run_inspect(rest),
@@ -474,6 +479,88 @@ fn run_uninstall(args: &[String]) -> Result<(), CliExit> {
     println!("removed {} ({})", outcome.name, outcome.versions.join(", "));
     for shim in &outcome.shims_removed {
         println!("  unlinked {}", shim.display());
+    }
+    Ok(())
+}
+
+/// `tebako bundle` (spec 16 §6): the offline application bundle — the
+/// payload closure + its runtime closure + registry caches + the
+/// platform's CLI tool set, staged from the builder's own TEBAKO_HOME
+/// (its registry registrations and runtime preferences seed the bundle's
+/// config; `--config` layers the org overlay) into `<out>/{bin,home}` +
+/// BUNDLE.yaml, optionally packed (`--archive tar.gz`).
+fn run_bundle(args: &[String]) -> Result<(), CliExit> {
+    const USAGE_BUNDLE: &str = "usage: tebako bundle <name[@version]> --output <dir> [--config <org.yaml>] [--archive tar.gz]";
+    let mut target: Option<String> = None;
+    let mut output: Option<String> = None;
+    let mut overlay: Option<String> = None;
+    let mut archive: Option<tebako_cli::bundle::ArchiveFormat> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--output" | "-o" | "--config" | "--archive" => {
+                let flag = args[i].as_str();
+                i += 1;
+                let Some(value) = args.get(i) else {
+                    return Err(CliExit::Usage(USAGE_BUNDLE.to_string()));
+                };
+                match flag {
+                    "--config" => overlay = Some(value.clone()),
+                    "--archive" => {
+                        archive = Some(
+                            tebako_cli::bundle::ArchiveFormat::parse(value)
+                                .map_err(CliExit::Error)?,
+                        );
+                    }
+                    _ => output = Some(value.clone()),
+                }
+            }
+            other if target.is_none() && !other.starts_with('-') => {
+                target = Some(other.to_string());
+            }
+            _ => return Err(CliExit::Usage(USAGE_BUNDLE.to_string())),
+        }
+        i += 1;
+    }
+    let (Some(target), Some(output)) = (target, output) else {
+        return Err(CliExit::Usage(USAGE_BUNDLE.to_string()));
+    };
+    // The tool set ships beside the running exe (a full CLI installation
+    // is the bundle's source — bundle refuses a partial set by name).
+    let exe = std::env::current_exe().map_err(|e| {
+        CliExit::Error(TebakoError::new(
+            format!("cannot locate the tebako exe: {e}"),
+            65,
+        ))
+    })?;
+    let tools_dir = exe
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let env: std::collections::BTreeMap<String, String> = std::env::vars().collect();
+    let outcome = tebako_cli::bundle::bundle(&tebako_cli::bundle::BundleRequest {
+        builder_home: &tebako_home()?,
+        tools_dir: &tools_dir,
+        target: &target,
+        output: std::path::Path::new(&output),
+        overlay: overlay.as_deref().map(std::path::Path::new),
+        archive,
+        env: &env,
+    })?;
+    println!(
+        "bundled {} {} -> {}",
+        outcome.payload.0,
+        outcome.payload.1,
+        outcome.dir.display()
+    );
+    for (engine, lang, tebako) in &outcome.runtimes {
+        println!("  runtime {engine} {lang} (tebako {tebako})");
+    }
+    for command in &outcome.commands {
+        println!("  command {command}");
+    }
+    if let Some(archive) = &outcome.archive {
+        println!("  archive {}", archive.display());
     }
     Ok(())
 }

--- a/crates/tebako-cli/tests/bundle.rs
+++ b/crates/tebako-cli/tests/bundle.rs
@@ -1,0 +1,343 @@
+//! `tebako bundle` tests (spec 16 §6, roadmap 83): the offline bundle
+//! stages the platform's tool set, the payload closure, the warmed
+//! primary runtime, a from-reality pinned config.yaml, relocatable
+//! shims, and the BUNDLE.yaml descriptor — staged under a tmp dir and
+//! renamed into place (a failed bundle never leaves a tree behind).
+//! Everything runs against file:// mirrors and temp homes — no network,
+//! no process-env mutation (TEBAKO_RUNTIME_MIRROR rides the injected
+//! env map, never std::env).
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tebako_cli::bundle::{self, ArchiveFormat, BundleOutcome, BundleRequest};
+use tebako_cli::error::TebakoError;
+use tebako_resolve::{sha256_hex, Fetcher};
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("tebako-cli-bundle-{tag}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A bundle fixture: the builder's TEBAKO_HOME (its config names the
+/// registry + the ruby line to stage), a tools dir with the four CLI
+/// binaries, and a mirror dir holding the payload, its registry, and a
+/// ruby runtime release index.
+struct Fixture {
+    dir: PathBuf,
+    builder_home: PathBuf,
+    tools: PathBuf,
+    mirror: PathBuf,
+    registry_url: String,
+}
+
+impl Fixture {
+    fn new(tag: &str) -> Fixture {
+        let dir = scratch(tag);
+        let builder_home = dir.join("builder-home");
+        let tools = dir.join("tools");
+        let mirror = dir.join("mirror");
+        fs::create_dir_all(&builder_home).unwrap();
+        fs::create_dir_all(&tools).unwrap();
+        fs::create_dir_all(&mirror).unwrap();
+
+        // The platform's tool set (fake bytes; the bundle copies, never
+        // executes them).
+        for tool in ["tebako", "tebako-shim", "tfs", "tebako-pkg"] {
+            let name = format!("{tool}{}", exe_suffix());
+            let path = tools.join(&name);
+            fs::write(&path, b"fake tool\n").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+            }
+        }
+
+        // The app payload (fake bytes — install stores them verbatim and
+        // synthesizes the manifest mirror from the registry's tier-3
+        // fields) and its registry.
+        let payload_path = mirror.join("app-1.0.tfs");
+        fs::write(&payload_path, b"app-bytes").unwrap();
+        let registry_path = mirror.join("tpkg-registry.yaml");
+        fs::write(
+            &registry_path,
+            format!(
+                "schema_version: 1\npayloads:\n  - name: app\n    kind: app\n    versions:\n      - version: 1.0\n        platforms: universal\n        release: {{ref: {}}}\n        runtime_requirement: {{engine: ruby, constraint: \">= 3.1\"}}\n        entrypoints: [app, app-helper]\n    default: 1.0\n",
+                tebako_http::file_url(&payload_path)
+            ),
+        )
+        .unwrap();
+        let registry_url = tebako_http::file_url(&registry_path);
+
+        // The builder's config registers the registry and pins the ruby
+        // line to stage (the operator flow: the bundle stages the lines
+        // the config names; the warm's index probe reads {mirror}/v0.0.1).
+        fs::write(
+            builder_home.join("config.yaml"),
+            format!(
+                "registries:\n  - {registry_url}\nruntimes:\n  ruby:\n    version: \"3.3.5\"\n    tebako: \"0.0.1\"\n"
+            ),
+        )
+        .unwrap();
+
+        // The ruby runtime release mirror (the factory's locked index
+        // shape, spec 13 §2a): one version, real sha256 anchors.
+        let platform = tebako_shim::runtime::platform_string();
+        let rt_dir = mirror.join("v0.0.1");
+        fs::create_dir_all(&rt_dir).unwrap();
+        let exe_name = format!("tebako-runtime-0.0.1-3.3.5-{platform}{}", exe_suffix());
+        let image_name = format!("tebako-runtime-0.0.1-3.3.5-{platform}.tfs");
+        fs::write(rt_dir.join(&exe_name), b"fake runtime exe\n").unwrap();
+        fs::write(rt_dir.join(&image_name), b"fake runtime image\n").unwrap();
+        fs::write(
+            rt_dir.join("manifest.json"),
+            format!(
+                "[{{\"tebako_version\": \"0.0.1\", \"contract_era\": 2, \"contract_version\": 2, \"mount_root\": \"/__tfs__\", \"ruby_version\": \"3.3.5\", \"platform\": \"{platform}\", \"filename\": \"{exe_name}\", \"sha256\": \"{}\", \"image\": {{\"filename\": \"{image_name}\", \"sha256\": \"{}\"}}}}]\n",
+                sha256_hex(b"fake runtime exe\n"),
+                sha256_hex(b"fake runtime image\n")
+            ),
+        )
+        .unwrap();
+
+        Fixture {
+            dir,
+            builder_home,
+            tools,
+            mirror,
+            registry_url,
+        }
+    }
+
+    /// Bundle `app` against this fixture. TEBAKO_RUNTIME_MIRROR rides
+    /// the injected env map (the warm's channel-2 download).
+    fn run(
+        &self,
+        out: &Path,
+        overlay: Option<&Path>,
+        archive: Option<ArchiveFormat>,
+    ) -> Result<BundleOutcome, TebakoError> {
+        let mut env = BTreeMap::new();
+        env.insert(
+            "TEBAKO_RUNTIME_MIRROR".to_string(),
+            self.mirror.to_string_lossy().to_string(),
+        );
+        bundle::bundle_with(
+            &BundleRequest {
+                builder_home: &self.builder_home,
+                tools_dir: &self.tools,
+                target: "app",
+                output: out,
+                overlay,
+                archive,
+                env: &env,
+            },
+            &Fetcher::new(),
+        )
+    }
+
+    fn output(&self) -> PathBuf {
+        self.dir.join("out")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn exe_suffix() -> &'static str {
+    if cfg!(windows) {
+        ".exe"
+    } else {
+        ""
+    }
+}
+
+#[test]
+fn bundle_stages_a_self_consistent_offline_tree() {
+    let fx = Fixture::new("happy");
+    let out = fx.output();
+    let outcome = fx.run(&out, None, None).unwrap();
+
+    assert_eq!(outcome.payload, ("app".to_string(), "1.0".to_string()));
+
+    // bin/: the whole tool set.
+    for tool in ["tebako", "tebako-shim", "tfs", "tebako-pkg"] {
+        assert!(
+            out.join("bin")
+                .join(format!("{tool}{}", exe_suffix()))
+                .is_file(),
+            "missing tool {tool}"
+        );
+    }
+
+    // home/payloads: the payload image + its trust anchor.
+    let image = out.join("home/payloads/app/1.0.tfs");
+    assert!(image.is_file(), "payload image staged");
+    assert_eq!(fs::read(&image).unwrap(), b"app-bytes");
+    assert!(out.join("home/payloads/app/1.0.tfs.sha256").is_file());
+
+    // home/runtimes: the primary runtime WARMED (install alone leaves it
+    // to first dispatch — the bundle is offline, so it must be staged).
+    let runtimes_dir = out.join("home/runtimes");
+    let entries: Vec<_> = fs::read_dir(&runtimes_dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    assert_eq!(entries.len(), 1, "exactly the primary runtime: {entries:?}");
+    let expected = format!(
+        "ruby-3.3.5-0.0.1-{}",
+        tebako_shim::runtime::platform_string()
+    );
+    assert_eq!(entries[0], expected);
+
+    // home/config.yaml: the registries survive, and runtimes: is pinned
+    // FROM REALITY (the staged store, not the builder's hope).
+    let cfg = tebako_shim::config::load_config(&out.join("home")).unwrap();
+    assert_eq!(cfg.registries, vec![fx.registry_url.clone()]);
+    let ruby = cfg.runtimes.get("ruby").expect("ruby pin");
+    assert_eq!(ruby.version, "3.3.5");
+    assert_eq!(ruby.tebako, "0.0.1");
+
+    // BUNDLE.yaml: the installer's descriptor — and version round-trips
+    // as a STRING ("1.0" must not re-type as a float).
+    let text = fs::read_to_string(out.join("BUNDLE.yaml")).unwrap();
+    let doc: serde_yml::Value = serde_yml::from_str(&text).unwrap();
+    assert_eq!(doc["payload"].as_str(), Some("app"));
+    assert_eq!(doc["version"].as_str(), Some("1.0"), "{text}");
+    assert_eq!(
+        doc["runtimes"][0]["engine"].as_str(),
+        Some("ruby"),
+        "{text}"
+    );
+    let commands: Vec<&str> = doc["commands"]
+        .as_sequence()
+        .unwrap()
+        .iter()
+        .filter_map(|c| c.as_str())
+        .collect();
+    assert!(commands.contains(&"app"), "{text}");
+
+    // The shims exist and (unix) are RELATIVE — the tree relocates as
+    // one piece.
+    let shim = out
+        .join("home/shims")
+        .join(tebako_shim::manage::shim_file_name("app"));
+    assert!(fs::symlink_metadata(&shim).is_ok(), "shim staged");
+    #[cfg(unix)]
+    {
+        let target = fs::read_link(&shim).unwrap();
+        assert!(
+            !target.is_absolute(),
+            "the shim link is relative: {target:?}"
+        );
+        assert_eq!(
+            target,
+            Path::new("../../bin").join(format!("tebako-shim{}", exe_suffix()))
+        );
+        // And it resolves inside the bundle.
+        let resolved = shim.parent().unwrap().join(&target);
+        assert!(
+            resolved
+                .canonicalize()
+                .unwrap()
+                .starts_with(out.canonicalize().unwrap()),
+            "the shim resolves inside the bundle"
+        );
+    }
+}
+
+#[test]
+fn bundle_overlay_layers_the_org_config() {
+    let fx = Fixture::new("overlay");
+    let overlay = fx.dir.join("org.yaml");
+    fs::write(
+        &overlay,
+        "defaults:\n  app: \"1.0\"\nnetwork:\n  proxy: http://corp:3128\n",
+    )
+    .unwrap();
+    let out = fx.output();
+    fx.run(&out, Some(&overlay), None).unwrap();
+    let cfg = tebako_shim::config::load_config(&out.join("home")).unwrap();
+    assert_eq!(cfg.defaults.get("app").unwrap(), "1.0");
+    assert_eq!(cfg.network.proxy.as_deref(), Some("http://corp:3128"));
+    // The from-reality pin still lands over the overlay.
+    assert_eq!(cfg.runtimes.get("ruby").unwrap().version, "3.3.5");
+}
+
+#[test]
+fn bundle_refuses_an_occupied_output_and_a_partial_tool_set() {
+    let fx = Fixture::new("guards");
+    // Occupied output: refused by name, nothing staged.
+    let out = fx.output();
+    fs::create_dir_all(&out).unwrap();
+    let err = fx.run(&out, None, None).unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("already exists"), "{err:?}");
+
+    // A missing tool: named, not silently skipped.
+    fs::remove_file(fx.tools.join(format!("tfs{}", exe_suffix()))).unwrap();
+    let out2 = fx.dir.join("out2");
+    let err = fx.run(&out2, None, None).unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(err.message.contains("incomplete"), "{err:?}");
+    assert!(!out2.exists(), "a failed bundle leaves no tree");
+}
+
+#[test]
+fn bundle_packs_a_relocatable_tarball() {
+    let fx = Fixture::new("archive");
+    let out = fx.output();
+    let outcome = fx.run(&out, None, Some(ArchiveFormat::TarGz)).unwrap();
+    let archive = outcome.archive.expect("the archive path");
+    assert!(archive.is_file(), "the tarball landed");
+    assert_eq!(archive.extension().and_then(|e| e.to_str()), Some("gz"));
+
+    // The tree packed under the bundle's own directory name, symlinks
+    // preserved (the relocatable shims ARE the dispatch surface).
+    let file = fs::File::open(&archive).unwrap();
+    let dec = flate2::read::GzDecoder::new(file);
+    let mut tar = tar::Archive::new(dec);
+    let mut names = Vec::new();
+    let mut link_names = Vec::new();
+    for entry in tar.entries().unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path().unwrap().to_string_lossy().to_string();
+        if entry.header().entry_type() == tar::EntryType::Symlink {
+            link_names.push(path.clone());
+        }
+        names.push(path);
+    }
+    let base = out.file_name().unwrap().to_string_lossy().to_string();
+    assert!(
+        names
+            .iter()
+            .any(|n| *n == format!("{base}/home/config.yaml")),
+        "config packed: {names:?}"
+    );
+    #[cfg(unix)]
+    assert!(
+        link_names.iter().any(|n| n.contains("shims/app")),
+        "the shim link survived the pack: {link_names:?}"
+    );
+}
+
+#[test]
+fn bundle_zip_is_a_named_error_until_pr2() {
+    let fx = Fixture::new("zipstub");
+    let out = fx.output();
+    let err = fx.run(&out, None, Some(ArchiveFormat::Zip)).unwrap_err();
+    assert_eq!(err.code, 65, "{err:?}");
+    assert!(
+        err.message.contains("zip bundle leg is not written yet"),
+        "{err:?}"
+    );
+    // The tree still staged and renamed — the pack failure post-dates it.
+    assert!(out.join("BUNDLE.yaml").is_file());
+}

--- a/docs/spec/16-distribution-and-installation.md
+++ b/docs/spec/16-distribution-and-installation.md
@@ -120,7 +120,73 @@ metanorma --version
 tebako use metanorma@1.2.2                # instant rollback
 ```
 
-## 6. Implementation gaps (roadmap 28)
+## 6. Offline application bundles (`tebako bundle`)
+
+Persona B's airgapped half (roadmap 82/83 — BSH's SCCM class): an
+installer-facing tree composed ENTIRELY from the canonical published
+artifacts, pre-positioned so the target machine may never see the
+network.
+
+```
+tebako bundle <name[@ver]> --output <dir> [--config <org.yaml>] [--archive tar.gz]
+```
+
+The two hard rules:
+
+1. **Canonical bytes, never rebuilt.** Payloads and runtimes stage
+   through the store's own machinery (registry resolution, sha256 +
+   signature verification per the trust rules of §4) — the bundle is a
+   PRE-SEEDED store, byte-identical with what the registries published.
+2. **Configurability lives in the rendered `config.yaml`, never in
+   rebuilt bytes.** The `--config` org overlay layers the spec 04
+   `network:` block (proxy / tls_roots / extra_ca), per-engine runtime
+   preferences, per-tool defaults, and extra registries over the
+   builder's own config.
+
+Layout (`<out>` is created by the verb; an occupied path is a named
+usage error, exit 65 — a bundle never overwrites):
+
+```
+<out>/bin/          the platform's CLI tool set (tebako, tebako-shim,
+                    tfs, tebako-pkg — copied from beside the running
+                    exe; a partial set is a named error, exit 65)
+<out>/home/         the staged TEBAKO_HOME, verbatim store grammar:
+                    payloads/, runtimes/, registries/ caches, shims/,
+                    config.yaml, journal.log
+<out>/BUNDLE.yaml   the descriptor (schema_version 1): payload identity,
+                    platform, the staged runtimes, the command list an
+                    installer materializes onto PATH
+```
+
+Staging semantics:
+
+- The payload installs through `tebako install`'s own path — the eager
+  closure (dependencies, spawned-edge runtimes, spec 30/32) included.
+- The PRIMARY runtime is additionally **warmed**: install alone leaves
+  the payload's own `kind: language` edge to first dispatch, which an
+  offline machine cannot do — the bundle resolves it at stage time
+  through the dispatch resolver (cache → pins → mirror → registries →
+  default, spec 05 §2).
+- After staging, `runtimes:` in the shipped config is **re-pinned from
+  the staged reality** (one pin per staged engine, newest line): the
+  bundle's config never names a runtime it does not carry. An operator
+  pin for an engine the bundle did not stage survives verbatim.
+- Unix shims are rewritten to the bundle-relative
+  `../../bin/tebako-shim` — the tree relocates as one piece; windows
+  shims are byte copies and self-contained already.
+- The whole tree stages under `<parent>/.bundle-staging-<pid>` and
+  renames into place: a failed bundle never leaves a half-tree.
+- `--archive tar.gz` packs the tree next to itself (symlinks preserved —
+  they ARE the dispatch surface). The zip form is PLANNED (it lands
+  with the windows installer templates); requesting it is a named error.
+
+Bundles build for the HOST platform only — a cross-target bundle is the
+per-platform CI leg's output, not a flag. The installer's side: drop the
+tree, point `TEBAKO_HOME` at `home/` (or relocate its contents into the
+user store), put `bin/` + `home/shims/` on PATH. Trust verification
+happened at stage time; the target machine verifies nothing new.
+
+## 7. Implementation gaps (roadmap 28)
 
 - ~~`tpkg-registry.yaml` fetch/listing (the resolver tail of item 07)~~ —
   SHIPPED (28.1): the registry model + resolution in tebako-resolve and


### PR DESCRIPTION
## `tebako bundle` (spec 16 §6, roadmap 83 work item 1)

The offline application bundle: persona B's airgapped half (BSH's SCCM
class). One verb composes an installer-facing tree ENTIRELY from the
canonical published artifacts:

```
tebako bundle metanorma@1.16.9 --output dist/metanorma --config org.yaml --archive tar.gz
```

```
<out>/bin/          the platform's CLI tool set (all four, or a named error)
<out>/home/         a pre-seeded TEBAKO_HOME: payloads/ + runtimes/ (the
                    eager closure AND the warmed primary runtime) +
                    registries/ caches + shims/ + config.yaml
<out>/BUNDLE.yaml   the installer's descriptor (schema_version 1)
```

Hard rules (the owner's 2026-09-10/12 constraints, enforced in code):

- **Canonical bytes, never rebuilt** — payloads and runtimes stage
  through the store's own machinery (registry resolution, sha256 +
  signature verification); the bundle is byte-identical with what the
  registries published, merely pre-positioned.
- **Configurability lives in the rendered config.yaml, never in rebuilt
  bytes** — `--config` layers the org overlay (the spec 04 `network:`
  block, runtime prefs, defaults, extra registries) over the builder's
  own config.
- After staging, `runtimes:` is **re-pinned from the staged reality** —
  the shipped config never names a runtime the bundle does not carry.
- The primary runtime is **warmed at stage time** (install alone defers
  it to first dispatch — meaningless on an airgapped machine).
- Unix shims are rewritten bundle-relative (`../../bin/tebako-shim`) so
  the tree relocates as one piece; the whole tree stages under
  `.bundle-staging-<pid>` and renames into place — a failed bundle never
  leaves a half-tree; an occupied output is a named refusal (exit 65).
- `--archive tar.gz` packs the tree with symlinks preserved (they ARE
  the dispatch surface); `zip` is a named error until the windows
  installer templates land (roadmap 83 PR-2).

Also fixes a latent rendering hazard in the new YAML writers: a plain
scalar that the YAML core schema would re-type (`version: 1.0` → float)
now renders double-quoted — versions round-trip as strings.

Spec 16 gains §6 (the bundle contract); the gaps section renumbers to
§7 (no external references — the only "16 §6" cites are this change's).

## Tests

`crates/tebako-cli/tests/bundle.rs` — five tests over file:// mirrors +
temp homes (no network, no process-env mutation; TEBAKO_RUNTIME_MIRROR
rides the injected env map):

- the happy path stages a self-consistently pinned offline tree (tool
  set, payload + trust anchor, warmed runtime, from-reality pin,
  relative shims that resolve inside the bundle, descriptor);
- the org overlay layers (`network.proxy`, `defaults:`) under the
  from-reality pin;
- occupied output and a partial tool set are named refusals that leave
  no tree;
- the tarball packs under the bundle's own directory name with the shim
  symlinks preserved;
- `--archive zip` is the named not-yet error.

Full `cargo test -p tebako-cli` green (see the PR run).

## Not in this PR (roadmap 83 PR-2)

WiX/productbuild templates + the spec 31 pkg amendment + the release.yml
installer legs (work items 2–4); the zip archive form; packed-mn's
client-keyed installers (item 5 — credentials already provisioned per
the 83 file's State block).
