### PR TITLE
ci: the system installer legs — MSI + pkg templates, release legs, spec 16 §7 + spec 31 §5a (roadmap 83 PR-2)

### DIFF
--- a/.github/workflows/lib/finalize.sh
+++ b/.github/workflows/lib/finalize.sh
@@ -21,6 +21,7 @@ FRAG=fragments
 mkdir -p out/sidecars
 : > out/SHA256SUMS
 for platform_dir in "$FRAG"/frag-*; do
+  case "$platform_dir" in */frag-installers-*) continue ;; esac   # installer frags: their own section below
   platform="${platform_dir##*/frag-}"
   exe=""; case "$platform" in windows-*) exe=".exe" ;; esac
   for tool in tebako-bootstrap tfs tebako-pkg tebako tebako-shim tebako-runtime-launcher; do
@@ -30,6 +31,25 @@ for platform_dir in "$FRAG"/frag-*; do
     echo "$sha  $name" > "out/sidecars/${name}.sha256"
   done
 done
+
+# ---- installer fragments (roadmap 83, spec 16 §7) -------------------------
+# The installer legs upload frag-installers-<platform>/ dirs holding one
+# <asset>.sha256 + <asset>.size per SHIPPED installer container (asset
+# names are complete: tebako-setup-<VERSION>-<platform>.{msi,pkg}). A leg
+# whose signing gate was disarmed ships nothing and uploads a .disabled
+# marker instead — the glob simply finds no hashes. Installers get the
+# same SHA256SUMS line + sidecar treatment as every released part.
+for installer_dir in "$FRAG"/frag-installers-*/; do
+  [ -d "$installer_dir" ] || continue
+  for shafile in "$installer_dir"*.sha256; do
+    [ -e "$shafile" ] || continue
+    asset=$(basename "$shafile" .sha256)
+    sha=$(cat "$shafile")
+    echo "$sha  $asset" >> out/SHA256SUMS
+    echo "$sha  $asset" > "out/sidecars/${asset}.sha256"
+  done
+done
+
 sort -k2 -o out/SHA256SUMS out/SHA256SUMS
 
 # ---- manifest.json ------------------------------------------------------
@@ -46,6 +66,7 @@ sort -k2 -o out/SHA256SUMS out/SHA256SUMS
 jq_entries() {
   local tool="$1"
   for platform_dir in "$FRAG"/frag-*; do
+    case "$platform_dir" in */frag-installers-*) continue ;; esac
     platform="${platform_dir##*/frag-}"
     [ -f "$platform_dir/${tool}-${platform}.sha256" ] || continue
     exe=""; case "$platform" in windows-*) exe=".exe" ;; esac
@@ -67,6 +88,30 @@ cli_json=$(jq_entries tebako | jq -s 'sort_by(.platform)')
 shim_json=$(jq_entries tebako-shim | jq -s 'sort_by(.platform)')
 launcher_json=$(jq_entries tebako-runtime-launcher | jq -s 'sort_by(.platform)')
 
+# Installers (roadmap 83): platform parsed out of the asset name
+# (tebako-setup-<VERSION>-<platform>.<ext>); empty array when no leg
+# shipped (gates disarmed — the key is always present, the array may be
+# empty: additive schema, old readers ignore it).
+installers_json=$(
+  for installer_dir in "$FRAG"/frag-installers-*/; do
+    [ -d "$installer_dir" ] || continue
+    for shafile in "$installer_dir"*.sha256; do
+      [ -e "$shafile" ] || continue
+      asset=$(basename "$shafile" .sha256)
+      sha=$(cat "$shafile")
+      size=$(cat "$installer_dir/$asset.size")
+      stem="${asset%.*}"                      # strip .msi / .pkg
+      platform="${stem#*-setup-"$VERSION"-}"  # strip <name>-setup-<VERSION>-
+      jq -cn \
+        --arg platform "$platform" \
+        --arg file "$asset" \
+        --arg sha256 "$sha" \
+        --argjson size_bytes "$size" \
+        '{platform: $platform, file: $file, sha256: $sha256, size_bytes: $size_bytes}'
+    done
+  done | jq -s 'sort_by(.platform)'
+)
+
 jq -n \
   --arg version "$VERSION" \
   --argjson assets "$bootstrap_json" \
@@ -75,10 +120,12 @@ jq -n \
   --argjson cli "$cli_json" \
   --argjson shim "$shim_json" \
   --argjson launcher "$launcher_json" \
+  --argjson installers "$installers_json" \
   '{
     name: "tebako-rs",
     version: $version,
     assets: $assets,
