### PR TITLE
tebako-resolve: DEFAULT_TEBAKO_VERSION 0.16.23 — the signed factory line (+ ruby 3.3.12 pairing)

### DIFF
--- a/crates/tebako-cli/src/scenario.rs
+++ b/crates/tebako-cli/src/scenario.rs
@@ -12,7 +12,12 @@ use crate::error::{packaging_error, plain_error, TebakoError};
 /// differentiation (gem's Tebako::BUNDLER_VERSION).
 pub const BUNDLER_MIN_VERSION: &str = "2.4.22";
 
-pub const DEFAULT_RUBY_VERSION: &str = "3.3.7";
+/// The default ruby pairs with `tebako_resolve::DEFAULT_TEBAKO_VERSION`:
+/// the default line must PUBLISH this version (resolution of a version a
+/// line does not carry is the named exit-120 error with the available set
+/// — the pairing is exercised by the press e2e suite). The 0.16.23 line
+/// carries 3.1.6 / 3.2.11 / 3.3.12 / 3.4.10 / 4.0.6.
+pub const DEFAULT_RUBY_VERSION: &str = "3.3.12";
 pub const MIN_RUBY_VERSION_WINDOWS: &str = "3.1.6";
 
 /// Ruby versions the CLI can press packages for (the prebuilt runtime

--- a/crates/tebako-cli/tests/cli_e2e.rs
+++ b/crates/tebako-cli/tests/cli_e2e.rs
@@ -1037,7 +1037,7 @@ fn image_era_fixture(tag: &str) -> Option<(PathBuf, String, String, String)> {
         );
         return None;
     }
-    let ruby = "3.3.7";
+    let ruby = "3.3.12";
     let asset = format!("tebako-runtime-{ver}-{ruby}-{plat}");
     let exe_src = dir.join(&asset);
     let image_name = format!("{asset}.tfs");
@@ -1118,7 +1118,7 @@ fn press_against_mirror(
         .arg("-p")
         .arg(&prefix)
         .arg("-R")
-        .arg("3.3.7")
+        .arg("3.3.12")
         .env(
             "TEBAKO_RUNTIME_MIRROR",
             tebako_http::file_url(Path::new(&mirror_root)),
@@ -1163,7 +1163,7 @@ fn image_era_press_and_cold_run() {
 
     // The press installed the image into the cache (bootstrap interop).
     let entry_dir = home.join("runtimes").join(format!(
-        "ruby-3.3.7-{}-{}",
+        "ruby-3.3.12-{}-{}",
         tebako_cli::DEFAULT_TEBAKO_VERSION,
         tebako_cli::options::host_platform().unwrap()
     ));
@@ -1300,7 +1300,7 @@ fn official_pair_fixture(tag: &str) -> Option<(PathBuf, String, String, String)>
         );
         return None;
     }
-    let ruby = "3.3.7";
+    let ruby = "3.3.12";
     let asset = format!("tebako-runtime-{ver}-{ruby}-{plat}");
     let image_name = format!("{asset}.tfs");
 
@@ -1363,7 +1363,7 @@ fn image_era_full_flow_official_pair() {
     };
     let home = work.join("home");
     let entry_dir = home.join("runtimes").join(format!(
-        "ruby-3.3.7-{}-{}",
+        "ruby-3.3.12-{}-{}",
         tebako_cli::DEFAULT_TEBAKO_VERSION,
         tebako_cli::options::host_platform().unwrap()
     ));
@@ -1552,7 +1552,7 @@ fn native_ext_press_builds_and_packages() {
         eprintln!("skipping native-ext e2e: runtime resolution failed");
         return;
     };
-    let Some(sdk_mirror) = sdk_mirror_fixture(&work, "3.3.7") else {
+    let Some(sdk_mirror) = sdk_mirror_fixture(&work, "3.3.12") else {
         eprintln!("skipping native-ext e2e: cannot mirror the ruby src release");
         return;
     };
@@ -1583,7 +1583,7 @@ fn native_ext_press_builds_and_packages() {
         .arg("-p")
         .arg(&prefix)
         .arg("-R")
-        .arg("3.3.7")
+        .arg("3.3.12")
         .env(
             "TEBAKO_RUNTIME_MIRROR",
             tebako_http::file_url(Path::new(&mirror_root)),
@@ -1675,7 +1675,7 @@ fn native_ext_press_builds_and_packages() {
         .arg("-p")
         .arg(&prefix)
         .arg("-R")
-        .arg("3.3.7")
+        .arg("3.3.12")
         .env(
             "TEBAKO_RUNTIME_MIRROR",
             tebako_http::file_url(Path::new(&mirror_root)),

--- a/crates/tebako-cli/tests/fixtures/fontist-app/Gemfile
+++ b/crates/tebako-cli/tests/fixtures/fontist-app/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby "3.3.7"
+ruby "3.3.12"
 
 gem "fontist", "3.0.10"
 

--- a/crates/tebako-cli/tests/fixtures/fontist-app/Gemfile.lock
+++ b/crates/tebako-cli/tests/fixtures/fontist-app/Gemfile.lock
@@ -203,7 +203,7 @@ DEPENDENCIES
   racc (= 1.7.3)
 
 RUBY VERSION
-   ruby 3.3.7p123
+   ruby 3.3.12p206
 
 BUNDLED WITH
    2.5.22

--- a/crates/tebako-cli/tests/fixtures/nokogiri-app/Gemfile
+++ b/crates/tebako-cli/tests/fixtures/nokogiri-app/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
-ruby "3.3.7"
+ruby "3.3.12"
 
 gem "nokogiri", "1.19.4"

--- a/crates/tebako-resolve/Cargo.toml
+++ b/crates/tebako-resolve/Cargo.toml
@@ -17,7 +17,7 @@ default = ["git", "network"]
 # selection; tebako-http always brings its own). tebako-bootstrap links
 # this crate with default-features = false: the loader never fetches git
 # references, and keeping the git stack out holds its 3 MiB size gate.
-git = ["dep:gix", "dep:reqwest", "dep:rustls"]
+git = ["dep:gix", "dep:reqwest", "dep:rustls", "dep:jiff"]
 # Enterprise networking (TODO.v2-1/33): proxy honoring + additive trust
 # anchors, forwarded to tebako-http. Off in the bootstrap (same gate),
 # where a set proxy/CA env is the named NetworkingCompiledOut error.
@@ -59,6 +59,14 @@ gix = { version = "0.87", default-features = false, optional = true, features = 
     "revision",
 ] }
 reqwest = { version = "0.13", default-features = false, optional = true, features = ["rustls-no-provider"] }
+# jiff 0.2.36 (2026-09-12) shipped broken: its lib.rs doc-includes
+# (COMPARE/DESIGN/PLATFORM/CHANGELOG.md) escape the package root — the
+# published .crate lacks the files, so every fresh resolution fails to
+# compile (the workspace Cargo.lock is gitignored — resolutions float,
+# owner rule). Bound the float via the `git` feature (jiff enters only
+# through gix-date) until upstream yanks or fixes; dropping the bound is
+# the bump branch's job.
+jiff = { version = ">=0.2, <=0.2.35", optional = true }
 
 [target.'cfg(not(all(windows, target_env = "gnu")))'.dependencies]
 rustls = { version = "0.23", default-features = false, optional = true, features = ["ring", "std", "tls12", "logging"] }
@@ -80,6 +88,9 @@ proptest = "1"
 # The git fixtures are built with gix itself — no git CLI anywhere, tests
 # included (spec 14 §3).
 gix = { version = "0.87", default-features = false, features = ["sha1"] }
+# Test builds pull gix non-optionally: the jiff bound (above) must hold
+# here too or `cargo test` on a fresh checkout floats to broken 0.2.36.
+jiff = { version = ">=0.2, <=0.2.35" }
 
 # The per-entry cache flock on Windows (cache.rs — LockFileEx on one byte
 # at offset 0, the tebako-bootstrap platform.rs shape). Unix uses libc's

--- a/crates/tebako-resolve/src/lib.rs
+++ b/crates/tebako-resolve/src/lib.rs
@@ -81,8 +81,12 @@ pub use transport::{HttpTransport, Transport};
 /// `kind: executable` edge (the xml2rfc leg of metanorma's requires
 /// block) — reproduced against the published 0.16.18 macos-arm64 exe:
 /// "unknown variant `executable` … the payload's self-description
-/// lies".
-pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.22";
+/// lies". From 0.16.23 every factory artifact is SIGNED (the spec 09
+/// plane armed factory-side; `TEBAKO_REQUIRE_SIGNED=1` resolves this
+/// line and refuses 0.16.22's unsigned one) and the line adds ruby
+/// 4.0.6 — the ruby 4 flavor's runtime source. Same v2.3.0 driver
+/// unit as 0.16.22 (contract 2, unchanged).
+pub const DEFAULT_TEBAKO_VERSION: &str = "0.16.23";
 
 /// Fetch `reference` (pin-verified at the fetch boundary) and install it
 /// as `payloads/<name>/<version>.tfs` — or return the existing entry.


### PR DESCRIPTION
# DEFAULT_TEBAKO_VERSION → 0.16.23 (the signed factory line) + DEFAULT_RUBY_VERSION → 3.3.12

## Why

`DEFAULT_TEBAKO_VERSION` still named **0.16.22** — the last **unsigned**
runtime line. With the spec 09 plane armed factory-side, 0.16.23 is the
first line whose artifacts are all SIGNED, and it adds **ruby 4.0.6**
(the ruby-4 flavor's runtime source). A CLI defaulting to 0.16.22 makes
`TEBAKO_REQUIRE_SIGNED=1` users fail closed on the *default* resolution
— exactly backwards. Found during the wave-5 signed-closure acceptance.

The line change forces the ruby pairing: 0.16.23 publishes
**3.1.6 / 3.2.11 / 3.3.12 / 3.4.10 / 4.0.6** (verified against the
release's `manifest.json`) — 3.3.7 is gone, so `DEFAULT_RUBY_VERSION`
moves 3.3.7 → **3.3.12** (same ABI 3.3.0, same patchlevel family; the
paired-constants coupling is now documented on both sides).

Same driver unit as 0.16.22 (v2.3.0, contract 2 — trr `contract.yml`
`link_unit_release` unchanged), so no bootstrap/driver compatibility
surface moves.

## What changes

- `tebako-resolve`: `DEFAULT_TEBAKO_VERSION` 0.16.22 → 0.16.23 (comment
  now records the signed-line + ruby-4 rationale).
- `tebako-cli`: `DEFAULT_RUBY_VERSION` 3.3.7 → 3.3.12 (comment now
  records the pairing rule: the default ruby must be published on the
  default line — a miss is the named exit-120 "available set" error).
- e2e suite follows the line: every live-resolution e2e site
  (`image_era_fixture`, `official_pair_fixture`, `press_against_mirror`,
  the native-ext press + SDK mirror) pins ruby **3.3.12**. Offline
  synthetic fixtures (9.9.9/0.15.9 lines, unit literals) untouched.
- fontist/nokogiri fixture Gemfiles pin `ruby "3.3.12"`; the fontist
  lockfile's `RUBY VERSION` becomes `ruby 3.3.12p206` (patchlevel read
  from the 3.3.12 runtime image's rbconfig). All native pins
  (bigdecimal 3.1.5 / json 2.7.2 / racc 1.7.3 / strscan-carried
  constraint) verified unchanged against the 3.3.12 env image's
  specifications — the runtime carries exactly those versions, and
  bundler 2.5.22 still matches every fixture lock's `BUNDLED WITH`.

## Verification

- `cargo test -p tebako-resolve` + `-p tebako-shim`: green (16 targets).
- `TEBAKO_CLI_SKIP_E2E=1 cargo test -p tebako-cli`: green (all targets,
  0 failures).
- `cargo build -p tebako-bootstrap` (own invocation) + full
  `cargo test --workspace`: **green — 121 targets ok**, incl. the full
  live-line e2e set against 0.16.23 (14/14 in cli_e2e, 520 s):
  `press_gemfile_fontist_modern_resolution_and_platform_gems`,
  `press_gemfile_nokogiri_precompiled_runs`,
  `image_era_full_flow_official_pair`, `native_ext_press_builds_and_packages`,
  `golden_side_by_side_with_the_gem`. (One transient: the workspace-wide
  parallel run's rustdoc leg hit E0463 `can't find crate for tebako_pkg`
  mid-restamp — the libtfs.rlib collision class, roadmap 71; the doctest
  target re-run in isolation is green, 0 doctests exist.)

## Ride-along: jiff ≤ 0.2.35 bound (tebako-resolve)

jiff **0.2.36** (published 2026-09-12, NOT yanked at writing) is broken
upstream: its lib.rs doc-includes (`../../../../COMPARE.md` etc.) escape
the package root — the published `.crate` lacks the files, so every
fresh resolution fails to compile with E0463-style "couldn't read"
errors. The workspace `Cargo.lock` is gitignored (resolutions float,
owner rule), so CI on ANY new PR would go red today. jiff enters only
through `gix-date` ← `gix` (the `git` feature): the bound rides that
feature (`dep:jiff` added to it) plus a dev-dependency line for the
non-optional test-profile gix. Verified: with the worktree lock deleted,
fresh resolution locks jiff 0.2.35 and `cargo check -p tebako-resolve
--all-features` is green. Dropping the bound belongs to the next bump
branch (or upstream's yank).