+    installers: $installers,
     tools: {
       "tfs": $tfs,
       "tebako-pkg": $pkg,
@@ -100,11 +147,19 @@ cat out/manifest.json
   echo ""
   echo "| platform | binary | size (bytes) |"
   echo "|---|---|---|"
-  for platform_dir in $(ls -d "$FRAG"/frag-* | sort); do
+  for platform_dir in $(ls -d "$FRAG"/frag-* | grep -v '/frag-installers-' | sort); do
     platform="${platform_dir##*/frag-}"
     for tool in tebako-bootstrap tfs tebako-pkg tebako tebako-shim tebako-runtime-launcher; do
       size=$(cat "$platform_dir/${tool}-${platform}.size")
       echo "| $platform | $tool | $size |"
+    done
+  done
+  for installer_dir in "$FRAG"/frag-installers-*/; do
+    [ -d "$installer_dir" ] || continue
+    for sizefile in "$installer_dir"*.size; do
+      [ -e "$sizefile" ] || continue
+      asset=$(basename "$sizefile" .size)
+      echo "| installer | $asset | $(cat "$sizefile") |"
     done
   done
   echo ""

--- a/.github/workflows/lib/sign-release.sh
+++ b/.github/workflows/lib/sign-release.sh
@@ -63,13 +63,27 @@ chmod +x "$PKG"
 
 # ---- the parts to sign ---------------------------------------------------
 # Everything on the release except the indexes (SHA256SUMS, manifest.json)
-# and the derived .sha256 sidecars. Exactly 49 parts: 6 tools x 7
-# platforms + 7 link-unit tarballs (the completeness gate's arithmetic).
+# and the derived .sha256 sidecars. 49 base parts (6 tools x 7 platforms +
+# 7 link-unit tarballs) + the installer containers (roadmap 83) EXACTLY
+# when their OS planes armed them: the MSI ships signed-only
+# (WINDOWS_SIGNING_ENABLED), the pkgs signed+notarized+stapled or not at
+# all (APPLE_INSTALLER_SIGNING_ENABLED + APPLE_SIGNING_ENABLED) — the same
+# gate vars the installer legs ship on, so the count never drifts from
+# the release's real content.
+INSTALLER_PARTS=0
+if [ "${WINDOWS_SIGNING_ENABLED:-}" = "true" ]; then
+  INSTALLER_PARTS=$(( INSTALLER_PARTS + 1 ))
+fi
+if [ "${APPLE_INSTALLER_SIGNING_ENABLED:-}" = "true" ] && [ "${APPLE_SIGNING_ENABLED:-}" = "true" ]; then
+  INSTALLER_PARTS=$(( INSTALLER_PARTS + 2 ))
+fi
+EXPECTED_PARTS=$(( 49 + INSTALLER_PARTS ))
+EXPECTED_SIGS=$(( 51 + INSTALLER_PARTS ))
 gh release download "$TAG" --dir "$WORK/assets" --clobber
 mapfile -t PARTS < <(find "$WORK/assets" -maxdepth 1 -type f \
   ! -name 'SHA256SUMS' ! -name 'manifest.json' ! -name '*.sha256' | sort)
-if [ "${#PARTS[@]}" -ne 49 ]; then
-  echo "NAMED FAILURE: expected 49 released parts to sign, found ${#PARTS[@]}" >&2
+if [ "${#PARTS[@]}" -ne "$EXPECTED_PARTS" ]; then
+  echo "NAMED FAILURE: expected $EXPECTED_PARTS released parts to sign (49 + $INSTALLER_PARTS installers), found ${#PARTS[@]}" >&2
   printf '  %s\n' "${PARTS[@]}" >&2
   exit 1
 fi
@@ -91,8 +105,8 @@ fi
 mv "$WORK"/assets/*.asc out/signatures/
 mv out/SHA256SUMS.asc out/manifest.json.asc out/signatures/
 COUNT=$(ls out/signatures/*.asc | wc -l)
-if [ "$COUNT" -ne 51 ]; then
-  echo "NAMED FAILURE: expected 51 signatures (49 parts + SHA256SUMS.asc + manifest.json.asc), have $COUNT" >&2
+if [ "$COUNT" -ne "$EXPECTED_SIGS" ]; then
+  echo "NAMED FAILURE: expected $EXPECTED_SIGS signatures ($EXPECTED_PARTS parts + SHA256SUMS.asc + manifest.json.asc), have $COUNT" >&2
   exit 1
 fi
 echo "signed: $COUNT signatures in out/signatures/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,16 @@
 # APPLE_SIGNING_ENABLED=true arms the gate; armed + a missing APPLE_*
 # secret is a fast named failure, never a partial release.
 #
+# Installer containers (roadmap 83, spec 16 §7): the installer-msi /
+# installer-pkg legs build the system MSI/pkg from THIS release's own
+# signed bytes (downloaded back from the release, verified against the
+# platform legs' sign-then-hash fragments), sign the CONTAINER on its own
+# plane (Azure Artifact Signing for the MSI; Developer ID Installer +
+# notarize + staple for the pkg), and gate on a real install rehearsal.
+# The container SHIPS only when its signing plane is armed — an unsigned
+# installer never lands on the release (the loose binaries remain the
+# unsigned-first-class path).
+#
 # Windows (ucrt64) ships from the `windows` job (the five binaries,
 # platform id windows-ucrt64 per the spec 03 §3 axis) and the
 # `windows-link-unit` job (the factory's staticlib input).
@@ -639,7 +649,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-24.04
-    needs: [prepare, macos, linux-gnu, linux-musl, windows-link-unit, windows]
+    needs: [prepare, macos, linux-gnu, linux-musl, windows-link-unit, windows, installer-msi, installer-pkg]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -691,6 +701,12 @@ jobs:
           TAG: ${{ needs.prepare.outputs.tag_name }}
           TEBAKO_RELEASE_SIGNING_ENABLED: ${{ vars.TEBAKO_RELEASE_SIGNING_ENABLED }}
           TEBAKO_RELEASE_SIGNING_KEY: ${{ secrets.TEBAKO_RELEASE_SIGNING_KEY }}
+          # roadmap 83: the installer containers join the signed part set
+          # exactly when their OS planes armed them (same gate vars the
+          # installer legs ship on — sign-release.sh derives its counts).
+          WINDOWS_SIGNING_ENABLED: ${{ vars.WINDOWS_SIGNING_ENABLED }}
+          APPLE_SIGNING_ENABLED: ${{ vars.APPLE_SIGNING_ENABLED }}
+          APPLE_INSTALLER_SIGNING_ENABLED: ${{ vars.APPLE_INSTALLER_SIGNING_ENABLED }}
         run: bash .github/workflows/lib/sign-release.sh
 
       - name: Upload detached signatures
@@ -700,17 +716,31 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # item 11's completeness gate: the release job fails unless every
-      # expected asset actually landed (partial-upload race class).
+      # expected asset actually landed (partial-upload race class). The
+      # installer containers (roadmap 83) add their assets + sidecars +
+      # .asc's exactly when their signing planes armed them (the same
+      # gate vars the installer legs ship on — never a name list).
       - name: Completeness gate
         if: needs.prepare.outputs.upload_url != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.prepare.outputs.tag_name }}
           TEBAKO_RELEASE_SIGNING_ENABLED: ${{ vars.TEBAKO_RELEASE_SIGNING_ENABLED }}
+          WINDOWS_SIGNING_ENABLED: ${{ vars.WINDOWS_SIGNING_ENABLED }}
+          APPLE_SIGNING_ENABLED: ${{ vars.APPLE_SIGNING_ENABLED }}
+          APPLE_INSTALLER_SIGNING_ENABLED: ${{ vars.APPLE_INSTALLER_SIGNING_ENABLED }}
         run: |
           EXPECTED=$(( 6 * 7 + 7 + 2 + 6 * 7 ))   # 6 tools x 7 platforms (incl. windows-ucrt64; +tebako-runtime-launcher, the spec-29 wrapper exe) + 7 link-unit tarballs + SHA256SUMS + manifest.json + 42 per-asset sidecars (tebako#493)
+          INSTALLERS=0
+          if [ "${WINDOWS_SIGNING_ENABLED:-}" = "true" ]; then
+            INSTALLERS=$(( INSTALLERS + 1 ))   # the MSI (ships signed-only — the container gate)
+          fi
+          if [ "${APPLE_INSTALLER_SIGNING_ENABLED:-}" = "true" ] && [ "${APPLE_SIGNING_ENABLED:-}" = "true" ]; then
+            INSTALLERS=$(( INSTALLERS + 2 ))   # the two pkgs (signed + notarized + stapled, or nothing)
+          fi
+          EXPECTED=$(( EXPECTED + INSTALLERS * 2 ))   # each installer asset + its .sha256 sidecar
           if [ "${TEBAKO_RELEASE_SIGNING_ENABLED:-}" = "true" ]; then
-            EXPECTED=$(( EXPECTED + 6 * 7 + 7 + 2 ))   # + one .asc per released part (42 tools + 7 link-units) + SHA256SUMS.asc + manifest.json.asc (spec 09 §2)
+            EXPECTED=$(( EXPECTED + 6 * 7 + 7 + 2 + INSTALLERS ))   # + one .asc per released part (42 tools + 7 link-units + the installers) + SHA256SUMS.asc + manifest.json.asc (spec 09 §2)
           fi
           COUNT=$(gh release view "$TAG" --json assets --jq '.assets | length')
           echo "release assets: $COUNT / $EXPECTED expected"
@@ -1139,3 +1169,275 @@ jobs:
         run: gh release upload "${{ needs.prepare.outputs.tag_name }}" "tebako-rs/out/tebako-runtime-launcher-${{ needs.prepare.outputs.version }}-windows-ucrt64.exe" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ==========================================================================
+  # Installer containers (roadmap 83, spec 16 §7): the system MSI + pkg,
+  # built from THIS release's own signed bytes (downloaded back from the
+  # release + verified against the platform legs' sign-then-hash fragments).
+  # The build runs on every release (the templates' CI signal); the
+  # CONTAINER ships only when its signing plane is armed — an unsigned
+  # installer is a trap for exactly the audience containers serve (the
+  # loose binaries remain the unsigned-first-class path, spec 00
+  # invariant 7). No job-level if: a skipped need would skip finalize.
+  # ==========================================================================
+  installer-msi:
+    name: Windows MSI installer
+    permissions:
+      contents: write
+      # id-token:write is the spec 34 §3 OIDC boundary (see the windows
+      # job's note) — the same windows-signing environment federates
+      # this leg's Azure token.
+      id-token: write
+    environment: windows-signing
+    runs-on: windows-latest
+    needs: [prepare, windows]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: tebako-rs
+
+      - name: Arm check — Windows signing (spec 34 §4)
+        id: signgate
+        working-directory: tebako-rs
+        shell: bash
+        env:
+          WINDOWS_SIGNING_ENABLED: ${{ vars.WINDOWS_SIGNING_ENABLED }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AZURE_ENDPOINT: ${{ vars.AZURE_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT_NAME: ${{ vars.AZURE_SIGNING_ACCOUNT_NAME }}
+          AZURE_SIGNING_CERT_PROFILE: ${{ vars.AZURE_SIGNING_CERT_PROFILE }}
+        run: bash ci/windows-sign-gate.sh
+
+      # The MSI wraps THIS release's bytes: download the four PATH tools
+      # back from the release (the windows leg uploaded them) and verify
+      # each against the leg's sign-then-hash fragments (ci script).
+      - name: Download this release's windows-ucrt64 tools
+        if: needs.prepare.outputs.upload_url != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p staged
+          for tool in tebako tebako-shim tfs tebako-pkg; do
+            gh release download "${{ needs.prepare.outputs.tag_name }}" --dir staged --clobber \
+              --pattern "${tool}-${VERSION}-windows-ucrt64.exe"
+          done
+
+      - name: Download the windows-ucrt64 fragments (sign-then-hash anchors)
+        if: needs.prepare.outputs.upload_url != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: frag-windows-ucrt64
+          path: fragments/frag-windows-ucrt64
+
+      - name: Set up WiX v5
+        if: needs.prepare.outputs.upload_url != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet tool install --global wix --version 5.0.2
+          echo "$USERPROFILE/.dotnet/tools" >> "$GITHUB_PATH"
+          wix --version
+
+      - name: Build the MSI (unsigned — the Azure step signs in place)
+        if: needs.prepare.outputs.upload_url != ''
+        working-directory: tebako-rs
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          SRC_DIR: ${{ github.workspace }}/staged
+          FRAG_DIR: ${{ github.workspace }}/fragments/frag-windows-ucrt64
+          # The tebako product line's UpgradeCode — LOCKED FOREVER (MSI
+          # upgrades pair on it). Generated 2026-09-12; a client build
+          # binds its OWN (templates/installers/README.md).
+          MSI_UPGRADE_CODE: 9A404514-715E-44F6-B02E-B800845759A9
+        run: bash ci/windows-msi-build.sh build
+
+      - name: Azure login (OIDC, spec 34 §5)
+        if: steps.signgate.outputs.armed == 'true' && needs.prepare.outputs.upload_url != ''
+        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2 (sha-pinned 2026-09-11)
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign the MSI (spec 34 §5 — Azure Artifact Signing signs MSI natively)
+        if: steps.signgate.outputs.armed == 'true' && needs.prepare.outputs.upload_url != ''
+        uses: Azure/artifact-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # v1 (sha-pinned 2026-09-11)
+        with:
+          endpoint: ${{ vars.AZURE_ENDPOINT }}
+          signing-account-name: ${{ vars.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.AZURE_SIGNING_CERT_PROFILE }}
+          files-folder: tebako-rs/out
+          files-folder-filter: msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: tebako installer (tamatebako)
+
+      - name: Verify the MSI signature (spec 34 §7.1/§7.2)
+        if: steps.signgate.outputs.armed == 'true' && needs.prepare.outputs.upload_url != ''
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $msi = @(Get-ChildItem -Path 'tebako-rs/out' -Filter '*.msi' -File)
+          if ($msi.Count -ne 1) { Write-Host "::error::expected exactly 1 MSI under tebako-rs/out, found $($msi.Count)"; exit 1 }
+          $signtool = @(
+            Get-ChildItem -Path "$env:LOCALAPPDATA\TrustedSigning\Microsoft.Windows.SDK.BuildTools" -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue
+            Get-ChildItem -Path "$env:LOCALAPPDATA\ArtifactSigning\Microsoft.Windows.SDK.BuildTools" -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue
+            Get-ChildItem -Path 'C:\Program Files (x86)\Windows Kits\10\bin' -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue
+          ) | Where-Object { $_.FullName -match '\\x64\\' } |
+              Sort-Object FullName -Descending | Select-Object -First 1
+          if (-not $signtool) { Write-Host "::error::spec 34 §7.1: signtool.exe not found"; exit 1 }
+          $out = & $signtool.FullName verify /pa /v $msi[0].FullName 2>&1 | Out-String
+          Write-Host $out
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::signtool verify /pa FAILED for the MSI"; exit 1 }
+          if ($out -notmatch 'signature is timestamped' -and $out -notmatch 'RFC ?3161') { Write-Host "::error::no RFC 3161 countersignature on the MSI (§7.2)"; exit 1 }
+          $sig = Get-AuthenticodeSignature $msi[0].FullName
+          if ($sig.Status -ne 'Valid') { Write-Host "::error::Get-AuthenticodeSignature status '$($sig.Status)'"; exit 1 }
+          if ($null -eq $sig.TimeStamperCertificate) { Write-Host "::error::no TimeStamperCertificate on the MSI"; exit 1 }
+          Write-Host "MSI signed+timestamped: $($sig.SignerCertificate.Subject)"
+
+      - name: Frag over the FINAL bytes (sign-then-hash, spec 34 §1.3)
+        if: steps.signgate.outputs.armed == 'true' && needs.prepare.outputs.upload_url != ''
+        working-directory: tebako-rs
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          SRC_DIR: ${{ github.workspace }}/staged
+        run: bash ci/windows-msi-build.sh frag
+
+      # The install rehearsal gates ALWAYS (signed or not — it proves the
+      # template's MSI actually installs, the PATH/bindings land, and the
+      # installed tool runs; a broken wxs fails HERE, never on a user box).
+      - name: Install rehearsal (msiexec round-trip)
+        if: needs.prepare.outputs.upload_url != ''
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $msi = @(Get-ChildItem -Path 'tebako-rs/out' -Filter '*.msi' -File)
+          if ($msi.Count -ne 1) { Write-Host "::error::expected exactly 1 MSI under tebako-rs/out"; exit 1 }
+          $p = Start-Process msiexec.exe -Wait -PassThru -ArgumentList '/i', $msi[0].FullName, '/qn', '/norestart'
+          if ($p.ExitCode -ne 0) { Write-Host "::error::msiexec /i failed: $($p.ExitCode)"; exit 1 }
+          & 'C:\Program Files\tebako\bin\tebako.exe' --version
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::installed tebako.exe --version failed"; exit 1 }
+          $p = Start-Process msiexec.exe -Wait -PassThru -ArgumentList '/x', $msi[0].FullName, '/qn', '/norestart'
+          if ($p.ExitCode -ne 0) { Write-Host "::error::msiexec /x failed: $($p.ExitCode)"; exit 1 }
+          if (Test-Path 'C:\Program Files\tebako') { Write-Host "::error::uninstall left C:\Program Files\tebako"; exit 1 }
+          Write-Host 'install rehearsal OK (install → run → uninstall, clean)'
+
+      - name: Upload the MSI
+        if: steps.signgate.outputs.armed == 'true' && needs.prepare.outputs.upload_url != ''
+        run: gh release upload "${{ needs.prepare.outputs.tag_name }}" "tebako-rs/out/tebako-setup-${{ needs.prepare.outputs.version }}-windows-ucrt64.msi" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mark the installer frag as not-shipped (gate disarmed or dry run)
+        if: steps.signgate.outputs.armed != 'true' || needs.prepare.outputs.upload_url == ''
+        working-directory: tebako-rs
+        shell: bash
+        run: |
+          mkdir -p fragments/frag-installers-windows-ucrt64
+          echo "no MSI shipped this run (gate disarmed or dry run)" > fragments/frag-installers-windows-ucrt64/.disabled
+
+      - name: Upload installer fragment artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: frag-installers-windows-ucrt64
+          path: tebako-rs/fragments/frag-installers-windows-ucrt64
+          if-no-files-found: error
+
+  installer-pkg:
+    name: macOS pkg installer (${{ matrix.platform }})
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            platform: macos-arm64
+          - os: macos-15-intel
+            platform: macos-x86_64
+    runs-on: ${{ matrix.os }}
+    needs: [prepare, macos]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: tebako-rs
+
+      # The spec 31 §5a gate: Developer ID **Installer** cert (a DIFFERENT
+      # cert from the Application one), requires the §5 notary plane armed
+      # beside it — a signed-but-unnotarized pkg never ships.
+      - name: Set up Apple installer signing (spec 31 §5a enablement gate)
+        id: signgate
+        working-directory: tebako-rs
+        env:
+          APPLE_INSTALLER_SIGNING_ENABLED: ${{ vars.APPLE_INSTALLER_SIGNING_ENABLED }}
+          APPLE_SIGNING_ENABLED: ${{ vars.APPLE_SIGNING_ENABLED }}
+          APPLE_DEVELOPER_ID_INSTALLER_P12: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_P12 }}
+          APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD }}
+        run: bash ci/macos-sign-setup-installer.sh
+
+      - name: Download this release's ${{ matrix.platform }} tools
+        if: needs.prepare.outputs.upload_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          mkdir -p staged
+          for tool in tebako tebako-shim tfs tebako-pkg; do
+            gh release download "${{ needs.prepare.outputs.tag_name }}" --dir staged --clobber \
+              --pattern "${tool}-${VERSION}-${PLATFORM}"
+          done
+
+      - name: Download the ${{ matrix.platform }} fragments (sign-then-hash anchors)
+        if: needs.prepare.outputs.upload_url != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: frag-${{ matrix.platform }}
+          path: fragments/frag-${{ matrix.platform }}
+
+      # Build → [armed] productsign + notarize + STAPLE → ship gates →
+      # install rehearsal (always) → frag (armed only). All in-script —
+      # signing is in-script on macOS (the sign-then-hash law holds by
+      # construction).
+      - name: Build + sign + notarize + rehearse the pkg
+        if: needs.prepare.outputs.upload_url != ''
+        working-directory: tebako-rs
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+          SRC_DIR: ${{ github.workspace }}/staged
+          FRAG_DIR: ${{ github.workspace }}/fragments/frag-${{ matrix.platform }}
+          APPLE_INSTALLER_SIGNING_ENABLED: ${{ vars.APPLE_INSTALLER_SIGNING_ENABLED }}
+          APPLE_ASC_KEY_P8: ${{ secrets.APPLE_ASC_KEY_P8 }}
+          APPLE_ASC_KEY_ID: ${{ secrets.APPLE_ASC_KEY_ID }}
+          APPLE_ASC_ISSUER_ID: ${{ secrets.APPLE_ASC_ISSUER_ID }}
+        run: bash ci/macos-pkg-build.sh
+
+      - name: Upload the pkg
+        if: steps.signgate.outputs.armed == 'true' && needs.prepare.outputs.upload_url != ''
+        run: gh release upload "${{ needs.prepare.outputs.tag_name }}" "tebako-rs/out/tebako-setup-${{ needs.prepare.outputs.version }}-${{ matrix.platform }}.pkg" --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mark the installer frag as not-shipped (gate disarmed or dry run)
+        if: steps.signgate.outputs.armed != 'true' || needs.prepare.outputs.upload_url == ''
+        working-directory: tebako-rs
+        run: |
+          mkdir -p fragments/frag-installers-${{ matrix.platform }}
+          echo "no pkg shipped this run (gate disarmed or dry run)" > fragments/frag-installers-${{ matrix.platform }}/.disabled
+
+      - name: Upload installer fragment artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: frag-installers-${{ matrix.platform }}
+          path: tebako-rs/fragments/frag-installers-${{ matrix.platform }}
+          if-no-files-found: error

--- a/ci/macos-pkg-build.sh
+++ b/ci/macos-pkg-build.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# macos-pkg-build.sh — build the system pkg installer from the release's
+# own staged macOS binaries (roadmap 83, spec 16 §7 / spec 31 §5a).
+# pkgbuild (component) → productbuild (distribution) → [armed] productsign
+# (Developer ID **Installer** — NOT the Application cert) → notarize →
+# STAPLE (a pkg carries the offline Gatekeeper ticket bare exes cannot).
+# Sign-then-hash is honored by construction: signing is IN-SCRIPT before
+# the fragment is written (the macOS pattern — spec 34 §1.3's two-phase
+# dance is the Windows exception, needed only because its signing is a
+# workflow action).
+#
+# Required env: VERSION (tag minus v), PLATFORM (macos-arm64|macos-x86_64),
+# SRC_DIR (the 4 staged binaries), FRAG_DIR (the downloaded
+# frag-<platform> artifact — the sign-then-hash anchors; THIS release's
+# SHA256SUMS does not exist yet, finalize makes it AFTER us), RUNNER_TEMP.
+# Optional: PRODUCT_NAME (tebako), ORG_ID (org.tamatebako),
+# INSTALL_ROOT (/opt/tebako), MIN_MACOS (12.0).
+# Gate env (the workflow's setup step): APPLE_INSTALLER_SIGNING_ENABLED,
+# INSTALLER_SIGN_HASH, INSTALLER_KEYCHAIN; notary: APPLE_ASC_KEY_P8,
+# APPLE_ASC_KEY_ID, APPLE_ASC_ISSUER_ID.
+#
+# Ship gates (all run in-script, before any upload): pkgutil
+# --check-signature (armed), stapler validate + spctl --assess -t install
+# (armed), and ALWAYS a real install rehearsal (sudo installer -target /)
+# proving the payload lands and postinstall writes the paths.d entry.
+set -euo pipefail
+
+: "${VERSION:?VERSION is required (the release version, tag minus v)}"
+: "${PLATFORM:?PLATFORM is required (macos-arm64|macos-x86_64)}"
+: "${SRC_DIR:?SRC_DIR is required (staged binaries + SHA256SUMS)}"
+PRODUCT_NAME="${PRODUCT_NAME:-tebako}"
+ORG_ID="${ORG_ID:-org.tamatebako}"
+INSTALL_ROOT="${INSTALL_ROOT:-/opt/tebako}"
+MIN_MACOS="${MIN_MACOS:-12.0}"
+TOOLS="tebako tebako-shim tfs tebako-pkg"
+ASSET="${PRODUCT_NAME}-setup-${VERSION}-${PLATFORM}.pkg"
+
+# ---- 1. stage + verify the binaries against the leg's fragments ---------
+# The macOS leg's frags were computed over the SIGNED+notarized bytes
+# (sign-then-hash, spec 31 §5) — the pkg wraps EXACTLY the published
+# bytes; a corrupted download inside a signed installer is the failure
+# this precludes.
+: "${FRAG_DIR:?FRAG_DIR is required (the downloaded frag-$PLATFORM artifact)}"
+rm -rf pkg-root build out
+mkdir -p "pkg-root$INSTALL_ROOT/bin" build/scripts out
+for tool in $TOOLS; do
+  bin="${tool}-${VERSION}-${PLATFORM}"
+  [ -f "$SRC_DIR/$bin" ] || { echo "::error::$bin not staged in $SRC_DIR"; exit 1; }
+  [ -f "$FRAG_DIR/${tool}-${PLATFORM}.sha256" ] || { echo "::error::no fragment ${tool}-${PLATFORM}.sha256 in $FRAG_DIR — the macos leg did not complete"; exit 1; }
+  want=$(cat "$FRAG_DIR/${tool}-${PLATFORM}.sha256")
+  got=$(shasum -a 256 "$SRC_DIR/$bin" | cut -d' ' -f1)
+  [ "$got" = "$want" ] || { echo "::error::sha256 mismatch on $bin — got $got want $want"; exit 1; }
+  cp "$SRC_DIR/$bin" "pkg-root$INSTALL_ROOT/bin/$tool"
+  chmod 755 "pkg-root$INSTALL_ROOT/bin/$tool"
+done
+echo "staged + verified against the leg's signed-byte fragments: $TOOLS"
+
+# ---- 2. render the template tokens (productbuild has no binds) ----------
+sed -e "s/@PRODUCT_NAME@/$PRODUCT_NAME/g" -e "s/@VERSION@/$VERSION/g" \
+    -e "s/@ORG_ID@/$ORG_ID/g" -e "s/@MIN_MACOS@/$MIN_MACOS/g" \
+    templates/installers/macos/distribution.xml > build/distribution.xml
+sed -e "s/@PRODUCT_NAME@/$PRODUCT_NAME/g" -e "s|@INSTALL_ROOT@|$INSTALL_ROOT|g" \
+    templates/installers/macos/scripts/postinstall > build/scripts/postinstall
+chmod +x build/scripts/postinstall
+if grep -qE '@(PRODUCT_NAME|VERSION|ORG_ID|MIN_MACOS|INSTALL_ROOT)@' build/distribution.xml build/scripts/postinstall; then
+  echo "::error::unrendered template token left in the pkg inputs — the template drifted from this script"; exit 1
+fi
+
+# ---- 3. pkgbuild → productbuild ------------------------------------------
+pkgbuild --root "pkg-root$INSTALL_ROOT" --install-location / \
+  --identifier "$ORG_ID.$PRODUCT_NAME.pkg" --version "$VERSION" \
+  --scripts build/scripts \
+  "build/$PRODUCT_NAME-component.pkg"
+productbuild --distribution build/distribution.xml \
+  --package-path build "out/$ASSET.unsigned"
+mv "out/$ASSET.unsigned" "out/$ASSET"
+
+# ---- 4. sign + notarize + staple (the armed path) -------------------------
+if [ "${APPLE_INSTALLER_SIGNING_ENABLED:-false}" = "true" ]; then
+  : "${INSTALLER_SIGN_HASH:?the setup step did not export INSTALLER_SIGN_HASH}"
+  : "${INSTALLER_KEYCHAIN:?the setup step did not export INSTALLER_KEYCHAIN}"
+  mv "out/$ASSET" "out/$ASSET.unsigned"
+  productsign --keychain "$INSTALLER_KEYCHAIN" --sign "$INSTALLER_SIGN_HASH" \
+    "out/$ASSET.unsigned" "out/$ASSET"
+  pkgutil --check-signature "out/$ASSET" | tee build/pkg-sig.txt
+  grep -q "Developer ID Installer" build/pkg-sig.txt \
+    || { echo "::error::pkg not signed by a Developer ID Installer identity"; exit 1; }
+  grep -q 'Status: signed' build/pkg-sig.txt || { echo "::error::pkgutil reports the pkg unsigned"; exit 1; }
+
+  work="$RUNNER_TEMP/tebako-pkg-notarize"
+  mkdir -p "$work"
+  printf '%s' "$APPLE_ASC_KEY_P8" > "$work/AuthKey.p8"
+  xcrun notarytool submit "out/$ASSET" --key "$work/AuthKey.p8" \
+    --key-id "$APPLE_ASC_KEY_ID" --issuer "$APPLE_ASC_ISSUER_ID" \
+    --wait --timeout 20m | tee "$work/notary.txt"
+  grep -q 'status: Accepted' "$work/notary.txt" || {
+    xcrun notarytool log "$(grep -m1 -oE '[0-9a-f-]{36}' "$work/notary.txt")" \
+      --key "$work/AuthKey.p8" --key-id "$APPLE_ASC_KEY_ID" --issuer "$APPLE_ASC_ISSUER_ID" 2>&1 | tail -20
+    echo "::error::notarytool did not Accept the pkg"; exit 1; }
+  xcrun stapler staple "out/$ASSET"
+  xcrun stapler validate "out/$ASSET"
+  # §6.3a: the pkg's assessment IS the right spctl gate (unlike bare
+  # exes): notarized + stapled must Assess accepted, source=Notarized
+  # Developer ID. (spctl prints its verdict on STDERR — 2>&1 or the tee
+  # captures nothing.)
+  spctl --assess -t install -v "out/$ASSET" 2>&1 | tee build/spctl.txt
+  grep -q "accepted" build/spctl.txt || { echo "::error::spctl rejected the notarized pkg"; exit 1; }
+  echo "signed + notarized + STAPLED: $ASSET"
+else
+  echo "::notice::spec 31 §5a gate disarmed — the pkg is UNSIGNED (spec 00 invariant 7); the install rehearsal still gates it"
+fi
+
+# ---- 5. the install rehearsal (always — signed or not) --------------------
+sudo installer -pkg "out/$ASSET" -target /
+[ -x "$INSTALL_ROOT/bin/$PRODUCT_NAME" ] || { echo "::error::$INSTALL_ROOT/bin/$PRODUCT_NAME missing after install"; exit 1; }
+"$INSTALL_ROOT/bin/$PRODUCT_NAME" --version
+[ -f "/etc/paths.d/$PRODUCT_NAME" ] || { echo "::error::/etc/paths.d/$PRODUCT_NAME missing — postinstall did not run"; exit 1; }
+grep -q "$INSTALL_ROOT/bin" "/etc/paths.d/$PRODUCT_NAME" || { echo "::error::/etc/paths.d/$PRODUCT_NAME content wrong"; exit 1; }
+sudo rm -rf "$INSTALL_ROOT" "/etc/paths.d/$PRODUCT_NAME"
+echo "install rehearsal OK (payload lands, postinstall writes the paths.d entry, the installed tool runs)"
+
+# ---- 6. the fragment over the FINAL bytes (ship-armed runs only) --------
+# A disarmed run still builds + rehearses the pkg (the template's CI
+# signal) but ships NOTHING — an unsigned installer container never lands
+# on the release (the container's audience is exactly the one SmartScreen
+# / Gatekeeper warnings burn; the loose binaries remain the
+# unsigned-first-class path, spec 00 invariant 7). No ship → no frag:
+# finalize folds whatever frags exist into SHA256SUMS, and a frag without
+# its asset is broken data.
+if [ "${APPLE_INSTALLER_SIGNING_ENABLED:-false}" = "true" ]; then
+  mkdir -p "fragments/frag-installers-$PLATFORM"
+  shasum -a 256 "out/$ASSET" | cut -d' ' -f1 > "fragments/frag-installers-$PLATFORM/$ASSET.sha256"
+  stat -f %z "out/$ASSET" > "fragments/frag-installers-$PLATFORM/$ASSET.size"
+  echo "frag: $(cat fragments/frag-installers-$PLATFORM/$ASSET.sha256)  $ASSET"
+fi

--- a/ci/macos-sign-setup-installer.sh
+++ b/ci/macos-sign-setup-installer.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# macos-sign-setup-installer.sh — the Developer ID **Installer** half of
+# the Apple signing setup (roadmap 83, spec 31 §5a): a DIFFERENT
+# certificate from the Developer ID Application one macos-sign-setup.sh
+# imports. productsign authenticates the pkg CONTAINER; codesign
+# authenticates the Mach-Os inside — two certs, two keychains, two gates.
+#
+# The repo variable APPLE_INSTALLER_SIGNING_ENABLED=true arms this gate;
+# anything else is a loud unsigned no-op (spec 00 invariant 7). Armed but
+# a secret unresolved is a FAST named failure (spec 31 §5's discipline).
+#
+# Armed, exports (via GITHUB_ENV):
+#   INSTALLER_SIGN_HASH  — the cert SHA-1 (sign by hash, NEVER by name —
+#                          the spec-31 duplicate-identity lesson)
+#   INSTALLER_KEYCHAIN   — the keychain productsign searches
+# and emits armed=<true|false> to GITHUB_OUTPUT (the leg's ship/upload
+# steps gate on it — the same contract as ci/windows-sign-gate.sh).
+#
+# Required env when armed: APPLE_DEVELOPER_ID_INSTALLER_P12 (base64),
+# APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD. Runner env: RUNNER_TEMP,
+# GITHUB_ENV.
+set -euo pipefail
+
+if [ "${APPLE_INSTALLER_SIGNING_ENABLED:-false}" != "true" ]; then
+  echo "::notice::spec 31 §5a: APPLE_INSTALLER_SIGNING_ENABLED != true — the pkg ships UNSIGNED (spec 00 invariant 7)"
+  echo "armed=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+missing=""
+for v in APPLE_DEVELOPER_ID_INSTALLER_P12 APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD; do
+  [ -n "${!v:-}" ] || missing="$missing $v"
+done
+if [ -n "$missing" ]; then
+  echo "::error::APPLE_INSTALLER_SIGNING_ENABLED=true but unset:$missing — fast failure, never a partial release (spec 31 §5a)"
+  exit 1
+fi
+# A signed-but-unnotarized pkg never ships: the productsign plane requires
+# the notary plane (spec 31 §5's APPLE_SIGNING_ENABLED) armed beside it.
+if [ "${APPLE_SIGNING_ENABLED:-false}" != "true" ]; then
+  echo "::error::APPLE_INSTALLER_SIGNING_ENABLED=true but APPLE_SIGNING_ENABLED != true — a signed pkg without notarization+stapling is a named misconfiguration (spec 31 §5a)"
+  exit 1
+fi
+
+work="$RUNNER_TEMP/tebako-sign-installer"
+mkdir -p "$work"
+printf '%s' "$APPLE_DEVELOPER_ID_INSTALLER_P12" | base64 -d > "$work/devid-installer.p12"
+KC="$work/sign-installer.keychain"
+security create-keychain -p sign-inst-kc-pass "$KC"
+security unlock-keychain -p sign-inst-kc-pass "$KC"
+security list-keychains -d user -s "$KC" $(security list-keychains -d user | tr -d '"')
+security import "$work/devid-installer.p12" -k "$KC" -P "$APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD" \
+  -T /usr/bin/productsign -T /usr/bin/security
+security set-key-partition-list -S apple-tool:,apple: -k sign-inst-kc-pass "$KC" >/dev/null
+
+HASH=$(security find-identity -v -p basic "$KC" | awk '/Developer ID Installer/ {print $2; exit}')
+[ -n "$HASH" ] || { echo "::error::no Developer ID Installer identity in the p12 (the Application cert is a DIFFERENT type and cannot productsign)"; exit 1; }
+echo "INSTALLER_SIGN_HASH=$HASH" >> "$GITHUB_ENV"
+echo "INSTALLER_KEYCHAIN=$KC" >> "$GITHUB_ENV"
+echo "armed=true" >> "$GITHUB_OUTPUT"
+echo "spec 31 §5a: installer signing armed — Developer ID Installer cert ${HASH:0:10}… (keychain $KC)"

--- a/ci/windows-msi-build.sh
+++ b/ci/windows-msi-build.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# windows-msi-build.sh — build (or re-hash) the system MSI installer from
+# the release's own staged windows exes (roadmap 83, spec 16 §7).
+#
+# Subcommands (the sign-then-hash law, spec 34 §1.3, splits the two —
+# signing is a workflow ACTION between them):
+#   build   verify the staged exes against the windows leg's OWN
+#           fragments (frag-<platform>/<tool>-<platform>.sha256 — the
+#           sign-then-hash anchors, spec 34 §1.3; THIS release's
+#           SHA256SUMS does not exist yet — finalize makes it AFTER us),
+#           then wix build the template into out/<asset>.msi (unsigned —
+#           the Azure Artifact Signing step signs it in place when armed).
+#   frag    hash the FINAL bytes (signed when the gate armed) into
+#           fragments/frag-installers-<platform>/<asset>.{sha256,size}
+#           for finalize.
+#
+# Required env: VERSION (tag minus v), SRC_DIR (the staged windows exes),
+# FRAG_DIR (the downloaded frag-<platform> artifact), RUNNER_TEMP.
+# Optional: PLATFORM (default windows-ucrt64), PRODUCT_NAME (default
+# tebako), MANUFACTURER (default tamatebako), MSI_UPGRADE_CODE (REQUIRED
+# for build — the pipeline passes the locked per-product GUID; clients
+# pass their own).
+#
+# The staged tool set is CURATED (the 4 PATH tools: tebako, tebako-shim,
+# tfs, tebako-pkg) — the bootstrap and runtime-launcher ship on the
+# release for press/embedding, not for PATH. A missing staged exe fails
+# HERE, named, never in a user's Add/Remove Programs.
+set -euo pipefail
+[ "$#" -eq 1 ] || { echo "usage: $0 build|frag" >&2; exit 64; }
+MODE="$1"
+
+: "${VERSION:?VERSION is required (the release version, tag minus v)}"
+: "${SRC_DIR:?SRC_DIR is required (staged exes + SHA256SUMS)}"
+PLATFORM="${PLATFORM:-windows-ucrt64}"
+PRODUCT_NAME="${PRODUCT_NAME:-tebako}"
+MANUFACTURER="${MANUFACTURER:-tamatebako}"
+TOOLS="tebako tebako-shim tfs tebako-pkg"
+ASSET="${PRODUCT_NAME}-setup-${VERSION}-${PLATFORM}.msi"
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
+  else shasum -a 256 "$1" | cut -d' ' -f1; fi
+}
+
+case "$MODE" in
+  build)
+    : "${MSI_UPGRADE_CODE:?MSI_UPGRADE_CODE is required (the locked per-product UpgradeCode GUID)}"
+    : "${FRAG_DIR:?FRAG_DIR is required (the downloaded frag-<platform> artifact)}"
+    # Verify the staged exes against the windows leg's OWN fragments —
+    # the MSI wraps EXACTLY the published signed bytes (the leg's frags
+    # were re-anchored post-signing, spec 34 §1.3; a corrupted download
+    # inside a signed installer is the failure this precludes).
+    mkdir -p "msi-input"
+    for tool in $TOOLS; do
+      exe="${tool}-${VERSION}-${PLATFORM}.exe"
+      [ -f "$SRC_DIR/$exe" ] || { echo "::error::$exe not staged in $SRC_DIR"; exit 1; }
+      [ -f "$FRAG_DIR/${tool}-${PLATFORM}.sha256" ] || { echo "::error::no fragment ${tool}-${PLATFORM}.sha256 in $FRAG_DIR — the windows leg did not complete"; exit 1; }
+      want=$(cat "$FRAG_DIR/${tool}-${PLATFORM}.sha256")
+      got=$(sha256_of "$SRC_DIR/$exe")
+      [ "$got" = "$want" ] || { echo "::error::sha256 mismatch on $exe (download corruption) — got $got want $want"; exit 1; }
+      cp "$SRC_DIR/$exe" "msi-input/$tool.exe"
+    done
+    echo "staged + verified against the leg's signed-byte fragments: $TOOLS"
+    mkdir -p out
+    command -v wix >/dev/null 2>&1 || { echo "::error::wix (WiX v5 dotnet tool) not on PATH — the workflow installs it"; exit 1; }
+    wix build -arch x64 \
+      templates/installers/windows/tebako.wxs \
+      -d "ProductName=$PRODUCT_NAME" \
+      -d "ProductVersion=$VERSION" \
+      -d "Manufacturer=$MANUFACTURER" \
+      -d "UpgradeCode=$MSI_UPGRADE_CODE" \
+      -d "BinDir=msi-input" \
+      -o "out/$ASSET"
+    echo "built: out/$ASSET (unsigned — the Azure step signs in place when armed)"
+    ;;
+  frag)
+    [ -f "out/$ASSET" ] || { echo "::error::out/$ASSET missing — build step did not run?"; exit 1; }
+    mkdir -p "fragments/frag-installers-$PLATFORM"
+    sha256_of "out/$ASSET" > "fragments/frag-installers-$PLATFORM/$ASSET.sha256"
+    stat -c %s "out/$ASSET" 2>/dev/null > "fragments/frag-installers-$PLATFORM/$ASSET.size" \
+      || stat -f %z "out/$ASSET" > "fragments/frag-installers-$PLATFORM/$ASSET.size"
+    echo "frag: $(cat fragments/frag-installers-$PLATFORM/$ASSET.sha256)  $ASSET (over the FINAL bytes — spec 34 §1.3)"
+    ;;
+  *) echo "usage: $0 build|frag" >&2; exit 64 ;;
+esac

--- a/docs/spec/16-distribution-and-installation.md
+++ b/docs/spec/16-distribution-and-installation.md
@@ -78,9 +78,8 @@ tebako install tfs+https://cdn.example.com/app.tfs?sha256=<hex>
 
 ### 3.4 Windows
 
-winget/scoop manifests pointing at the same standalone binaries (same
-template approach as brew taps); the tebako CLI itself follows once the
-Windows leg ships (roadmap 02).
+winget/scoop manifests ride the system MSI (§7) — the same template
+approach as brew taps, one container, no channel forks the binaries.
 
 ## 4. Trust per channel (locked)
 
@@ -186,7 +185,70 @@ tree, point `TEBAKO_HOME` at `home/` (or relocate its contents into the
 user store), put `bin/` + `home/shims/` on PATH. Trust verification
 happened at stage time; the target machine verifies nothing new.
 
-## 7. Implementation gaps (roadmap 28)
+## 7. Installer packages (MSI / pkg) — roadmap 83
+
+The OS-native installer is a CONTAINER over already-published bytes, for
+the audience a curl|sh or a brew tap does not reach (managed fleets,
+MDM/SCCM/Jamf, first-run-warn-free downloads). Two orthogonal axes:
+
+**WHO ships (identity).** The same parameterized templates
+(`templates/installers/`) serve the tebako system installer (Case A — the
+tamatebako identity) and a client product (Case B — packed-mn class — the
+client's own Azure Trusted Signing account, Apple Developer ID
+certificates, and OpenPGP key; no tamatebako identity leaks into a client
+product). Every installer carries THREE independently verified signature
+surfaces: the container (Authenticode / Developer ID Installer), the
+binaries inside (the release's already-signed exes), and the tebako-plane
+payload signatures for any staged content (spec 09).
+
+**WHAT ships (content shape).**
+
+| Shape | Content | Network at install | Network at first run | For |
+|---|---|---|---|---|
+| Tool-only | the 4 PATH tools (tebako, tebako-shim, tfs, tebako-pkg), signed | — | per-use (runtimes/payloads) | **tebako the system** |
+| Fat exe | self-contained preset (runtime as a slot) | — | — | single-runtime apps only |
+| Bundle | §6's pre-seeded store inside the container | — | — | **apps with spawned-runtime edges (metanorma)** |
+| Web bootstrapper | container that runs `tebako install` post-install | required | — | online convenience |
+
+A fat exe cannot carry spawned runtimes (metanorma spawns java + python
+as SEPARATE runtimes; no exe slot carries them) — the bundle is the
+installer content for serious apps. The system installer needs no
+fat/lean decision at all: the tool ships no payloads by construction.
+
+The locked rules:
+
+1. **Containers ship signed-only.** The MSI ships exactly when spec 34's
+   `WINDOWS_SIGNING_ENABLED` armed the pipeline (Azure Artifact Signing
+   signs MSI natively); the pkg ships exactly when spec 31 §5a's
+   `APPLE_INSTALLER_SIGNING_ENABLED` AND §5's `APPLE_SIGNING_ENABLED` are
+   both armed (a signed-but-unnotarized pkg never ships). Unsigned-first
+   (invariant 7) continues to cover the loose binaries; an unsigned
+   installer CONTAINER is a trap for exactly the audience containers
+   serve, so the legs build + rehearse it always (the template's CI
+   signal) and ship it never-unarmed.
+2. **Container content = the release's own bytes.** The legs download
+   this release's tools back from the release and verify each against
+   the platform leg's sign-then-hash fragments before wrapping — a
+   corrupted or stale input fails the leg, named.
+3. **Sign-then-hash extends to containers** (spec 34 §1.3): the
+   installer fragments hash the FINAL signed container bytes; finalize
+   folds them into SHA256SUMS / sidecars / manifest.json's `installers`
+   array like any other released part, and spec 09's release signing
+   covers them (one .asc per container).
+4. **Install rehearsal is the ship gate, always**: msiexec install → the
+   installed `tebako --version` runs → uninstall clean; `installer -pkg`
+   → payload lands + `/etc/paths.d` entry written → the installed tool
+   runs. A broken template fails the leg, never a user machine.
+5. Per-machine install root only (`Program Files\<product>`,
+   `/opt/<product>`); per-user state (the `~/.tebako` store, shims)
+   stays per-user — the installers install NO user-scope files. PATH
+   lands system-wide (MSI Environment row / `/etc/paths.d`), removed on
+   uninstall.
+6. winget/scoop (roadmap 28's §3.4) ride the MSI asset; brew and
+   install.sh stay the developer paths. No channel forks the binaries —
+   every channel ships the SAME signed bytes.
+
+## 8. Implementation gaps (roadmap 28)
 
 - ~~`tpkg-registry.yaml` fetch/listing (the resolver tail of item 07)~~ —
   SHIPPED (28.1): the registry model + resolution in tebako-resolve and

--- a/docs/spec/31-macos-signing-notarization.md
+++ b/docs/spec/31-macos-signing-notarization.md
@@ -2,7 +2,10 @@
 
 **Status: PARTIAL — §5's org pipelines (tebako release legs + factory
 runtime leg, gated on `APPLE_SIGNING_ENABLED`) and the §6.3 probe-proven
-notarization gate landed 2026-09-09; §2–§4 (the tpkg `signing:` block,
+notarization gate landed 2026-09-09; §5a (the pkg installer leg —
+Developer ID Installer + productsign + staple) spec'd 2026-09-12 with its
+pipeline in roadmap 83 PR-2, awaiting the owner-provisioned Installer
+certificate and its first armed release; §2–§4 (the tpkg `signing:` block,
 press entitlement merge, the publisher pipeline) remain PLANNED
 (drafted 2026-09-04).** Amends spec 03 §2 (the L1 manifest gains the `signing:` block),
 spec 23 §2 (a second non-host sibling declaration) and §4 (press merges
@@ -147,8 +150,9 @@ zip <stitched exe> && xcrun notarytool submit <zip> \
 - Notarytool latency (minutes) belongs in publish pipelines, never in
   press or in run paths.
 - Stapling: bare exes cannot be stapled; notarize the distribution zip
-  (Gatekeeper also resolves tickets online). A pkg/dmg wrapper for
-  stapled offline UX is optional polish, docs-level.
+  (Gatekeeper also resolves tickets online). The pkg/dmg wrapper that CAN
+  carry the offline ticket is §5a's installer leg, no longer optional
+  polish.
 - The composite action `tamatebako/tebako//actions/sign-notarize`
   packages exactly this sequence; the feedstock template inherits it.
 
@@ -172,6 +176,44 @@ zip <stitched exe> && xcrun notarytool submit <zip> \
   release. Required secrets: the Developer ID Application certificate
   (p12 + password), the App Store Connect API key (.p8, key id, issuer
   id).
+
+## 5a. The pkg installer leg (roadmap 83 — the system pkg)
+
+The OS-native pkg container is its own signing surface, layered OVER §5's
+signed+notarized Mach-Os (the installer-over-signed-binaries stack —
+spec 16 §7's three surfaces):
+
+- **A DIFFERENT certificate.** The pkg container authenticates with a
+  **Developer ID Installer** identity via `productsign` — §5's Developer
+  ID **Application** certificate cannot productsign, and Apple issues the
+  two as separate types (a reused CSR across the two requests is
+  rejected; each needs its own). Setup mirrors §5's keychain discipline
+  (`ci/macos-sign-setup-installer.sh`: throwaway keychain, import, sign
+  by HASH, never by name).
+- **Gating:** the repo variable `APPLE_INSTALLER_SIGNING_ENABLED=true`
+  arms the pkg leg's productsign; the leg REQUIRES §5's
+  `APPLE_SIGNING_ENABLED` armed beside it — a signed-but-unnotarized pkg
+  is a named misconfiguration, never shipped. Secrets:
+  `APPLE_DEVELOPER_ID_INSTALLER_P12` +
+  `APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD` beside §5's set.
+- **Notarize + STAPLE.** The pkg goes through notarytool like any Mach-O
+  zip, but unlike a bare exe a pkg CARRIES the stapled ticket — `xcrun
+  stapler staple` makes the stapled pkg pass Gatekeeper **offline** (the
+  §6.3 note's "stapling exists only for pkg/dmg containers" becomes
+  load-bearing here). This is the macOS first-run answer for managed
+  machines.
+- **Content:** the release's own signed bytes only — the leg downloads
+  this release's four PATH tools back from the release and verifies each
+  against the macOS leg's sign-then-hash fragments before wrapping
+  (spec 16 §7 rule 2). Install root `/opt/tebako`, PATH via
+  `/etc/paths.d/tebako` (SIP-safe), no user-scope files.
+- **Ship gates (all in-leg, before upload):** `pkgutil
+  --check-signature` names the Installer identity; `xcrun stapler
+  validate`; `spctl --assess -t install -v` — for a pkg this IS the
+  right assessment (unlike §6.3's bare-exe carve-out); and ALWAYS (armed
+  or not) a real `installer -pkg -target /` rehearsal proving the payload
+  lands and the installed tool runs. A disarmed leg still builds +
+  rehearses the pkg (the template's CI signal) and ships NOTHING.
 
 ## 6. Acceptance (fail-closed, one CI tier each)
 
@@ -199,6 +241,13 @@ zip <stitched exe> && xcrun notarytool submit <zip> \
    unreachable (§3 derives it); an unknown entitlement id fails the
    manifest validation with the named error; entitlement flags on
    non-macOS targets are a named press error.
+5. **The pkg gates (§5a)** — on an armed leg, in-leg before upload:
+   `pkgutil --check-signature` names the Developer ID **Installer**
+   identity (never the Application one), `xcrun stapler validate` proves
+   the stapled ticket, `spctl --assess -t install -v` accepts
+   (`source=Notarized Developer ID`), and the `installer -pkg -target /`
+   rehearsal runs the installed tool. The §5a wire-up's proving run is
+   roadmap 83's first armed release.
 
 ## 7. The other platforms (comparison, non-normative)
 

--- a/templates/installers/README.md
+++ b/templates/installers/README.md
@@ -1,0 +1,78 @@
+# Installer templates (roadmap 83, spec 16 §7)
+
+One parameterized template per OS-native installer container. TWO
+identities consume the SAME files — no forks:
+
+- **Case A — tebako the system:** the tamatebako/tebako release pipeline
+  (`installer-msi` / `installer-pkg` legs in release.yml) binds the
+  tamatebako identity and signs with the tamatebako Azure Trusted Signing
+  account / Apple Developer ID Installer certificate.
+- **Case B — a client product (packed-mn class):** the client's CI binds
+  its own product name, identifiers, upgrade code, install root — and
+  signs all three surfaces with ITS OWN credentials (its Azure account,
+  its Apple Developer ID certs, its OpenPGP key). Nothing in these
+  templates names tamatebako except defaults in the pipeline scripts.
+
+## windows/tebako.wxs (WiX v4/v5)
+
+Build: `wix build -arch x64 tebako.wxs -d ProductName=… -d
+ProductVersion=… -d Manufacturer=… -d UpgradeCode=… -d BinDir=<dir of
+staged *.exe> -o <name>.msi`
+
+| Bind | tebako value | Client MUST change |
+|---|---|---|
+| ProductName | `tebako` | yes (their product) |
+| ProductVersion | release version (3-part) | theirs |
+| Manufacturer | `tamatebako` | yes (registry key root) |
+| UpgradeCode | `9A404514-715E-44F6-B02E-B800845759A9` (generated 2026-09-12, LOCKED — never edit) | **yes — mint a new GUID and lock it forever** |
+| BinDir | the release's signed exes | their staged bundle bin/ |
+
+Everything in `BinDir/*.exe` installs to `%ProgramFiles%\<ProductName>\bin`
+and the system PATH gains that dir (part=last, removed on uninstall).
+
+## macos/distribution.xml + macos/scripts/postinstall
+
+`ci/macos-pkg-build.sh` renders the `@TOKENS@` (productbuild has no bind
+mechanism), then: pkgbuild (component pkg from the staged root
+`opt/<name>/bin/*` + the postinstall that writes
+`/etc/paths.d/<name>`) → productbuild → (armed) productsign with the
+**Developer ID Installer** identity → notarize → **staple**.
+
+| Token / knob | tebako value | Client MUST change |
+|---|---|---|
+| `@PRODUCT_NAME@` | `tebako` | yes |
+| `@VERSION@` | release version | theirs |
+| `@ORG_ID@` | `org.tamatebako` | yes (pkg identifier prefix) |
+| `@MIN_MACOS@` | `12.0` | theirs |
+| `@INSTALL_ROOT@` | `/opt/tebako` | theirs |
+
+## The signing credentials (owner provisioning, per identity)
+
+Windows (per publisher): an Azure Trusted Signing account + cert profile
++ the Entra app registration with a federated credential scoped to
+`<org>@<org-id>/<repo>@<repo-id>:environment:windows-signing` (the
+immutable-subject form). Repo: secrets `AZURE_CLIENT_ID` /
+`AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID`, vars `AZURE_ENDPOINT` /
+`AZURE_SIGNING_ACCOUNT_NAME` / `AZURE_SIGNING_CERT_PROFILE`, gate var
+`WINDOWS_SIGNING_ENABLED=true`.
+
+macOS (per publisher): **two distinct certificates** — Developer ID
+Application (signs the binaries inside; spec 31 §5's existing
+`APPLE_DEVELOPER_ID_P12`) and **Developer ID Installer** (productsign's
+identity — the pkg container). Plus the App Store Connect API key for
+notarytool. Repo: secrets `APPLE_DEVELOPER_ID_INSTALLER_P12` /
+`APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD` beside the spec-31 set, gate
+var `APPLE_INSTALLER_SIGNING_ENABLED=true` (pkg ships only when BOTH
+Apple gates are armed — a signed-but-unnotarized pkg never ships).
+
+### Provisioning the Developer ID Installer certificate (owner, Apple portal)
+
+1. developer.apple.com → Certificates, Identifiers & Profiles →
+   Certificates → **+**.
+2. Choose **Developer ID Installer** (NOT Application — the two are
+   different types; the Application one cannot productsign).
+3. Upload a NEW CSR (Keychain Access → Certificate Assistant → Request
+   from a CA — one CSR per certificate; Apple rejects a reused CSR).
+4. Download the .cer; in Keychain Access export cert+key as .p12 with a
+   password; `base64 -i cert.p12` → the `APPLE_DEVELOPER_ID_INSTALLER_P12`
+   secret; the password → `APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD`.

--- a/templates/installers/macos/distribution.xml
+++ b/templates/installers/macos/distribution.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  distribution.xml — productbuild distribution for the system pkg
+  installer (roadmap 83, spec 16 §7 / spec 31 §5a). Tokens rendered by
+  ci/macos-pkg-build.sh (productbuild has no bind mechanism — sed is the
+  template engine, and every token MUST be substituted: a literal @TOKEN@
+  in the rendered file fails the build gate):
+
+    @PRODUCT_NAME@    e.g. tebako
+    @VERSION@         the release version (tag minus v)
+    @ORG_ID@          reverse-DNS org prefix, e.g. org.tamatebako
+                      (client: org.metanorma — one prefix per publisher)
+    @MIN_MACOS@       minimum macOS, e.g. 12.0
+
+  The component pkg reference: <PRODUCT_NAME>-component.pkg, built by
+  pkgbuild from the staged root (binaries at opt/<name>/bin) with the
+  postinstall that writes /etc/paths.d/<name>.
+-->
+<installer-gui-script minSpecVersion="2">
+  <title>@PRODUCT_NAME@</title>
+  <organization>@ORG_ID@</organization>
+  <domains enable_localSystem="true"/>
+  <options customize="never" require-scripts="true" rootVolumeOnly="true"/>
+  <volume-check>
+    <allowed-os-versions>
+      <os-version min="@MIN_MACOS@"/>
+    </allowed-os-versions>
+  </volume-check>
+  <choices-outline>
+    <line choice="default">
+      <line choice="@ORG_ID@.@PRODUCT_NAME@"/>
+    </line>
+  </choices-outline>
+  <choice id="default"/>
+  <choice id="@ORG_ID@.@PRODUCT_NAME@" visible="false">
+    <pkg-ref id="@ORG_ID@.@PRODUCT_NAME@.pkg"/>
+  </choice>
+  <pkg-ref id="@ORG_ID@.@PRODUCT_NAME@.pkg" version="@VERSION@" onConclusion="none">@PRODUCT_NAME@-component.pkg</pkg-ref>
+</installer-gui-script>

--- a/templates/installers/macos/scripts/postinstall
+++ b/templates/installers/macos/scripts/postinstall
@@ -1,0 +1,11 @@
+#!/bin/bash
+# postinstall — put the installed bin dir on PATH via /etc/paths.d
+# (SIP-safe, MDM-friendly, picked up by path_helper for every NEW login
+# shell). Tokens rendered by ci/macos-pkg-build.sh:
+#   @INSTALL_ROOT@   e.g. /opt/tebako
+#   @PRODUCT_NAME@   e.g. tebako
+# Per-user state (the ~/.tebako store, the shims dir) is created by the
+# CLI itself at first use — the pkg installs NO per-user files.
+set -e
+printf '%s\n' "@INSTALL_ROOT@/bin" > "/etc/paths.d/@PRODUCT_NAME@"
+chmod 644 "/etc/paths.d/@PRODUCT_NAME@"

--- a/templates/installers/windows/tebako.wxs
+++ b/templates/installers/windows/tebako.wxs
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  tebako.wxs — WiX v4/v5 source for the system MSI installer (roadmap 83,
+  spec 16 §7). ONE template serves both identities: the tamatebako release
+  pipeline binds its own values (Case A); a client (packed-mn class) binds
+  its own product name / manufacturer / upgrade code against the same file
+  (Case B — no fork, spec 00 invariant 10: the template is the SSOT).
+
+  Required -d binds (all five — a missing bind fails the wix build loudly):
+    ProductName     e.g. tebako                      (MSI ProductName; also the Program Files dir name)
+    ProductVersion  MSI-safe major.minor.patch       (semver 3-part; MSI ignores a 4th field)
+    Manufacturer    e.g. tamatebako                  (registry key root: HKLM\Software\<Manufacturer>\<ProductName>)
+    UpgradeCode     a GUID, LOCKED FOREVER per product line (MajorUpgrade pairs on it;
+                    a client MUST mint its own — reusing tebako's makes the two
+                    products upgrade-collide on the same machine)
+    BinDir          directory holding the exes to install (ALL *.exe land in
+                    <root>\bin — curated by the caller's staging, spec 34 §7.3's
+                    enumeration-by-extension applies to what the caller stages)
+
+  Layout installed (per-machine):
+    %ProgramFiles%\<ProductName>\bin\*.exe
+    PATH (system, part=last) gains <root>\bin
+    HKLM\Software\<Manufacturer>\<ProductName> InstallDir = <root>
+
+  Per-user data stays per-user: the store is ~/.tebako (TEBAKO_HOME honored);
+  the MSI installs NO user-scope state and needs none.
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="$(var.ProductName)"
+           Manufacturer="$(var.Manufacturer)"
+           Version="$(var.ProductVersion)"
+           UpgradeCode="$(var.UpgradeCode)"
+           Scope="perMachine"
+           InstallerVersion="500"
+           Compressed="yes">
+
+    <MajorUpgrade Schedule="afterInstallInitialize"
+                  DowngradeErrorMessage="A newer version of [ProductName] is already installed. Uninstall it first, or install the newer build over this one." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <!-- PATH append, system scope, non-permanent (uninstall removes it).
+         The RegistryValue is the component KeyPath: an Environment row
+         alone leaves the component without a key path (ICE38). -->
+    <Component Id="PathEnvironment" Directory="BINFOLDER">
+      <Environment Id="TebakoPathEnvironment"
+                   Name="PATH"
+                   Action="set"
+                   Part="last"
+                   System="yes"
+                   Permanent="no"
+                   Value="[BINFOLDER]" />
+      <RegistryValue Root="HKLM"
+                     Key="Software\$(var.Manufacturer)\$(var.ProductName)"
+                     Name="InstallDir"
+                     Type="string"
+                     Value="[INSTALLFOLDER]"
+                     KeyPath="yes" />
+    </Component>
+  </Package>
+</Wix>


### PR DESCRIPTION
## What

Roadmap 83 PR-2: the OS-native installer containers (spec 16 §7, spec 31 §5a) — the system **MSI** (Windows) and **pkg** (macOS), built per release from THIS release's own signed bytes.

- **Templates** (`templates/installers/`): `windows/tebako.wxs` (WiX v4/v5, per-machine, system PATH append, MajorUpgrade on the locked UpgradeCode), `macos/distribution.xml` + `macos/scripts/postinstall` (`/etc/paths.d` PATH, `/opt/tebako` root), and a README carrying the full parameter contract for BOTH identities (Case A tamatebako, Case B client-keyed — packed-mn class).
- **CI scripts**: `ci/windows-msi-build.sh` (build|frag — the sign-then-hash split, spec 34 §1.3), `ci/macos-pkg-build.sh` (pkgbuild → productbuild → productsign → notarize → **staple** → ship gates → install rehearsal), `ci/macos-sign-setup-installer.sh` (the Developer ID **Installer** keychain — a DIFFERENT cert from the Application one).
- **release.yml**: `installer-msi` (windows-signing environment, Azure Artifact Signing with `files-folder-filter: msi`, signtool `/pa` + RFC-3161 verify, msiexec install→run→uninstall rehearsal) and `installer-pkg` (per-arch matrix) legs; finalize needs them; the completeness gate derives its count from the same gate vars the legs ship on.
- **finalize.sh**: folds `frag-installers-<platform>/` into SHA256SUMS + sidecars + a new `installers` array in manifest.json; marker-only (disarmed) frags contribute nothing.
- **sign-release.sh**: the 49/51 part/signature counts are now derived (49 + installers / 51 + installers) from the gate vars.
- **Specs**: spec 16 gains §7 (the installer family + the shape table + the six locked rules, gaps renumbered to §8); spec 31 gains §5a (the pkg leg) + §6.5 (the pkg acceptance gates) + the §4 "optional polish" note now points at §5a.

## The locked decisions (from the 83 file)

- **Containers ship signed-only.** MSI ships iff `WINDOWS_SIGNING_ENABLED=true`; pkg ships iff `APPLE_INSTALLER_SIGNING_ENABLED=true` AND `APPLE_SIGNING_ENABLED=true` (a signed-but-unnotarized pkg is a named misconfiguration). Disarmed legs still **build + rehearse** (the template's CI signal) and ship nothing; the loose binaries remain the unsigned-first-class path (spec 00 invariant 7).
- **Content = the release's own bytes, verified**: each leg downloads the four PATH tools back from the release and verifies them against the platform leg's sign-then-hash fragments before wrapping (finalize's SHA256SUMS does not exist yet — the legs' frags are the anchors).
- **The pkg is the macOS offline answer**: unlike bare exes, a pkg carries a stapled notarization ticket — `stapler validate` + `spctl --assess -t install` are the gates.
- Identity is parameterized end to end (product name / manufacturer / org-id / install root / UpgradeCode) — a client binds its own against the same templates; nothing forks.

## Verification

- `bash -n` on all five scripts; `xmllint` on the wxs + distribution.xml; `actionlint` clean on the whole release.yml.
- **pkg build rehearsed locally** (unsigned): token render + token-guard + pkgbuild + productbuild + `pkgutil --payload-files` — the payload lays out `bin/{tebako,tebako-shim,tfs,tebako-pkg}`, min macOS 12.0 honored.
- **finalize.sh rehearsed** against a synthetic fragments tree (one real pkg frag + one marker-only dir): SHA256SUMS line, per-asset sidecar, and the `installers` array all correct; platform frag loops provably skip `frag-installers-*`.
- The MSI's real compile + sign + install rehearsal is the CI leg itself (WiX needs a Windows runner); the leg builds even unarmed, so the template is exercised on every release from the first tag.

## Owner action outstanding (not this PR)

The tamatebako **Developer ID Installer** certificate (Apple portal → Certificates → Developer ID **Installer** → NEW CSR) → secrets `APPLE_DEVELOPER_ID_INSTALLER_P12` / `APPLE_DEVELOPER_ID_INSTALLER_P12_PASSWORD` + var `APPLE_INSTALLER_SIGNING_ENABLED=true`. Until then the pkg legs build+rehearse unsigned and ship nothing — by design. (templates/installers/README.md carries the click-path.)
